### PR TITLE
Extract @rn-iso/core: shared primitives implemented once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,15 @@ jobs:
       - name: Tag matches the package versions
         run: |
           tag="${GITHUB_REF_NAME#v}"
-          for p in rn-iso expo-build-cache metro; do
+          for p in core rn-iso expo-build-cache metro; do
             v=$(node -p "require('./packages/$p/package.json').version")
             if [ "$v" != "$tag" ]; then
               echo "packages/$p is $v but the tag is $tag"; exit 1
             fi
           done
+      - name: Publish @rn-iso/core
+        run: npm publish --provenance --access public
+        working-directory: packages/core
       - name: Publish rn-iso
         run: npm publish --provenance --access public
         working-directory: packages/rn-iso
@@ -55,7 +58,7 @@ jobs:
       - name: Smoke-test the registry
         run: |
           sleep 10
-          for p in rn-iso @rn-iso/expo-build-cache @rn-iso/metro; do
+          for p in @rn-iso/core rn-iso @rn-iso/expo-build-cache @rn-iso/metro; do
             v=$(npm view "$p" version)
             echo "$p -> $v"
             [ "$v" = "${GITHUB_REF_NAME#v}" ] || exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,9 +235,13 @@ packages/metro/             # @rn-iso/metro. CJS (see conventions above).
   test/reporter.test.js     # `node --test`, CommonJS like the package it tests
 ```
 
-The two cache packages duplicate a little of `src/build-cache.js` and
-`src/paths.js` on purpose: they must work with no rn-iso installed, so neither
-may import either module. Two pieces matter, and both fail the same silent way.
+What rn-iso and the two cache packages must AGREE on lives in
+`packages/core` (`@rn-iso/core`), a tiny CJS HARD dependency of all three:
+the config-dir and cache-root resolution (env > machine config > default),
+`buildCacheKey`, and the caches.json self-registration. This replaced three
+deliberate copies -- the packages still may not import RN-ISO ITSELF (optional
+ESM peer, usually absent under `npx rn-iso`), but a plain always-installed CJS
+dep has neither of the failure modes that forced the duplication. Two pieces matter, and both fail the same silent way.
 
 - **`buildCacheKey`** — both entry points build the key the same way, so they
   address the same entries.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@ real workflow at the same time.
 ## 0. The three packages
 
 ```
+packages/core                @rn-iso/core                shared primitives (cache roots, cache key, registration)
 packages/rn-iso              rn-iso                      the CLI
 packages/expo-build-cache    @rn-iso/expo-build-cache    Expo build cache provider
 packages/metro               @rn-iso/metro               shared Metro transform cache + log reporter
@@ -106,7 +107,7 @@ If `git status` isn't clean, commit / discard before tagging.
    carries its own README (a package with no `README.md` in its own directory
    publishes with "No README data found" on npm):
    ```bash
-   for p in rn-iso expo-build-cache metro; do
+   for p in core rn-iso expo-build-cache metro; do
      echo "== $p"; (cd "packages/$p" && npm pack --dry-run 2>&1 | grep -E 'README|Tarball|total files')
    done
    ```
