### PR TITLE
Release via OIDC trusted publishing (tag push + one approval)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+# Publishes the three packages to npm via OIDC trusted publishing when a
+# version tag is pushed. There is NO token: npm trusts a short-lived OIDC
+# credential minted for exactly this repo + workflow + environment, and the
+# `release` environment requires a manual approval, which replaces the OTP.
+#
+# Third-party actions are pinned by commit SHA and the job is deliberately
+# minimal -- nothing here may run code that could tamper with the tarballs.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          # Node 24 bundles an npm new enough for OIDC trusted publishing.
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Install (lifecycle scripts stay blocked)
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
+      - name: Tag matches the package versions
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for p in rn-iso expo-build-cache metro; do
+            v=$(node -p "require('./packages/$p/package.json').version")
+            if [ "$v" != "$tag" ]; then
+              echo "packages/$p is $v but the tag is $tag"; exit 1
+            fi
+          done
+      - name: Publish rn-iso
+        run: npm publish --provenance --access public
+        working-directory: packages/rn-iso
+      - name: Publish @rn-iso/expo-build-cache
+        run: npm publish --provenance --access public
+        working-directory: packages/expo-build-cache
+      - name: Publish @rn-iso/metro
+        run: npm publish --provenance --access public
+        working-directory: packages/metro
+      - name: Smoke-test the registry
+        run: |
+          sleep 10
+          for p in rn-iso @rn-iso/expo-build-cache @rn-iso/metro; do
+            v=$(npm view "$p" version)
+            echo "$p -> $v"
+            [ "$v" = "${GITHUB_REF_NAME#v}" ] || exit 1
+          done

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -132,7 +132,11 @@ If `git status` isn't clean, commit / discard before tagging.
    gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/notes.md
    ```
    Sections: `New`, `Removed (breaking)`, `Fixes`, `Docs`, `Migration notes` (if any). Skip empty sections. Link prior commits with `[<short-sha>](https://github.com/janicduplessis/rn-iso/commit/<sha>)`. Say which package a line is about when it is not the CLI.
-7. **Publish to npm, `rn-iso` first.** The two cache packages name it as a peer
+7. **Publish to npm.** Pushing the tag (previous step) triggers the
+   `Release` workflow, which publishes all three packages via OIDC trusted
+   publishing (no token, `--provenance`) once you APPROVE the run in the
+   `release` environment on GitHub -- that approval replaces the OTP. Manual
+   fallback, `rn-iso` first: The two cache packages name it as a peer
    and their READMEs link to it, so a registry that has a cache package but not
    the CLI version it points at is the wrong order to be interrupted in:
 


### PR DESCRIPTION
Tag push -> environment-gated publish of all three packages with --provenance. No token exists: npm trusts the OIDC credential for exactly this repo+workflow+environment. Actions SHA-pinned, job minimal, tag-vs-version guard, registry smoke test. The `release` environment (required reviewer: janicduplessis) is already created. Activates once trusted publishers are configured on npmjs.com for each package.