### PR TITLE
fix(ci): build before typecheck, so the cache packages resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,25 @@ jobs:
       - name: Install (workspace root)
         run: npm ci
 
-      # Lint / format / types are fast and fail early. oxlint and oxfmt are the
-      # oxc toolchain; typecheck is the production src (tests run under vitest).
+      # Lint and format are fast and fail early. oxlint and oxfmt are the oxc
+      # toolchain; typecheck is the production src (tests run under vitest),
+      # and it now sits below the build -- see why on that step.
       - name: Lint (oxlint)
         run: npm run lint
 
       - name: Format check (oxfmt)
         run: npm run format:check
+
+      # Build every package with tsdown (rn-iso -> dist ESM, the two cache
+      # packages -> dist CJS). Proves the published artifacts compile.
+      #
+      # BEFORE typecheck, and that order is load-bearing. The two cache
+      # packages are CJS and are consumed by rn-iso's suite as
+      # `@rn-iso/expo-build-cache` and `@rn-iso/metro`; their .d.ts files are
+      # build OUTPUT, so a typecheck that runs first cannot resolve either
+      # module and fails with TS2307 on a tree that is perfectly fine.
+      - name: Build (tsdown, all packages)
+        run: npm run build
 
       - name: Typecheck (production)
         run: npm run typecheck
@@ -57,11 +69,6 @@ jobs:
       # surface honest as the codebase changes.
       - name: Dead code (knip)
         run: npm run knip
-
-      # Build every package with tsdown (rn-iso -> dist ESM, the two cache
-      # packages -> dist CJS). Proves the published artifacts compile.
-      - name: Build (tsdown, all packages)
-        run: npm run build
 
       # The unit suite on vitest (rolldown-vite): rn-iso + both cache packages,
       # 52 files. Real processes, real ports, real git; fakes for xcrun/adb.


### PR DESCRIPTION
## Description

CI has been red on `main` since the TypeScript migration. Every run fails at **Typecheck (production)** with the same four errors:

```
packages/rn-iso/src/__tests__/cache-packages.test.ts(41,35): error TS2307: Cannot find module '@rn-iso/expo-build-cache' or its corresponding type declarations.
packages/rn-iso/src/__tests__/cache-packages.test.ts(67,48): error TS2307: Cannot find module '@rn-iso/metro' or its corresponding type declarations.
```

The tree is fine. `@rn-iso/expo-build-cache` and `@rn-iso/metro` are the two CJS cache packages, and their `.d.ts` files are **build output** — so a typecheck that runs before the build has nothing to resolve those specifiers against. Nobody hits this locally because a working tree already has a `dist/` from an earlier build; CI starts from `npm ci` and has none.

## Solution

Move the Build step above Typecheck. That's the whole change — the comment on the step now records why the order matters, so it doesn't get reshuffled back.

## Test plan

Verified on a clean checkout of `main` (`npm ci`, no `dist/`):

- `npm run typecheck` alone → exit 1, the four TS2307s above.
- `npm run build && npm run typecheck` → exit 0.
- `npm run knip` → exit 0, and `npm test` → 1462 passed.

Related: unblocks #19, which can't show a green CI run until `main` is green.