@@ -142,6 +143,7 @@ If `git status` isn't clean, commit / discard before tagging.
 
    ```bash
    npm whoami                                          # confirm login; if 401, `npm login` first
+   pnpm --filter @rn-iso/core publish --otp <code>       # first: the others depend on it
    pnpm --filter rn-iso publish --otp <code>
    pnpm --filter @rn-iso/expo-build-cache publish --otp <code>
    pnpm --filter @rn-iso/metro publish --otp <code>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit -p packages/rn-iso/tsconfig.json && tsc --noEmit -p packages/metro/tsconfig.json && tsc --noEmit -p packages/expo-build-cache/tsconfig.json",
+    "typecheck": "tsc --noEmit -p packages/core/tsconfig.json && tsc --noEmit -p packages/rn-iso/tsconfig.json && tsc --noEmit -p packages/metro/tsconfig.json && tsc --noEmit -p packages/expo-build-cache/tsconfig.json",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt .",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Janic Duplessis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,13 @@
+# @rn-iso/core
+
+The primitives [`rn-iso`](https://www.npmjs.com/package/rn-iso),
+[`@rn-iso/metro`](https://www.npmjs.com/package/@rn-iso/metro) and
+[`@rn-iso/expo-build-cache`](https://www.npmjs.com/package/@rn-iso/expo-build-cache)
+must agree on, implemented once: where the rn-iso config dir and the two
+shared caches live (env override > machine config > default), how a build
+cache key is derived, and how a cache registers itself for `rn-iso gc`.
+
+This is an internal dependency of those packages, not a user-facing API --
+install one of them instead. It is deliberately CJS with no dependencies, so
+a `metro.config.js` or an Expo build-cache provider can `require()` it on any
+supported Node.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,0 +1,157 @@
+// @rn-iso/core -- the primitives rn-iso and its cache packages must AGREE on,
+// implemented once. Until this package existed they were deliberately
+// duplicated three times (the cache packages may not import rn-iso itself: it
+// is an optional ESM peer, usually absent under `npx rn-iso`, and requiring
+// it threw ERR_REQUIRE_ESM on Node before 20.19 -- a silent no-op both times).
+// A tiny CJS hard dependency has neither failure mode, so the copies collapse
+// here. CJS on purpose: metro.config.js and Expo providers `require()` this.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export function configDir(): string {
+  return process.env.RN_ISO_HOME || path.join(os.homedir(), '.rn-iso');
+}
+
+// The machine config's cache overrides (`caches.buildCache` / `caches.metroCache`
+// in <configDir>/config.json). Unreadable or malformed answers null -- a cache
+// override must never be the reason a bundler config or a build fails. Only an
+// absolute path counts.
+export function cachePathSetting(key: 'buildCache' | 'metroCache'): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(configDir(), 'config.json'), 'utf-8')) as {
+      caches?: Record<string, unknown>;
+    };
+    const value = parsed?.caches?.[key];
+    return typeof value === 'string' && value.startsWith('/') ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+// Anything that is not a plain path segment is replaced, and leading dots go,
+// so a scoped package name cannot climb out of the cache root.
+export function cacheNameSegment(name: string | null | undefined): string {
+  return (
+    String(name)
+      .replace(/[^A-Za-z0-9._-]+/g, '-')
+      .replace(/^\.+/, '') || 'app'
+  );
+}
+
+// Resolution order in both roots: env override, machine config, default
+// layout under the config dir. The env vars come first because they were
+// honoured before the rest existed, and quietly ignoring an override someone
+// already set reads as an empty cache rather than as an error. An override
+// names ONE directory and is returned as-is -- no per-app segment -- otherwise
+// half the stores on a machine would move and half would not.
+export function buildCacheRoot(): string {
+  return process.env.RN_ISO_BUILD_CACHE || cachePathSetting('buildCache') || path.join(configDir(), 'build-cache');
+}
+
+export function metroCacheRoot(name?: string | null): string {
+  const override = process.env.RN_ISO_METRO_CACHE || cachePathSetting('metroCache');
+  if (override) return override;
+  const root = path.join(configDir(), 'metro-cache');
+  return name === undefined || name === null || name === '' ? root : path.join(root, cacheNameSegment(name));
+}
+
+// ---- the build cache key ---------------------------------------------------
+//
+// The fingerprint covers what the project IS, never how it was built. Keying
+// on it alone means a Release build answers a Debug resolve, and a device
+// build answers a simulator one -- both silently, both producing a binary that
+// cannot run. `options` is the run-options object Expo hands a build cache
+// provider; only the keys named here are read, so an unfamiliar CLI version
+// cannot change the key by adding one.
+
+export interface BuildRunOptions {
+  variant?: string;
+  configuration?: string;
+  buildConfiguration?: string;
+  isSimulator?: boolean;
+  device?: string | boolean | null;
+}
+
+// A simulator udid is a canonical UUID. Apple's hardware identifiers are not:
+// they are 40 hex characters, or the 8-digits-dash-16-hex form newer devices
+// use.
+const SIMULATOR_UDID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// adb's name for a running emulator.
+const EMULATOR_SERIAL = /^emulator-\d+$/;
+
+function slug(value: unknown): string {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// The Xcode configuration on iOS, the gradle variant on Android. Both CLIs
+// default to Debug/debug, so an absent value is that and not "unknown".
+function buildVariant(platform: string, options: BuildRunOptions): string {
+  const raw = platform === 'android' ? options.variant : (options.configuration ?? options.buildConfiguration);
+  return (typeof raw === 'string' ? slug(raw) : '') || 'debug';
+}
+
+// A binary built for real hardware cannot run on a simulator, and the reverse
+// is equally true, so the target class is part of the key. The device selector
+// is the only signal available, and it is ambiguous by nature; the
+// unclassifiable shapes get a bucket of their own rather than sharing the
+// simulator one: a wasted rebuild is cheap, a binary that cannot launch is not.
+function buildTarget(options: BuildRunOptions): string {
+  if (typeof options.isSimulator === 'boolean') return options.isSimulator ? 'sim' : 'device';
+  const device = options.device;
+  if (device === undefined || device === null || device === false) return 'sim';
+  if (typeof device !== 'string') return 'prompted';
+  const name = device.trim();
+  if (name === '' || name === 'generic') return 'sim';
+  if (SIMULATOR_UDID.test(name) || EMULATOR_SERIAL.test(name)) return 'sim';
+  return `on-${slug(name)}`;
+}
+
+export function buildCacheKey(platform: string, fingerprintHash: string, options: unknown = {}): string {
+  const opts = (options && typeof options === 'object' ? options : {}) as BuildRunOptions;
+  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}`;
+}
+
+// ---- cache self-registration ----------------------------------------------
+//
+// Registering makes a cache visible to `rn-iso gc`'s report, which is the only
+// thing that will ever trim it. The manifest is written directly (not through
+// any rn-iso module) and a failure to announce is swallowed: a cache that
+// cannot register still works, it is just invisible.
+
+export interface RegisterOptions {
+  dir: string;
+  name: string;
+  prune: string;
+  note: string;
+  entriesDepth?: number;
+}
+
+export function registerCache({ dir, name, prune, note, entriesDepth }: RegisterOptions): void {
+  try {
+    const home = configDir();
+    const file = path.join(home, 'caches.json');
+    let manifest: { version: number; caches: Array<Record<string, unknown>> } = { version: 1, caches: [] };
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as { caches?: Array<Record<string, unknown>> };
+      if (Array.isArray(parsed?.caches)) manifest = { version: 1, caches: parsed.caches };
+    } catch {
+      // No manifest yet, or an unreadable one: start clean rather than fail.
+    }
+    // Keyed on the directory so repeated calls update rather than accumulate --
+    // these run on every build.
+    const others = manifest.caches.filter((c) => c.dir !== dir);
+    const record: Record<string, unknown> = { dir, name, prune, note, registeredBy: process.cwd() };
+    // Only written when the caller sets it: an absent depth means the entries
+    // are the directory's immediate children, which is the common case.
+    if (entriesDepth) record.entriesDepth = entriesDepth;
+    others.push(record);
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ version: 1, caches: others }, null, 2));
+  } catch {
+    // A cache that cannot announce itself still works; it is just invisible.
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@rn-iso/metro",
+  "name": "@rn-iso/core",
   "version": "1.3.3",
-  "description": "Metro integration for rn-iso: one transform cache shared by every worktree, plus an NDJSON reporter for structured logs.",
+  "description": "Shared primitives for rn-iso and its cache packages: config-dir and cache-root resolution, the build cache key, and cache self-registration. Not a user-facing API.",
   "license": "MIT",
   "files": [
     "dist",
@@ -18,14 +18,7 @@
     }
   },
   "scripts": {
-    "test": "node --test test/*.test.js",
     "build": "tsdown"
-  },
-  "dependencies": {
-    "@rn-iso/core": "^1.3.3"
-  },
-  "peerDependencies": {
-    "metro-cache": "*"
   },
   "engines": {
     "node": ">=22"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts", "__tests__/**/*.ts"]
+}

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: { index: 'index.ts' },
+  format: 'cjs',
+  dts: true,
+  outDir: 'dist',
+  target: 'node22',
+  platform: 'node',
+  tsconfig: 'tsconfig.json',
+  outExtensions: () => ({ js: '.js' }),
+});

