### PR TITLE
Quick-win issue fixes (#14, #10, #16)

### DIFF
--- a/packages/rn-iso/skill/SKILL.md
+++ b/packages/rn-iso/skill/SKILL.md
@@ -10,7 +10,9 @@ You are an AI agent working on a React Native / Expo project, possibly alongside
 
 Invoke the CLI via `npx`: `npx rn-iso <command>`. Don't `npm install -g`.
 
-`npx` usually resolves the latest published version, but not always: a stale entry in the npm cache (or a different node version's cache) can serve an old one, and an old CLI silently lacks commands this file documents. **Check once per session** -- `npx rn-iso --version` -- and use `npx rn-iso@latest` if it disagrees with the version stamped at the bottom of this file. `start` warns when the two are out of step.
+`npx` usually resolves the latest published version, but not always: a stale entry in the npm cache (or a different node version's cache) can serve an old one, and an old CLI silently lacks commands this file documents. **Check once per session** -- `npx rn-iso --version` -- and use `npx rn-iso@latest` if it disagrees with the version stamped at the bottom of this file.
+
+**In a repo whose `.npmrc` pins a private registry** (`registry=https://<host>/...`, common in company monorepos), `npx` tries to fetch `rn-iso` from THAT registry and fails -- typically `npm error code E401` (expired token) -- because rn-iso is published on the public npm registry. Point npx at the public registry for this one package: `npx --registry=https://registry.npmjs.org rn-iso <command>` (and the same on `rn-iso@latest`). An `E401`/`E404` on `npx rn-iso` is almost always this, not a broken install.
 
 ## Read the CLI's own docs for anything specific
 

--- a/packages/rn-iso/src/commands/gc.ts
+++ b/packages/rn-iso/src/commands/gc.ts
@@ -115,7 +115,11 @@ interface RunGcOptions {
 // Bounds each device listing so a wedged simctl/emulator daemon can't hang
 // `gc` forever -- see the comment above the listAllIosSims/listAvds calls
 // in collectGcReport below.
-const DEVICE_LIST_TIMEOUT_MS = 10000;
+// 30s, not 10s: on a loaded machine (several booted emulators, a busy
+// CoreSimulator) `emulator -list-avds` / `simctl list` genuinely take longer
+// than 10s to answer, and a premature skip means an orphaned emulator holding
+// gigabytes never surfaces. A real hang still bounds out and prints the notice.
+const DEVICE_LIST_TIMEOUT_MS = 30000;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/packages/rn-iso/src/commands/worktree.ts
+++ b/packages/rn-iso/src/commands/worktree.ts
@@ -184,6 +184,19 @@ export function registerCreate(worktree: Command): void {
             : `Branched ${branch} from ${baseRef} (${baseSha}).`,
         ),
       );
+      // `fresh` (and `head`) branch from a REMOTE-TRACKING ref that is only as
+      // current as the last `git fetch`. rn-iso does not fetch (that is a
+      // network call with its own auth/offline failure modes, not a worktree
+      // creation's job), so an agent told to work "on latest main" against a
+      // ref last fetched days ago would silently build on stale code. Say so.
+      if (!reusedBranch && (base === 'fresh' || base === 'head')) {
+        console.error(
+          chalk.dim(
+            `  ${baseRef} is a local ref, current as of the last \`git fetch\`. If you need the very latest, ` +
+              `run \`git -C ${root} fetch\` first.`,
+          ),
+        );
+      }
 
       // Fall back to settings on emptiness, not just on null: a
       // `.worktreeinclude` that exists but is blank/comment-only returns


### PR DESCRIPTION
Quick-win issue fixes (the batch agreed as low-risk).

- **Fixes #14** — gc's `DEVICE_LIST_TIMEOUT_MS` was 10s, easy to hit on a loaded machine, so an orphaned emulator holding gigabytes never surfaced. Bumped to 30s.
- **Fixes #10** — `worktree create` now warns that `fresh`/`head` branch from a remote-tracking ref only as current as the last `git fetch`. (rn-iso still doesn't fetch — network/auth/offline concerns — but no longer silently builds on stale code.)
- **Fixes #16** — SKILL.md explains that `npx rn-iso` fails with E401 behind a private-registry `.npmrc` and to use `npx --registry=https://registry.npmjs.org rn-iso`. Also removed a stale line about `start` warning on version skew (that warning went with the skill command).

Already fixed on main, closing separately: **#11** (hoisted expo bin — `readProjectConfig` uses `expoBinPath`'s upward walk) and **#6** (carry-ignored `.DerivedData` — excluded by `isWorkspaceArtifact`).

typecheck 0, oxlint 0, knip 0, vitest 1399.
