### PR TITLE
fix(gc): reap orphaned sims that are shut down

### DIFF
--- a/src/sim/ios.js
+++ b/src/sim/ios.js
@@ -67,7 +67,23 @@ export function parseOccupyingApps(launchctlOutput) {
 // deleting a sim that may still be driven by a foreign UI-test runner, which
 // is exactly what the probe exists to prevent. Same direction as the
 // unmounted-volume guard: on doubt, skip, do not destroy.
+//
+// A device that is not booted is the one case that is not doubt: nothing can
+// be running on it, and `simctl spawn` cannot answer for it either -- it exits
+// non-zero with "device is not booted", which the probe alone would read as
+// occupied. That made a shut-down orphan permanently unreapable: `gc` reported
+// it and skipped it on every run, forever. Check the state first, and only
+// probe a device that is actually booted.
 export function isSimOccupied(udid) {
+  let sim;
+  try {
+    sim = listAllIosSims().find(s => s.udid === udid);
+  } catch {
+    // Could not read the device list: that IS doubt, so fall through to the
+    // probe and let it fail closed.
+    sim = undefined;
+  }
+  if (sim && sim.state !== 'Booted') return false;
   const out = getExecutor().runQuiet(`xcrun simctl spawn ${udid} launchctl list`);
   if (out === null || out === undefined) return true;
   return parseOccupyingApps(out).length > 0;

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -112,10 +112,13 @@ test('release verifies iOS ownership before probing occupancy', async () => {
     },
   });
   const execCalls = [];
+  // Booted on purpose: isSimOccupied short-circuits to "not occupied" for a
+  // device that is not booted, so a shut-down fixture would never reach the
+  // probe this test is asserting the ordering of.
   const listJson = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
-        { udid: 'UDID-ABC', name: 'rn-iso-app', state: 'Shutdown', isAvailable: true },
+        { udid: 'UDID-ABC', name: 'rn-iso-app', state: 'Booted', isAvailable: true },
       ],
     },
   });

--- a/test/sim-ios.test.js
+++ b/test/sim-ios.test.js
@@ -264,3 +264,48 @@ test('isSimOccupied reports not-occupied when the probe answers with nothing', a
   assert.equal(isSimOccupied('UDID-X'), false);
   resetExecutor();
 });
+
+// A shut-down device cannot be occupied, and `simctl spawn` cannot answer for
+// one -- it exits non-zero with "device is not booted", which the probe alone
+// reads as occupied. That left a shut-down orphan permanently unreapable: gc
+// reported it and skipped it every run. The state check has to come first.
+test('isSimOccupied reports not-occupied for a shut-down device without probing', async () => {
+  const { setExecutor, resetExecutor } = await import('../src/exec.js');
+  const { isSimOccupied } = await import('../src/sim/ios.js');
+  const devices = JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
+        { udid: 'UDID-X', name: 'rn-iso-x', state: 'Shutdown', isAvailable: true },
+      ],
+    },
+  });
+  let probed = false;
+  setExecutor({
+    run: () => devices,
+    runQuiet: () => {
+      probed = true;
+      return null;
+    },
+    spawn: () => {},
+  });
+  assert.equal(isSimOccupied('UDID-X'), false);
+  assert.equal(probed, false, 'must not spawn into a device that is not booted');
+  resetExecutor();
+});
+
+// The state check must not weaken the guard for a device that IS booted: an
+// unanswerable probe there is still doubt, and doubt still means occupied.
+test('isSimOccupied still fails closed for a booted device whose probe cannot answer', async () => {
+  const { setExecutor, resetExecutor } = await import('../src/exec.js');
+  const { isSimOccupied } = await import('../src/sim/ios.js');
+  const devices = JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
+        { udid: 'UDID-X', name: 'rn-iso-x', state: 'Booted', isAvailable: true },
+      ],
+    },
+  });
+  setExecutor({ run: () => devices, runQuiet: () => null, spawn: () => {} });
+  assert.equal(isSimOccupied('UDID-X'), true);
+  resetExecutor();
+});


### PR DESCRIPTION
## Description

`isSimOccupied` probes with `simctl spawn <udid> launchctl list` and treats an unanswerable probe as occupied. That default is right — a teardown site must not delete a sim a foreign UI-test runner is still driving — but it swallows one case that isn't doubt at all.

On a device that is not booted, that spawn *always* fails:

```
$ xcrun simctl spawn <udid> launchctl list
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=405):
Process spawn via launchd failed because device is not booted.
```

`runQuiet` returns `null`, the probe reports occupied, and `gc` skips it — permanently. A shut-down orphan is reported and skipped on every run, and the message blames a process that does not exist:

```
Skipped ios sim rn-iso-gctest (20AF...): in use by another process (occupied) -- left for a later gc
```

I hit this with a sim left behind by a killed agent session. Shutting it down — the obvious first thing to try — is precisely what makes it unreapable.

## Solution

A device that is not booted cannot be occupied, so check the state before probing and only spawn into a booted device. `listAllIosSims` already carries `state`.

Failing to read the device list *is* doubt, so that path falls through to the probe and keeps the existing fail-closed behaviour. The guard is unchanged for every case it was actually protecting.

## Test plan

Live, against a real orphan (created with `up ios`, shut down, project directory deleted):

```
published 0.13.0:  Skipped ... (occupied) -- left for a later gc   →  Reclaimed 0K
this branch:       Deleted ios sim rn-iso-gctest                   →  sim gone
```

300/300 unit tests pass, including two new ones: a shut-down device reports not-occupied *without* spawning, and a booted device whose probe cannot answer still reports occupied.

One existing test (`release verifies iOS ownership before probing occupancy`) used a `Shutdown` fixture while asserting an ordering invariant about the probe. With the short-circuit that device correctly never probes, so the fixture is now `Booted` — the assertion it exists to make is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS simulator occupancy detection by recognizing shut-down simulators as available.
  * Preserved occupied status when a booted simulator does not respond to the occupancy check.
  * Improved release ordering behavior for simulated iOS devices.

* **Tests**
  * Added regression coverage for shut-down and booted simulator states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->