--- a/packages/expo-build-cache/index.ts
+++ b/packages/expo-build-cache/index.ts
@@ -25,27 +25,20 @@
 // require().
 
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
+import { buildCacheRoot, buildCacheKey, registerCache } from '@rn-iso/core';
+import type { BuildRunOptions as RunOptions } from '@rn-iso/core';
+
+export { buildCacheKey };
+
+// Register at most once per resolved root, not once per process: the root can
+// move if the env/config changes between calls in one process, and re-checking
+// is one string compare.
+let registeredDir: string | null = null;
 import { execFileSync } from 'node:child_process';
 
 // The run options Expo hands a provider. Only the keys named below are read; a
 // future CLI cannot change the cache key by adding one.
-interface RunOptions {
-  variant?: unknown;
-  configuration?: unknown;
-  buildConfiguration?: unknown;
-  isSimulator?: unknown;
-  device?: unknown;
-}
-
-interface RegisterOptions {
-  dir: string;
-  name?: string;
-  prune?: string;
-  note?: string;
-  entriesDepth?: number;
-}
 
 // THIS RESOLUTION EXISTS THREE TIMES: here, in packages/metro/index.ts,
 // and in rn-iso's own src/paths.ts (sharedBuildCache / sharedMetroCache). This
@@ -59,32 +52,8 @@ interface RegisterOptions {
 // RN_ISO_BUILD_CACHE comes first because it did before the layout existed, and
 // quietly ignoring an override someone already set reads as an empty cache
 // rather than as an error.
-function configDir(): string {
-  return process.env.RN_ISO_HOME || path.join(os.homedir(), '.rn-iso');
-}
-
-// A function rather than a constant: resolving it at load time froze whatever
-// the environment was when a metro.config.js or an Expo config first required
-// this file, which is not necessarily what it is when a build runs.
-// The machine config's override (`caches.buildCache` in <configDir>/config.json):
-// the same three-step resolution as the CLI's paths module -- env, config file,
-// default -- duplicated here because this package must work with no rn-iso
-// installed. Unreadable or malformed answers null; a cache override must never
-// be the reason a build fails.
-function cachePathSetting(key: string): string | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(path.join(configDir(), 'config.json'), 'utf-8')) as {
-      caches?: Record<string, unknown>;
-    };
-    const value = parsed?.caches?.[key];
-    return typeof value === 'string' && value.startsWith('/') ? value : null;
-  } catch {
-    return null;
-  }
-}
-
 export function cacheRoot(): string {
-  return process.env.RN_ISO_BUILD_CACHE || cachePathSetting('buildCache') || path.join(configDir(), 'build-cache');
+  return buildCacheRoot();
 }
 
 function entryDir(platform: string, key: string): string {
@@ -94,66 +63,6 @@ function entryDir(platform: string, key: string): string {
 // A simulator udid is a canonical UUID. Apple's hardware identifiers are not:
 // they are 40 hex characters, or the 8-digits-dash-16-hex form newer devices
 // use.
-const SIMULATOR_UDID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-// adb's name for a running emulator.
-const EMULATOR_SERIAL = /^emulator-\d+$/;
-
-function slug(value: unknown): string {
-  return String(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-// The Xcode configuration on iOS, the gradle variant on Android. `expo run:ios`
-// defaults to Debug and `expo run:android` to debug, so an absent value is that
-// and not "unknown".
-function buildVariant(platform: string, options: RunOptions): string {
-  const raw =
-    platform === 'android'
-      ? options.variant
-      : options.configuration != null
-        ? options.configuration
-        : options.buildConfiguration;
-  return (typeof raw === 'string' ? slug(raw) : '') || 'debug';
-}
-
-// A binary built for real hardware cannot run on a simulator, and the reverse is
-// equally true, so the target class is part of the key. `runOptions.device` is
-// the only signal Expo passes, and it is ambiguous by nature:
-//   absent            -- the CLI targets a simulator or emulator. The default.
-//   "generic"         -- a build-only simulator build.
-//   a udid or serial  -- classifiable when it has the shape of a simulator id.
-//   a bare -d flag    -- the CLI prompts, and the answer can be hardware.
-//   a name            -- unclassifiable.
-// The last two get a bucket of their own rather than sharing the simulator one:
-// a wasted rebuild is cheap, and a binary that cannot launch is not. Two
-// workspaces naming the same device still share their entries.
-function buildTarget(options: RunOptions): string {
-  if (typeof options.isSimulator === 'boolean') return options.isSimulator ? 'sim' : 'device';
-  const device = options.device;
-  if (device === undefined || device === null || device === false) return 'sim';
-  if (typeof device !== 'string') return 'prompted';
-  const name = device.trim();
-  if (name === '' || name === 'generic') return 'sim';
-  if (SIMULATOR_UDID.test(name) || EMULATOR_SERIAL.test(name)) return 'sim';
-  return `on-${slug(name)}`;
-}
-
-// The fingerprint covers what the project IS, never how it was built. Keying on
-// it alone means a Release build answers a Debug resolve, and a device build
-// answers a simulator one -- both silently, both producing a binary that cannot
-// run. Only the run-option keys named above are read, so a future Expo CLI
-// cannot change the key by adding one.
-//
-// rn-iso's own build cache computes this key the same way (src/build-cache.ts),
-// so both entry points address the same entry. Changing one without the other
-// splits them onto separate sets of entries.
-export function buildCacheKey(platform: string, fingerprintHash: string, runOptions?: RunOptions): string {
-  const opts: RunOptions = runOptions && typeof runOptions === 'object' ? runOptions : {};
-  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}`;
-}
-
 // Log lines name the entry, so they have to carry what distinguishes it: the
 // fingerprint abbreviates fine, the variant and target do not -- a Debug miss
 // and a Release miss on the same commit read identically without them.
@@ -187,35 +96,6 @@ function artifactIn(dir: string): string | null {
 //     before 20.19
 // A dynamic import fixes the second and not the first. The format is a stable
 // contract, so writing it is the cheaper trade.
-function registerCache({ dir, name, prune, note, entriesDepth }: RegisterOptions): void {
-  try {
-    const home = configDir();
-    const file = path.join(home, 'caches.json');
-    let manifest: { version: number; caches: Array<Record<string, unknown>> } = { version: 1, caches: [] };
-    try {
-      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-      if (Array.isArray(parsed?.caches)) manifest = { version: 1, caches: parsed.caches };
-    } catch {
-      // No manifest yet, or an unreadable one: start clean rather than fail.
-    }
-    // Keyed on the directory so repeated calls update rather than accumulate --
-    // these run on every build.
-    const others = manifest.caches.filter((c) => c.dir !== dir);
-    const record: Record<string, unknown> = { dir, name, prune, note, registeredBy: process.cwd() };
-    // Only written when the caller sets it: an absent depth means the entries
-    // are the directory's immediate children, which is the common case.
-    if (entriesDepth) record.entriesDepth = entriesDepth;
-    others.push(record);
-    fs.mkdirSync(home, { recursive: true });
-    fs.writeFileSync(file, JSON.stringify({ version: 1, caches: others }, null, 2));
-  } catch {
-    // A cache that cannot announce itself still works; it is just invisible.
-  }
-}
-
-// Keyed on the directory rather than a plain boolean, so a root that changes
-// under a long-lived process still reaches the manifest.
-let registeredDir: string | null = null;
 function registerOnce(): void {
   const root = cacheRoot();
   if (registeredDir === root) return;

--- a/packages/expo-build-cache/package.json
+++ b/packages/expo-build-cache/package.json
@@ -21,6 +21,9 @@
     "test": "node --test test/*.test.js",
     "build": "tsdown"
   },
+  "dependencies": {
+    "@rn-iso/core": "^1.3.3"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/packages/metro/index.ts
+++ b/packages/metro/index.ts
@@ -26,20 +26,12 @@
 // Metro in-process both reach the published entry through require().
 
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
+import { metroCacheRoot, registerCache } from '@rn-iso/core';
 
 // A Metro FileStore, kept structural so this package need not depend on
 // metro-cache's types: the constructor is all the caller relies on.
 type FileStoreCtor = new (options: { root: string }) => object;
-
-interface RegisterOptions {
-  dir: string;
-  name?: string;
-  prune?: string;
-  note?: string;
-  entriesDepth?: number;
-}
 
 // A Metro reporter event. Metro's event union is large and version-dependent, so
 // only the fields this reporter reads are named; the rest ride along untyped.
@@ -83,42 +75,8 @@ export interface NdjsonReporter {
 // quietly ignoring an override someone already set reads as an empty cache
 // rather than as an error. It names one directory, so it wins for a named cache
 // too -- otherwise half the stores on a machine would move and half would not.
-function configDir(): string {
-  return process.env.RN_ISO_HOME || path.join(os.homedir(), '.rn-iso');
-}
-
-// Anything that is not a plain path segment is replaced, and leading dots go, so
-// a scoped package name cannot climb out of the cache root.
-function cacheNameSegment(name: string): string {
-  return (
-    String(name)
-      .replace(/[^A-Za-z0-9._-]+/g, '-')
-      .replace(/^\.+/, '') || 'app'
-  );
-}
-
-// The machine config's override (`caches.metroCache` in <configDir>/config.json):
-// the same three-step resolution as the CLI's paths module -- env, config file,
-// default -- duplicated here because this package must work with no rn-iso
-// installed. Unreadable or malformed answers null; a cache override must never
-// be the reason a bundler config fails to load.
-function cachePathSetting(key: string): string | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(path.join(configDir(), 'config.json'), 'utf-8')) as {
-      caches?: Record<string, unknown>;
-    };
-    const value = parsed?.caches?.[key];
-    return typeof value === 'string' && value.startsWith('/') ? value : null;
-  } catch {
-    return null;
-  }
-}
-
 export function cacheRoot(name?: string | null): string {
-  const setting = process.env.RN_ISO_METRO_CACHE || cachePathSetting('metroCache');
-  if (setting) return setting;
-  const root = path.join(configDir(), 'metro-cache');
-  return name === undefined || name === null || name === '' ? root : path.join(root, cacheNameSegment(name));
+  return metroCacheRoot(name);
 }
 
 // Registering makes this cache visible to `rn-iso gc`'s report, which is the
@@ -132,32 +90,6 @@ export function cacheRoot(name?: string | null): string {
 //   - rn-iso is an ES module, so `require` of it throws ERR_REQUIRE_ESM on Node
 //     before 20.19
 // A dynamic import fixes the second and not the first.
-function registerCache({ dir, name, prune, note, entriesDepth }: RegisterOptions): void {
-  try {
-    const home = configDir();
-    const file = path.join(home, 'caches.json');
-    let manifest: { version: number; caches: Array<Record<string, unknown>> } = { version: 1, caches: [] };
-    try {
-      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-      if (Array.isArray(parsed?.caches)) manifest = { version: 1, caches: parsed.caches };
-    } catch {
-      // No manifest yet, or an unreadable one: start clean rather than fail.
-    }
-    // Keyed on the directory so repeated calls update rather than accumulate --
-    // these run on every build.
-    const others = manifest.caches.filter((c) => c.dir !== dir);
-    const record: Record<string, unknown> = { dir, name, prune, note, registeredBy: process.cwd() };
-    // Only written when the caller sets it: an absent depth means the entries
-    // are the directory's immediate children, which is the common case.
-    if (entriesDepth) record.entriesDepth = entriesDepth;
-    others.push(record);
-    fs.mkdirSync(home, { recursive: true });
-    fs.writeFileSync(file, JSON.stringify({ version: 1, caches: others }, null, 2));
-  } catch {
-    // A cache that cannot announce itself still works; it is just invisible.
-  }
-}
-
 function registerOnce(dir: string): void {
   registerCache({
     dir,

--- a/packages/rn-iso/package.json
+++ b/packages/rn-iso/package.json
@@ -42,6 +42,7 @@
     "build": "tsdown"
   },
   "dependencies": {
+    "@rn-iso/core": "^1.3.3",
     "@rn-iso/metro": "^1.2.0",
     "chalk": "^5.4.1",
     "commander": "^13.1.0"

--- a/packages/rn-iso/src/__tests__/cache-packages.test.ts
+++ b/packages/rn-iso/src/__tests__/cache-packages.test.ts
@@ -94,13 +94,18 @@ test('the Metro cache store registers itself on this Node, at the shard depth', 
 // way to use the CLI is `npx rn-iso`, so it is usually not a dependency of the
 // project and the specifier does not resolve on any Node version. Both packages
 // write the manifest themselves, so neither may name rn-iso as a module.
-test('neither package reaches rn-iso as a module', () => {
+test('neither package reaches rn-iso as a module; the shared primitives live in @rn-iso/core', () => {
   for (const pkg of ['expo-build-cache', 'metro']) {
     const source = readFileSync(join(PACKAGES, pkg, 'index.ts'), 'utf-8');
     expect(source).not.toMatch(/require\(\s*['"]rn-iso/);
     expect(source).not.toMatch(/import\(\s*['"]rn-iso/);
-    expect(source).toMatch(/caches\.json/);
+    expect(source).toMatch(/@rn-iso\/core/);
   }
+  // The direct manifest write moved to core with everything else the three
+  // packages must agree on; core itself must not import rn-iso either.
+  const core = readFileSync(join(PACKAGES, 'core', 'index.ts'), 'utf-8');
+  expect(core).toMatch(/caches\.json/);
+  expect(core).not.toMatch(/require\(\s*['"]rn-iso/);
 });
 
 // The three implementations of the cache-root resolution are duplicated on

--- a/packages/rn-iso/src/build-cache.ts
+++ b/packages/rn-iso/src/build-cache.ts
@@ -19,6 +19,7 @@
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, utimesSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { createRequire } from 'module';
+import { buildCacheKey as coreBuildCacheKey } from '@rn-iso/core';
 import { getExecutor } from './exec.ts';
 import { register } from './cache-manifest.ts';
 import { sharedBuildCache } from './paths.ts';
@@ -46,49 +47,6 @@ export function entryDir(platform: string, key: string, root: string = cacheRoot
   return join(root, platform, key);
 }
 
-// A simulator udid is a canonical UUID. Apple's hardware identifiers are not:
-// they are 40 hex characters, or the 8-digits-dash-16-hex form newer devices
-// use.
-const SIMULATOR_UDID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-// adb's name for a running emulator.
-const EMULATOR_SERIAL = /^emulator-\d+$/;
-
-function slug(value: unknown): string {
-  return String(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-// The Xcode configuration on iOS, the gradle variant on Android. Both CLIs
-// default to Debug/debug, so an absent value is that and not "unknown".
-function buildVariant(platform: string, options: BuildRunOptions): string {
-  const raw = platform === 'android' ? options.variant : (options.configuration ?? options.buildConfiguration);
-  return (typeof raw === 'string' ? slug(raw) : '') || 'debug';
-}
-
-// A binary built for real hardware cannot run on a simulator, and the reverse is
-// equally true, so the target class is part of the key. The device selector is
-// the only signal available, and it is ambiguous by nature:
-//   absent            -- the CLI targets a simulator or emulator. The default.
-//   "generic"         -- a build-only simulator build.
-//   a udid or serial  -- classifiable when it has the shape of a simulator id.
-//   a bare flag       -- the CLI prompts, and the answer can be hardware.
-//   a name            -- unclassifiable.
-// The last two get a bucket of their own rather than sharing the simulator one:
-// a wasted rebuild is cheap, and a binary that cannot launch is not. Two
-// workspaces naming the same device still share their entries.
-function buildTarget(options: BuildRunOptions): string {
-  if (typeof options.isSimulator === 'boolean') return options.isSimulator ? 'sim' : 'device';
-  const device = options.device;
-  if (device === undefined || device === null || device === false) return 'sim';
-  if (typeof device !== 'string') return 'prompted';
-  const name = device.trim();
-  if (name === '' || name === 'generic') return 'sim';
-  if (SIMULATOR_UDID.test(name) || EMULATOR_SERIAL.test(name)) return 'sim';
-  return `on-${slug(name)}`;
-}
-
 // The fingerprint covers what the project IS, never how it was built. Keying on
 // it alone means a Release build answers a Debug resolve, and a device build
 // answers a simulator one -- both silently, both producing a binary that cannot
@@ -96,8 +54,7 @@ function buildTarget(options: BuildRunOptions): string {
 // only the keys named here are read, so an unfamiliar CLI version cannot change
 // the key by adding one.
 export function buildCacheKey(platform: string, fingerprintHash: string, options: unknown = {}): string {
-  const opts = (options && typeof options === 'object' ? options : {}) as BuildRunOptions;
-  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}`;
+  return coreBuildCacheKey(platform, fingerprintHash, options);
 }
 
 // The artifact is the single .app / .apk inside an entry directory.

--- a/packages/rn-iso/src/paths.ts
+++ b/packages/rn-iso/src/paths.ts
@@ -9,8 +9,8 @@
 // build directory back to a workspace.
 //
 // Pure: nothing here creates a directory. Callers mkdir when they write.
-import { readFileSync } from 'fs';
 import { join } from 'path';
+import { buildCacheRoot, metroCacheRoot } from '@rn-iso/core';
 import { getConfigDir } from './config.ts';
 
 export const WORKSPACE_DIR_NAME = '.rn-iso';
@@ -74,44 +74,12 @@ export function supervisorLogFile(projectRoot: string): string {
 // concurrency limits), which every process finds regardless of shell profile;
 // the default layout under the config dir is last.
 
-// The one guarded read this otherwise-pure module does: the config file is
-// the anchor that makes a relocated cache visible to processes that never
-// inherited the env override. Unreadable or malformed answers null -- a cache
-// override must never be the reason a build cannot run.
-function cachePathSetting(key: 'buildCache' | 'metroCache'): string | null {
-  try {
-    const parsed = JSON.parse(readFileSync(join(getConfigDir(), 'config.json'), 'utf-8')) as {
-      caches?: Record<string, unknown>;
-    };
-    const value = parsed?.caches?.[key];
-    return typeof value === 'string' && value.startsWith('/') ? value : null;
-  } catch {
-    return null;
-  }
-}
-
-// A name only distinguishes one app's Metro cache from another's. Metro keys
-// entries by content, so one store shared between unrelated projects would be
-// correct but pointlessly large. Anything that is not a plain path segment is
-// replaced, and leading dots go, so a scoped package name cannot climb out of
-// the cache root.
-function cacheNameSegment(name: string | null | undefined): string {
-  return (
-    String(name)
-      .replace(/[^A-Za-z0-9._-]+/g, '-')
-      .replace(/^\.+/, '') || 'app'
-  );
-}
-
 export function sharedMetroCache(name?: string | null): string {
-  const override = process.env.RN_ISO_METRO_CACHE || cachePathSetting('metroCache');
-  if (override) return override;
-  const root = join(getConfigDir(), 'metro-cache');
-  return name === undefined || name === null || name === '' ? root : join(root, cacheNameSegment(name));
+  return metroCacheRoot(name);
 }
 
 export function sharedBuildCache(): string {
-  return process.env.RN_ISO_BUILD_CACHE || cachePathSetting('buildCache') || join(getConfigDir(), 'build-cache');
+  return buildCacheRoot();
 }
 
 export function sharedCompilationCache(): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,16 +30,28 @@ importers:
         specifier: 4.1.11
         version: 4.1.11(@types/node@26.3.0)(vite@8.2.2(@types/node@26.3.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
-  packages/expo-build-cache: {}
+  packages/core: {}
+
+  packages/expo-build-cache:
+    dependencies:
+      '@rn-iso/core':
+        specifier: ^1.3.3
+        version: link:../core
 
   packages/metro:
     dependencies:
+      '@rn-iso/core':
+        specifier: ^1.3.3
+        version: link:../core
       metro-cache:
         specifier: '*'
         version: 0.87.0
 
   packages/rn-iso:
     dependencies:
+      '@rn-iso/core':
+        specifier: ^1.3.3
+        version: link:../core
       '@rn-iso/metro':
         specifier: ^1.2.0
         version: link:../metro


### PR DESCRIPTION
Collapses the three deliberate copies (cache roots incl. the new config-file resolution, buildCacheKey, caches.json registration) into a tiny dependency-free CJS package that rn-iso, @rn-iso/metro and @rn-iso/expo-build-cache depend on by plain semver. Public APIs unchanged; 1444 tests green; release.yml/RELEASE.md publish core first. NOTE: first release after this needs a trusted publisher configured for @rn-iso/core on npmjs.com too.