### PR TITLE
Cache locations in the machine config (env still wins)

### DIFF
--- a/packages/expo-build-cache/README.md
+++ b/packages/expo-build-cache/README.md
@@ -44,4 +44,4 @@ npx rn-iso gc --delete --older-than 30   # drop entries unused for 30 days
 rn-iso is an optional peer. Without it the cache works exactly the same; it is
 just invisible to housekeeping.
 
-`RN_ISO_BUILD_CACHE` overrides the location.
+The location can be overridden by `RN_ISO_BUILD_CACHE`, or machine-wide by `caches.buildCache` in `~/.rn-iso/config.json` (an absolute path; the env var wins). The CLI and this package resolve both identically, so they always share one store.

--- a/packages/expo-build-cache/index.ts
+++ b/packages/expo-build-cache/index.ts
@@ -66,8 +66,25 @@ function configDir(): string {
 // A function rather than a constant: resolving it at load time froze whatever
 // the environment was when a metro.config.js or an Expo config first required
 // this file, which is not necessarily what it is when a build runs.
+// The machine config's override (`caches.buildCache` in <configDir>/config.json):
+// the same three-step resolution as the CLI's paths module -- env, config file,
+// default -- duplicated here because this package must work with no rn-iso
+// installed. Unreadable or malformed answers null; a cache override must never
+// be the reason a build fails.
+function cachePathSetting(key: string): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(configDir(), 'config.json'), 'utf-8')) as {
+      caches?: Record<string, unknown>;
+    };
+    const value = parsed?.caches?.[key];
+    return typeof value === 'string' && value.startsWith('/') ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 export function cacheRoot(): string {
-  return process.env.RN_ISO_BUILD_CACHE || path.join(configDir(), 'build-cache');
+  return process.env.RN_ISO_BUILD_CACHE || cachePathSetting('buildCache') || path.join(configDir(), 'build-cache');
 }
 
 function entryDir(platform: string, key: string): string {

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -39,7 +39,7 @@ only the entries nothing has touched, not the whole cache.
 rn-iso is an optional peer. Without it the cache works exactly the same; it is
 just invisible to housekeeping.
 
-`RN_ISO_METRO_CACHE` overrides the location.
+The location can be overridden by `RN_ISO_METRO_CACHE`, or machine-wide by `caches.metroCache` in `~/.rn-iso/config.json` (an absolute path; the env var wins). The CLI and this package resolve both identically, so they always share one store.
 
 ## The NDJSON log reporter
 

--- a/packages/metro/index.ts
+++ b/packages/metro/index.ts
@@ -97,8 +97,26 @@ function cacheNameSegment(name: string): string {
   );
 }
 
+// The machine config's override (`caches.metroCache` in <configDir>/config.json):
+// the same three-step resolution as the CLI's paths module -- env, config file,
+// default -- duplicated here because this package must work with no rn-iso
+// installed. Unreadable or malformed answers null; a cache override must never
+// be the reason a bundler config fails to load.
+function cachePathSetting(key: string): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(configDir(), 'config.json'), 'utf-8')) as {
+      caches?: Record<string, unknown>;
+    };
+    const value = parsed?.caches?.[key];
+    return typeof value === 'string' && value.startsWith('/') ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 export function cacheRoot(name?: string | null): string {
-  if (process.env.RN_ISO_METRO_CACHE) return process.env.RN_ISO_METRO_CACHE;
+  const setting = process.env.RN_ISO_METRO_CACHE || cachePathSetting('metroCache');
+  if (setting) return setting;
   const root = path.join(configDir(), 'metro-cache');
   return name === undefined || name === null || name === '' ? root : path.join(root, cacheNameSegment(name));
 }

--- a/packages/rn-iso/src/__tests__/cache-packages.test.ts
+++ b/packages/rn-iso/src/__tests__/cache-packages.test.ts
@@ -10,7 +10,7 @@
 // the module), but its cache root is resolved per call rather than at load
 // time -- which is what lets a test set the environment after importing, and
 // what keeps an override from being frozen into a long-lived Metro process.
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -120,6 +120,20 @@ test('both packages resolve the same cache roots the CLI does', async () => {
     expect(metro.cacheRoot()).toBe(sharedMetroCache());
     expect(metro.cacheRoot('demo')).toBe(sharedMetroCache('demo'));
     expect(metro.cacheRoot('demo')).toBe(join(home, 'metro-cache', 'demo'));
+
+    // The machine-config override has to move all three together, and the
+    // env override has to beat it.
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ caches: { buildCache: join(home, 'cfg-build'), metroCache: join(home, 'cfg-metro') } }),
+    );
+    expect(provider.cacheRoot()).toBe(sharedBuildCache());
+    expect(provider.cacheRoot()).toBe(join(home, 'cfg-build'));
+    expect(metro.cacheRoot('demo')).toBe(sharedMetroCache('demo'));
+    expect(metro.cacheRoot('demo')).toBe(join(home, 'cfg-metro'));
+    // A relative path in the config is ignored, never joined into nonsense.
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ caches: { buildCache: 'relative/nope' } }));
+    expect(provider.cacheRoot()).toBe(join(home, 'build-cache'));
 
     // The env overrides have to move all three together too.
     process.env.RN_ISO_BUILD_CACHE = join(home, 'elsewhere-build');

