### PR TITLE
Every phase line shows how long the step took

### DIFF
--- a/packages/rn-iso/README.md
+++ b/packages/rn-iso/README.md
@@ -64,13 +64,13 @@ npx rn-iso stop              # supervisor down, sim shut down, port freed
 
 ```
 $ npx rn-iso start
-OK: dev server on port 8082, supervisor pid 41233 (expo-child)
+OK: dev server on port 8082, supervisor pid 41233 (expo-child) (6s)
 
 $ npx rn-iso ios
-device      rn-iso-myproject (BF2A..) booted
-fingerprint a3f9b1.. hit
-install     from cache (3.1s)
-launch      com.example.app
+device      rn-iso-myproject (BF2A..) booted (9s)
+fingerprint a3f9b1.. hit (2s)
+install     from cache (3s)
+launch      com.example.app (1s)
 OK: com.example.app launched on BF2A..
 ```
 

--- a/packages/rn-iso/src/__tests__/android-command.test.ts
+++ b/packages/rn-iso/src/__tests__/android-command.test.ts
@@ -362,6 +362,12 @@ describe('a cache hit', () => {
     expect(labelled(h.stderr, 'metro')[0]).toMatch(/port 8082 \(pid 41233\)/);
     expect(labelled(h.stderr, 'launch')[0]).toMatch(/com\.example\.app/);
     expect(labelled(h.stderr, 'logs')[0]).toMatch(/collector pid 9001/);
+    // Every timed phase line carries its own duration, in formatDuration's
+    // shape ("4s", "1m4s"), at the end of the line.
+    expect(labelled(h.stderr, 'fingerprint')[0]).toMatch(/\(\d+m?\d*s\)$/);
+    expect(labelled(h.stderr, 'device')[0]).toMatch(/booted \(\d+m?\d*s\)$/);
+    expect(labelled(h.stderr, 'install')[0]).toMatch(/from local cache \(\d+m?\d*s\)$/);
+    expect(labelled(h.stderr, 'launch')[0]).toMatch(/\(\d+m?\d*s\)$/);
     // Output discipline: everything above is stderr, and stdout carries the
     // single outcome line an agent reads.
     expect(h.stdout.length).toBe(1);

--- a/packages/rn-iso/src/__tests__/ios-command.test.ts
+++ b/packages/rn-iso/src/__tests__/ios-command.test.ts
@@ -774,7 +774,7 @@ describe('the remote cache', () => {
     expect(storedEntry.path).toBe(remoteApp);
     expect(storedEntry.key).toBe(calls.args.resolveBuild.key);
     expect(calls.args.installIosApp.appPath).toBe(storedApp);
-    expect(errs.join('\n')).toMatch(/^cache {7}remote hit \(eas\) -> stored locally$/m);
+    expect(errs.join('\n')).toMatch(/^cache {7}remote hit \(eas\) -> stored locally \(\d+m?\d*s\)$/m);
     const facts = parseFirst(logs);
     expect(facts.cacheHit).toBe('remote');
     expect(facts.appPath).toBe(storedApp);
@@ -1542,11 +1542,12 @@ describe('success output', () => {
     expect(logs.length).toBe(1);
     expect(logs[0]).toMatch(/^OK: com\.example\.app on rn-iso-fixture \(BF2A\.\.\), Metro port 8082/);
     const text = errs.join('\n');
-    expect(text).toMatch(/^device {6}rn-iso-fixture \(BF2A\.\.\) booted$/m);
-    expect(text).toMatch(/^fingerprint a3f9b1\.\. miss$/m);
+    // Every phase line carries its own duration, in formatDuration's shape.
+    expect(text).toMatch(/^device {6}rn-iso-fixture \(BF2A\.\.\) booted \(\d+m?\d*s\)$/m);
+    expect(text).toMatch(/^fingerprint a3f9b1\.\. miss \(\d+m?\d*s\)$/m);
     expect(text).toMatch(/^build {7}ok \(2m41s\)$/m);
-    expect(text).toMatch(/^install {5}-> rn-iso-fixture \(BF2A\.\.\)$/m);
-    expect(text).toMatch(/^launch {6}com\.example\.app$/m);
+    expect(text).toMatch(/^install {5}-> rn-iso-fixture \(BF2A\.\.\) \(\d+m?\d*s\)$/m);
+    expect(text).toMatch(/^launch {6}com\.example\.app \(\d+m?\d*s\)$/m);
   });
 
   test('--json emits exactly one line of facts on stdout', async () => {

--- a/packages/rn-iso/src/__tests__/start.test.ts
+++ b/packages/rn-iso/src/__tests__/start.test.ts
@@ -749,7 +749,8 @@ describe('output contract', () => {
     }
 
     expect(result.exitCode).toBe(null);
-    expect(result.logs.join('\n')).toMatch(/OK: dev server on port 8160/);
+    // The OK line carries the total wait, in formatDuration's shape.
+    expect(result.logs.join('\n')).toMatch(/OK: dev server on port 8160.* \(\d+m?\d*s\)/);
     expect(result.logs.join('\n')).toMatch(/expo-child/);
     expect(result.logs.join('\n')).toMatch(new RegExp(workspaceLogsDir(root).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     for (const line of result.logs) {

--- a/packages/rn-iso/src/commands/android.ts
+++ b/packages/rn-iso/src/commands/android.ts
@@ -57,6 +57,9 @@ import {
   noMetroRemedy,
   pickDevClientScheme,
   resolveMetroWithRetry,
+  // The one step stopwatch both commands stamp their phase lines with, so a
+  // duration reads the same ("4s", "1m4s") whichever platform printed it.
+  stepTimer,
 } from './ios.ts';
 import { resolveSettings } from '../settings.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
@@ -966,15 +969,28 @@ export async function runAndroid(
   // to sit whole in front of the build. The catch holds a rare boot failure
   // until the await, where it fails with the same code it always did -- and
   // the build that ran anyway is in the shared cache for the retry.
-  const bootPromise = Promise.resolve(ensureDeviceBooted({ platform: PLATFORM, device, out })).catch((e) => ({
-    failed: true as const,
-    reason: String((e as Error)?.message || e),
-    serial: null,
-  }));
+  // The boot's own elapsed time, stamped the moment its promise settles: the
+  // boot overlaps the build by design, so reading the clock at the await
+  // would report the build's time, not the boot's.
+  const bootTimer = stepTimer(now);
+  let bootDuration = '';
+  const bootPromise = Promise.resolve(ensureDeviceBooted({ platform: PLATFORM, device, out }))
+    .catch((e) => ({
+      failed: true as const,
+      reason: String((e as Error)?.message || e),
+      serial: null,
+    }))
+    .then((result) => {
+      bootDuration = bootTimer();
+      return result;
+    });
   record.avdName = device.avdName ?? null;
   record.deviceName = device.deviceName ?? device.avdName ?? null;
 
   // ---- fingerprint ----------------------------------------------------
+  // Covers the fingerprint compute plus the LOCAL cache resolve; a remote
+  // consult reports its own time on its own cache line below.
+  const fingerprintTimer = stepTimer(now);
   let hash;
   try {
     // Scoped to Android. Unscoped, ios/ hashes into this key: a podspec that
@@ -1005,7 +1021,10 @@ export async function runAndroid(
   const cached = useBuildCache ? resolveCached(PLATFORM, cacheKey) : null;
   record.cacheHit = cached ? 'local' : false;
   record.cacheSkipped = !useBuildCache;
-  phase('fingerprint', `${shortHash(hash)} ${cached ? 'hit' : 'miss'}${useBuildCache ? '' : ' (--no-build-cache)'}`);
+  phase(
+    'fingerprint',
+    `${shortHash(hash)} ${cached ? 'hit' : 'miss'}${useBuildCache ? '' : ' (--no-build-cache)'} ${fingerprintTimer()}`,
+  );
 
   // ---- level two: the project's OWN Expo build-cache provider ----------
   //
@@ -1051,6 +1070,7 @@ export async function runAndroid(
   }
 
   if (remote && useBuildCache) {
+    const remoteTimer = stepTimer(now);
     const hit = await resolveRemoteBuild({
       logWriter: writer,
       provider: remote.provider,
@@ -1069,7 +1089,7 @@ export async function runAndroid(
       }
       apkPath = stored || hit.appPath;
       record.cacheHit = 'remote';
-      phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''}`);
+      phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''} ${remoteTimer()}`);
     } else if (hit?.timedOut) {
       abandonedRemote = true;
       phase(
@@ -1085,7 +1105,7 @@ export async function runAndroid(
           : null;
       phase('cache', chalk.yellow(authNote || `${remote.name} could not be used: ${hit.failed}; building instead`));
     } else {
-      phase('cache', `remote miss (${remote.name})`);
+      phase('cache', `remote miss (${remote.name}) ${remoteTimer()}`);
     }
   }
 
@@ -1281,12 +1301,12 @@ export async function runAndroid(
     );
   }
   const serial = booted.serial;
-  phase('device', `${device.avdName || serial} (${serial}) booted`);
+  phase('device', `${device.avdName || serial} (${serial}) booted ${bootDuration}`);
 
   // serial and apkPath are provably set by this point: booted.failed already
   // returned, and apkPath is set by either the cache branch or a build that
   // did not report `failed`.
-  const installStarted = now();
+  const installTimer = stepTimer(now);
   const installed: InstallResultLike = install({ serial: serial!, apkPath: apkPath! });
   if (installed.failed) {
     return fail(
@@ -1296,10 +1316,7 @@ export async function runAndroid(
       { lastBuildStatus: true },
     );
   }
-  phase(
-    'install',
-    `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} (${formatDuration(now() - installStarted)})`,
-  );
+  phase('install', `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} ${installTimer()}`);
 
   // ---- launch (Contract 6) ---------------------------------------------
   // Project files first, then the APK itself: on a cache hit no prebuild ran,
@@ -1323,6 +1340,7 @@ export async function runAndroid(
   // iOS command gives: an app.json is not the truth on a project with a
   // dynamic config, and the artifact is in hand.
   const scheme = resolveDevClientScheme(root, apkPath);
+  const launchTimer = stepTimer(now);
   const launchedAt = now();
   // launchAndroidApp returns one of four flat shapes (see engine/app-install.ts);
   // read through the local, all-optional interface rather than the union.
@@ -1354,7 +1372,7 @@ export async function runAndroid(
   // workspace's bundle, `am-start` / `monkey` open whatever the launcher
   // activity shows.
   const launchMode = launched.mode === 'deep-link' ? 'expo-dev-client deep link' : launched.mode;
-  phase('launch', launchMode ? `${androidPackage} (${launchMode})` : androidPackage);
+  phase('launch', `${launchMode ? `${androidPackage} (${launchMode})` : androidPackage} ${launchTimer()}`);
 
   // Contract 6, reported. Both mechanisms ran before the launch and until now
   // NOTHING consumed their result: launchAndroidApp has always returned

--- a/packages/rn-iso/src/commands/guide.ts
+++ b/packages/rn-iso/src/commands/guide.ts
@@ -580,10 +580,10 @@ but --base <ref> resolves to <sha>"  (worktree create)
   #    installed (or built), app launched wired to port 8082, device-log
   #    collector attached.
   npx rn-iso ios          # or: npx rn-iso android
-    device      rn-iso-app-412 (BF2A..) booted
-    fingerprint a3f9b1.. hit
-    install     from cache (3.1s)
-    launch      com.example.app
+    device      rn-iso-app-412 (BF2A..) booted (9s)
+    fingerprint a3f9b1.. hit (2s)
+    install     from cache (3s)
+    launch      com.example.app (1s)
 
   # 4. Did it work? Empty output and exit 0 is the pass condition.
   npx rn-iso logs --errors --json

--- a/packages/rn-iso/src/commands/ios.ts
+++ b/packages/rn-iso/src/commands/ios.ts
@@ -210,6 +210,15 @@ export function formatDuration(ms: unknown): string {
   return `${minutes}m${seconds}s`;
 }
 
+// A per-step stopwatch: created the moment a step is kicked off, read when
+// its phase line prints. Steps that overlap others (the boot runs beside the
+// build) stamp their result the moment they finish, so the number answers
+// "how long did this step itself take", never "how long was it awaited".
+export function stepTimer(now: () => number = Date.now): () => string {
+  const t0 = now();
+  return () => `(${formatDuration(now() - t0)})`;
+}
+
 // Enough of a fingerprint to compare two runs by eye, never enough to mistake
 // for the whole hash -- the ".." is the part that says so.
 export function shortHash(hash: unknown): string {
@@ -1079,15 +1088,28 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   // added the whole boot ahead of a multi-minute compile for no reason. The
   // catch holds a rare boot failure until the await, where it fails with the
   // same code it always did.
+  // The boot's own elapsed time, stamped the moment its promise settles: the
+  // boot overlaps the build by design, so reading the clock where the await
+  // happens would report the build's time, not the boot's.
+  const bootTimer = stepTimer(d.now);
+  let bootDuration = '';
   const bootPromise: Promise<{ ok?: boolean; reason?: string; udid?: string } | null | undefined> = Promise.resolve(
     d.ensureBooted({ platform: PLATFORM, device, out: note }),
-  ).catch((e) => ({ ok: false, reason: String((e as Error)?.message || e) }));
+  )
+    .catch((e) => ({ ok: false, reason: String((e as Error)?.message || e) }))
+    .then((result) => {
+      bootDuration = bootTimer();
+      return result;
+    });
   // The build destination: the udid exists as soon as the device record does.
   // The rare record without one (legacy shapes) waits for the boot to resolve
   // it, which is exactly the old ordering.
   const udid = (device.deviceUdid as string | undefined) ?? (await bootPromise)?.udid ?? '';
 
   // ---- fingerprint and cache ----
+  // Covers the fingerprint compute plus the LOCAL cache resolve; a remote
+  // consult reports its own time on its own cache line below.
+  const fingerprintTimer = stepTimer(d.now);
   let fingerprint;
   try {
     // Scoped to iOS: an unscoped hash folds android/ into the iOS key (and
@@ -1117,7 +1139,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   let cacheHit: CacheHitLevel = cached ? 'local' : false;
   phase(
     'fingerprint',
-    `${shortHash(fingerprint)} ${cached ? 'hit' : 'miss'}${useBuildCache ? '' : ' (--no-build-cache)'}`,
+    `${shortHash(fingerprint)} ${cached ? 'hit' : 'miss'}${useBuildCache ? '' : ' (--no-build-cache)'} ${fingerprintTimer()}`,
   );
 
   let appPath: string | null = cached;
@@ -1172,6 +1194,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   }
 
   if (remote && useBuildCache) {
+    const remoteTimer = stepTimer(d.now);
     const hit = await d.resolveRemote({
       logWriter: logWriter(),
       provider: remote.provider,
@@ -1191,7 +1214,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       }
       appPath = stored || hit.appPath;
       cacheHit = 'remote';
-      phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''}`);
+      phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''} ${remoteTimer()}`);
     } else if (hit?.timedOut) {
       abandonedRemote = true;
       note(
@@ -1215,7 +1238,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         ),
       );
     } else {
-      phase('cache', `remote miss (${remote.name})`);
+      phase('cache', `remote miss (${remote.name}) ${remoteTimer()}`);
     }
   }
 
@@ -1465,12 +1488,13 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       remedy: 'Run `rn-iso ios` again to re-establish an owned simulator for this workspace.',
     });
   }
-  phase('device', `${deviceLabel(device, udid)} booted`);
+  phase('device', `${deviceLabel(device, udid)} booted ${bootDuration}`);
 
   // ---- install ----
   // appPath and bundleId are provably set by this point: the cache branch above
   // fails early when bundleId cannot be read, and the build branch's buildIos
   // success shape always carries both.
+  const installTimer = stepTimer(d.now);
   const installed = d.installIosApp({ udid, appPath: appPath! });
   if (installed?.failed) {
     return fail({
@@ -1480,7 +1504,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       build: { ...buildFailure, appPath, bundleId },
     });
   }
-  phase('install', `-> ${deviceLabel(device, udid)}`);
+  phase('install', `-> ${deviceLabel(device, udid)} ${installTimer()}`);
 
   // ---- launch, wired to THIS workspace's port (Contract 6) ----
   //
@@ -1488,6 +1512,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   // dev-client app launched without its deep link opens the dev-launcher's
   // server picker, and the picker lists every workspace on the machine.
   const scheme = d.devClientScheme(root, appPath);
+  const launchTimer = stepTimer(d.now);
   const launchedAt = d.now();
   const launched = d.launchIosApp({
     udid,
@@ -1503,7 +1528,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       build: { ...buildFailure, appPath, bundleId },
     });
   }
-  phase('launch', bundleId!);
+  phase('launch', `${bundleId!} ${launchTimer()}`);
 
   // The launch marker (Contract 1). `logs --errors` uses it to bound the
   // window: errors from the run BEFORE this launch are not this run's.

--- a/packages/rn-iso/src/commands/start.ts
+++ b/packages/rn-iso/src/commands/start.ts
@@ -29,6 +29,9 @@ import { detectAndroidPackage, detectBundleId, detectIsExpo, findProjectRoot } f
 import { readWorkspaceState } from '../supervisor/state.ts';
 import { ensureWorkspaceIgnored } from '../engine/workspace.ts';
 import { spawnEntry } from '../spawn-entry.ts';
+// The same stopwatch the build commands stamp their phase lines with, so the
+// OK line's total wait reads the same way ("4s", "1m4s").
+import { stepTimer } from './ios.ts';
 
 const DEFAULT_WAIT_SECONDS = 60;
 const POLL_MS = 500;
@@ -195,6 +198,9 @@ export function registerStart(program: Command): void {
     .option('--wait <seconds>', `How long to wait for the dev server to answer (default ${DEFAULT_WAIT_SECONDS})`)
     .action(async (opts: StartOptions) => {
       const json = Boolean(opts.json);
+      // Total wait, command start to the OK line: `start` blocks on health by
+      // contract, and how long that took is part of the report.
+      const waitTimer = stepTimer();
       const out = (line: string) => {
         if (json) console.error(line);
         else console.log(line);
@@ -273,7 +279,7 @@ export function registerStart(program: Command): void {
           note(chalk.dim(`A dev server for this project already answers on port ${port}, started outside rn-iso.`));
           note(chalk.dim('Leaving it alone: rn-iso will not start a second bundler over a working one.'));
         }
-        report({ json, out, port, supervisor, logsDir, alreadyRunning: true });
+        report({ json, out, port, supervisor, logsDir, alreadyRunning: true, waited: waitTimer() });
         return;
       }
 
@@ -297,7 +303,7 @@ export function registerStart(program: Command): void {
           });
         }
         supervisor = liveSupervisor({ state: readWorkspaceState(root), project: getProject(root), port }) || supervisor;
-        report({ json, out, port, supervisor, logsDir, alreadyRunning: true });
+        report({ json, out, port, supervisor, logsDir, alreadyRunning: true, waited: waitTimer() });
         return;
       }
 
@@ -377,7 +383,7 @@ export function registerStart(program: Command): void {
         // child.pid is only undefined if the spawn itself failed, which the
         // health check above would already have turned into a failure.
         { pid: child.pid as number, port, mode: null, startedAt: null };
-      report({ json, out, port, supervisor, logsDir, alreadyRunning: false });
+      report({ json, out, port, supervisor, logsDir, alreadyRunning: false, waited: waitTimer() });
     });
 }
 
@@ -480,6 +486,7 @@ function report({
   supervisor,
   logsDir,
   alreadyRunning,
+  waited,
 }: {
   json: boolean;
   out: (line: string) => void;
@@ -487,6 +494,9 @@ function report({
   supervisor: LiveSupervisor | null;
   logsDir: string;
   alreadyRunning: boolean;
+  // Pre-rendered "(4s)": the total wait, stamped by the caller's stepTimer.
+  // The --json payload does not carry it -- one contract, unchanged.
+  waited: string;
 }): StartFacts {
   // LiveSupervisor is a closed, non-null shape (see above); SupervisorRecord
   // is the loose index-signature bag startFacts (and the wider --json
@@ -505,7 +515,7 @@ function report({
   const who = facts.supervisorPid
     ? `supervisor pid ${facts.supervisorPid}${facts.mode ? ` (${facts.mode})` : ''}`
     : 'started outside rn-iso';
-  out(chalk.green(`OK: dev server on port ${port}, ${who}${alreadyRunning ? ' (already running)' : ''}`));
+  out(chalk.green(`OK: dev server on port ${port}, ${who}${alreadyRunning ? ' (already running)' : ''} ${waited}`));
   out(chalk.dim(`Logs: ${logsDir}`));
   return facts;
 }

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -17,13 +17,13 @@ npx rn-iso stop              # supervisor down, sim shut down, port freed
 
 ```
 $ npx rn-iso start
-OK: dev server on port 8082, supervisor pid 41233 (expo-child)
+OK: dev server on port 8082, supervisor pid 41233 (expo-child) (6s)
 
 $ npx rn-iso ios
-device      rn-iso-myproject (BF2A..) booted
-fingerprint a3f9b1.. hit
-install     from cache (3.1s)
-launch      com.example.app
+device      rn-iso-myproject (BF2A..) booted (9s)
+fingerprint a3f9b1.. hit (2s)
+install     from cache (3s)
+launch      com.example.app (1s)
 OK: com.example.app launched on BF2A..
 ```
 


### PR DESCRIPTION
Uniform (Xs)/(XmYs) suffixes across ios/android/start phase lines via a shared stepTimer; boot reports its own elapsed since it overlaps the build; warnings and JSON contracts untouched. Docs examples updated; 1451 tests green.