### PR TITLE
Store build artifacts as APFS clones (fallback: plain copy)

### DIFF
--- a/packages/expo-build-cache/index.ts
+++ b/packages/expo-build-cache/index.ts
@@ -171,7 +171,13 @@ export async function uploadBuildCache({
   const staging = `${dest}.staging-${process.pid}`;
   fs.rmSync(staging, { recursive: true, force: true });
   fs.mkdirSync(staging, { recursive: true });
-  execFileSync('cp', ['-R', buildPath, path.join(staging, path.basename(buildPath))]);
+  // APFS clone first (milliseconds for a big .app on the same volume), plain
+  // copy where cloning cannot work -- the same trade the CLI-side twin makes.
+  try {
+    execFileSync('cp', ['-c', '-R', buildPath, path.join(staging, path.basename(buildPath))]);
+  } catch {
+    execFileSync('cp', ['-R', buildPath, path.join(staging, path.basename(buildPath))]);
+  }
 
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.rmSync(dest, { recursive: true, force: true });

--- a/packages/rn-iso/src/__tests__/build-cache.test.ts
+++ b/packages/rn-iso/src/__tests__/build-cache.test.ts
@@ -71,9 +71,10 @@ test('storeBuild stages elsewhere and renames, so a partial copy is never visibl
     },
     runFile: (file, args) => {
       calls.push({ file, args });
-      // Stand in for `cp -R`: create the destination the real command would.
-      mkdirSync(args[2], { recursive: true });
-      writeFileSync(join(args[2], 'bin'), 'x');
+      // Stand in for `cp -c -R`: create the destination the real command would.
+      const dest = args[args.length - 1];
+      mkdirSync(dest, { recursive: true });
+      writeFileSync(join(dest, 'bin'), 'x');
       return '';
     },
     runQuiet: () => '',
@@ -87,8 +88,9 @@ test('storeBuild stages elsewhere and renames, so a partial copy is never visibl
   const call = calls[0];
   assert(call);
   expect(call.file).toBe('cp');
-  expect(call.args.slice(0, 2)).toEqual(['-R', build]);
-  expect(call.args[2]).toMatch(/\.staging-\d+/);
+  // -c first (APFS clone; the mock accepts it, standing in for same-volume APFS).
+  expect(call.args.slice(0, 3)).toEqual(['-c', '-R', build]);
+  expect(call.args[3]).toMatch(/\.staging-\d+/);
   expect(existsSync(`${entryDir('ios', 'fp1', root)}.staging-${process.pid}`)).toBe(false);
 });
 
@@ -166,8 +168,8 @@ test('storeBuild passes the build path as one argument, never through a shell', 
     },
     runFile: (_file, args) => {
       seen = args;
-      mkdirSync(args[2], { recursive: true });
-      writeFileSync(join(args[2], 'bin'), 'x');
+      mkdirSync(args[3], { recursive: true });
+      writeFileSync(join(args[3], 'bin'), 'x');
       return '';
     },
     runQuiet: () => '',
@@ -176,7 +178,7 @@ test('storeBuild passes the build path as one argument, never through a shell', 
 
   storeBuild('ios', 'fp4', build, root);
   assert(seen);
-  expect(seen[1]).toBe(build);
+  expect(seen[2]).toBe(build);
 });
 
 // Against the real `cp`, not a mock: a mock proves the argument list was built,

--- a/packages/rn-iso/src/build-cache.ts
+++ b/packages/rn-iso/src/build-cache.ts
@@ -209,7 +209,15 @@ export function storeBuild(
   const staging = `${dest}.staging-${process.pid}`;
   rmSync(staging, { recursive: true, force: true });
   mkdirSync(staging, { recursive: true });
-  getExecutor().runFile('cp', ['-R', buildPath, join(staging, basename(buildPath))]);
+  // -c asks APFS for a copy-on-write clone: storing a several-hundred-MB
+  // .app costs milliseconds instead of seconds when the cache shares the
+  // artifact's volume. It errors on non-APFS or across volumes, where the
+  // plain copy is the correct price.
+  try {
+    getExecutor().runFile('cp', ['-c', '-R', buildPath, join(staging, basename(buildPath))]);
+  } catch {
+    getExecutor().runFile('cp', ['-R', buildPath, join(staging, basename(buildPath))]);
+  }
 
   mkdirSync(dirname(dest), { recursive: true });
   rmSync(dest, { recursive: true, force: true });


### PR DESCRIPTION
Kills the store cost on the miss path better than parallelizing it: cp -c clones the .app/.apk into the cache in milliseconds on the same APFS volume, plain cp -R remains the cross-volume/non-APFS fallback. Both the CLI storeBuild and the Expo provider's twin.