--- a/packages/rn-iso/src/commands/guide.ts
+++ b/packages/rn-iso/src/commands/guide.ts
@@ -867,6 +867,20 @@ or via the environment, which overrides the file:
 Unset, 0, or any non-positive value means NO enforcement -- the default, where
 rn-iso limits nothing. See \`guide lifecycle\` for what each cap does.
 
+CACHE LOCATIONS ARE MACHINE-LEVEL TOO
+The shared build cache and Metro transform cache default to living under
+~/.rn-iso. To relocate them (say, to an external disk), set a top-level
+\`caches\` key in ~/.rn-iso/config.json, edited by hand -- absolute paths:
+
+  {
+    "caches": { "buildCache": "/Volumes/SSD/rn-iso/build-cache",
+                "metroCache": "/Volumes/SSD/rn-iso/metro-cache" }
+  }
+
+RN_ISO_BUILD_CACHE / RN_ISO_METRO_CACHE in the environment override the file.
+The CLI and both cache packages resolve these identically, so every process
+finds the same store regardless of shell profile. A relative path is ignored.
+
 PREFER SELF-REGISTRATION OVER THE 'caches' SETTING
 There is no 'cache' command. A cache registers itself from code instead, once,
 and every 'gc' report shows it from then on, tagged (registered):

--- a/packages/rn-iso/src/paths.ts
+++ b/packages/rn-iso/src/paths.ts
@@ -78,7 +78,7 @@ export function supervisorLogFile(projectRoot: string): string {
 // the anchor that makes a relocated cache visible to processes that never
 // inherited the env override. Unreadable or malformed answers null -- a cache
 // override must never be the reason a build cannot run.
-export function cachePathSetting(key: 'buildCache' | 'metroCache'): string | null {
+function cachePathSetting(key: 'buildCache' | 'metroCache'): string | null {
   try {
     const parsed = JSON.parse(readFileSync(join(getConfigDir(), 'config.json'), 'utf-8')) as {
       caches?: Record<string, unknown>;

--- a/packages/rn-iso/src/paths.ts
+++ b/packages/rn-iso/src/paths.ts
@@ -9,6 +9,7 @@
 // build directory back to a workspace.
 //
 // Pure: nothing here creates a directory. Callers mkdir when they write.
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { getConfigDir } from './config.ts';
 
@@ -67,7 +68,27 @@ export function supervisorLogFile(projectRoot: string): string {
 //
 // RN_ISO_BUILD_CACHE / RN_ISO_METRO_CACHE come first in all three: both were
 // honoured before this layout existed, and quietly ignoring an override someone
-// already set reads as an empty cache rather than as an error.
+// already set reads as an empty cache rather than as an error. Next comes the
+// machine config (`caches.buildCache` / `caches.metroCache` in
+// <configDir>/config.json -- same no-CLI, config-plus-env pattern as the
+// concurrency limits), which every process finds regardless of shell profile;
+// the default layout under the config dir is last.
+
+// The one guarded read this otherwise-pure module does: the config file is
+// the anchor that makes a relocated cache visible to processes that never
+// inherited the env override. Unreadable or malformed answers null -- a cache
+// override must never be the reason a build cannot run.
+export function cachePathSetting(key: 'buildCache' | 'metroCache'): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(getConfigDir(), 'config.json'), 'utf-8')) as {
+      caches?: Record<string, unknown>;
+    };
+    const value = parsed?.caches?.[key];
+    return typeof value === 'string' && value.startsWith('/') ? value : null;
+  } catch {
+    return null;
+  }
+}
 
 // A name only distinguishes one app's Metro cache from another's. Metro keys
 // entries by content, so one store shared between unrelated projects would be
@@ -83,13 +104,14 @@ function cacheNameSegment(name: string | null | undefined): string {
 }
 
 export function sharedMetroCache(name?: string | null): string {
-  if (process.env.RN_ISO_METRO_CACHE) return process.env.RN_ISO_METRO_CACHE;
+  const override = process.env.RN_ISO_METRO_CACHE || cachePathSetting('metroCache');
+  if (override) return override;
   const root = join(getConfigDir(), 'metro-cache');
   return name === undefined || name === null || name === '' ? root : join(root, cacheNameSegment(name));
 }
 
 export function sharedBuildCache(): string {
-  return process.env.RN_ISO_BUILD_CACHE || join(getConfigDir(), 'build-cache');
+  return process.env.RN_ISO_BUILD_CACHE || cachePathSetting('buildCache') || join(getConfigDir(), 'build-cache');
 }
 
 export function sharedCompilationCache(): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     // These suites tap process.stdout/stderr directly (and were written for
     // `node --test`); let console output flow to the real streams unwrapped.
     disableConsoleIntercept: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+// The machine running the suite may legitimately export RN_ISO_* overrides
+// (this machine relocates the shared caches to an external SSD via
+// ~/.zshenv). Tests assert the DEFAULT layout and set their own overrides,
+// so ambient ones must not leak in.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('RN_ISO_')) delete process.env[key];
+}


### PR DESCRIPTION
caches.buildCache / caches.metroCache in ~/.rn-iso/config.json, resolved identically by the CLI and both cache packages (pinned in cache-packages.test). Env overrides beat the file; overrides are final paths; relative paths ignored. Docs: guide settings, both package READMEs. Test hygiene: vitest clears ambient RN_ISO_* env.