### PR TITLE
Remove narrative comments from the remote-device merge

### DIFF
--- a/packages/rn-iso/src/__tests__/agent-device.test.ts
+++ b/packages/rn-iso/src/__tests__/agent-device.test.ts
@@ -1,11 +1,3 @@
-// engine/agent-device.js -- the remote device's control surface, asserted as
-// exact argv and as an exact on-disk profile.
-//
-// Two invariants carry the security of this module and each has a test that
-// fails loudly if it regresses:
-//   1. The daemon token NEVER reaches disk. It travels as an env var on the
-//      child, and the profile written next to it must not contain it.
-//   2. The profile is written in global workspace storage, never in the project.
 import {
   DAEMON_TOKEN_ENV,
   closeArgs,
@@ -25,25 +17,16 @@ const DAEMON = { baseUrl: 'https://sim-42.eas.dev/daemon', token: 'tok_secret' }
 
 describe('the connection profile', () => {
   test('never contains the token', () => {
-    // ADR 0007: "Generated connection profiles are non-secret ... must strip
-    // daemon and Metro bearer tokens." A profile is a plain file with no
-    // special mode; a token in it outlives the command that needed it.
     const profile = remoteProfile({ daemon: DAEMON, platform: 'ios', label: 'wt' });
     const serialized = JSON.stringify(profile);
     expect(serialized).not.toContain('tok_secret');
     expect(serialized).not.toContain('AuthToken');
   });
 
-  // Live-verified against agent-device 0.20.10 (CLAUDE.md item 9): a profile
-  // without these two is refused with
-  //   Error (INVALID_ARGS): connect requires tenant in remote config
-  //   Error (INVALID_ARGS): connect requires runId in remote config
-  // Neither is optional, and no mock would have caught their absence.
   test('carries the tenant and runId connect refuses to run without', () => {
     const profile = remoteProfile({ daemon: DAEMON, platform: 'ios', label: 'wt' });
     expect(profile.tenant).toBe('rn-iso-wt');
     expect(profile.runId).toBe('rn-iso-wt');
-    // Metadata without this is not an isolation boundary.
     expect(profile.sessionIsolation).toBe('tenant');
   });
 
@@ -55,8 +38,6 @@ describe('the connection profile', () => {
   });
 
   test('runId is stable across runs of one workspace, so a re-run reuses its own lease', () => {
-    // A fresh runId per invocation would leave the previous lease held until
-    // its idle expiry, and `rn-iso ios` is idempotent by design.
     const first = remoteProfile({ daemon: DAEMON, platform: 'ios', label: 'wt' });
     const second = remoteProfile({ daemon: DAEMON, platform: 'ios', label: 'wt' });
     expect(first.runId).toBe(second.runId);
@@ -69,13 +50,10 @@ describe('the connection profile', () => {
       daemonTransport: 'http',
       platform: 'ios',
     });
-    // Setting metroProjectRoot makes agent-device demand a bridge origin, and
-    // the self-hosted proxy has no bridge. Metro stays rn-iso's problem.
     expect('metroProjectRoot' in profile).toBe(false);
   });
 
   test('the session name is per-workspace, so two worktrees never share one', () => {
-    // A shared session name is how worktree A adopts worktree B's connection.
     expect(sessionNameFor('wt-a')).not.toBe(sessionNameFor('wt-b'));
     expect(remoteProfile({ daemon: DAEMON, platform: 'ios', label: 'wt' }).session).toBe(sessionNameFor('wt'));
   });
@@ -96,8 +74,6 @@ describe('the connection profile', () => {
 
 describe('the token travels as an environment variable', () => {
   test('daemonEnv uses the name agent-device and eas-cli both already use', () => {
-    // eas-cli writes exactly this name in .env.eas-simulator
-    // (simulator/utils.ts getRemoteSessionEnvironmentVariables).
     expect(DAEMON_TOKEN_ENV).toBe('AGENT_DEVICE_DAEMON_AUTH_TOKEN');
     expect(daemonEnv(DAEMON)).toEqual({ AGENT_DEVICE_DAEMON_AUTH_TOKEN: 'tok_secret' });
   });
@@ -107,9 +83,6 @@ describe('argv', () => {
   const profilePath = '/work/app/.rn-iso/agent-device.remote.json';
 
   test('every command carries the profile, so none of them guess a connection', () => {
-    // "Explicit command-line flags override connected defaults" -- an
-    // agent-device call with no profile can adopt another workspace's ambient
-    // connection, which is exactly the collision rn-iso exists to prevent.
     for (const args of [
       connectArgs(profilePath),
       installArgs(profilePath, '/tmp/My App.app'),
@@ -121,17 +94,12 @@ describe('argv', () => {
   });
 
   test('install passes the .app path as one literal argv element', () => {
-    // A .app path with a space in it must reach the tool as one argument,
-    // and the bundle id is not repeated: the .app already carries it.
     const args = installArgs(profilePath, '/tmp/My App.app');
     expect(args[0]).toBe('install');
     expect(args[1]).toBe('/tmp/My App.app');
   });
 
   test('open with a dev-client url passes it as the url positional', () => {
-    // This is the whole reason rn-iso is not blocked by agent-device#1245:
-    // `open <app> <url>` runs simctl openurl with the url verbatim, so
-    // rn-iso's own expo-dev-client link works without the upstream fix.
     const url = 'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082';
     const args = openArgs(profilePath, 'com.example.app', url);
     expect(args[0]).toBe('open');
@@ -152,9 +120,6 @@ describe('argv', () => {
 });
 
 describe('isLoopbackDaemon', () => {
-  // The question behind Metro reachability: a loopback daemon drives a
-  // simulator sharing THIS host's loopback, so `localhost:<port>` in the deep
-  // link reaches rn-iso's own Metro. Anywhere else, localhost is that machine.
   test('loopback forms are this machine', () => {
     for (const url of ['http://127.0.0.1:4310', 'http://localhost:4310', 'http://[::1]:4310']) {
       expect(isLoopbackDaemon(url)).toBe(true);
@@ -172,8 +137,6 @@ describe('isLoopbackDaemon', () => {
   });
 
   test('an unparseable url is not assumed local', () => {
-    // Guessing "local" here would point a remote app at a Metro it cannot
-    // reach and report the launch as fine.
     expect(isLoopbackDaemon('not a url')).toBe(false);
     expect(isLoopbackDaemon('')).toBe(false);
   });
@@ -182,10 +145,6 @@ describe('isLoopbackDaemon', () => {
 describe('the bare-RN Metro hint', () => {
   const profilePath = '/w/.rn-iso/agent-device.remote.json';
 
-  // Live-verified: without these flags a remote bare-RN app asks for its
-  // compiled-in 8081, never reaches the reserved port, and the run reports
-  // UNVERIFIED. With them the same run reports "bundle requested from Metro
-  // port 8085".
   test('open carries the host and port a bare RN app reads', () => {
     const args = openArgs(profilePath, 'com.example.app', null, { host: 'localhost', port: '8085' });
     expect(args[args.indexOf('--metro-host') + 1]).toBe('localhost');
@@ -201,9 +160,6 @@ describe('the bare-RN Metro hint', () => {
   });
 
   test('a portless origin takes its port from the scheme', () => {
-    // Returning null here sent NO hint, which left a stale RCT_jsLocation in
-    // charge: the device then asked for https://<tunnel-host>:8085/... and
-    // could never resolve it. Observed on a real EAS simulator.
     expect(metroHintFrom('https://abc.trycloudflare.com')).toEqual({ host: 'abc.trycloudflare.com', port: '443' });
     expect(metroHintFrom('http://abc.example.com')).toEqual({ host: 'abc.example.com', port: '80' });
   });
@@ -215,10 +171,6 @@ describe('the bare-RN Metro hint', () => {
 
 describe('closeArgs', () => {
   test('closes through the profile, so it targets this workspace session', () => {
-    // agent-device keeps a device claim per session that outlives the lease
-    // AND the daemon. rn-iso leaves the app running, so it never reaches a
-    // natural close; without this a re-run hits DEVICE_IN_USE or
-    // "Lease does not match session owner". Both observed live.
     const args = closeArgs('/w/.rn-iso/agent-device.remote.json');
     expect(args[0]).toBe('close');
     expect(args[args.indexOf('--remote-config') + 1]).toBe('/w/.rn-iso/agent-device.remote.json');

--- a/packages/rn-iso/src/__tests__/android-command.test.ts
+++ b/packages/rn-iso/src/__tests__/android-command.test.ts
@@ -94,8 +94,6 @@ describe('--remote', () => {
   });
 });
 
-// --- the harness -----------------------------------------------------------
-
 function fakeApk(name = 'app-debug.apk') {
   const dir = join(root, 'android', 'app', 'build', 'outputs', 'apk', 'debug');
   mkdirSync(dir, { recursive: true });
@@ -866,8 +864,6 @@ describe('explicit remote backend behavior', () => {
     expect(JSON.parse(json.stdout[0] ?? '{}')).toMatchObject({ launched: LAUNCH_UNVERIFIED, logs: null });
   });
 });
-
-// --- the flow --------------------------------------------------------------
 
 describe('a cache hit', () => {
   test('skips the build entirely and installs the cached artifact', async () => {

--- a/packages/rn-iso/src/__tests__/device-remote.test.ts
+++ b/packages/rn-iso/src/__tests__/device-remote.test.ts
@@ -1,14 +1,3 @@
-// engine/device-remote.js -- the four dep overrides remote mode installs.
-//
-// These are asserted as exact argv against a mock executor, for the reason
-// CLAUDE.md item 9 gives: a mocked exec proves the right arguments were
-// composed, and that is the half a unit test can prove. The other half --
-// that `eas sim` and `agent-device` accept them -- is the field test.
-//
-// The ORDERING property is the one worth guarding. Locally the Metro gate
-// sits between ensureOwnedDevice (cheap) and ensureBooted (slow). Remote
-// inverts which step is expensive, so the session must be created in
-// ensureBooted, after the gate, and never in ensureOwnedDevice.
 import assert from 'node:assert';
 import { setExecutor, resetExecutor, type Executor } from '../exec.ts';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from 'node:fs';
@@ -31,11 +20,6 @@ import {
 import { withEasProjectLock } from '../engine/eas-project-lock.ts';
 import { readEasSessionLedger, recordEasSessionClaim } from '../engine/eas-session-ledger.ts';
 
-// The same-machine proxy: the simulator shares this host's loopback, so
-// localhost in the deep link reaches rn-iso's own Metro. Live-verified.
-// A same-machine `agent-device proxy`. The device sharing this host is now
-// ASSERTED with tunnelMode 'off' rather than inferred from the loopback URL --
-// `ssh -L` makes that inference false. See engine/metro-reach.ts.
 const LOOPBACK = { baseUrl: 'http://127.0.0.1:4310', token: 'tok_proxy' };
 
 const CREATED = JSON.stringify({
@@ -114,8 +98,6 @@ function ctx(overrides: Partial<Parameters<typeof remoteIosDeps>[0]> = {}) {
     easBin: '/bin/eas',
     agentDeviceBin: '/bin/agent-device',
     easLedgerRoot: tmpHome,
-    // The readiness poll is bounded at three minutes of real time; a test
-    // asserting the give-up path must not pay it.
     sleep: async () => {},
     ...overrides,
   };
@@ -300,9 +282,6 @@ process.stdout.write(${JSON.stringify(CREATED)});
 
 describe('the expensive step happens after the Metro gate', () => {
   test('ensureOwnedDevice creates no session and runs no command', async () => {
-    // The gate runs between ensureOwnedDevice and ensureBooted. Creating a
-    // billable cloud session in the first would mean paying for it and only
-    // then discovering the dev server is dead.
     const exec = mockExec();
     const deps = remoteIosDeps(ctx());
     const device = await deps.ensureOwnedDevice();
@@ -605,9 +584,6 @@ describe('session creation', () => {
   });
 
   test('sends no duration of its own, because the cap is per-account', async () => {
-    // Live: a hardcoded 120 was rejected with "must not exceed 115 minutes
-    // for this account", failing the command before a session existed. EAS
-    // has its own default; teardown is what bounds the cost.
     const exec = mockExec({ outputs: { sim: CREATED } });
     await remoteIosDeps(ctx()).ensureBooted({});
     expect(exec.calls[0]?.args ?? []).not.toContain('--max-duration-minutes');
@@ -625,7 +601,6 @@ describe('session creation', () => {
       id: 'drs_9',
       remoteConfig: { __typename: 'AppiumRunSessionRemoteConfig', appiumUrl: 'https://x' },
     });
-    // The get re-read returns the same unusable config.
     mockExec({ outputs: { sim: appium, 'simulator:get': appium } });
     const booted = await remoteIosDeps(ctx()).ensureBooted({});
     expect(booted.failed).toBe(true);
@@ -640,15 +615,11 @@ describe('session creation', () => {
   });
 
   test('an operator-supplied daemon creates no session at all', async () => {
-    // The `agent-device proxy` case: rn-iso is a guest on someone else's
-    // device, so it must not create a session and must not destroy one.
     const exec = mockExec();
     const deps = remoteIosDeps(ctx({ existingDaemon: { baseUrl: 'https://proxy.local/daemon', token: 'tok_proxy' } }));
     const booted = await deps.ensureBooted({});
     expect(booted.ok).toBe(true);
     expect(deps.createdSessionId()).toBeNull();
-    // close runs first, best-effort, to release any claim a previous run
-    // left on the device. See closeArgs.
     expect(exec.calls.map((c) => c.args[0])).toEqual(['close', 'connect']);
   });
 });
@@ -801,8 +772,6 @@ describe('install and launch match their local counterparts', () => {
   });
 
   test('a dev-client launch sends rn-iso own deep link, not agent-device metro hint', async () => {
-    // agent-device#1245: its hint writes bare-RN RCT_jsLocation, which a
-    // dev-client ignores. open <app> <url> runs simctl openurl verbatim.
     const exec = mockExec({ outputs: { sim: CREATED } });
     const deps = remoteIosDeps(ctx({ existingDaemon: LOOPBACK, tunnelMode: 'off' }));
     await deps.ensureBooted({});
@@ -846,8 +815,6 @@ describe('install and launch match their local counterparts', () => {
 
 describe('the local device cap does not apply', () => {
   test('checkDeviceCapacity never refuses', () => {
-    // maxDevices caps booted sims on THIS machine. Escaping that ceiling is
-    // the reason to go remote, so enforcing it here refuses the request.
     expect(remoteIosDeps(ctx()).checkDeviceCapacity()).toBeNull();
   });
 });
@@ -970,13 +937,6 @@ describe('teardown', () => {
 });
 
 describe('Metro reachability', () => {
-  // The hard part of a remote device, and the one agent-device does NOT solve
-  // for a self-hosted proxy: verified against 0.20.10, `agent-device proxy`
-  // serves no /api/metro route at all, so there is no bridge to lean on.
-  //
-  // Which address to use is now DECLARED (engine/metro-reach.ts), not inferred
-  // from the daemon's URL -- `ssh -L` made that inference false. These cover
-  // the wiring; the policy itself is pinned in metro-reach.test.ts.
   test('an asserted-local device uses localhost and needs no gate', () => {
     expect(resolveMetroOrigin({ metroPort: 8082, mode: 'off' })).toEqual({
       origin: 'http://localhost:8082',
@@ -992,8 +952,6 @@ describe('Metro reachability', () => {
   });
 
   test('no address and nothing to build one with is a refusal, never localhost', () => {
-    // The bug this replaced: `localhost` sent to a device on another machine
-    // resolves there, and the run reads as merely unverified.
     const r = resolveMetroOrigin({ metroPort: 8082, mode: 'auto', isExpo: false, available: [] });
     expect('failed' in r).toBe(true);
     assert('failed' in r);
@@ -1024,10 +982,6 @@ describe('Metro reachability', () => {
   });
 });
 
-// Reach planning, the tunnel and the gate run in ensureMetroReachable, which
-// commands/ios.ts calls AFTER the reserved port is known and the local Metro
-// gate has confirmed a dev server is on it -- and still before ensureBooted,
-// which is what creates the billable session.
 async function reach(over: Record<string, unknown> = {}) {
   const context = {
     root,
@@ -1056,8 +1010,6 @@ describe('the Metro refusal comes before anything billable', () => {
   });
 
   test('a loopback daemon is NOT taken as proof the device is local', async () => {
-    // `ssh -L 4310:localhost:4310 macmini` is exactly this shape and the
-    // device is on the other machine, so nothing may infer "local" from it.
     const { result } = await reach({ available: [] });
     expect('failed' in result).toBe(true);
   });
@@ -1153,7 +1105,6 @@ describe('a tunnel rn-iso starts for itself', () => {
     expect('failed' in result).toBe(true);
     assert('failed' in result);
     expect(result.code).toBe('RN_ISO_REMOTE_METRO_WRONG');
-    // Nothing downstream may treat this run as reachable.
     expect(context.publicMetroUrl).toBeNull();
   });
 
@@ -1175,10 +1126,6 @@ describe('a tunnel rn-iso starts for itself', () => {
 });
 
 describe('a session rn-iso created is never abandoned', () => {
-  // The window this closes: between `eas sim` succeeding and ensureBooted
-  // returning, the session exists and bills but its id is recorded nowhere,
-  // so stop/gc/worktree-remove cannot find it. Observed live -- a session
-  // with no endpoint yet left an IN_PROGRESS session nothing could reach.
   const NO_ENDPOINT = JSON.stringify({ id: 'drs_9', remoteConfig: null });
 
   test('a session that never becomes reachable is stopped, not left running', async () => {
@@ -1200,8 +1147,6 @@ describe('a session rn-iso created is never abandoned', () => {
   });
 
   test('when the stop also fails, the id and the manual command are reported', async () => {
-    // A leak nobody is told about is the worst outcome, so the message has to
-    // carry enough to fix it by hand.
     mockExec({ outputs: { sim: NO_ENDPOINT, 'simulator:get': NO_ENDPOINT }, fail: 'simulator:stop' });
     const booted = await remoteIosDeps(ctx({ existingDaemon: null })).ensureBooted({});
     expect(booted.reason).toContain('eas simulator:stop --id drs_9');
@@ -1260,8 +1205,6 @@ describe('a session rn-iso created is never abandoned', () => {
   });
 
   test('a connect failure against an operator daemon stops nothing', async () => {
-    // rn-iso created no session here, so it has none to end -- and ending
-    // someone else's would be destroying a device it does not own.
     const exec = mockExec({ existingDaemonMode: true, fail: 'connect' });
     const booted = await remoteIosDeps(ctx({ existingDaemon: LOOPBACK, tunnelMode: 'off' })).ensureBooted({});
     expect(booted.failed).toBe(true);
@@ -1270,10 +1213,6 @@ describe('a session rn-iso created is never abandoned', () => {
 });
 
 describe('a re-run does not orphan the session it already has', () => {
-  // `eas sim` defaults to --force, so without this every run minted a fresh
-  // session while the previous one stayed live, unrecorded (state.json's id is
-  // overwritten) and billing to its cap. The documented loop re-runs `ios`
-  // after every native change, so it fired constantly.
   function recordSession(id: string): void {
     ensureWorkspaceStorage(root);
     writeFileSync(workspaceStateFile(root), JSON.stringify({ remoteDevice: { platform: 'ios', sessionId: id } }));
@@ -1296,7 +1235,6 @@ describe('a re-run does not orphan the session it already has', () => {
     const booted = await deps.ensureBooted({});
     expect(booted.ok).toBe(true);
     expect(deps.createdSessionId()).toBeNull();
-    // The whole point: `eas sim` never ran.
     expect(exec.calls.some((c) => c.args[0] === 'sim')).toBe(false);
     const get = exec.calls.find((c) => c.args[0] === 'simulator:get');
     expect(get?.timeoutMs).toBe(30_000);
@@ -1356,8 +1294,6 @@ describe('a re-run does not orphan the session it already has', () => {
   });
 
   test('a STOPPED session is not reused, even though it still reports a config', async () => {
-    // eas still returns remoteConfig for a stopped session, so reusing on
-    // config alone would connect to a daemon that is gone.
     recordSession('drs_dead');
     const dead = JSON.stringify({
       id: 'drs_dead',
@@ -1452,8 +1388,6 @@ describe('a re-run does not orphan the session it already has', () => {
   });
 
   test('an operator-supplied daemon touches no recorded session at all', async () => {
-    // rn-iso is a guest there: it did not create that device and must not
-    // stop anything on the way in.
     recordSession('drs_old');
     const exec = mockExec();
     await remoteIosDeps(ctx({ existingDaemon: LOOPBACK, tunnelMode: 'off' })).ensureBooted({});
@@ -1462,10 +1396,6 @@ describe('a re-run does not orphan the session it already has', () => {
 });
 
 describe("the alert rn-iso's own url open raises", () => {
-  // A cloud simulator is always fresh, so iOS asks "Open in <app>?" in front
-  // of the deep link on EVERY remote run. Nothing requests a bundle until it
-  // is answered, which made `verify` report UNVERIFIED on launches that were
-  // fine. Observed on a real EAS Simulator.
   test('a dev-client launch accepts it, so the bundle can actually load', async () => {
     const exec = mockExec({ outputs: { sim: CREATED } });
     const deps = remoteIosDeps(ctx({ existingDaemon: LOOPBACK, tunnelMode: 'off' }));
@@ -1473,7 +1403,6 @@ describe("the alert rn-iso's own url open raises", () => {
     deps.launchIosApp({ udid: 'drs_42', bundleId: 'com.example.app', metroPort: 8082, devClientScheme: 'myapp' });
     const after = exec.calls.map((c) => c.args.slice(0, 2).join(' '));
     expect(after).toContain('alert accept');
-    // Order matters: the alert exists only because `open` raised it.
     expect(after.indexOf('alert accept')).toBeGreaterThan(after.indexOf('open com.example.app'));
   });
 
@@ -1486,8 +1415,6 @@ describe("the alert rn-iso's own url open raises", () => {
   });
 
   test('no alert to accept still leaves the launch successful', async () => {
-    // The ordinary case once a device has seen one. `alert accept` exits
-    // non-zero with nothing showing, and that must not fail a good launch.
     const exec = mockExec({ outputs: { sim: CREATED }, fail: 'alert accept' });
     const deps = remoteIosDeps(ctx({ existingDaemon: LOOPBACK, tunnelMode: 'off' }));
     await deps.ensureBooted({});
@@ -1503,10 +1430,6 @@ describe("the alert rn-iso's own url open raises", () => {
 });
 
 describe('the android adapter', () => {
-  // On a REMOTE device the launch is the same operation as iOS: locally
-  // Android points the app at 10.0.2.2 (the emulator's route to its OWN host)
-  // and iOS at localhost, and the one public origin replaces both. So this is
-  // an adapter over the same core, not a second implementation.
   test('android creates its session with --platform android', async () => {
     const exec = mockExec({ outputs: { sim: CREATED } });
     const deps = remoteAndroidDeps(ctx());
@@ -1539,9 +1462,6 @@ describe('the android adapter', () => {
   });
 
   test('the launch points at the public origin, never 10.0.2.2 or a reverse', async () => {
-    // Both local mechanisms are host-relative: a reverse maps to the host
-    // running adb, and 10.0.2.2 is the emulator's own host. On a remote
-    // emulator both name the wrong machine.
     const exec = mockExec({ outputs: { sim: CREATED } });
     const deps = remoteAndroidDeps(ctx({ publicMetroUrl: 'https://abc.trycloudflare.com' }));
     await deps.ensureDeviceBooted({});
@@ -1552,7 +1472,6 @@ describe('the android adapter', () => {
     const flat = (open?.args ?? []).join(' ');
     expect(flat).not.toContain('10.0.2.2');
     expect(flat).not.toContain('reverse');
-    // The hint agent-device turns into debug_http_host on the device.
     expect(open?.args[open.args.indexOf('--metro-host') + 1]).toBe('abc.trycloudflare.com');
     expect(open?.args[open.args.indexOf('--metro-port') + 1]).toBe('443');
   });
@@ -1572,10 +1491,6 @@ describe('the android adapter', () => {
 });
 
 describe('a release-shaped remote launch', () => {
-  // Upstream's release flow passes metroPort: null -- the JS is embedded and
-  // Metro is not part of the run. The reachability refusal below exists only
-  // for a dev build, so it must not fire here and turn a launch that needs no
-  // dev server into a failure.
   test('a null port launches without asking where Metro is', async () => {
     const exec = mockExec({ outputs: { sim: CREATED } });
     const deps = remoteIosDeps(ctx());
@@ -1584,13 +1499,11 @@ describe('a release-shaped remote launch', () => {
     expect(result.ok).toBe(true);
     expect(result.mode).toBe('launch');
     const open = exec.calls.find((c) => c.args[0] === 'open');
-    // No url, and no Metro hint: there is no dev server to point at.
     expect(open?.args[1]).toBe('com.example.app');
     expect(open?.args).not.toContain('--metro-host');
   });
 
   test('a dev launch on an unreachable device still refuses', async () => {
-    // The guard is not simply removed -- it still fires when a port IS given.
     mockExec({ outputs: { sim: CREATED } });
     const deps = remoteIosDeps(ctx());
     await deps.ensureBooted({});

--- a/packages/rn-iso/src/__tests__/doctor.test.ts
+++ b/packages/rn-iso/src/__tests__/doctor.test.ts
@@ -559,23 +559,13 @@ test('detectFingerprintParity skips silently outside a git repo without invoking
   }
 });
 
-// --- the remote device ------------------------------------------------------
-//
-// Silent unless this project actually uses one. doctor's whole value is that
-// every line it prints is worth reading, so a note about a feature the machine
-// never touches is worse than no note.
-
 test('a project with no remote device gets no remote finding', () => {
   expect(checkRemoteDevice({})).toBeNull();
-  // Not even when the tools happen to be installed: having agent-device on
-  // PATH is not a request for a remote device.
   expect(checkRemoteDevice({ agentDeviceOnPath: true, easCliResolvable: true })).toBeNull();
   expect(checkRemoteDevice({ daemonInEnv: true, agentDeviceOnPath: true })).toBeNull();
 });
 
 test('a configured remote with no agent-device is a cost, not a note', () => {
-  // It fails at the device step, which is AFTER the build -- the expensive
-  // place to discover a missing tool.
   const f = checkRemoteDevice({ configured: 'eas', agentDeviceOnPath: false });
   assert(f);
   expect(f.level).toBe('cost');
@@ -589,7 +579,6 @@ test('the proxy backend reports that the operator owns the daemon', () => {
   const f = checkRemoteDevice({ configured: 'proxy', daemonInEnv: true, agentDeviceOnPath: true });
   assert(f);
   expect(f.level).toBe('note');
-  // The load-bearing half: rn-iso neither creates nor stops that session.
   expect(f.detail).toContain('does not create or stop the remote device');
 });
 

--- a/packages/rn-iso/src/__tests__/eas-simulator.test.ts
+++ b/packages/rn-iso/src/__tests__/eas-simulator.test.ts
@@ -1,13 +1,3 @@
-// engine/eas-simulator.js -- the `eas sim` session, asserted as exact argv
-// and against eas-cli's real JSON shapes.
-//
-// The shapes below are eas-cli's own, read from source rather than guessed:
-//   commands/simulator/index.ts  printJsonOnlyOutput({id, name, type,
-//                                deviceRunSessionUrl, remoteConfig})
-//   simulator/utils.ts           AgentDeviceRunSessionRemoteConfig carries
-//                                agentDeviceRemoteSessionUrl / ...Token
-//   commands/simulator/list.ts   printJsonOnlyOutput({sessions, pageInfo})
-//   commands/simulator/stop.ts   printJsonOnlyOutput({id, status})
 import assert from 'node:assert';
 import type { Executor } from '../exec.ts';
 import {
@@ -26,8 +16,6 @@ import {
   stopSessionArgs,
 } from '../engine/eas-simulator.ts';
 
-// eas-cli emits pure JSON on stdout under --json; every non-JSON message goes
-// to stderr. These fixtures are therefore whole-stdout, not fragments.
 const AGENT_DEVICE_CONFIG = {
   __typename: 'AgentDeviceRunSessionRemoteConfig',
   agentDeviceRemoteSessionUrl: 'https://sim-42.eas.dev/daemon',
@@ -168,8 +156,6 @@ describe('definitive missing-session errors', () => {
 describe('createSessionArgs', () => {
   test('never writes .env.eas-simulator into the project', () => {
     const args = createSessionArgs({ label: 'wt', platform: 'ios' });
-    // --out-config-type env makes eas PRINT the config instead of writing a
-    // dotenv into the project dir, which it does even under --json.
     const i = args.indexOf('--out-config-type');
     expect(i).toBeGreaterThan(-1);
     expect(args[i + 1]).toBe('env');
@@ -235,8 +221,6 @@ describe('remoteDaemonFrom', () => {
   });
 
   test('refuses a session of another type rather than half-reading it', () => {
-    // rn-iso drives agent-device. An appium or argent session is a real
-    // session that this backend cannot speak to, so it must not look usable.
     expect(remoteDaemonFrom({ __typename: 'AppiumRunSessionRemoteConfig', appiumUrl: 'x' })).toBeNull();
     expect(remoteDaemonFrom(null)).toBeNull();
     expect(remoteDaemonFrom(undefined)).toBeNull();
@@ -385,9 +369,6 @@ describe('the read and destroy argv', () => {
   });
 
   test('stopSessionArgs names the session explicitly, never the ambient dotenv', () => {
-    // stop defaults to .env.eas-simulator when --id is absent, which would
-    // reach for whatever session that file names -- possibly another
-    // workspace's.
     expect(stopSessionArgs('drs_42')).toEqual(['simulator:stop', '--id', 'drs_42', '--json', '--non-interactive']);
   });
 
@@ -418,8 +399,6 @@ describe('the read and destroy argv', () => {
 
 describe('the executor seam', () => {
   test('every eas call runs through runFile, in the project directory', () => {
-    // eas sim resolves its project from cwd and takes no positional for it,
-    // unlike `expo config --json <root>`.
     const exec = recordingExec();
     exec.runFile('/bin/eas', createSessionArgs({ label: 'wt', platform: 'ios' }), { cwd: '/work/app' });
     expect(exec.calls[0]?.[0]).toBe('/bin/eas');
@@ -428,11 +407,6 @@ describe('the executor seam', () => {
 });
 
 describe('the shape eas sim actually prints', () => {
-  // VERBATIM from a live `eas sim --platform ios --json` against appandflow.
-  // The point of this fixture is what it does NOT have: __typename. That
-  // field exists on eas-cli's in-memory GraphQL object, which is what its own
-  // source switches on, but printJsonOnlyOutput does not serialize it.
-  // Requiring it rejected every real session -- the bug this pins.
   const LIVE = JSON.stringify({
     id: '01a03fb5-c9f7-7403-8810-712f74e6cafc',
     name: 'rn-iso endpoint probe',
@@ -456,8 +430,6 @@ describe('the shape eas sim actually prints', () => {
   });
 
   test('__typename is honoured when present but never required', () => {
-    // A caller reading the GraphQL object directly still gets the strict
-    // answer; a caller reading the CLI's JSON is not punished for its absence.
     expect(
       remoteDaemonFrom({
         __typename: 'AppiumRunSessionRemoteConfig',

--- a/packages/rn-iso/src/__tests__/eas-simulator.test.ts
+++ b/packages/rn-iso/src/__tests__/eas-simulator.test.ts
@@ -407,6 +407,7 @@ describe('the executor seam', () => {
 });
 
 describe('the shape eas sim actually prints', () => {
+  // Captured from eas sim --platform ios --json; the payload intentionally omits __typename.
   const LIVE = JSON.stringify({
     id: '01a03fb5-c9f7-7403-8810-712f74e6cafc',
     name: 'rn-iso endpoint probe',

--- a/packages/rn-iso/src/__tests__/gc.test.ts
+++ b/packages/rn-iso/src/__tests__/gc.test.ts
@@ -1512,9 +1512,6 @@ describe('EAS orphan session sweep', () => {
   });
 });
 
-// A bare `gc` must never write. The unmounted-volume entry is the one that
-// matters: an unplugged external SSD makes a live project look dead, and
-// unregistering it would drop its device claim (CLAUDE.md item 8).
 test('a bare gc leaves every registered entry in place', async () => {
   const localDeadPath = join(fakeHome, 'no-longer-here');
   saveConfig({

--- a/packages/rn-iso/src/__tests__/guide.test.ts
+++ b/packages/rn-iso/src/__tests__/guide.test.ts
@@ -172,8 +172,6 @@ test('the guide distinguishes local stop behavior from EAS session teardown', ()
   expect(lifecycle).toMatch(/recorded EAS session[^.]*irreversibly ends/i);
 });
 
-// The commands v3 deleted. A guide that still teaches one of them is worse than
-// no guide: the agent runs it and gets "unknown command".
 test('no topic teaches a command this binary does not have', () => {
   const gone = [
     'rn-iso up',
@@ -278,8 +276,6 @@ test('the skill teaches the complete remote-device contract', () => {
   expect(skill).toMatch(/recorded EAS session[^.]*irreversibly ends/i);
 });
 
-// The surface list in the skill IS the surface an agent reads first. A command
-// listed there that the binary does not register is a guaranteed dead end.
 test('the skill advertises exactly the commands bin/cli.js registers', () => {
   const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
   const cli = readFileSync(new URL('../../bin/cli.ts', import.meta.url), 'utf-8');

--- a/packages/rn-iso/src/__tests__/ios-command.test.ts
+++ b/packages/rn-iso/src/__tests__/ios-command.test.ts
@@ -105,11 +105,6 @@ function parseRemoteOption(args: string[]): unknown {
   return command.opts().remote;
 }
 
-// Every engine call is a seam. The defaults describe the happy path with a
-// cache MISS; each test overrides the one fact it is about.
-// The first NDJSON payload a --json command put on stdout, parsed. Asserts it
-// is present (noUncheckedIndexedAccess) then parses; the parsed value stays
-// JSON.parse-shaped, read one field at a time by the caller.
 function parseFirst(lines: string[]) {
   const [first] = lines;
   assert(first);
@@ -2023,11 +2018,6 @@ describe('concurrency limits', () => {
   });
 });
 
-// --- the remote device ------------------------------------------------------
-//
-// `--remote` swaps FOUR entries in the dep seam and nothing else. These tests
-// are about that boundary: which implementation each phase reached for, and
-// that the local path is untouched when the flag is absent.
 describe('--remote', () => {
   test('the CLI parser accepts only an explicit proxy or eas backend', () => {
     expect(parseRemoteOption(['--remote', 'proxy'])).toBe('proxy');
@@ -2036,8 +2026,6 @@ describe('--remote', () => {
     expect(() => parseRemoteOption(['--remote', 'cloud'])).toThrow(/proxy.*eas/i);
   });
 
-  // A stand-in for engine/device-remote's return value. Records which device
-  // calls went through the remote implementation rather than the local one.
   function remoteStub(createdSessionId: string | null = 'drs_42') {
     const hits: string[] = [];
     const backends: unknown[] = [];
@@ -2057,8 +2045,6 @@ describe('--remote', () => {
             },
           };
         },
-        // The reach step runs between the Metro gate and the boot; these
-        // tests are about the device phases, not about tunnels.
         ensureMetroReachable: async () => ({ ok: true as const }),
         detectProviders: () => [],
         remoteIosDeps: () => ({
@@ -2103,7 +2089,6 @@ describe('--remote', () => {
       'launchIosApp',
     ]);
     expect(remote.backends).toEqual(['eas']);
-    // The local implementations were never reached for those phases.
     expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
     expect(calls.order.includes('installIosApp')).toBeFalsy();
   });
@@ -2112,8 +2097,6 @@ describe('--remote', () => {
     const remote = remoteStub();
     reserve();
     const { calls } = await run({ remote: 'eas' }, remote.deps);
-    // The whole premise of remote mode: the fingerprint, the cache and the
-    // build are untouched, because none of them care where the device is.
     expect(calls.order.includes('fingerprintProject')).toBeTruthy();
     expect(calls.order.includes('resolveBuild')).toBeTruthy();
     expect(calls.order.includes('buildIos')).toBeTruthy();
@@ -2136,9 +2119,6 @@ describe('--remote', () => {
   });
 
   test('the Metro gate still runs BEFORE the session is created', async () => {
-    // Remote inverts which device step is expensive: creating a billable
-    // cloud session happens in ensureBooted, so a dead port must still refuse
-    // before it. Same ordering property as local, opposite mechanics.
     const remote = remoteStub();
     reserve();
     const { exitCode } = await run(
@@ -2207,12 +2187,7 @@ describe('--remote', () => {
   });
 
   test('the reach step gets the RESERVED port, and runs after the Metro gate', async () => {
-    // The bug this pins: resolving reach with the dep overrides meant no port
-    // was passed, so it defaulted to 8081 -- a managed tunnel got built to
-    // whatever was on 8081, routinely a DIFFERENT workspace's Metro, which is
-    // the exact failure the gate exists to prevent.
     const remote = remoteStub();
-    // A port that is deliberately NOT 8081, so defaulting is visible.
     reserve(8092);
     let seenPort: unknown = null;
     const order: string[] = [];
@@ -2232,16 +2207,10 @@ describe('--remote', () => {
       },
     );
     expect(seenPort).toBe(8092);
-    // And the local gate answers "is there a dev server at all" first, so an
-    // absent one reports RN_ISO_NO_METRO rather than "serving a different
-    // dev server".
     expect(order).toEqual(['metroGate', 'reach']);
   });
 
   test('a remote build targets the simulator platform, not a udid', async () => {
-    // Live-verified failure this pins: `id=<session-id>` makes xcodebuild exit
-    // 70 with "Unable to find a device matching the provided destination
-    // specifier", because a remote device is not on this machine.
     const remote = remoteStub();
     reserve();
     let seen = null as Record<string, unknown> | null;
@@ -2275,12 +2244,6 @@ describe('--remote', () => {
   });
 });
 
-// --- a diagnosed MISS: what changed since this workspace's previous build ---
-//
-// The fingerprint line alone says only "the hash moved". When the previous
-// build's cache entry stored its sources (fingerprint-sources.json, written by
-// storeBuild), a miss can NAME the inputs that moved: up to three on the phase
-// line, the capped full list in the build log as a fingerprint_diff record.
 test('a miss with a prior stored entry appends the changed-sources suffix and logs fingerprint_diff', async () => {
   reserve();
   writeWorkspaceState(root, {
@@ -2486,8 +2449,6 @@ describe('the remote browser preview', () => {
   }
 
   test('the --json payload carries the preview url', async () => {
-    // A person cannot see a device in a datacenter. This is the handle a
-    // caller gives them.
     reserve();
     const { logs } = await run({ remote: 'eas', json: true }, previewStub('https://preview.example/abc'));
     expect(parseFirst(logs).webPreviewUrl).toBe('https://preview.example/abc');
@@ -2500,7 +2461,6 @@ describe('the remote browser preview', () => {
   });
 
   test('a device with no preview omits the key rather than carrying null', async () => {
-    // An always-present key invites a caller to print an empty link.
     reserve();
     const { logs } = await run({ remote: 'eas', json: true }, previewStub(null));
     expect('webPreviewUrl' in parseFirst(logs)).toBe(false);
@@ -2512,14 +2472,6 @@ describe('the remote browser preview', () => {
     expect('webPreviewUrl' in parseFirst(logs)).toBe(false);
   });
 });
-// --- issue #59: the artifact is stored under the POST-mutation key ----------
-//
-// `expo prebuild` generates ios/ and rewrites package.json's scripts and the
-// app config; `pod install` writes ios/Podfile.lock. All of them are
-// fingerprint SOURCES, so the hash a cold run looked up is not the hash its
-// tree has by the time there is an artifact. Storing under the lookup key
-// produced an entry no later run in that tree could ever hit -- field-measured
-// as 104 MB of cache nothing would ever look up.
 describe('re-fingerprint after the steps that rewrite fingerprinted files', () => {
   const COLD = 'aaaaaa1111';
   const WARM = 'bbbbbb2222';

--- a/packages/rn-iso/src/__tests__/metro-gate.test.ts
+++ b/packages/rn-iso/src/__tests__/metro-gate.test.ts
@@ -1,15 +1,8 @@
-// engine/metro-gate.js -- proving a public address reaches THIS Metro.
-//
-// The bug this exists for, observed live: a cloudflared tunnel was built for
-// port 8085, `rn-iso stop` released 8085, another workspace took it, and the
-// tunnel then published THAT project's dev server. Healthy, answering, and
-// wrong -- which is why liveness is not the test and identity is.
 import { describeMiss, gateMetroOrigin, probeBundleUrl, REMOTE_METRO_WRONG } from '../engine/metro-gate.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
 
 const ORIGIN = 'https://abc.trycloudflare.com';
 
-// A clock the test drives, so a 25s timeout costs nothing and cannot flake.
 function clock(start = 1_000) {
   let t = start;
   return { now: () => t, sleep: async (ms: number) => void (t += ms) };
@@ -38,8 +31,6 @@ describe('the proof is a request arriving in THIS workspace log', () => {
   });
 
   test('a HEALTHY foreign server is refused -- liveness is not identity', async () => {
-    // The live failure: the tunnel answered 200 the whole time, from another
-    // project's Metro. Nothing ever reached ours.
     const result = await gate({ probe: async () => 200, isProof: () => false });
     expect(result.failed).toBe(true);
     expect(result.code).toBe(REMOTE_METRO_WRONG);
@@ -55,12 +46,9 @@ describe('the proof is a request arriving in THIS workspace log', () => {
 
 describe('records from BEFORE the probe do not count', () => {
   test('an older bundle event is not proof', async () => {
-    // Otherwise any previously-built bundle would vouch for any address.
     const stale: NdjsonRecord[] = [{ ts: 10, src: 'metro', level: 'info', msg: 'bundle' }];
     const result = await gate({
       readRecords: () => stale,
-      // The real isBundleProof compares against `since`; this asserts the gate
-      // actually passes a sane `since` rather than 0.
       isProof: (r, since) => (r.ts ?? 0) >= since,
     });
     expect(result.failed).toBe(true);
@@ -73,8 +61,6 @@ describe('what the miss says', () => {
   });
 
   test('a 5xx points at the tunnel rather than the project', () => {
-    // cloudflared returns 502/522 when the edge is up and the origin is not:
-    // the tunnel exists, the port behind it does not.
     expect(describeMiss(ORIGIN, 8085, 502)).toContain('not a dev server');
     expect(describeMiss(ORIGIN, 8085, 522)).toContain('not a dev server');
   });
@@ -114,9 +100,6 @@ describe('failing closed', () => {
   });
 
   test('the request is abandoned once the proof lands', async () => {
-    // The proof is the log entry, not the response body -- waiting for four
-    // megabytes of bundle would make the gate cost as much as the thing it
-    // guards.
     let aborted = false;
     const result = await gate({
       probe: (_url, signal) =>

--- a/packages/rn-iso/src/__tests__/metro-reach.test.ts
+++ b/packages/rn-iso/src/__tests__/metro-reach.test.ts
@@ -1,12 +1,3 @@
-// engine/metro-reach.js -- the one decision about how a remote device reaches
-// this workspace's Metro.
-//
-// The property these pin hardest is the DIRECTION OF THE DEFAULT. rn-iso used
-// to infer "the device is on this machine" from "the daemon URL is loopback",
-// which `ssh -L` makes false, and the app was then pointed at a localhost that
-// resolved on the other machine. Nothing here infers; `auto` assumes the
-// device is elsewhere, because a device that CAN reach localhost loses nothing
-// by being handed a tunnel and a device that cannot loses the whole run.
 import assert from 'node:assert';
 import { detectProviders, planMetroReach, TUNNEL_MODES } from '../engine/metro-reach.ts';
 
@@ -15,9 +6,6 @@ const EXPO = { metroPort: 8085, isExpo: true } as const;
 
 describe('off is an assertion, not a guess', () => {
   test('off uses localhost and skips the gate', () => {
-    // The one case with no third party in the path: a same-machine
-    // `agent-device proxy`. There is nothing to verify because rn-iso is not
-    // trusting anyone else's address.
     expect(planMetroReach({ ...BARE, mode: 'off' })).toEqual({ origin: 'http://localhost:8085', gate: false });
   });
 
@@ -38,8 +26,6 @@ describe('an address the operator supplied', () => {
   });
 
   test('is GATED, because rn-iso did not create it', () => {
-    // The stale-tunnel bug: a URL rn-iso did not build is one it cannot vouch
-    // for, so it must be proven to reach THIS workspace's Metro.
     const plan = planMetroReach({ ...BARE, mode: 'auto', publicUrl: 'https://abc.example' });
     expect('gate' in plan && plan.gate).toBe(true);
   });
@@ -94,8 +80,6 @@ describe('a managed provider', () => {
   });
 
   test('auto with nothing installed refuses, and names every way out', () => {
-    // The refusal has to be actionable: install one, point at an existing
-    // tunnel, or declare the device local.
     const plan = planMetroReach({ ...BARE, mode: 'auto', available: [] });
     expect('failed' in plan).toBe(true);
     assert('failed' in plan);
@@ -105,9 +89,6 @@ describe('a managed provider', () => {
   });
 
   test('auto NEVER falls back to localhost', () => {
-    // The whole point. Falling back would recreate the bug this file exists
-    // to remove: a remote device told to fetch from a localhost that is not
-    // this machine.
     for (const available of [[], ['ngrok'] as const, ['cloudflared'] as const]) {
       const plan = planMetroReach({ ...BARE, mode: 'auto', available });
       expect('origin' in plan).toBe(false);
@@ -135,9 +116,6 @@ describe('provider detection', () => {
   });
 
   test('prefers ngrok when both are installed', () => {
-    // A cloudflared quick tunnel takes MINUTES to become routable and gets a
-    // new hostname every run; ngrok routes immediately. Both work, so the
-    // faster one is the default when there is a choice.
     expect(detectProviders(() => true)).toEqual(['ngrok', 'cloudflared']);
   });
 

--- a/packages/rn-iso/src/__tests__/reclaim.test.ts
+++ b/packages/rn-iso/src/__tests__/reclaim.test.ts
@@ -130,17 +130,6 @@ test('reclaimProject refuses to kill an unidentified process on the port', async
   resetExecutor();
 });
 
-// --- the remote session ----------------------------------------------------
-//
-// A remote session bills until its max duration, so `worktree remove` and
-// `gc` ending it is not housekeeping -- it is the difference between a clean
-// teardown and money spent on nothing.
-//
-// TIMING is what these pin. The session id lives in the workspace's
-// state.json and `eas simulator:stop` needs a project directory, so both are
-// gone the moment the caller removes the tree. Ending it has to happen inside
-// reclaim, before that.
-
 function workspaceWithSession(sessionId: string): string {
   const root = mkdtempSync(join(tmpdir(), 'rn-iso-ws-'));
   ensureWorkspaceStorage(root);
@@ -164,9 +153,6 @@ test('reclaim ends the remote session recorded for the workspace', async () => {
 });
 
 test('the session is ended even without deleteOwnedDevices', async () => {
-  // deleteOwnedDevices guards DESTROYING a local sim, which is a real choice
-  // because a shut-down sim can be booted again. A session cannot be handed
-  // back: the workspace holding its id is going away either way.
   const root = workspaceWithSession('drs_7');
   let called = false;
   await reclaimProject(root, {
@@ -186,8 +172,6 @@ test('a session that could not be stopped keeps the entry and names the manual f
     stopSession: () => ({ status: 'failed', reason: 'offline' }),
   });
   expect(r.stoppedSession).toBeNull();
-  // keptEntry is what stops `worktree remove` reporting a clean teardown, and
-  // what leaves a record naming the session that is still running.
   expect(r.keptEntry).toBe(true);
   expect(getProject(root)).toBeTruthy();
   const reported = r.failedDevices[0]?.reason ?? '';
@@ -215,8 +199,6 @@ test('a stopped session with an unreconciled claim keeps the workspace retry han
 });
 
 test('a throwing stop is contained, so the caller still removes the tree', async () => {
-  // A propagated throw would abort reclaim before `git worktree remove` runs,
-  // and re-running would hit it forever.
   const root = workspaceWithSession('drs_5');
   const r = await reclaimProject(root, {
     stopSession: () => {
@@ -294,12 +276,6 @@ test('reclaim clears a verified terminal record without issuing stop', async () 
   rmSync(root, { recursive: true, force: true });
 });
 
-// --- a tunnel `ios`/`android --remote` started for itself -------------------
-//
-// The same timing constraint as the remote session: engine/tunnel.ts's pid
-// lives in the workspace's state.json, gone the moment the caller removes the
-// tree, so it has to be reaped inside reclaim, before that happens.
-
 function workspaceWithManagedTunnel(pid: number): string {
   const root = mkdtempSync(join(tmpdir(), 'rn-iso-ws-'));
   ensureWorkspaceStorage(root);
@@ -370,9 +346,6 @@ test('reclaim preserves a replacement managed tunnel record', async () => {
 });
 
 test('the tunnel is stopped even without deleteOwnedDevices', async () => {
-  // deleteOwnedDevices guards DESTROYING a local sim; a tunnel process is not
-  // a device it could hand back later, it is simply leaked once its
-  // workspace is gone, so this is unconditional.
   const root = workspaceWithManagedTunnel(4242);
   let called = false;
   await reclaimProject(root, {
@@ -449,9 +422,6 @@ test('an Expo-hosted tunnel has no process of its own -- reclaim never calls sto
 });
 
 test('an operator-supplied tunnel (metro.publicUrl) is never recorded, so reclaim never touches it', async () => {
-  // rn-iso only reaps what it created: an operator's own tunnel is never
-  // written to state.json's metroTunnel key, so there is nothing here to
-  // find, let alone kill.
   const root = mkdtempSync(join(tmpdir(), 'rn-iso-ws-'));
   upsertProject(root, { label: 'agent-1' });
   let called = false;

--- a/packages/rn-iso/src/__tests__/stop.test.ts
+++ b/packages/rn-iso/src/__tests__/stop.test.ts
@@ -634,12 +634,6 @@ test('a not-owned skip is not given an occupancy hint', async () => {
   expect(!/pid 1/.test(reason)).toBeTruthy();
 });
 
-// --- the remote session ----------------------------------------------------
-//
-// A remote session is the ONE device `stop` destroys rather than shuts down.
-// Locally that would be wrong (a shut-down sim costs nothing to keep); a
-// cloud session bills until its max duration, so leaving one up is worse.
-
 function withRemoteSession(sessionId: string) {
   saveConfig(
     makeConfig({
@@ -673,8 +667,6 @@ test('stopping ends the remote session this workspace created', async () => {
 });
 
 test('a session that could not be stopped fails the command, so it is not reported as clean', async () => {
-  // The failure mode this guards: a session nothing stopped keeps billing,
-  // and a green `stop` is how nobody finds out.
   withRemoteSession('drs_99');
   const r = await runStop({
     root: tmpRoot,
@@ -687,8 +679,6 @@ test('a session that could not be stopped fails the command, so it is not report
 
   expect(r.ok).toBe(false);
   expect(r.outcomes.device.remote?.status).toBe('failed');
-  // The record SURVIVES a failed stop, for the same reason a failed local
-  // teardown keeps its device record: it is the only handle left to retry.
   const state = JSON.parse(readFileSync(workspaceStateFile(tmpRoot), 'utf-8'));
   expect(state.remoteDevice.sessionId).toBe('drs_99');
 });
@@ -705,7 +695,6 @@ test('a successful stop drops the record but keeps lastBuild', async () => {
   });
   const state = JSON.parse(readFileSync(workspaceStateFile(tmpRoot), 'utf-8'));
   expect(state.remoteDevice).toBeUndefined();
-  // Taking the fingerprint away would make the next build a guaranteed miss.
   expect(state.lastBuild.hash).toBe('keepme');
 });
 
@@ -816,15 +805,9 @@ test('a workspace with no remote session never calls the remote teardown', async
 });
 
 test('a remote session is stopped even when something still holds the port', async () => {
-  // The stillHolding guard spares a LOCAL device from being yanked out from
-  // under a supervisor that ignored SIGTERM. A session in a datacenter is not
-  // what that supervisor is holding, and it bills by the minute regardless --
-  // so leaving it up because something else refused to die is the one outcome
-  // that costs money.
   const stopped: string[] = [];
   const r = await runStop({
     root: tmpRoot,
-    // A supervisor that will not die is what sets stillHolding.
     isAlive: () => true,
     killGroup: () => false,
     resolveMetro: async () => ({ missing: true }),
@@ -838,12 +821,6 @@ test('a remote session is stopped even when something still holds the port', asy
   expect(stopped).toEqual(['drs_42']);
   expect(r.outcomes.device?.remote?.status).toBe('torn-down');
 });
-
-// --- a tunnel `ios`/`android --remote` started for itself -------------------
-//
-// engine/tunnel.ts's own process (a managed provider), unrelated to the
-// supervisor or to any local device -- reaped unconditionally, the same
-// reasoning as the remote session above.
 
 function withManagedTunnel() {
   saveConfig(makeConfig({ projects: { [tmpRoot]: { label: 'agent-1', metroPort: 8083, platforms: {} } } }));
@@ -894,7 +871,6 @@ test('stopping reaps a managed tunnel this workspace started', async () => {
   expect(r.outcomes.metroTunnel).toEqual({ status: 'stopped', provider: 'ngrok', reason: undefined });
   const state = JSON.parse(readFileSync(workspaceStateFile(tmpRoot), 'utf-8'));
   expect(state.metroTunnel).toBeUndefined();
-  // Taking the fingerprint away would make the next build a guaranteed miss.
   expect(state.lastBuild.hash).toBe('keepme');
 });
 
@@ -970,11 +946,6 @@ test('a workspace with no recorded tunnel never calls stopMetroTunnel', async ()
 });
 
 test('the tunnel is stopped even when something still holds the port', async () => {
-  // Same stillHolding setup as "a supervisor that outlives the wait is
-  // reported, never SIGKILLed" above: a recorded supervisor that ignores
-  // SIGTERM. The guard that spares a LOCAL device from being yanked out from
-  // under it does not apply here -- a tunnel is engine/tunnel.ts's own
-  // detached process, independent of the supervisor.
   const stopped: number[] = [];
   const { calls, opts } = seams({
     state: { pid: 4242, port: 8083 },
@@ -1031,16 +1002,10 @@ test('an Expo tunnel record is dropped once the port is freed, not left stale fo
     clearRegistration: async () => {},
     report: () => {},
   });
-  // Nothing else was in the file, so clearing the last key removes it.
   expect(existsSync(workspaceStateFile(tmpRoot))).toBe(false);
 });
 
 test('an Expo tunnel record survives while something still holds the port', async () => {
-  // The expo child that fronts it is very likely still running -- the same
-  // reason the local device shutdown step is skipped in this case. Proven by
-  // the bookkeeping step (the only place that drops the record) never
-  // running at all: a supervisor that outlives the wait is what sets
-  // stillHolding, the same setup as the "outlives the wait" test above.
   const { calls, opts } = seams({
     state: { pid: 4242, port: 8083 },
     isAlive: (pid: number) => pid === 4242,
@@ -1050,16 +1015,10 @@ test('an Expo tunnel record survives while something still holds the port', asyn
   const r = await runStop(opts);
   expect(r.outcomes.port.status).toBe('kept');
   expect(calls.stateCleared).toBe(0);
-  // 'not-managed': there is a recorded tunnel, but no process of its own to
-  // stop, and the record was left alone rather than dropped.
   expect(r.outcomes.metroTunnel.status).toBe('not-managed');
 });
 
 test('an operator-supplied tunnel (metro.publicUrl) is never recorded, so `stop` never touches it', async () => {
-  // rn-iso only reaps what it created (CLAUDE.md item 2's ownership rule,
-  // applied to tunnels): an operator's own tunnel is used through
-  // metro.publicUrl and is never written to state.json's metroTunnel key,
-  // so there is nothing here for `stop` to find, let alone kill.
   saveConfig(makeConfig({ projects: { [tmpRoot]: { label: 'agent-1', metroPort: 8083, platforms: {} } } }));
   let called = false;
   const r = await runStop({

--- a/packages/rn-iso/src/__tests__/supervisor-expo.test.ts
+++ b/packages/rn-iso/src/__tests__/supervisor-expo.test.ts
@@ -361,22 +361,11 @@ test('inferLevel classifies Expo bundling failures as errors', () => {
   expect(inferLevel('Bundling 100%')).toBe('info');
 });
 
-// --- the public Metro address -----------------------------------------------
-//
-// Expo composes the manifest's hostUri from the Host header it was called
-// with plus ITS OWN port. Behind a tunnel that yields
-// "<tunnel-host>:8085" while the tunnel listens on 443, and a remote device
-// following that manifest can never connect. Verified on a real EAS
-// Simulator; the manifest wins over the launch URL, so it cannot be fixed
-// from the device side.
-
 test('a workspace with no public URL sets nothing', () => {
   expect(expoProxyEnv({})).toEqual({});
 });
 
 test('the public URL becomes EXPO_PACKAGER_PROXY_URL', () => {
-  // One variable, not two that must agree by hand: this is the same value
-  // `ios --remote` points the device at.
   expect(expoProxyEnv({ RN_ISO_METRO_PUBLIC_URL: 'https://abc.trycloudflare.com' })).toEqual({
     EXPO_PACKAGER_PROXY_URL: 'https://abc.trycloudflare.com',
   });
@@ -389,8 +378,6 @@ test('a trailing slash is dropped', () => {
 });
 
 test('an explicit EXPO_PACKAGER_PROXY_URL is never overridden', () => {
-  // A project that set it has said something more specific than rn-iso can
-  // infer.
   expect(
     expoProxyEnv({
       EXPO_PACKAGER_PROXY_URL: 'https://chosen.example.com',
@@ -471,7 +458,6 @@ describe('starting a tunnel', () => {
       onTunnelUrl: (url) => urls.push(url),
     });
     child.stdout!.emit('data', 'Waiting on exp://abc123.exp.direct\n');
-    // A reload reprints the same banner; only the first report matters.
     child.stdout!.emit('data', 'Waiting on exp://abc123.exp.direct\n');
     expect(urls).toEqual(['https://abc123.exp.direct']);
   });
@@ -491,12 +477,6 @@ describe('starting a tunnel', () => {
     expect(urls).toEqual([]);
   });
 });
-// --- the shared transform store, injected into the Expo child --------------
-//
-// The bare path appends a store to the config it hosts. Here the dev server is
-// the project's own `expo start`, so the only seam is the environment -- and
-// the rule that matters is that NODE_OPTIONS is APPENDED to, never replaced:
-// the caller may have set it for reasons rn-iso knows nothing about.
 describe('the Metro store injected into an Expo child', () => {
   const adapter = '/pkg/rn-iso/shim/expo-metro-config.cjs';
 

--- a/packages/rn-iso/src/__tests__/supervisor-run.test.ts
+++ b/packages/rn-iso/src/__tests__/supervisor-run.test.ts
@@ -349,9 +349,6 @@ describe('runSupervisor', () => {
         return server.handle;
       },
     });
-    // startBareServer's own signature does not read `tunnel` at all; this
-    // only pins that runSupervisor still passes it through uniformly rather
-    // than special-casing the bare starter.
     expect(bareSawTunnel).toBe(true);
   });
 

--- a/packages/rn-iso/src/__tests__/tunnel.test.ts
+++ b/packages/rn-iso/src/__tests__/tunnel.test.ts
@@ -1,11 +1,3 @@
-// engine/tunnel.ts -- starting, waiting out, and reaping a tunnel rn-iso
-// starts for itself.
-//
-// The property this file pins hardest is the one recorded in tunnel.ts's own
-// header: a provider PRINTING its URL is not the same fact as that URL being
-// routable, so startTunnel must never report success before a probe actually
-// confirms reachability -- and that confirmation must be provable on a fake
-// clock, because the real timeout is minutes long.
 import {
   readTunnelProcessArgs,
   readTunnelProcessToken,
@@ -23,8 +15,6 @@ import { join } from 'node:path';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { makeChildProcess } from './_factories.ts';
 
-// A clock the test drives, so a multi-minute timeout costs nothing and
-// cannot flake. Same shape as engine/metro-gate.test.ts's clock().
 function clock(start = 1_000) {
   let t = start;
   return { now: () => t, sleep: async (ms: number) => void (t += ms) };
@@ -975,9 +965,6 @@ describe('readTunnelProcessToken', () => {
 });
 
 describe('against output cloudflared really printed', () => {
-  // CLAUDE.md item 9: a hand-written sample proves the regex matches what the
-  // test author imagined. These lines are copied verbatim from a cloudflared
-  // 2026.8.2 run captured while building this feature.
   const BANNER =
     '2026-08-26T19:50:27Z INF |  https://priest-contribute-mysql-leslie.trycloudflare.com                                  |';
   const REQUEST_ERROR =
@@ -990,14 +977,10 @@ describe('against output cloudflared really printed', () => {
   });
 
   test('a url carrying a PATH still yields only the origin', () => {
-    // cloudflared logs `dest=<url>/status` on every failed request. Returning
-    // the path too would be handed to the device as a bundle host.
     expect(parseCloudflaredLine(REQUEST_ERROR)).toBe('https://priest-contribute-mysql-leslie.trycloudflare.com');
   });
 
   test('the pre-banner line naming the domain is NOT a url', () => {
-    // It appears seconds before the real one. Matching it would hand out
-    // "trycloudflare.com" as the tunnel.
     expect(parseCloudflaredLine(PRECHECK)).toBeNull();
   });
 });

--- a/packages/rn-iso/src/__tests__/tunnel.test.ts
+++ b/packages/rn-iso/src/__tests__/tunnel.test.ts
@@ -965,6 +965,7 @@ describe('readTunnelProcessToken', () => {
 });
 
 describe('against output cloudflared really printed', () => {
+  // Captured from cloudflared 2026.8.2; keep these raw lines as parser fixtures.
   const BANNER =
     '2026-08-26T19:50:27Z INF |  https://priest-contribute-mysql-leslie.trycloudflare.com                                  |';
   const REQUEST_ERROR =

--- a/packages/rn-iso/src/__tests__/worktree-remove.test.ts
+++ b/packages/rn-iso/src/__tests__/worktree-remove.test.ts
@@ -489,9 +489,6 @@ test('action: main-checkout artifact deletion blocks a concurrent replacement tu
   expect(existsSync(workspaceStateFile(mainDir))).toBe(false);
 });
 
-// A registered directory that is not a git repo at all: there is no worktree
-// to hand to git and no git status to guard, so environment reclaim is the
-// only thing `remove` can mean there -- and it gets exactly that.
 test('action: a registered project directory that is not a git repo gets the same environment reclaim', async () => {
   upsertProject(wtDir, {
     metroPort: 8087,
@@ -654,12 +651,6 @@ test('action: a retained EAS session prevents generic worktree removal', async (
   expect(errs.join('\n')).toContain('eas simulator:stop --id drs_retained');
 });
 
-// Regression: in a monorepo, `rn-iso ios` registers a nested app dir (e.g.
-// `<worktree>/apps/mobile`) as its own config key -- a different key from
-// the worktree root that `worktree create` registers. That nested key is
-// where metroPort and the device claim actually live. Reclaiming only the
-// exact `path` argument (the old behaviour) leaves the nested entry, its
-// Metro process, and its port claim to leak until `gc --delete` runs.
 test('action: reclaims a nested monorepo app-dir project registered under the worktree root, not just the root itself', async () => {
   const nestedDir = join(wtDir, 'apps', 'mobile');
   upsertProject(wtDir, { metroPort: null, worktreeRoot: true });
@@ -958,8 +949,6 @@ test('action: an unregistered nested remote start cannot bypass the worktree rem
   await expect(withManagedRemoteWorktreeLock(wtDir, async () => 'released')).resolves.toBe('released');
 });
 
-// Containment: a path out of `git status` is relative to the worktree, and
-// anything that resolves outside it is left alone whatever it says.
 test('action: a dirty path escaping the worktree is never removed', async () => {
   upsertProject(wtDir, { metroPort: 8093 });
   const outside = join(mainDir, '.rn-iso');

--- a/packages/rn-iso/src/commands/android.ts
+++ b/packages/rn-iso/src/commands/android.ts
@@ -583,8 +583,6 @@ interface RunAndroidOptions {
   useBuildCache?: boolean;
   variant?: string | null;
   readApkPackage?: (apkPath: string | null) => string | null;
-  // `--remote`. Named for the device rather than the flag because `remote`
-  // already means the build-cache provider in this file.
   remoteDevice?: RemoteDeviceBackend | null;
   resolveSettingsFor?: typeof resolveSettings;
   resolveRemoteDeviceContext?: typeof resolveRemoteContext;
@@ -1383,7 +1381,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     return { ok: false, error: { code, message, remedy: remedy ?? null } };
   };
 
-  // ---- project facts -------------------------------------------------
   const settings = resolveSettingsFor({
     projectPath: root,
     gitCommonDir: gitCommonDir(root),
@@ -1397,10 +1394,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       `Set ios.remote and android.remote to one of: ${REMOTE_DEVICE_BACKENDS.join(', ')}.`,
     );
   }
-  // The flavored variant drives the gradle task, the APK location and the
-  // cache key below. Precedence: the --variant flag (per-invocation judgment)
-  // over the android.variant setting (the repo-level default) over nothing --
-  // the plain assembleDebug flow, unchanged.
   const variant = resolveVariant(variantFlag, settings);
   const release = isReleaseVariant(variant);
   const isExpo = detectIsExpo(root);
@@ -1417,11 +1410,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   const project = getProject(root);
   const label = projectShortcut(root, project);
 
-  // The backend name is known here, but no remote tool or device operation
-  // runs until the local Metro gate below succeeds.
   let remoteDevice: ReturnType<typeof makeRemoteDeviceDeps> | null = null;
 
-  // ---- metro (fail fast, before remote resolution and device work) ----
   const reservedPort = project?.metroPort ?? null;
   let metroPort: number | null = null;
   let phaseFailure: RunAndroidResult | null = null;
@@ -1470,11 +1460,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
 
   if (!(await resolveMetroPort())) return phaseFailure!;
 
-  // ---- remote device: five dep overrides, or none ----
-  //
-  // The local Metro identity is known before remote setup begins. A debug
-  // run then proves the public route before ensureDeviceBooted can connect a
-  // proxy device or create a billable EAS session.
   if (remoteBackend) {
     const resolved = await resolveRemoteDeviceContext({
       root,
@@ -1507,7 +1492,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     launch = remoteDevice.launch;
   }
 
-  // ---- concurrency: opt-in, unlimited by default ----
   const limits = getLimits();
   const capacity = checkCapacity({
     platform: PLATFORM,
@@ -1516,7 +1500,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   });
   if (capacity) return fail(capacity.code, capacity.message, capacity.remedy);
 
-  // ---- device --------------------------------------------------------
   const emuLog = emulatorLogFile(root);
   let device: OwnedDeviceRecord;
   try {
@@ -1544,13 +1527,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     });
   }
 
-  // Local boot is kicked off here and awaited only at install: gradle needs
-  // no device, so a cold AVD boot overlaps the build. Remote boot is awaited
-  // below because its EAS session must be recorded before build work starts.
-  // The catch converts a rare boot rejection into the normal result shape.
-  // The boot's own elapsed time, stamped the moment its promise settles: the
-  // boot overlaps the build by design, so reading the clock at the await
-  // would report the build's time, not the boot's.
   const bootTimer = stepTimer(now);
   let bootDuration = '';
   const boot = (): Promise<AndroidBootLike> =>
@@ -1578,8 +1554,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     return result;
   });
 
-  // A remote session must be durable before fingerprinting, dependency
-  // setup, or a build can fail. Local boot keeps overlapping the build.
   if (remoteDevice) {
     const booted = await bootPromise;
     if (booted.failed) {

--- a/packages/rn-iso/src/commands/gc.ts
+++ b/packages/rn-iso/src/commands/gc.ts
@@ -1,25 +1,3 @@
-// `gc` is the machine-hygiene command: it reports what rn-iso has left behind
-// and, with --delete, reclaims it.
-//
-// Six things still orphan, and none of them is a build artifact any more.
-//
-//   1. dead project entries   a directory deleted by hand leaves a registry
-//                             entry and a reserved Metro port behind
-//   2. owned devices          orphaned ones, plus (with --older-than) ones
-//                             whose project has gone untouched for weeks
-//   3. stale device records   the mirror image of 2: the DEVICE is gone and the
-//                             live project's record still points at it
-//   4. stale build locks      a single-flight lock (engine/build-lock.js) whose
-//                             builder is no longer running: a reboot or a
-//                             SIGKILL in the middle of a compile
-//   5. shared caches          alive by design, never dead, only bigger
-//   6. EAS sessions           an rn-iso-owned session whose workspace state
-//                             disappeared
-//
-// The cache paths are prescribed, so there is nothing to register or forget by
-// hand; gc just reports them, and there is no separate register / forget / list
-// verb. The programmatic `rn-iso/cache-manifest` export stays --
-// that is how @rn-iso/metro and src/build-cache.js self-register.
 import { existsSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
@@ -95,7 +73,6 @@ interface EasSessionSweep {
   deletionSafe: boolean;
 }
 
-// Everything gc knows, gathered by collectGcReport without writing anything.
 interface GcReport {
   skipped: GcSkip[];
   deadProjects: string[];
@@ -149,13 +126,6 @@ interface GcDependencies {
   precollectedEasSessionSweep?: EasSessionSweep;
 }
 
-// Bounds each device listing so a wedged simctl/emulator daemon can't hang
-// `gc` forever -- see the comment above the listAllIosSims/listAvds calls
-// in collectGcReport below.
-// 30s, not 10s: on a loaded machine (several booted emulators, a busy
-// CoreSimulator) `emulator -list-avds` / `simctl list` genuinely take longer
-// than 10s to answer, and a premature skip means an orphaned emulator holding
-// gigabytes never surfaces. A real hang still bounds out and prints the notice.
 const DEVICE_LIST_TIMEOUT_MS = 30000;
 const EAS_OPERATION_TIMEOUT_MS = 30000;
 const EAS_COLLECTION_TIMEOUT_MS = 60000;
@@ -613,10 +583,6 @@ async function withRemoteSessionGcLocks<T>(
   });
 }
 
-// A cache key is a 64-char fingerprint plus its variant and target. The whole
-// thing in a report line is noise; enough of it to match against a build's own
-// `fingerprint <hash>` line is not. Same rule, and the same shape, as
-// shortHash in commands/ios.js.
 function shortKey(key: unknown) {
   const text = String(key ?? '');
   return text.length > 6 ? `${text.slice(0, 6)}..` : text;
@@ -703,9 +669,6 @@ export function formatGcReport({
     }
   }
 
-  // A lock whose builder is gone. Harmless -- the next build takes it over on
-  // the pid-liveness check rather than waiting on it -- so this is tidiness,
-  // and the only thing --delete removes here.
   if (staleLocks.length) {
     lines.push(`Stale build locks (${staleLocks.length}) - the process that was building is gone:`);
     for (const lock of staleLocks) {
@@ -863,8 +826,6 @@ function emptyCache(cache: CacheDescriptor): {
   return { removed, bytes: failed ? 0 : (cache.bytes ?? 0), failed, skipped: null };
 }
 
-// Everything gc knows, gathered without writing anything. `runGc` prints this
-// and then, only with --delete, acts on it.
 export async function collectGcReport(
   {
     olderThan = null,
@@ -875,11 +836,6 @@ export async function collectGcReport(
   }: CollectGcReportOptions = {},
   deps: GcDependencies = {},
 ): Promise<GcReport> {
-  // Reported on every run: the cache paths are prescribed and there is no
-  // `cache list`, so this report is the only way to see a registered cache. Sizing walks
-  // the directories, which is the cost of the report being complete.
-  // With --all each row is annotated with whether it would be emptied and, if
-  // not, why -- decided here so the report and the action cannot disagree.
   const caches = planCacheEmptying(sizeCaches(discoverCaches({ declared: declaredCachePaths() })), all);
 
   const mountedVolumes = listMountedVolumes();
@@ -1001,9 +957,6 @@ export async function collectGcReport(
   };
 }
 
-// Report, then (only with --delete) act. Exported so the suite can drive the
-// device sweep with `unsafeAllowScopedDeviceSweep`; commander supplies only
-// the flags declared below.
 export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}): Promise<void> {
   let projectRoot: string | null = null;
   try {
@@ -1092,9 +1045,6 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     easSessionSweep,
     caches,
   } = report;
-  // Caches only count as actionable with --older-than: emptying one whole is a
-  // performance decision aimed at a specific cache, not something a sweep
-  // should do on the way past.
   const actionable =
     deadProjects.length > 0 ||
     orphanedDevices.length > 0 ||
@@ -1135,8 +1085,6 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     if (result.stoppedTunnel) {
       console.log(chalk.dim(`  stopped ${result.stoppedTunnel} tunnel`));
     }
-    // A session whose stop failed is money still being spent, so it is a
-    // warning with the manual command in it, not a dim note.
     for (const s of result.skippedDevices) {
       console.log(chalk.yellow(`  ${s.name}: ${s.reason}`));
     }

--- a/packages/rn-iso/src/commands/gc.ts
+++ b/packages/rn-iso/src/commands/gc.ts
@@ -126,6 +126,7 @@ interface GcDependencies {
   precollectedEasSessionSweep?: EasSessionSweep;
 }
 
+// simctl and emulator listings can exceed 10 seconds on loaded hosts; 30 seconds still bounds hangs.
 const DEVICE_LIST_TIMEOUT_MS = 30000;
 const EAS_OPERATION_TIMEOUT_MS = 30000;
 const EAS_COLLECTION_TIMEOUT_MS = 60000;

--- a/packages/rn-iso/src/commands/ios.ts
+++ b/packages/rn-iso/src/commands/ios.ts
@@ -100,6 +100,7 @@ function writePhase(name: unknown, text: string): void {
 
 export const PLATFORM = 'ios';
 
+// xcodebuild cannot target a remote simulator UDID, so remote builds use the generic destination.
 const GENERIC_SIM_DESTINATION = 'generic/platform=iOS Simulator';
 
 interface DeviceLike {

--- a/packages/rn-iso/src/commands/ios.ts
+++ b/packages/rn-iso/src/commands/ios.ts
@@ -100,16 +100,7 @@ function writePhase(name: unknown, text: string): void {
 
 export const PLATFORM = 'ios';
 
-// Build for the simulator platform rather than one device. Used only when the
-// device is remote: see the buildIos call for why `id=<udid>` cannot work
-// there.
 const GENERIC_SIM_DESTINATION = 'generic/platform=iOS Simulator';
-
-// --- local, flat shapes for engine results ---------------------------------
-//
-// These interfaces describe only the shape THIS file reads off the engine and
-// sim results -- a deliberately local, all-optional view, looser than the
-// producers' own exported types, matching the defensive reads underneath.
 
 interface DeviceLike {
   deviceName?: string | null;
@@ -526,8 +517,6 @@ export function iosFacts({
     metroPort,
     logs: { dir: logsDir },
     durationMs,
-    // Omitted entirely on a local device rather than carried as null: a key
-    // that is always present invites a caller to print an empty link.
     ...(webPreviewUrl ? { webPreviewUrl } : {}),
   };
 }
@@ -618,8 +607,6 @@ export async function replaceCollector({
 }
 
 interface IosDeps {
-  // Remote mode's two entries. Everything else in this seam is a local
-  // engine call; these are what let `--remote` swap the device out.
   resolveRemoteContext: typeof resolveRemoteContext;
   ensureMetroReachable: typeof ensureMetroReachable;
   ensureRemoteBootOwned: typeof ensureRemoteBootOwned;
@@ -1203,9 +1190,6 @@ async function finishIosRun({
 }
 
 export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> = {}): Promise<IosFacts | null> {
-  // Annotated explicitly: spreading a Partial<> over the full DEFAULT_DEPS
-  // would otherwise let TS infer some properties as possibly-undefined, even
-  // though every key is always present (DEFAULT_DEPS supplies every one).
   let d: typeof DEFAULT_DEPS = { ...DEFAULT_DEPS, ...overrides };
   const json = Boolean(opts.json);
   const metroCheck = opts.metroCheck !== false;
@@ -1315,11 +1299,6 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   const proj = d.getProject(root);
   const label = d.projectShortcut(root, proj);
 
-  // ---- remote device: four dep overrides, or none ----
-  //
-  // `--remote` swaps the device out and NOTHING else. The build, the
-  // fingerprint, the cache and Metro all stay exactly where they were, which
-  // is why this is four entries in the dep seam rather than a second command.
   let remoteDevice: ReturnType<typeof d.remoteIosDeps> | null = null;
   if (remoteBackend) {
     const resolved = await d.resolveRemoteContext({
@@ -1342,7 +1321,6 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     };
   }
 
-  // ---- concurrency: opt-in, unlimited by default ----
   const limits = d.getConcurrencyLimits();
 
   const capacity = d.checkDeviceCapacity({

--- a/packages/rn-iso/src/commands/start.ts
+++ b/packages/rn-iso/src/commands/start.ts
@@ -1,19 +1,3 @@
-// src/commands/start.js -- reserve the port, spawn the detached supervisor,
-// wait until the dev server is verifiably THIS project's, print the facts.
-//
-// `start` is the one command that blocks on purpose: waiting for health is its
-// contract, because everything an agent does next (build, install, launch)
-// fails slowly and confusingly if the bundler is not up yet.
-//
-// Health is `resolveProjectMetro`, never a bare /status probe. A port is not
-// identity: a foreign bundler answering /status on our reserved port would
-// send the agent's build at someone else's dev server, which is exactly what
-// the identity check exists to prevent -- and the reserved port moves instead
-// of being reported as a conflict the caller can do nothing about.
-//
-// Three flags: --json, --wait, and --remote. Anything a project needs
-// beyond that is the project's own bundler command, which is not rn-iso's
-// judgment to make.
 import chalk from 'chalk';
 import type { ChildProcess } from 'node:child_process';
 import { mkdirSync, openSync, readFileSync } from 'node:fs';
@@ -58,8 +42,6 @@ import {
   type TunnelRecord,
 } from '../engine/tunnel.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
-// The same stopwatch the build commands stamp their phase lines with, so the
-// OK line's total wait reads the same way ("4s", "1m4s").
 import { stepTimer } from './ios.ts';
 
 const DEFAULT_WAIT_SECONDS = 60;
@@ -80,15 +62,6 @@ interface WaitResult {
   error?: string;
 }
 
-// PURE. Whether THIS Expo dev server should tunnel itself.
-//
-// Matches engine/metro-reach.ts's own condition for its `{ expoTunnel: true }`
-// branch (mode is "expo") and its precedence
-// (a named metro.publicUrl wins over starting anything). Not routed through
-// planMetroReach itself: that function also decides between a managed
-// provider and a refusal, neither of which `start` can act on -- there is no
-// device here yet to hand a tunnel to, and no `available` providers worth
-// probing for a decision this narrow.
 export function wantsExpoOwnTunnel({
   isExpo,
   remote,
@@ -375,8 +348,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
         Boolean(opts.remote) || remoteIosSetting(settings) !== null || remoteAndroidSetting(settings) !== null;
       const tunnelMode = tunnelModeSetting(settings) ?? 'auto';
       const publicUrl = publicUrlSetting(settings);
-      // Decided here, not at `ios`/`android --remote` time: a later run
-      // cannot retroactively add `--tunnel` to an already-running dev server.
       const tunnel = wantsExpoOwnTunnel({
         isExpo,
         remote,
@@ -406,8 +377,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
 
         const spawnSupervisor = (origin: string | null): ChildProcess => {
           mkdirSync(logsDir, { recursive: true });
-          // One append-only descriptor preserves stdout and stderr order and
-          // records failures that occur before structured logging starts.
           const fd = openSync(logFile, 'a');
           spawnedTs = Date.now();
           const supervisorArgs = [
@@ -420,8 +389,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           ];
           const child = getExecutor().spawn(process.execPath, supervisorArgs, {
             cwd: root,
-            // The supervisor owns its process group so it survives this command
-            // and can be stopped without signalling the caller's shell.
             detached: true,
             stdio: ['ignore', fd, fd],
             env: origin
@@ -704,8 +671,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           }
         };
 
-        // Already up: the whole point of an idempotent start. Two `start` runs in
-        // a row must leave one supervisor, not two bundlers fighting for a port.
         if (!spawnedChild && resolution.metro) {
           if (managedTunnelExited()) return failExitedManagedTunnel();
           if (tunnel && supervisor) {
@@ -742,10 +707,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           return;
         }
 
-        // A live supervisor that is not answering yet is either still starting
-        // (the common case, when two `start` runs race) or wedged. Either way,
-        // spawning a second one would leave the workspace with two supervisors
-        // and one port, so we wait on the one that exists instead.
         if (!spawnedChild && supervisor) {
           note(
             chalk.dim(
@@ -799,7 +760,6 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           return;
         }
 
-        // ---- spawn the supervisor ----
         if (managedTunnelExited()) return failExitedManagedTunnel();
         const child = spawnedChild ?? spawnSupervisor(publicOrigin);
         const attemptStartedTs = spawnedTs ?? Date.now();
@@ -808,22 +768,12 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           root,
           port,
           seconds: waitSeconds,
-          // A supervisor that has already exited is never going to answer, so
-          // the wait ends at second one instead of at sixty.
           aborted: () => childExit !== null || (child.pid ? !isPidAlive(child.pid) : false) || managedTunnelExited(),
         });
 
         if (!healthy) {
           if (managedTunnelExited()) return failExitedManagedTunnel();
-          // A supervisor that is GONE and one that is merely slow need different
-          // next steps, so the two are distinguished rather than both reported
-          // as a timeout. The exit event is the better evidence; the liveness
-          // check catches the case where the process died without us seeing it.
           const gone = childExit !== null || (child.pid ? !isPidAlive(child.pid) : false);
-          // Cast rather than rely on narrowing: childExit is only ever
-          // reassigned inside the 'exit'/'error' listeners above, and TS's flow
-          // analysis does not see through those closures back to its declared
-          // type here.
           const exitInfo = childExit as ChildExitInfo | null;
           const how = exitInfo
             ? exitInfo.signal
@@ -868,10 +818,12 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           }
         }
 
-        supervisor = liveSupervisor({ state: readWorkspaceState(root), project: getProject(root), port }) ||
-          // child.pid is only undefined if the spawn itself failed, which the
-          // health check above would already have turned into a failure.
-          { pid: child.pid as number, port, mode: null, startedAt: null };
+        supervisor = liveSupervisor({ state: readWorkspaceState(root), project: getProject(root), port }) || {
+          pid: child.pid as number,
+          port,
+          mode: null,
+          startedAt: null,
+        };
         report({ json, out, port, supervisor, logsDir, alreadyRunning: false, waited: waitTimer() });
       };
 
@@ -955,10 +907,6 @@ async function waitForExpoTunnel({
   return !aborted() && readMetroTunnel(root)?.kind === 'expo';
 }
 
-// The evidence a start failure carries: the last lines of the supervisor's raw
-// stdio, then the path to the rest of it. That file is the ONLY record of a
-// supervisor that died before it could write a structured one, which is why
-// every failure quotes it.
 function logTailLines(logFile: string): string[] {
   return [...readLogTail(logFile), `Supervisor log: ${logFile}`];
 }

--- a/packages/rn-iso/src/commands/stop.ts
+++ b/packages/rn-iso/src/commands/stop.ts
@@ -59,9 +59,6 @@ export function readCollectorState(root: string): CollectorStateMap {
   return collectors && typeof collectors === 'object' ? (collectors as CollectorStateMap) : {};
 }
 
-// The remote session this workspace created, if any. Written by `ios --remote`
-// the moment the session exists, so a build that failed later still leaves a
-// handle here. Only the session id: the token is never persisted.
 interface RemoteDeviceRecord {
   platform?: string | null;
   sessionId?: string;
@@ -70,15 +67,10 @@ function readRemoteDeviceState(root: string): RemoteDeviceRecord | null {
   return readRemoteSession(root);
 }
 
-// Drops the named top-level keys from state.json. NOT a delete of the file:
-// `ios` / `android` write `lastBuild` beside `supervisor` and `collectors`,
-// and taking the build fingerprint away with a pid would turn every stop into
-// a guaranteed cache miss on the next build.
 function dropStateKeys(root: string, keys: string[]): void {
   clearWorkspaceStateKeys(root, keys);
 }
 
-// Drops the supervisor block and the pid file.
 export function clearSupervisorState(root: string): void {
   try {
     rmSync(supervisorPidFile(root), { force: true });
@@ -239,10 +231,6 @@ interface DeviceOutcomeEntry {
 interface DeviceOutcome {
   ios: DeviceOutcomeEntry | null;
   android: DeviceOutcomeEntry | null;
-  // Only set when this workspace created a remote session. Unlike ios and
-  // android, its `torn-down` means DESTROYED, not shut down: see the device
-  // step in runStop for why remote is the one exception to "stop never
-  // deletes".
   remote?: DeviceOutcomeEntry | null;
 }
 
@@ -261,23 +249,12 @@ interface StopOutcomes {
   metroTunnel: TunnelOutcome;
 }
 
-// A tunnel this workspace's Metro is reachable through, and what happened to
-// it here. Only a MANAGED tunnel (`ios`/`android --remote`'s engine/tunnel.ts)
-// has anything to stop: an Expo-hosted one has no process of its own, and an
-// operator-supplied metro.publicUrl is never recorded at all, so `stop` never
-// sees it and never touches it -- the ownership rule (CLAUDE.md item 2)
-// applied to tunnels.
 interface TunnelOutcome {
-  status: string; // none | not-managed | stopped | missing | failed
+  status: string;
   provider?: string;
   reason?: string;
 }
 
-// Every side effect is injected so the ORDER -- which is the part that can
-// strand a live process or free a port out from under one -- is testable
-// without signalling anything.
-// The real teardown: resolve eas-cli against the project, then end the
-// session. Injected in tests so `stop`'s own suite never shells out.
 function defaultTeardownRemoteSession(
   root: string,
   sessionId: string,
@@ -328,8 +305,6 @@ export async function runStop({
   teardownIos?: (udid: string, opts: { del?: boolean; label?: string }) => TeardownResult;
   teardownAvd?: (avdName: string, opts: { del?: boolean }) => TeardownResult;
   remoteDevice?: RemoteDeviceRecord | null;
-  // `undefined` reads the real recorded tunnel; pass an explicit value
-  // (including `null`) in a test.
   metroTunnel?: ReturnType<typeof readMetroTunnel> | undefined;
   stopMetroTunnel?: typeof stopTunnel;
   teardownRemoteSession?: (root: string, sessionId: string) => { status: 'torn-down' | 'failed'; reason?: string };
@@ -405,18 +380,6 @@ export async function runStop({
     if (outcomes.device.ios?.status === 'failed' || outcomes.device.android?.status === 'failed') ok = false;
   }
 
-  // A remote session is the ONE device rn-iso stops by DESTROYING. Locally
-  // `stop` never deletes, because a shut-down simulator costs nothing to
-  // keep. A cloud session bills until its max duration, so leaving one up is
-  // the worse failure -- and `ios --remote` creates a fresh one anyway.
-  //
-  // OUTSIDE the stillHolding guard, unlike the local shutdown above. That
-  // guard exists so a supervisor still driving a simulator does not get the
-  // device yanked out from under it -- a reason about a LOCAL device. A
-  // session in a datacenter is not what that supervisor is holding, and it
-  // charges by the minute whether or not a local process ignored SIGTERM.
-  // Leaving it up because something else refused to die is the one outcome
-  // that costs money.
   const remote = remoteDevice === undefined ? readRemoteDeviceState(root) : remoteDevice;
   const sessionId = typeof remote?.sessionId === 'string' ? remote.sessionId : null;
   if (sessionId) {
@@ -436,11 +399,6 @@ export async function runStop({
     }
   }
 
-  // A tunnel `ios`/`android --remote` started for itself. Its own detached
-  // process, unrelated to the supervisor or to any local device, so -- same
-  // reasoning as the remote session above -- it is reaped OUTSIDE the
-  // stillHolding guard: nothing about a supervisor that ignored SIGTERM makes
-  // a separate ngrok/cloudflared process any less safe to stop.
   const tunnel = metroTunnel === undefined ? readMetroTunnel(root) : metroTunnel;
   let tunnelHolding: string | null = null;
   if (tunnel?.kind === 'managed') {
@@ -470,8 +428,6 @@ export async function runStop({
     outcomes.metroTunnel = { status: 'not-managed' };
   }
 
-  // Step 5: the port, and step 6: the records. Both are bookkeeping, and both
-  // are wrong while a process this command failed to stop is still holding on.
   if (stillHolding) {
     outcomes.port = { status: 'kept', port: reservedPort, reason: stillHolding };
     report(chalk.yellow(`port: keeping reservation ${reservedPort ?? '(none)'} -- ${stillHolding}`));
@@ -491,10 +447,6 @@ export async function runStop({
     }
     clearState(root);
     await clearRegistration(root);
-    // An Expo-hosted tunnel has no process of its own here: it dies with the
-    // expo child the supervisor step above already stopped. Its record is
-    // stale the moment that server stops -- the next `start` writes a fresh
-    // one if metro.tunnel still calls for it.
     if (tunnel?.kind === 'expo') dropStateKeys(root, ['metroTunnel']);
   }
 

--- a/packages/rn-iso/src/commands/worktree.ts
+++ b/packages/rn-iso/src/commands/worktree.ts
@@ -359,11 +359,8 @@ interface ReclaimAllResult {
   skippedDevices: SkippedDevice[];
   keptEntries: string[];
   retainedResources: RetainedResource[];
-  // Every key that was reclaimed, including nested registered projects.
   reclaimedKeys: string[];
-  // The remote sessions this reclaim ended. Each one was billing.
   stoppedSessions: string[];
-  // The managed tunnels (ngrok/cloudflared) this reclaim ended.
   stoppedTunnels: string[];
   removedWorkspaceDirs: string[];
   failedWorkspaceDirs: string[];
@@ -474,19 +471,6 @@ function hasRegisteredProjectUnder(rootPath: string): boolean {
   return Object.keys(cfg?.projects ?? {}).some((key) => isPathPrefix(rootPath, key));
 }
 
-// `worktree remove` on the MAIN working tree (or on a registered directory
-// that is not a git repo at all): everything the normal removal does to
-// rn-iso's own state -- reclaim every registered key under the root with the
-// owned devices deleted, drop the registry entries, delete each global
-// workspace directory -- with the source tree itself left completely alone. There is
-// no `git worktree remove` here (git cannot remove the main tree) and no
-// dirty/unpushed guard: those protect work in a tree about to be deleted,
-// and nothing here is deleted but rn-iso's own state dir, so dirt is not
-// this command's business and is not mentioned. Every line goes to stderr,
-// mirroring the normal removal's reporting.
-//
-// A retained owned-resource record keeps its global workspace directory and
-// makes the command exit 1, so the next removal attempt can retry the teardown.
 async function reclaimEnvironment(root: string, why: string): Promise<void> {
   await withManagedRemoteWorktreeRemovalLock(root, () =>
     withReclaimLocks(root, async (lockedKeys) => {

--- a/packages/rn-iso/src/doctor.ts
+++ b/packages/rn-iso/src/doctor.ts
@@ -236,15 +236,6 @@ export function checkConcurrency({
   );
 }
 
-// The remote device, and ONLY when this project has asked for one.
-//
-// Silent by default, for the reason checkConcurrency is: a machine that never
-// uses a remote device should not read about one on every run. "Asked for
-// one" means `ios.remote` or `android.remote` names a backend.
-//
-// PURE: the caller resolves both facts. The one thing worth being loud about
-// is a configured remote with no agent-device, because that fails at the
-// device step AFTER the build, which is the expensive place to find out.
 export function checkRemoteDevice({
   configured = null,
   daemonInEnv = false,
@@ -301,8 +292,6 @@ export function checkRemoteDevice({
   );
 }
 
-// Runs every check against one project directory. Pure enough to test: all file
-// reads happen here, and each check is a function of the text it was given.
 export function runDoctor(
   projectRoot: string,
   {
@@ -372,9 +361,6 @@ export function runDoctor(
     });
   }
 
-  // The remote device. Both facts are cheap, and the check returns null unless
-  // one of them says this project actually uses one, so an ordinary project
-  // pays a settings read and nothing else.
   const projectSettings = resolveSettings({ projectPath: projectRoot, repoRoot: projectRoot });
   const remoteBackends = [
     ...new Set([remoteIosSetting(projectSettings), remoteAndroidSetting(projectSettings)]),
@@ -415,9 +401,6 @@ export function runDoctor(
   ].filter((f): f is Finding => Boolean(f));
 }
 
-// Fails CLOSED to "present": a `command -v` that itself fails must not turn a
-// working setup into a "install agent-device" finding. The real refusal at the
-// device step is the authority; this is advice.
 function agentDeviceIsOnPath(): boolean {
   try {
     return Boolean(getExecutor().runQuiet('command -v agent-device', { timeoutMs: 5000 }));
@@ -426,8 +409,6 @@ function agentDeviceIsOnPath(): boolean {
   }
 }
 
-// The thin I/O behind the concurrency note. Both fail OPEN (0): a flaky simctl
-// or adb must not turn a read-only advice command into an error.
 function countLiveDevices(): number {
   let sims: IosSimRecord[] = [];
   let adb: AdbDevices = { emulators: [], physical: [], unhealthy: [] };

--- a/packages/rn-iso/src/engine/agent-device.ts
+++ b/packages/rn-iso/src/engine/agent-device.ts
@@ -1,45 +1,12 @@
-// src/engine/agent-device.ts -- the remote device's control surface.
-//
-// Once a session exists (engine/eas-simulator.ts made it, or an operator ran
-// `agent-device proxy`), everything rn-iso does to the device goes through
-// the agent-device CLI pointed at that daemon. This module composes those
-// calls; it never decides WHETHER the device is remote.
-//
-// The workflow is agent-device's own documented remote one:
-//   connect --remote-config <profile>
-//   install <bundleId> <path>
-//   open <bundleId> [url] --relaunch
-//   disconnect --remote-config <profile>
-// `connect` is what defers and then performs Metro preparation, and
-// `disconnect` is what "release[s] the lease and stop[s] the owned Metro
-// companion". rn-iso therefore does NOT drive `metro prepare` itself: the
-// companion tunnel that makes rn-iso's local Metro reachable from a cloud
-// simulator is agent-device's to own, and a second driver would fight it.
-//
-// TWO INVARIANTS, both covered by tests that fail loudly:
-//
-// 1. THE TOKEN NEVER REACHES DISK. It travels as an env var on the child
-//    process. agent-device's own ADR 0007 says the same thing about its
-//    generated profiles -- "must strip daemon and Metro bearer tokens" --
-//    and a profile is an ordinary file with no special mode, so a token
-//    written there outlives the command that needed it.
-//
-// 2. THE PROFILE IS RN-ISO'S FILE. It lives in global workspace storage,
-//    never in the project directory.
 import { join } from 'node:path';
 import { workspaceDir } from '../paths.ts';
 import { sanitizeDeviceLabel } from '../sim/ios.ts';
 import type { RemoteDaemon } from './eas-simulator.ts';
 
-// The name agent-device reads a token from, and the name eas-cli writes into
-// .env.eas-simulator (simulator/utils.ts,
-// getRemoteSessionEnvironmentVariables). The two agreeing is what lets one
-// backend serve EAS Simulator and a self-hosted proxy unchanged.
 export const DAEMON_TOKEN_ENV = 'AGENT_DEVICE_DAEMON_AUTH_TOKEN';
 
 const PROFILE_FILE = 'agent-device.remote.json';
 
-/** The non-secret half of a connection: routing only, per ADR 0007. */
 export interface RemoteProfile {
   daemonBaseUrl: string;
   daemonTransport: 'http';
@@ -50,50 +17,14 @@ export interface RemoteProfile {
   sessionIsolation: 'tenant';
 }
 
-// PURE. agent-device's session name for this workspace.
-//
-// Per-workspace by construction. agent-device's docs are explicit that a
-// flagless command "can reuse active connection state", so two worktrees
-// sharing a session name is how one of them adopts the other's connection --
-// the same collision rn-iso's port and device ownership exist to prevent.
 export function sessionNameFor(label: string): string {
   return `rn-iso-${sanitizeDeviceLabel(label)}`;
 }
 
-// PURE. Where rn-iso keeps the profile: its own directory, not the project's.
 export function remoteProfilePath(root: string): string {
   return join(workspaceDir(root), PROFILE_FILE);
 }
 
-// PURE. The profile, with no credential in it.
-//
-// `daemonTransport: 'http'` is stated rather than left to discovery: a remote
-// daemon is reached over HTTP by definition, and socket discovery against a
-// remote URL is a wasted probe on every command.
-//
-// `tenant` and `runId` are REQUIRED by `agent-device connect --remote-config`,
-// which refuses with INVALID_ARGS when either is absent. Both are the
-// workspace label because the workspace is genuinely both things here: it is
-// the isolation boundary (worktree A must not adopt worktree B's lease) and
-// it has exactly one live run at a time.
-//
-// Deriving runId from the workspace rather than minting a fresh one per
-// invocation is deliberate. `rn-iso ios` is idempotent, and a new runId each
-// time would leave the previous lease held until its idle expiry, so a
-// re-run would contend with itself.
-//
-// `sessionIsolation: 'tenant'` is what makes the tenant scoping apply rather
-// than being metadata.
-//
-// NO `metroProjectRoot`, deliberately. Setting it makes agent-device treat
-// Metro as its to prepare and then refuse without a bridge origin:
-//   INVALID_ARGS: Deferred Metro preparation requires metroPublicBaseUrl or
-//   metroProxyBaseUrl when Metro settings are provided.
-// rn-iso already owns Metro, and the self-hosted `agent-device proxy` serves
-// no bridge at all (`/api/metro/bridge` is a 404 there; its routes are
-// /health, /rpc, /upload and /artifacts). Both facts were established against
-// agent-device 0.20.10. Metro reachability is therefore rn-iso's problem, and
-// it is solved in device-remote.ts by choosing the deep link's host.
 export function remoteProfile({
   daemon,
   platform,
@@ -115,59 +46,22 @@ export function remoteProfile({
   };
 }
 
-// PURE. The env additions a child agent-device call needs.
 export function daemonEnv(daemon: RemoteDaemon): Record<string, string> {
   return { [DAEMON_TOKEN_ENV]: daemon.token };
 }
 
-// Every argv below carries --remote-config. agent-device falls back to an
-// "active connection" when a command has no explicit selectors, which in a
-// repo with several worktrees means adopting a connection that belongs to a
-// different one.
 function withProfile(profilePath: string, args: string[]): string[] {
   return [...args, '--remote-config', profilePath];
 }
 
-// PURE. Establish the connection.
-//
-// `--force` is required, not defensive. rn-iso rewrites the profile on every
-// run, and a remote session hands back a different daemon URL each time, so
-// the second run of a workspace hits
-//   INVALID_ARGS: Active remote connection config changed.
-//   Run agent-device connect --force to refresh it.
-// Verified against agent-device 0.20.10.
 export function connectArgs(profilePath: string): string[] {
   return withProfile(profilePath, ['connect', '--force']);
 }
 
-// PURE. Push a locally-built artifact to the remote device.
-//
-// The one-positional form (`install <path>`, as opposed to
-// `install <app> <path>`) is deliberate: a `.app` carries its own bundle id,
-// so naming it again would be a second source of truth for the same fact.
-// It also keeps this signature identical to the local installIosApp, which
-// is what lets the remote path drop into the existing dep seam unchanged.
-//
-// The path is its own argv element, so a `.app` under a directory with a
-// space in it arrives as one argument. Against a remote daemon the client
-// uploads the file and the daemon materializes it
-// (src/daemon/install-source-resolution.ts, the `path` + uploadedArtifactId
-// branch), which is why a local build needs no public URL and no EAS Build.
 export function installArgs(profilePath: string, artifactPath: string): string[] {
   return withProfile(profilePath, ['install', artifactPath]);
 }
 
-// PURE. Launch, optionally via a deep link.
-//
-// `open <app> <url>` runs `simctl openurl` with the URL verbatim
-// (platforms/apple/core/app-launch.ts). That is what lets rn-iso pass its own
-// expo-dev-client link and sidestep callstack/agent-device#1245, where
-// agent-device's Metro hint writes only bare-RN's RCT_jsLocation and a
-// dev-client ignores it.
-//
-// `--relaunch` because rn-iso's contract is that `ios` produces a freshly
-// launched app on this workspace's Metro. Attaching to a process left over
-// from a previous run would report success while running an older bundle.
 export function openArgs(
   profilePath: string,
   bundleId: string,
@@ -175,37 +69,10 @@ export function openArgs(
   metro: { host: string; port: string } | null = null,
 ): string[] {
   const positional = url ? [bundleId, url] : [bundleId];
-  // The bare-RN half of Contract 6. A dev-client app is pointed by the deep
-  // link above; a bare RN app reads RCT_jsLocation, which locally rn-iso
-  // writes itself with `simctl spawn defaults write`. It cannot do that on a
-  // device it has no simctl for, so agent-device's own hint carries it --
-  // these two flags are exactly that write, and they are correct here because
-  // the thing they do not reach is expo-dev-client (#1245), which rn-iso is
-  // already handling with its own URL.
-  //
-  // Without this a remote bare-RN app asks for the compiled-in default 8081,
-  // never reaches this workspace's reserved port, and the run reports
-  // UNVERIFIED. Observed live before the flags were added.
   const hint = metro ? ['--metro-host', metro.host, '--metro-port', metro.port] : [];
   return withProfile(profilePath, ['open', ...positional, '--relaunch', ...hint]);
 }
 
-// PURE. Split a Metro origin into the host and port agent-device's hint flags
-// take, defaulting the port FROM THE SCHEME when the URL omits it.
-//
-// The default is not a convenience, it is the fix for a live failure. A
-// tunnel URL is normally portless (`https://x.trycloudflare.com`), and
-// returning null for it sent no hint at all -- which left whatever
-// RCT_jsLocation already held on the device in charge. The app then composed
-// the tunnel's HOST with a stale local PORT and asked for
-//
-//   https://x.trycloudflare.com:8085/index.ts.bundle
-//
-// which can never resolve: the tunnel listens on 443. Observed on a real EAS
-// simulator, and it survived passing `:443` in the deep link, because
-// RCTBundleURLProvider prefers RCT_jsLocation over the launch URL
-// (packagerServerHostPort, line 267). Naming the port explicitly is what
-// takes that decision away from the device.
 export function metroHintFrom(origin: string): { host: string; port: string } | null {
   let url: URL;
   try {
@@ -217,48 +84,18 @@ export function metroHintFrom(origin: string): { host: string; port: string } | 
   return port ? { host: url.hostname, port } : null;
 }
 
-// PURE. Accept the alert that OUR OWN url open just raised.
-//
-// iOS asks "Open in <app>?" the first time a URL is opened into an app on a
-// simulator, and a cloud simulator is always a fresh one -- so a remote
-// dev-client launch lands behind that alert every single time. The bundle is
-// never requested until someone answers it, which made `verify` report
-// UNVERIFIED on a launch that was in fact fine, on every remote run.
-//
-// Safe to accept without reading it: this runs immediately after rn-iso's own
-// `open <app> <url>`, so the alert in front of us is the one that open just
-// caused. Best-effort at the call site -- no alert is the normal case on a
-// bare-RN launch, and on a device that never shows one this is a no-op.
 export function acceptAlertArgs(profilePath: string): string[] {
   return withProfile(profilePath, ['alert', 'accept']);
 }
 
-// PURE. Release the lease and stop the Metro companion this workspace owns.
 export function disconnectArgs(profilePath: string): string[] {
   return withProfile(profilePath, ['disconnect']);
 }
 
-// PURE. End the device session, releasing its claim on the device.
-//
-// Run BEFORE connect, best-effort. agent-device holds a device claim per
-// session that outlives both the lease and the daemon (it is a file under
-// ~/.agent-device/device-claims). rn-iso deliberately leaves the app running
-// when `ios` finishes, so it never reaches a natural close, and the next run
-// then fails one of two ways depending on timing:
-//   DEVICE_IN_USE: Device is already in use by session "<name>"
-//   UNAUTHORIZED:  Lease does not match session owner (leaseId)
-// Both observed live. Closing first makes a re-run idempotent, which is the
-// contract `rn-iso ios` already promises.
 export function closeArgs(profilePath: string): string[] {
   return withProfile(profilePath, ['close']);
 }
 
-// PURE. Is this daemon on the machine rn-iso is running on?
-//
-// The whole question behind Metro reachability. A loopback daemon drives a
-// simulator that shares THIS host's loopback, so the app can be pointed at
-// `localhost:<reserved port>` and reach rn-iso's own Metro. Any other daemon
-// is on another machine, where `localhost` is that machine.
 export function isLoopbackDaemon(baseUrl: string): boolean {
   let host: string;
   try {

--- a/packages/rn-iso/src/engine/agent-device.ts
+++ b/packages/rn-iso/src/engine/agent-device.ts
@@ -3,10 +3,12 @@ import { workspaceDir } from '../paths.ts';
 import { sanitizeDeviceLabel } from '../sim/ios.ts';
 import type { RemoteDaemon } from './eas-simulator.ts';
 
+// agent-device and eas-cli share this token name. The token stays in the child environment.
 export const DAEMON_TOKEN_ENV = 'AGENT_DEVICE_DAEMON_AUTH_TOKEN';
 
 const PROFILE_FILE = 'agent-device.remote.json';
 
+/** agent-device ADR 0007 requires generated profiles to omit bearer tokens. */
 export interface RemoteProfile {
   daemonBaseUrl: string;
   daemonTransport: 'http';
@@ -35,6 +37,7 @@ export function remoteProfile({
   label: string;
 }): RemoteProfile {
   const scope = sessionNameFor(label);
+  // agent-device 0.20.10 requires tenant and runId in remote profiles.
   return {
     daemonBaseUrl: daemon.baseUrl,
     daemonTransport: 'http',
@@ -51,10 +54,12 @@ export function daemonEnv(daemon: RemoteDaemon): Record<string, string> {
 }
 
 function withProfile(profilePath: string, args: string[]): string[] {
+  // Explicit profiles prevent agent-device from reusing another workspace's active connection.
   return [...args, '--remote-config', profilePath];
 }
 
 export function connectArgs(profilePath: string): string[] {
+  // agent-device 0.20.10 rejects a changed daemon URL unless connect uses --force.
   return withProfile(profilePath, ['connect', '--force']);
 }
 
@@ -69,6 +74,7 @@ export function openArgs(
   metro: { host: string; port: string } | null = null,
 ): string[] {
   const positional = url ? [bundleId, url] : [bundleId];
+  // The deep link bypasses https://github.com/callstack/agent-device/issues/1245 for Expo dev clients.
   const hint = metro ? ['--metro-host', metro.host, '--metro-port', metro.port] : [];
   return withProfile(profilePath, ['open', ...positional, '--relaunch', ...hint]);
 }
@@ -80,11 +86,13 @@ export function metroHintFrom(origin: string): { host: string; port: string } | 
   } catch {
     return null;
   }
+  // agent-device writes RCT_jsLocation, so portless tunnels must override any stale Metro port.
   const port = url.port || (url.protocol === 'https:' ? '443' : url.protocol === 'http:' ? '80' : '');
   return port ? { host: url.hostname, port } : null;
 }
 
 export function acceptAlertArgs(profilePath: string): string[] {
+  // Fresh iOS simulators block the first app URL behind a confirmation alert.
   return withProfile(profilePath, ['alert', 'accept']);
 }
 
@@ -93,6 +101,7 @@ export function disconnectArgs(profilePath: string): string[] {
 }
 
 export function closeArgs(profilePath: string): string[] {
+  // agent-device claims outlive leases, so close clears a prior workspace claim.
   return withProfile(profilePath, ['close']);
 }
 

--- a/packages/rn-iso/src/engine/agent-device.ts
+++ b/packages/rn-iso/src/engine/agent-device.ts
@@ -37,6 +37,7 @@ export function remoteProfile({
   label: string;
 }): RemoteProfile {
   const scope = sessionNameFor(label);
+  // agent-device 0.20.10 requires metroProjectRoot to expose a bridge URL; the self-hosted proxy has none.
   // agent-device 0.20.10 requires tenant and runId in remote profiles.
   return {
     daemonBaseUrl: daemon.baseUrl,

--- a/packages/rn-iso/src/engine/app-install.ts
+++ b/packages/rn-iso/src/engine/app-install.ts
@@ -631,8 +631,6 @@ function findBundleRequest(
   return null;
 }
 
-// Exported so the remote Metro gate reads this workspace's timeline the
-// same way launch verification does. Both checks use the same proof records.
 export function readMetroRecords(logsDir: string | undefined): NdjsonRecord[] {
   return readNdjson(logsDir, 'metro.ndjson');
 }
@@ -666,9 +664,6 @@ export function unverifiedLaunchLines({
   serial?: string | null;
   devClientUrl?: string | null;
   mode?: string | null;
-  // A remote device has no simctl on this machine, and the app was pointed at
-  // metroOrigin rather than at localhost, so the local steps below are all
-  // wrong for it -- `xcrun simctl openurl <session-id>` names nothing.
   remote?: boolean;
   metroOrigin?: string | null;
   // Explicit return type: isolatedDeclarations requires one at every module
@@ -684,10 +679,6 @@ export function unverifiedLaunchLines({
   let step = 0;
   const push = (text: string) => lines.push(`  ${++step}. ${text}`);
   if (remote) {
-    // The device is not on this machine, so every simctl/adb step is
-    // unusable. What CAN be wrong is reachability: the app fetches from
-    // metroOrigin, and unlike a local run that address has to work from the
-    // device's network, not from here.
     push(
       `Check that ${origin} is reachable FROM THE DEVICE's network, not just from this machine. That is the usual cause: a tunnel that stopped, or one this machine can reach and the device cannot.`,
     );

--- a/packages/rn-iso/src/engine/device-remote.ts
+++ b/packages/rn-iso/src/engine/device-remote.ts
@@ -1,24 +1,3 @@
-// src/engine/device-remote.ts -- the remote half of the device, shaped to
-// drop into the dep seam commands/ios.ts already has.
-//
-// THE SEAM IS NOT NEW. `DEFAULT_DEPS` in commands/ios.ts is documented as
-// "the test seam. Every engine call goes through it", and four of its entries
-// are the entire device surface: ensureOwnedDevice, ensureBooted,
-// installIosApp, launchIosApp. Remote mode replaces those four and nothing
-// else. Inventing a parallel DeviceBackend abstraction beside a seam that
-// already exists would be a second way to say the same thing.
-//
-// The consequence worth stating: every call site, every phase line and every
-// existing test is untouched. The local path is not refactored at all, so a
-// regression there cannot be caused by this file.
-//
-// WHERE THE EXPENSIVE WORK SITS. Locally, ensureOwnedDevice is cheap (a
-// simctl create) and ensureBooted is the ~10s one, which is why the Metro
-// gate sits between them: a dead port must cost a second, not a boot. Remote
-// inverts the cost -- creating a cloud session is the slow, billable step --
-// so `ensureOwnedDevice` here does NOTHING but record intent, and the session
-// is created in `ensureBooted`, AFTER the gate. Same ordering property, same
-// reason, opposite mechanics.
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, resolve as resolvePath } from 'node:path';
 import { getExecutor } from '../exec.ts';
@@ -65,33 +44,8 @@ import { getConfigDir } from '../config.ts';
 export const REMOTE_SESSION_ERROR = 'RN_ISO_NO_REMOTE_SESSION';
 const REMOTE_METRO_ERROR = 'RN_ISO_REMOTE_METRO_UNREACHABLE';
 
-// Where the app should look for Metro, when the device is not on this machine.
-// Set it to a URL that reaches THIS workspace's dev server from the device's
-// network -- a cloudflared/ngrok tunnel in front of the reserved port.
 export { PUBLIC_METRO_ENV } from './metro-reach.ts';
 
-/**
- * PURE. The origin the launched app should fetch its bundle from, or a
- * refusal.
- *
- * THIS IS THE HARD PART OF A REMOTE DEVICE, and it is not solved by
- * agent-device for a self-hosted proxy. Established against agent-device
- * 0.20.10: `agent-device proxy` serves /health, /rpc, /upload and /artifacts
- * and NOTHING under /api/metro, so `/api/metro/bridge` is a 404 and the
- * companion-tunnel path is a cloud-only feature. A device on another machine
- * therefore has no route to this laptop's Metro that agent-device will build.
- *
- * So the honest rule:
- *   loopback daemon -> the simulator shares this host's loopback, and
- *                      `localhost:<reserved port>` is correct and verified.
- *   anything else   -> rn-iso cannot invent a reachable address. It refuses,
- *                      unless the operator names one via RN_ISO_METRO_PUBLIC_URL.
- *
- * Refusing beats guessing. `localhost` sent to a remote device resolves on
- * THAT machine, so the app would silently load nothing (or, worse, another
- * project's bundler) and the run would look like a launch that merely failed
- * to verify.
- */
 export function resolveMetroOrigin({
   metroPort,
   publicUrl = null,
@@ -108,30 +62,12 @@ export function resolveMetroOrigin({
   const plan = planMetroReach({ mode, metroPort, publicUrl, isExpo, available });
   if ('origin' in plan) return plan;
   if ('failed' in plan) return plan;
-  // expoTunnel / start are decisions the COMMAND layer acts on before a launch
-  // ever happens; by the time an origin is needed one of them has produced a
-  // publicUrl. Reaching here means that step was skipped.
   return {
     failed: 'Metro has no address the device can reach yet.',
     remedy: 'This is an rn-iso bug: the tunnel step did not run before the launch.',
   };
 }
 
-// NO DEFAULT DURATION, deliberately.
-//
-// The cap is per-account and rn-iso cannot know it. A hardcoded 120 was
-// rejected live with "Device run session max duration must not exceed 115
-// minutes for this account; received 120 minutes", which failed the whole
-// command before a session existed. EAS derives its own default from the job
-// run priority, so omitting the flag is both correct and account-portable.
-//
-// What actually bounds the cost is teardown -- `stop`, `worktree remove` and
-// `gc` all end the session -- not a number invented here. A caller who wants
-// a tighter bound passes one, and the flag is only sent when they do.
-
-// The device record the rest of ios.ts reads. Only `deviceName` is consumed
-// (by deviceLabel), so it says what this device IS rather than pretending to
-// be a simulator model.
 interface RemoteDeviceRecord {
   deviceName: string;
   owned: true;
@@ -144,14 +80,6 @@ interface OpFailure {
   reason: string;
 }
 
-// The exact shapes the local counterparts in engine/app-install.ts return.
-// Named because isolatedDeclarations requires it, and useful anyway: this IS
-// the contract the dep seam swaps on.
-// FLAT and all-optional, matching engine/device.ts's BootResult and the
-// app-install results these stand in for. A discriminated union would be
-// tidier in isolation, but every caller and every test in this codebase reads
-// these shapes field-by-field, and the seam's whole point is that the remote
-// half is indistinguishable from the local one.
 export interface BootResult {
   ok?: boolean;
   udid?: string;
@@ -192,37 +120,23 @@ function describe(err: unknown): string {
   return stderr || String(e?.message ?? err);
 }
 
-/** What a remote run needs to know, resolved once by the command layer. */
 export interface RemoteContext {
   root: string;
   label: string;
   backend: RemoteDeviceBackend;
   easBin: string;
   agentDeviceBin: string;
-  // Which device this run wants. Reaches `eas sim --platform` and the
-  // connection profile; nothing else in a remote run differs by platform.
   platform?: 'ios' | 'android';
   maxDurationMinutes?: number | null;
-  // A URL that reaches THIS workspace's Metro from the device's network.
-  // Only consulted when the daemon is not on this machine.
   publicMetroUrl?: string | null;
-  // Carried so the launch resolves the origin the same way resolveRemoteContext
-  // already did, rather than second-guessing it.
   tunnelMode?: TunnelMode;
   isExpo?: boolean;
-  // The readiness poll's wait, injectable so a test does not sleep for real.
   sleep?: (ms: number) => Promise<void>;
-  // Set when the operator already has a daemon (an `agent-device proxy`, or
-  // an exported EAS session). rn-iso then creates NO session and destroys
-  // none: it is a guest on someone else's device.
   existingDaemon?: RemoteDaemon | null;
   easLedgerRoot?: string;
   removeEasSessionClaim?: typeof removeEasSessionClaim;
 }
 
-// The live session for one `rn-iso ios` run. Held in a closure rather than in
-// state.json because the token must not reach disk; the session ID does get
-// recorded by the command layer so `stop` and `gc` can find it later.
 interface RemoteSession {
   id: string | null;
   daemon: RemoteDaemon;
@@ -253,24 +167,6 @@ function writeProfile(ctx: RemoteContext, daemon: RemoteDaemon): string {
   return path;
 }
 
-/**
- * The four dep overrides remote mode installs over DEFAULT_DEPS, plus the
- * session accessor the command layer needs to record the id.
- *
- * Each returned function matches its local counterpart's signature exactly.
- * That is the whole design: ios.ts calls `d.installIosApp({udid, appPath})`
- * whether the device is a simulator on this Mac or one in a datacenter.
- */
-/**
- * The device operations remote mode performs, in platform-NEUTRAL names.
- *
- * The two platform adapters below are thin because on a remote device the
- * launch is genuinely the same operation: locally iOS points the app at
- * `localhost` and Android at `10.0.2.2` (its own host's loopback), and BOTH
- * are replaced by the one public origin the tunnel serves. What is left
- * differing is only what the two command files call their fields --
- * udid/serial, bundleId/packageName, appPath/apkPath.
- */
 function exec() {
   return getExecutor();
 }
@@ -282,29 +178,14 @@ function remoteDeviceDeps(ctx: RemoteContext) {
   const easEnv = easExecOptions(ctx.root);
 
   return {
-    // Remote has no local device to count. maxDevices caps booted simulators
-    // on THIS machine, and escaping that ceiling is the entire reason to run
-    // remote, so enforcing it here would refuse the thing it was asked for.
     checkCapacity: () => null,
 
-    // Records intent only. The session is created in ensureBooted so the
-    // Metro gate still runs before the expensive, billable step.
-    //
-    // The name says which KIND of remote device this is, because the two
-    // behave differently in ways an operator needs to see in one line: an EAS
-    // session is rn-iso's to create and destroy, a daemon from the
-    // environment is somebody else's and is never stopped here.
     ensureDevice: async (): Promise<RemoteDeviceRecord> => ({
       deviceName: ctx.backend === 'proxy' ? 'remote device (your daemon)' : 'EAS Simulator',
       owned: true,
       remote: true,
     }),
 
-    // Creates the session (unless the operator brought one), writes the
-    // connection profile, and connects. `connect` is also what prepares
-    // Metro: it registers rn-iso's local dev server with the daemon through
-    // agent-device's companion tunnel, which is how a cloud simulator reaches
-    // a bundler on this laptop.
     ensureBooted: async ({ out = () => {} }: { out?: (msg: string) => void } = {}): Promise<BootResult> => {
       session = null;
       createdSession = null;
@@ -319,16 +200,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
       let id: string | null = null;
       let createdHere: string | null = null;
 
-      // A live owned session with a daemon is reused. Any other recorded
-      // session is verified before replacement.
-      //
-      // `eas sim` defaults to --force, so every run would otherwise mint a
-      // fresh session while the previous one stayed live, unrecorded (the id
-      // in state.json is overwritten) and billing to its cap. The documented
-      // loop re-runs `ios` after every native change, so that fired
-      // constantly. Reuse also removes a 60-90s session creation from the
-      // common case, which is the difference between `ios --remote` being
-      // idempotent and being expensive.
       if (!daemon) {
         const recorded = readRemoteSession(ctx.root);
         if (recorded && recorded.platform !== (ctx.platform ?? 'ios')) {
@@ -383,11 +254,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
         }
         id = created.id;
         createdHere = created.id;
-        // The session EXISTS from this line on, and it bills. Every failure
-        // below therefore has to end it rather than return and forget it:
-        // nothing else can, because the id is not recorded until this
-        // function succeeds. Observed live -- a session with no endpoint yet
-        // left an IN_PROGRESS session nothing could find.
         daemon = created.daemon ?? (await waitForDaemon(ctx, created.id, note, { sleep: ctx.sleep ?? defaultSleep }));
         if (!daemon) {
           return abandonSession(
@@ -406,8 +272,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
         if (createdHere) return abandonSession(ctx, createdHere, reason);
         return { failed: true, reason };
       }
-      // Best-effort, and its failure is expected on a first run: there is no
-      // session to close. See closeArgs for why it has to happen anyway.
       try {
         exec().runFile(ctx.agentDeviceBin, closeArgs(profilePath), {
           cwd: ctx.root,
@@ -426,17 +290,9 @@ function remoteDeviceDeps(ctx: RemoteContext) {
         return { failed: true, reason: `agent-device connect failed: ${describe(err)}` };
       }
 
-      // Surfaced the moment the session is reachable, not at the end: it is
-      // how a HUMAN watches a device they cannot see, and it is most useful
-      // while the build is still running. On its own line so terminals
-      // linkify it.
       session = { id, daemon, profilePath };
       createdSession = createdHere;
       if (daemon.webPreviewUrl) note(`Watch this device: ${daemon.webPreviewUrl}`);
-      // `udid` is the field ios.ts reads and prints, and shortUdid truncates
-      // it for the phase line. A session id shortens to something meaningful;
-      // a base URL shortens to "http..", which is noise. So a daemon with no
-      // session of its own reports its host instead.
       return { ok: true, udid: id ?? daemonHostLabel(daemon.baseUrl) };
     },
 
@@ -467,10 +323,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
       devClientScheme?: string | null;
     }): LaunchResult => {
       if (!session) return notConnected(LAUNCH_ERROR);
-      // A null port is a RELEASE-shaped launch: the JS is embedded, Metro is
-      // not part of the run, and there is nothing to point the app at. The
-      // reachability question below only exists for a dev build, so skip it
-      // rather than refusing a launch that needs no dev server.
       if (metroPort === null) {
         try {
           exec().runFile(ctx.agentDeviceBin, openArgs(session.profilePath, appId, null, null), {
@@ -482,9 +334,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
           return { failed: true, code: LAUNCH_ERROR, reason: `agent-device open ${appId} failed: ${describe(err)}` };
         }
       }
-      // WHERE the app looks for Metro is decided first, and a device that
-      // cannot reach this workspace's dev server is a refusal rather than a
-      // launch that will never load a bundle.
       const origin = resolveMetroOrigin({
         metroPort,
         publicUrl: ctx.publicMetroUrl ?? null,
@@ -495,11 +344,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
         return { failed: true, code: REMOTE_METRO_ERROR, reason: `${origin.failed} ${origin.remedy}` };
       }
 
-      // The dev-client link is composed HERE rather than left to
-      // agent-device's own Metro hint. That hint writes bare-RN's
-      // RCT_jsLocation, which an expo-dev-client ignores
-      // (callstack/agent-device#1245). `open <app> <url>` runs simctl openurl
-      // with the url verbatim, so rn-iso's own link works today.
       const url = devClientScheme
         ? `${devClientScheme}://expo-development-client/?url=${encodeURIComponent(origin.origin)}`
         : null;
@@ -508,13 +352,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
           cwd: ctx.root,
           env: daemonEnv(session.daemon),
         });
-        // Reports the origin the app was actually pointed at, not a
-        // jsLocation this path never wrote.
-        // The alert only exists because the line above opened a URL, and it
-        // holds the deep link until it is answered -- which is why a remote
-        // dev-client launch used to report UNVERIFIED every time. Best-effort:
-        // a bare-RN launch opens no URL and raises no alert, and this is then
-        // a no-op that must not fail the run.
         if (url) {
           try {
             exec().runFile(ctx.agentDeviceBin, acceptAlertArgs(session.profilePath), {
@@ -535,8 +372,6 @@ function remoteDeviceDeps(ctx: RemoteContext) {
       }
     },
 
-    // Not a dep override. The command layer records a session created by this
-    // boot attempt. A reused session already has its durable ownership record.
     createdSessionId: (): string | null => createdSession,
 
     abandonCreatedSession: (): AbandonCreatedSessionResult => {
@@ -550,21 +385,10 @@ function remoteDeviceDeps(ctx: RemoteContext) {
       return stopped;
     },
 
-    // Not a dep override either. The browser preview for this device, so the
-    // --json payload can carry it and a caller can hand it to a person.
     webPreviewUrl: (): string | null => session?.daemon.webPreviewUrl ?? null,
   };
 }
 
-/**
- * Where a remote run gets its tools and, optionally, its daemon.
- *
- *   { ctx }                ready to run
- *   { failed: reason, remedy }  a refusal the command prints as-is
- *
- * The selected backend decides whether credentials connect to an existing
- * proxy or EAS creates a session.
- */
 export async function resolveRemoteContext({
   root,
   label,
@@ -580,8 +404,6 @@ export async function resolveRemoteContext({
   backend: RemoteDeviceBackend;
   platform?: 'ios' | 'android';
   easBin: string | null;
-  // How this workspace expects the device to reach Metro, and what it has to
-  // work with. See engine/metro-reach.ts.
   tunnelMode?: TunnelMode;
   publicUrl?: string | null;
   isExpo?: boolean;
@@ -634,19 +456,6 @@ export async function resolveRemoteContext({
     };
   }
 
-  // Metro reachability is decided HERE, before anything is created or built.
-  //
-  // It used to be checked at launch, which is the worst possible place: a run
-  // with no reachable Metro would create a billable session, compile for
-  // minutes, install, and only then refuse. Everything needed to answer the
-  // question is already known at this point -- an EAS session is cloud-hosted
-  // and therefore never loopback, and an operator daemon carries its URL.
-  //
-  // NOTHING IS INFERRED. This used to accept a loopback daemon URL as proof
-  // that the device shares this machine, which `ssh -L 4310:localhost:4310
-  // macmini` makes false -- and the app was then pointed at a localhost that
-  // resolved on the Mac mini. `metro.tunnel: "off"` is how that case is
-  // DECLARED instead; see engine/metro-reach.ts.
   return {
     ctx: {
       root,
@@ -656,17 +465,12 @@ export async function resolveRemoteContext({
       easBin: easBin ?? '',
       agentDeviceBin,
       maxDurationMinutes,
-      // Filled in later by ensureMetroReachable, once the reserved port is
-      // known and the local Metro gate has confirmed a dev server is there.
       publicMetroUrl: null,
       existingDaemon,
     },
   };
 }
 
-// PURE-ish. Is this binary on PATH? Used to decide which tunnel providers
-// rn-iso could start. Fails CLOSED to "absent": a probe that itself fails
-// must not make rn-iso try to spawn something that is not there.
 export function binOnPath(bin: string): boolean {
   try {
     return Boolean(getExecutor().runQuiet(`command -v ${bin}`, { timeoutMs: 5000 }));
@@ -681,28 +485,15 @@ function defaultLookupAgentDevice(): string | null {
   return file || null;
 }
 
-// How long to wait for a freshly created session to publish its endpoint,
-// and how often to ask. A cloud VM boot is tens of seconds; `eas sim` polls
-// internally too but has been seen returning before the endpoint exists.
 const DAEMON_WAIT_MS = 180_000;
 const DAEMON_POLL_MS = 5_000;
 
-/**
- * Poll `simulator:get` until the session publishes an agent-device endpoint.
- *
- * Bounded, because the alternative is a command that hangs on a session that
- * will never be ready -- while billing.
- */
 async function waitForDaemon(
   ctx: RemoteContext,
   sessionId: string,
   out: (msg: string) => void,
   { sleep = defaultSleep }: { sleep?: (ms: number) => Promise<void> } = {},
 ): Promise<RemoteDaemon | null> {
-  // Bounded by ATTEMPTS, not by a wall-clock deadline. A deadline read from
-  // the real clock spins without limit the moment `sleep` does not actually
-  // sleep, which is exactly what a test injects -- it burned a worker to an
-  // out-of-memory before this was counted instead.
   const attempts = Math.ceil(DAEMON_WAIT_MS / DAEMON_POLL_MS);
   for (let attempt = 0; attempt < attempts; attempt++) {
     const daemon = readDaemon(ctx, sessionId);
@@ -717,16 +508,6 @@ function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * End a session rn-iso created but cannot use, and fold the outcome into the
- * refusal.
- *
- * A session that fails between create and record is invisible to `stop`,
- * `gc` and `worktree remove`, so this is the ONLY place it can be ended. If
- * the stop also fails, the id goes in the message: a human can still run
- * `eas simulator:stop --id <id>`, and a leak nobody is told about is the
- * worst outcome here.
- */
 function stopCreatedSession(ctx: RemoteContext, sessionId: string): AbandonCreatedSessionResult {
   let stopOutput: string;
   try {
@@ -879,8 +660,6 @@ export async function ensureRemoteBootOwned<T extends BootResult>({
   }
 }
 
-// PURE. The host:port of a daemon, for a phase line that has room for one
-// short token. Falls back to the whole URL when it will not parse.
 function daemonHostLabel(baseUrl: string): string {
   try {
     return new URL(baseUrl).host;
@@ -897,18 +676,8 @@ function notConnected(code: string): OpFailure {
   };
 }
 
-// Re-reads the session so the token is fetched, never stored. Returns null on
-// any failure: the caller turns that into a refusal with the session id in it,
-// which is more useful than a parse error from here.
-// The statuses eas-cli reports for a session that still exists and can still
-// be driven. Anything else (STOPPED, ERRORED) is a session to replace.
 const LIVE_STATUSES = new Set(['NEW', 'IN_PROGRESS']);
 
-// Like readDaemon, but ALSO requires the session to still be live.
-//
-// Reuse needs both facts and readDaemon only proves one: a STOPPED session
-// can still report a remoteConfig, so reusing on config alone would connect
-// to a daemon that is gone and fail at install instead of creating a session.
 function readLiveDaemon(ctx: RemoteContext, sessionId: string): RemoteDaemon | null {
   let stdout: string;
   try {
@@ -941,15 +710,7 @@ function readDaemon(ctx: RemoteContext, sessionId: string): RemoteDaemon | null 
   }
 }
 
-/**
- * The dep overrides `ios --remote` installs over DEFAULT_DEPS.
- *
- * Names match commands/ios.ts's seam exactly, so every call site, phase line
- * and existing test is untouched.
- */
 export function remoteIosDeps(ctx: RemoteContext): {
-  // Handed back so the command layer can pass it to ensureMetroReachable,
-  // which fills in the origin once the reserved port is known.
   ctx: RemoteContext;
   checkDeviceCapacity: () => null;
   ensureOwnedDevice: () => Promise<RemoteDeviceRecord>;
@@ -981,21 +742,6 @@ export function remoteIosDeps(ctx: RemoteContext): {
   };
 }
 
-/**
- * The same, for `android --remote`, against commands/android.ts's own names.
- *
- * `adb reverse` and `10.0.2.2` do NOT appear here, and their absence is the
- * whole point. Both are host-relative -- a reverse maps a device port to the
- * host running adb, and 10.0.2.2 is the emulator's route to ITS OWN host --
- * so on a remote emulator both name the wrong machine. The public origin
- * replaces them, exactly as it replaces `localhost` on iOS, which is why this
- * adapter is thin rather than a second implementation.
- *
- * The Metro hint still lands: agent-device writes `debug_http_host` (and
- * `dev_server_https`, which a tunnel on 443 needs) into the app's shared
- * prefs from `--metro-host`/`--metro-port`, running adb against ITS OWN
- * emulator where a reverse would be meaningless from here.
- */
 export function remoteAndroidDeps(ctx: RemoteContext): {
   ctx: RemoteContext;
   checkCapacity: () => null;
@@ -1025,8 +771,6 @@ export function remoteAndroidDeps(ctx: RemoteContext): {
     ctx: shared,
     checkCapacity: core.checkCapacity,
     ensureDevice: core.ensureDevice,
-    // Same identity, different field name: android.ts reads `serial` where
-    // ios.ts reads `udid`.
     ensureDeviceBooted: async (opts) => {
       const booted = await core.ensureBooted(opts);
       return booted.ok ? { ok: true, serial: booted.udid } : booted;
@@ -1040,14 +784,6 @@ export function remoteAndroidDeps(ctx: RemoteContext): {
   };
 }
 
-/**
- * End the session recorded in state.json. The entry point `stop`, `gc` and
- * `worktree remove` use, so none of them has to know how to resolve a tool
- * or compose an argv.
- *
- * Resolves its own binaries because a teardown runs long after the `ios` that
- * created the session, in a process that has none of its context.
- */
 export function endRecordedSession({
   root,
   sessionId,
@@ -1082,15 +818,6 @@ export function endRecordedSession({
   );
 }
 
-/**
- * End a remote session. The inverse of ensureBooted, and the reason
- * `stop` gains a delete it never had locally: a cloud session bills while it
- * lives, so leaving one up is the worse failure.
- *
- * Disconnect first, so the lease is released and the Metro companion this
- * workspace owns is stopped, then stop the session itself. A disconnect
- * failure must not prevent the stop: the session is what costs money.
- */
 export function teardownRemote(
   ctx: RemoteContext,
   { sessionId }: { sessionId: string | null },
@@ -1148,27 +875,6 @@ export function teardownRemote(
   return { status: 'torn-down', reason: removeClaim() };
 }
 
-/**
- * Give the device an address for Metro, and PROVE it reaches this workspace's.
- *
- * SEPARATE FROM resolveRemoteContext, and called later, because it needs two
- * things that are not known when the dep overrides are installed: the port
- * this workspace actually reserved, and confirmation from the local Metro
- * gate that a dev server is running there at all.
- *
- * Running it earlier looked equivalent and was not. It defaulted the port to
- * 8081 -- so a managed tunnel was built to whatever happened to be on 8081,
- * which on this machine is routinely a DIFFERENT workspace -- and it probed
- * before the local gate had established there was a dev server to reach, so a
- * simply-absent Metro was reported as "the tunnel is serving a different dev
- * server" instead of RN_ISO_NO_METRO.
- *
- * It still runs before ensureBooted, which is what creates the billable
- * session, so every refusal here costs nothing.
- *
- * Mutates `ctx.publicMetroUrl`: remoteIosDeps has already closed over this
- * object by the time this runs, and the launch reads the origin from it.
- */
 export async function ensureMetroReachable({
   ctx,
   metroPort,
@@ -1193,8 +899,6 @@ export async function ensureMetroReachable({
   gateOrigin?: typeof gateMetroOrigin;
 }): Promise<{ ok: true } | { failed: string; remedy: string; code?: string }> {
   const { root } = ctx;
-  // The gate probes a platform-specific bundle path; ios is the shape both
-  // dev servers answer when a context predates the android wiring.
   const platform = ctx.platform ?? 'ios';
   const publicMetroUrl = env[PUBLIC_METRO_ENV]?.trim() || publicUrl || null;
   const recorded = readTunnelRecord(root);
@@ -1211,19 +915,12 @@ export async function ensureMetroReachable({
   });
   if ('failed' in plan) return plan;
 
-  // Act on the plan: an asserted-local origin needs nothing further; the
-  // other two branches produce an origin rn-iso has to arrange itself, and
-  // both are non-local -- see the `gate` decision below.
   let resolvedUrl: string | null = null;
   let gate = false;
   if ('origin' in plan) {
     resolvedUrl = plan.origin;
     gate = plan.gate;
   } else if ('expoTunnel' in plan) {
-    // `start` records the URL the moment Expo's own tunnel comes up (see
-    // supervisor/server-expo.ts); a remote run can only use it, never start
-    // one of its own -- `ios --remote` cannot add `--tunnel` to an
-    // already-running dev server.
     if (!recorded || recorded.kind !== 'expo') {
       return {
         failed:
@@ -1234,9 +931,6 @@ export async function ensureMetroReachable({
     resolvedUrl = recorded.url;
     gate = true;
   } else {
-    // { start: provider }. `start --remote` owns provider startup. The device
-    // command only accepts its live record, so retries cannot create a second
-    // process that has no teardown record.
     const port = Number(metroPort);
     const providerMatches = tunnelMode === 'auto' || (recorded?.kind === 'managed' && recorded.provider === plan.start);
     if (
@@ -1256,11 +950,6 @@ export async function ensureMetroReachable({
     gate = true;
   }
 
-  // The gate, before anything billable. `resolvedUrl` is a SECOND address for
-  // the reserved port -- an operator's own, Expo's, or a managed one -- and
-  // none of them are proven to still reach THIS workspace without it (see
-  // engine/metro-gate.ts's header for the tunnel-outlived-the-reservation bug
-  // this closes).
   if (gate && resolvedUrl) {
     const logsDir = workspaceLogsDir(root);
     const result = await gateOrigin({

--- a/packages/rn-iso/src/engine/device-remote.ts
+++ b/packages/rn-iso/src/engine/device-remote.ts
@@ -485,6 +485,7 @@ function defaultLookupAgentDevice(): string | null {
   return file || null;
 }
 
+// eas sim can return before its agent-device endpoint exists; cloud VM boot can take minutes.
 const DAEMON_WAIT_MS = 180_000;
 const DAEMON_POLL_MS = 5_000;
 
@@ -676,6 +677,7 @@ function notConnected(code: string): OpFailure {
   };
 }
 
+// EAS retains remoteConfig after STOPPED, so reuse also requires a live status.
 const LIVE_STATUSES = new Set(['NEW', 'IN_PROGRESS']);
 
 function readLiveDaemon(ctx: RemoteContext, sessionId: string): RemoteDaemon | null {
@@ -742,6 +744,7 @@ export function remoteIosDeps(ctx: RemoteContext): {
   };
 }
 
+// adb reverse and 10.0.2.2 resolve on the remote host, so Android uses the public Metro origin.
 export function remoteAndroidDeps(ctx: RemoteContext): {
   ctx: RemoteContext;
   checkCapacity: () => null;

--- a/packages/rn-iso/src/engine/eas-simulator.ts
+++ b/packages/rn-iso/src/engine/eas-simulator.ts
@@ -69,6 +69,7 @@ export function createSessionArgs({
   platform: 'ios' | 'android';
   maxDurationMinutes?: number | null;
 }): string[] {
+  // eas-cli's default output writes .env.eas-simulator; env output keeps project files unchanged.
   const args = [
     'sim',
     '--platform',
@@ -89,6 +90,7 @@ export function getSessionArgs(sessionId: string): string[] {
 }
 
 export function stopSessionArgs(sessionId: string): string[] {
+  // eas-cli otherwise selects the session in .env.eas-simulator, which can belong to another worktree.
   return ['simulator:stop', '--id', sessionId, '--json', '--non-interactive'];
 }
 
@@ -109,6 +111,7 @@ export function listOwnedSessionsArgs(after: string | null = null): string[] {
 
 export function remoteDaemonFrom(config: unknown): RemoteDaemon | null {
   if (!isRecord(config)) return null;
+  // eas sim --json omits GraphQL __typename, so the agent-device URL and token identify the variant.
   const typename = str(config['__typename']);
   if (typename && typename !== 'AgentDeviceRunSessionRemoteConfig') return null;
   const baseUrl = str(config.agentDeviceRemoteSessionUrl);

--- a/packages/rn-iso/src/engine/eas-simulator.ts
+++ b/packages/rn-iso/src/engine/eas-simulator.ts
@@ -1,37 +1,9 @@
-// src/engine/eas-simulator.ts -- the EAS Simulator session, which is how a
-// remote device comes into existence.
-//
-// rn-iso does not drive the remote simulator through eas-cli. It only uses
-// eas-cli to CREATE, READ and DESTROY the session; everything after that
-// speaks to the agent-device daemon the session hands back. That split is
-// what lets one backend serve both EAS Simulator and a self-hosted
-// `agent-device proxy`, which produce the same two values.
-//
-// Every shape below is eas-cli's own, read from its source rather than from
-// docs, and cited where it is parsed:
-//   packages/eas-cli/src/commands/simulator/index.ts
-//     printJsonOnlyOutput({id, name, type, deviceRunSessionUrl, remoteConfig})
-//   packages/eas-cli/src/simulator/utils.ts
-//     getRemoteSessionEnvironmentVariables() -- the AgentDevice branch is the
-//     only one carrying agentDeviceRemoteSessionUrl / ...Token
-//   packages/eas-cli/src/commands/simulator/list.ts   {sessions, pageInfo}
-//   packages/eas-cli/src/commands/simulator/stop.ts   {id, status}
-//
-// NOTHING HERE PERSISTS THE TOKEN. The session id is the durable handle; the
-// token is re-read per command via `simulator:get`. A state file or a pasted
-// build log must never carry a live credential.
 import { sanitizeDeviceLabel } from '../sim/ios.ts';
 
-// The prefix that marks a session as rn-iso's own. Identical in role to the
-// `rn-iso-` simulator-name prefix the local backend checks before it shuts
-// anything down: ownership is decided by name, not by a record we might have
-// got wrong.
 const OWNED_PREFIX = 'rn-iso-';
 
-// eas-cli's own status values, lower-cased as its --status flag accepts them.
 const LIVE_STATUSES = ['new', 'in-progress'] as const;
 
-/** The two values an agent-device client needs, plus the human preview link. */
 export interface RemoteDaemon {
   baseUrl: string;
   token: string;
@@ -79,34 +51,15 @@ const LIVE_SESSION_STATUSES = new Set(['NEW', 'IN_PROGRESS']);
 const TERMINAL_SESSION_STATUSES = new Set(['STOPPED', 'ERRORED']);
 const SESSION_PLATFORMS = new Set(['ios', 'android']);
 
-// PURE. The `rn-iso-` prefix is the ownership marker, so it is not optional.
-// A label that already carries it (a worktree literally named `rn-iso-test`)
-// would otherwise produce `rn-iso-rn-iso-test`, so strip one leading copy
-// before prefixing. Same rule, and the same reasoning, as ownedSimName.
 export function ownedSessionName(label: string): string {
   const clean = sanitizeDeviceLabel(label);
   return `${OWNED_PREFIX}${clean.startsWith(OWNED_PREFIX) ? clean.slice(OWNED_PREFIX.length) : clean}`;
 }
 
-// PURE. Defense in depth for every destructive path, exactly as
-// resolveOwnedIosSim's name check is: a session rn-iso did not name is a
-// session rn-iso must not stop.
 export function isOwnedSessionName(name: string | null | undefined): name is string {
   return typeof name === 'string' && name.startsWith(OWNED_PREFIX);
 }
 
-// PURE. argv for `eas`, creating a detached session.
-//
-// `--out-config-type env` is load-bearing, not a preference. The default,
-// `dotenv`, writes `.env.eas-simulator` INTO THE PROJECT DIRECTORY, and it
-// does so even under --json (commands/simulator/index.ts, the
-// writeSimulatorEnvSafelyAsync call after the poll loop). rn-iso does not
-// edit a project's files -- the same rule engine/remote-cache.ts states for
-// the build-cache provider -- so the config is printed and parsed instead.
-//
-// `--json --non-interactive` together make the command PRINT and RETURN
-// rather than block until the session ends, which is what lets the session
-// outlive the command that made it, the same way the supervisor does.
 export function createSessionArgs({
   label,
   platform,
@@ -131,23 +84,14 @@ export function createSessionArgs({
   return args;
 }
 
-// PURE. argv reading one session back, which is how the token is obtained
-// without ever having stored it.
 export function getSessionArgs(sessionId: string): string[] {
   return ['simulator:get', '--id', sessionId, '--json', '--non-interactive'];
 }
 
-// PURE. argv destroying one session.
-//
-// `--id` is always passed. Without it `simulator:stop` falls back to whatever
-// session `.env.eas-simulator` names, which in a repo with several worktrees
-// is a live session belonging to a different one.
 export function stopSessionArgs(sessionId: string): string[] {
   return ['simulator:stop', '--id', sessionId, '--json', '--non-interactive'];
 }
 
-// PURE. argv listing rn-iso's own LIVE sessions, which is what `gc` sweeps.
-// A stopped or errored session costs nothing and is not a leak.
 export function listOwnedSessionsArgs(after: string | null = null): string[] {
   const args = [
     'simulator:list',
@@ -163,34 +107,8 @@ export function listOwnedSessionsArgs(after: string | null = null): string[] {
   return args;
 }
 
-// PURE. The daemon coordinates, or null.
-//
-// Takes `unknown` because eas-cli's remoteConfig is genuinely dynamic
-// third-party output, narrowed field by field below rather than trusted
-// wholesale.
-//
-// IDENTIFIED BY ITS FIELDS, NOT BY __typename. eas-cli's own source switches
-// on `remoteConfig.__typename` to tell the union members apart, and an
-// earlier version of this function copied that -- but __typename exists only
-// on the in-memory GraphQL object. The JSON that `--json` prints does not
-// carry it, verified against a live session:
-//
-//   "remoteConfig": {
-//     "agentDeviceRemoteSessionUrl": "https://...ngrok.dev",
-//     "agentDeviceRemoteSessionToken": "...",
-//     "webPreviewUrl": "https://..."
-//   }
-//
-// so requiring it rejected every real agent-device session. The two fields
-// below ARE the discriminator: no other member of the union has them.
-//
-// Returns null rather than a partial record for a session of another type
-// (appium, argent, serve-sim). Those are real sessions this backend cannot
-// speak to, and a half-filled RemoteDaemon would fail later and further away.
 export function remoteDaemonFrom(config: unknown): RemoteDaemon | null {
   if (!isRecord(config)) return null;
-  // Honoured when present -- a caller reading the GraphQL object directly
-  // still gets the strict answer -- but never required.
   const typename = str(config['__typename']);
   if (typename && typename !== 'AgentDeviceRunSessionRemoteConfig') return null;
   const baseUrl = str(config.agentDeviceRemoteSessionUrl);
@@ -202,10 +120,6 @@ export function remoteDaemonFrom(config: unknown): RemoteDaemon | null {
   return daemon;
 }
 
-// Every parse below returns a value or null/[] and never throws: eas-cli
-// prints diagnostics to stderr under --json, but a version bump, an auth
-// prompt or an outage can still put something unparseable on stdout, and a
-// device backend must not die reading it.
 function parseJson(stdout: string): unknown {
   try {
     return JSON.parse(stdout) as unknown;
@@ -222,7 +136,6 @@ function str(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-// PURE. Authorizes teardown from the current server record, not the stored id.
 export function inspectSessionForTeardown(stdout: string, sessionId: string): SessionTeardownInspection {
   const data = parseJson(stdout);
   if (!isRecord(data)) {
@@ -249,7 +162,6 @@ export function inspectSessionForTeardown(stdout: string, sessionId: string): Se
   return { action: 'stop', name, status };
 }
 
-// PURE. Only a session-specific missing result proves the stored resource is gone.
 export function isDefinitiveMissingSessionError(error: unknown, sessionId: string): boolean {
   const candidate = error as { stderr?: unknown; message?: unknown };
   const stderr = typeof candidate?.stderr === 'string' ? candidate.stderr : '';
@@ -280,8 +192,6 @@ export function verifyStoppedSession(stdout: string, sessionId: string): { ok: t
   return { ok: true };
 }
 
-// PURE. `eas sim --json` stdout -> the session, or null if there is no id.
-// No id means no session was created, whatever else the payload says.
 export function parseCreatedSession(stdout: string): CreatedSession | null {
   const data = parseJson(stdout);
   if (!isRecord(data)) return null;
@@ -295,9 +205,6 @@ export function parseCreatedSession(stdout: string): CreatedSession | null {
   };
 }
 
-// PURE. `eas simulator:list --json` stdout -> the sessions.
-// A record with no id cannot be acted on, so it is dropped rather than
-// carried as a partial that a later stop would fail on.
 export function parseSessionList(stdout: string): SessionSummary[] {
   const data = parseJson(stdout);
   if (!isRecord(data) || !Array.isArray(data.sessions)) return [];
@@ -335,9 +242,6 @@ export function parseSessionListPage(
   };
 }
 
-// PURE. Selects active sessions carrying rn-iso's ownership prefix that no
-// readable workspace state references. The EAS list is scoped by its cwd, so
-// every returned row carries that project directory as its explicit scope.
 export function findOrphanedOwnedSessions({
   sessions,
   recordedSessionIds,
@@ -432,7 +336,6 @@ export function findOrphanedOwnedSessions({
   return { orphaned: [...candidates.values()], notices };
 }
 
-// PURE. `eas simulator:stop --json` stdout -> what eas confirmed.
 export function parseStoppedSession(stdout: string): StoppedSession | null {
   const data = parseJson(stdout);
   if (!isRecord(data)) return null;

--- a/packages/rn-iso/src/engine/eas-simulator.ts
+++ b/packages/rn-iso/src/engine/eas-simulator.ts
@@ -81,6 +81,7 @@ export function createSessionArgs({
     '--name',
     ownedSessionName(label),
   ];
+  // EAS duration limits vary by account, so omit the flag unless the caller sets a limit.
   if (maxDurationMinutes) args.push('--max-duration-minutes', String(maxDurationMinutes));
   return args;
 }

--- a/packages/rn-iso/src/engine/metro-gate.ts
+++ b/packages/rn-iso/src/engine/metro-gate.ts
@@ -1,33 +1,7 @@
-// src/engine/metro-gate.ts -- proving that an address actually reaches THIS
-// workspace's Metro, before anything expensive depends on it.
-//
-// WHY THIS EXISTS. The local Metro gate checks the reserved port for IDENTITY,
-// not occupancy: resolveProjectMetro proves the process listening there
-// belongs to this project and reports `notOurs: foreign-cwd` when it does not,
-// precisely so a foreign bundler cannot serve this app. A public URL is a
-// SECOND address for that same brokered resource, and it arrived with no such
-// check. Observed live: a tunnel built for port 8085 outlived the reservation,
-// another workspace took 8085, and the tunnel then published THAT project's
-// dev server -- healthy, answering, and wrong.
-//
-// HOW IT PROVES IT. Not by asking the address what it is; a foreign Metro
-// answers `/status` exactly like ours. It asks for a BUNDLE through the
-// address and then watches THIS workspace's own NDJSON log for the request
-// arriving. That is the same evidence verifyLaunch uses to prove a launch
-// reached this dev server, reused one step earlier -- so the gate cannot
-// disagree with the verification that follows it.
-//
-// The request is abandoned as soon as the proof lands: what is being measured
-// is that the bytes were ASKED FOR here, not that they arrived back. Metro
-// logs the build on start, so the answer comes long before four megabytes of
-// bundle would.
 import type { NdjsonRecord } from '../ndjson.ts';
 
 export const REMOTE_METRO_WRONG = 'RN_ISO_REMOTE_METRO_WRONG';
 
-// Long enough for a cold Metro to start building a large graph, short enough
-// that a dead tunnel does not hold up a run for a minute. A cold bundle can
-// take longer to FINISH, but the event this waits for is logged at start.
 const GATE_TIMEOUT_MS = 25_000;
 const POLL_MS = 250;
 
@@ -44,22 +18,14 @@ export interface GateOptions {
   metroPort: number | string;
   platform: 'ios' | 'android';
   entryPoint?: string;
-  /** Reads this workspace's Metro records, newest included. */
   readRecords: () => NdjsonRecord[];
-  /** True when a record proves a bundle was requested after `since`. */
   isProof: (record: NdjsonRecord, since: number) => boolean;
-  /** Status code only, or null when the request never landed. */
   probe?: (url: string, signal: AbortSignal) => Promise<number | null>;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   timeoutMs?: number;
 }
 
-// The bundle path differs between an Expo dev server and a bare one, but both
-// answer this: Expo rewrites /index.bundle onto its virtual entry, and bare RN
-// serves it directly. `dev=true` keeps it in the same cache bucket the app
-// will use, so the probe warms exactly the bundle the launch then wants
-// instead of building a second one.
 export function probeBundleUrl(origin: string, platform: 'ios' | 'android', entryPoint = 'index'): string {
   const entry = entryPoint.replace(/^\/+/, '').replace(/\.(?:[cm]?[jt]sx?)$/, '');
   return `${origin.replace(/\/+$/, '')}/${entry}.bundle?platform=${platform}&dev=true`;
@@ -74,13 +40,6 @@ const defaultProbe = async (url: string, signal: AbortSignal): Promise<number | 
   }
 };
 
-/**
- * Prove `origin` reaches THIS workspace's Metro, or refuse.
- *
- * Fails CLOSED. An address that cannot be proven is treated as the wrong
- * address, because the failure it guards against is silent: the app loads
- * another project's bundle and everything downstream looks fine.
- */
 export async function gateMetroOrigin({
   origin,
   metroPort,
@@ -95,10 +54,6 @@ export async function gateMetroOrigin({
 }: GateOptions): Promise<GateResult> {
   const since = now();
   const controller = new AbortController();
-  // Deliberately not awaited: the proof is the log entry, not the response.
-  // A rejection here is not a failure on its own -- aborting the request once
-  // the proof lands rejects it by design -- so the outcome is decided purely
-  // by what reached the log.
   const request = probe(probeBundleUrl(origin, platform, entryPoint), controller.signal);
   void request.catch(() => {});
 
@@ -126,8 +81,6 @@ export async function gateMetroOrigin({
   };
 }
 
-// PURE. What the probe's outcome says about the address, which is more useful
-// than "no proof arrived" on its own.
 export function describeMiss(origin: string, metroPort: number | string, status: number | null): string {
   if (status === null) {
     return `${origin} did not answer, so it cannot be this workspace's Metro (port ${metroPort}).`;
@@ -135,6 +88,5 @@ export function describeMiss(origin: string, metroPort: number | string, status:
   if (status >= 500) {
     return `${origin} answered ${status}, so it reached a tunnel but not a dev server (port ${metroPort} may no longer be forwarded).`;
   }
-  // The dangerous case: something healthy answered, and it was not us.
   return `${origin} answered ${status}, but the request never reached THIS workspace's Metro on port ${metroPort} -- it is serving a different dev server.`;
 }

--- a/packages/rn-iso/src/engine/metro-reach.ts
+++ b/packages/rn-iso/src/engine/metro-reach.ts
@@ -1,39 +1,12 @@
-// src/engine/metro-reach.ts -- how a REMOTE device reaches this workspace's
-// Metro, decided in one place.
-//
-// This exists because the question has several right answers and one very
-// wrong one, and the wrong one used to be the default. rn-iso previously
-// INFERRED "the device is on this machine" from "the daemon URL is loopback"
-// (isLoopbackDaemon). Those are not the same fact: `ssh -L 4310:localhost:4310
-// macmini` makes a REMOTE daemon loopback-reachable, and the inference then
-// pointed the app at `localhost:<port>`, which resolves on the Mac mini. Same
-// silent wrong-Metro class as a stale tunnel.
-//
-// So nothing is inferred here. The policy is declared, and `auto` -- the
-// default -- assumes the device is somewhere else, which is the safe
-// direction: a device that CAN reach localhost loses nothing by being handed
-// a tunnel, while a device that cannot loses the whole run.
-
-/** How the device is expected to reach Metro. */
 export type TunnelMode = 'auto' | 'off' | 'expo' | 'cloudflared' | 'ngrok';
 
 export const TUNNEL_MODES: readonly TunnelMode[] = ['auto', 'off', 'expo', 'cloudflared', 'ngrok'];
 
-/** The public Metro origin passed from `start` to remote device commands. */
 export const PUBLIC_METRO_ENV = 'RN_ISO_METRO_PUBLIC_URL';
 
-/** The tunnel providers rn-iso can start and reap itself. */
 const MANAGED_PROVIDERS = ['ngrok', 'cloudflared'] as const;
 export type ManagedProvider = (typeof MANAGED_PROVIDERS)[number];
 
-/**
- * What the caller must do to give the device an address for Metro.
- *
- *   { origin }            already known -- use it, no tunnel to start
- *   { expoTunnel: true }  the dev server carries it (`expo start --tunnel`)
- *   { start: provider }   rn-iso starts, records and reaps this one
- *   { failed, remedy }    nothing available; refuse with something actionable
- */
 export type ReachPlan =
   | { origin: string; gate: boolean }
   | { expoTunnel: true }
@@ -43,11 +16,8 @@ export type ReachPlan =
 export interface ReachInputs {
   mode: TunnelMode;
   metroPort: number | string;
-  /** An address the operator supplied: a stable tunnel, or a setting. */
   publicUrl?: string | null;
-  /** Whether this workspace's dev server is Expo's (it can tunnel itself). */
   isExpo: boolean;
-  /** Which managed providers are on PATH, most preferred first. */
   available?: readonly ManagedProvider[];
 }
 
@@ -56,34 +26,13 @@ const NAMED: Record<string, string> = {
   ngrok: '`ngrok` (brew install ngrok, then `ngrok config add-authtoken <token>`)',
 };
 
-/**
- * PURE. Decide how the device will reach Metro.
- *
- * Order matters and each step earns its place:
- *
- * 1. `off` is the operator ASSERTING the device shares this host -- a
- *    same-machine `agent-device proxy`. It is the one case that needs no
- *    tunnel and no gate, because localhost genuinely is the answer. It must
- *    be declared rather than detected, which is the whole point of this file.
- * 2. An explicit URL wins over starting anything: the operator already built
- *    a tunnel, and a second one would be waste. It IS gated, because an
- *    address rn-iso did not create is an address it cannot vouch for.
- * 3. Explicit `expo` mode lets Expo tunnel its own dev server.
- * 4. Otherwise rn-iso starts a managed provider, preferring whichever one
- *    the caller ranked first.
- */
 export function planMetroReach({ mode, metroPort, publicUrl = null, isExpo, available = [] }: ReachInputs): ReachPlan {
   const named = publicUrl?.trim().replace(/\/+$/, '') || null;
 
   if (mode === 'off') {
-    // Asserted local: no tunnel, and no gate to run -- there is no third
-    // party in the path to have got wrong.
     return { origin: `http://localhost:${metroPort}`, gate: false };
   }
 
-  // An operator-supplied address is used whatever the mode says, because
-  // starting a tunnel to a port that already has one is pure waste. It is
-  // gated: rn-iso did not create it and cannot vouch for what it reaches.
   if (named) return { origin: named, gate: true };
 
   if (mode === 'expo') {
@@ -106,7 +55,6 @@ export function planMetroReach({ mode, metroPort, publicUrl = null, isExpo, avai
     return { start: mode };
   }
 
-  // auto, on a bare RN workspace.
   const provider = available[0];
   if (provider) return { start: provider };
   return {
@@ -118,17 +66,6 @@ export function planMetroReach({ mode, metroPort, publicUrl = null, isExpo, avai
   };
 }
 
-/**
- * Which managed providers this machine can actually start, most preferred
- * first.
- *
- * ngrok outranks cloudflared deliberately. A cloudflared quick tunnel needs no
- * account, which is why it is the easy suggestion, but it hands back a new
- * random hostname every run and takes MINUTES to become routable -- long
- * enough that it reads as broken, which cost real debugging time here. ngrok
- * routes immediately and can hold a reserved domain. Whichever is present
- * wins; when both are, the faster one does.
- */
 export function detectProviders(onPath: (bin: string) => boolean): ManagedProvider[] {
   return MANAGED_PROVIDERS.filter((p) => onPath(p));
 }

--- a/packages/rn-iso/src/engine/metro-reach.ts
+++ b/packages/rn-iso/src/engine/metro-reach.ts
@@ -4,6 +4,7 @@ export const TUNNEL_MODES: readonly TunnelMode[] = ['auto', 'off', 'expo', 'clou
 
 export const PUBLIC_METRO_ENV = 'RN_ISO_METRO_PUBLIC_URL';
 
+// Prefer ngrok because Cloudflare quick tunnels can take minutes to become routable.
 const MANAGED_PROVIDERS = ['ngrok', 'cloudflared'] as const;
 export type ManagedProvider = (typeof MANAGED_PROVIDERS)[number];
 

--- a/packages/rn-iso/src/engine/tunnel.ts
+++ b/packages/rn-iso/src/engine/tunnel.ts
@@ -48,11 +48,13 @@ export function tunnelArgv(
 const CLOUDFLARED_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
 
 export function parseCloudflaredLine(line: string): string | null {
+  // cloudflared prints the quick-tunnel URL inside a stderr banner.
   const match = line.match(CLOUDFLARED_URL_RE);
   return match ? match[0] : null;
 }
 
 export function parseNgrokLine(line: string): string | null {
+  // ngrok --log-format=json emits the public URL in a line-level url field.
   let data: unknown;
   try {
     data = JSON.parse(line);
@@ -70,6 +72,7 @@ function parserFor(provider: ManagedProvider): (line: string) => string | null {
 
 const URL_TIMEOUT_MS = 15_000;
 
+// Cloudflare quick tunnels can take minutes to become routable after printing their URL.
 const REACHABLE_TIMEOUT_MS = 4 * 60_000;
 const REACHABLE_POLL_MS = 2_000;
 

--- a/packages/rn-iso/src/engine/tunnel.ts
+++ b/packages/rn-iso/src/engine/tunnel.ts
@@ -1,19 +1,3 @@
-// src/engine/tunnel.ts -- the lifecycle of a tunnel rn-iso starts for itself:
-// launch the provider named by engine/metro-reach.ts's `{ start: provider }`
-// plan, read the provider's own address back out of its (untrusted) output,
-// optionally prove that address serves, and reap the process again on `stop`.
-//
-// A provider PRINTING its URL is not the same fact as that URL being routable.
-// A cloudflared quick tunnel can take minutes to register with Cloudflare's
-// edge after its connection log appears. `requireReachable` selects the
-// startup contract: URL-only when Metro is not running yet, or a reachable URL
-// when it is.
-//
-// Parsing is kept pure and separate from invocation (CLAUDE.md item 3):
-// `parseCloudflaredLine` / `parseNgrokLine` take one line of a provider's
-// output and return a URL or null, with no process, no clock and no network
-// in sight, so the untrusted-output handling is tested without spawning
-// anything.
 import type { ChildProcess } from 'node:child_process';
 import { closeSync, mkdirSync, openSync, readFileSync, readSync, unlinkSync } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
@@ -25,13 +9,8 @@ import { createLineReader } from '../process-output.ts';
 import type { ManagedProvider } from './metro-reach.ts';
 import { withWorkspaceProcessLock, type WorkspaceProcessLockOptions } from './workspace-process-lock.ts';
 
-// The signature every spawn-injection seam in this module accepts:
-// getExecutor().spawn's shape, loosened to a plain options bag so callers do
-// not have to import SpawnOptions (same seam as engine/gradle.ts and
-// engine/deps.ts).
 type SpawnFn = (cmd: string, args: string[], opts: Record<string, unknown>) => ChildProcess;
 
-/** What `stop` needs to reap a tunnel this module started. */
 export interface TunnelRecord {
   provider: ManagedProvider;
   pid: number;
@@ -42,9 +21,6 @@ export interface TunnelRecord {
   logFile?: string | null;
 }
 
-// --- pure: argv and the untrusted-output parsers ---------------------------
-
-/** PURE. The argv rn-iso runs for a managed provider's own binary. */
 export function tunnelArgv(
   provider: ManagedProvider,
   port: number,
@@ -71,22 +47,11 @@ export function tunnelArgv(
 
 const CLOUDFLARED_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
 
-/**
- * PURE. cloudflared prints its quick-tunnel URL on STDERR inside a banner
- * line, not as a line of its own, so this matches the URL anywhere in the
- * line rather than requiring the whole line to be the URL.
- */
 export function parseCloudflaredLine(line: string): string | null {
   const match = line.match(CLOUDFLARED_URL_RE);
   return match ? match[0] : null;
 }
 
-/**
- * PURE. ngrok's `--log-format=json` prints one JSON object per line; the
- * tunnel's address is whichever line carries a `url` field. Parsed
- * defensively -- this is untrusted third-party output, and a provider
- * version bump that changes the schema must not throw.
- */
 export function parseNgrokLine(line: string): string | null {
   let data: unknown;
   try {
@@ -103,23 +68,12 @@ function parserFor(provider: ManagedProvider): (line: string) => string | null {
   return provider === 'cloudflared' ? parseCloudflaredLine : parseNgrokLine;
 }
 
-// --- starting a tunnel -------------------------------------------------
-
-// Long enough for a slow-starting binary to print its banner, short enough
-// that a provider which will never print a URL (wrong version, no account
-// configured) is reported as a failure rather than left hanging.
 const URL_TIMEOUT_MS = 15_000;
 
-// A cloudflared quick tunnel is the case that needs minutes, not seconds; see
-// the header. ngrok routes immediately, but the same generous timeout is
-// applied to both rather than branching per provider, because a slow network
-// path can make either one late.
 const REACHABLE_TIMEOUT_MS = 4 * 60_000;
 const REACHABLE_POLL_MS = 2_000;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
-// --- serializing one managed acquisition per workspace --------------------
 
 export async function withManagedTunnelLock<T>(
   root: string,
@@ -177,9 +131,6 @@ function managedRemoteWorktreeLockRoot(worktreeRoot: string): string {
   return join(getConfigDir(), 'process-locks', 'worktrees', key);
 }
 
-// Any HTTP response -- even a 404 from Metro's own router -- proves the
-// tunnel forwards traffic to something behind it; only a connection failure
-// means it is not routable yet.
 async function defaultProbeReachable(url: string, signal: AbortSignal): Promise<boolean> {
   try {
     const res = await fetch(url, { signal, redirect: 'follow' });
@@ -189,9 +140,6 @@ async function defaultProbeReachable(url: string, signal: AbortSignal): Promise<
   }
 }
 
-// Races the child's own stdout/stderr against its exit and a bounded
-// timeout. A provider that dies, or that never prints a matching line, ends
-// this the same way: url is null.
 function waitForUrl(
   child: ChildProcess,
   parseLine: (line: string) => string | null,
@@ -293,9 +241,6 @@ function removeRecordedTunnelLogFile(path: string | null | undefined): void {
   removeTunnelLogFile(resolved);
 }
 
-// Polls `url` until something answers or `timeoutMs` runs out. `now`/`sleep`
-// are the same clock-injection seam engine/metro-gate.ts uses, so a test
-// drives a four-minute timeout without spending four minutes.
 async function waitUntilReachable({
   url,
   now,
@@ -354,15 +299,6 @@ export type StartTunnelResult =
 const CLEANUP_TIMEOUT_MS = 1_000;
 const CLEANUP_POLL_MS = 25;
 
-/**
- * Start `provider`'s own binary against `port`, wait for it to print its
- * URL, then prove the URL actually serves before reporting success. Never
- * throws: every failure path (the binary would not start, it never printed a
- * URL, the URL never became reachable) is a returned `{ failed, reason }`.
- *
- * The process is left running, detached from this one, on success -- it is
- * `stopTunnel`'s job to reap it, not this call's caller exiting.
- */
 export async function startTunnel({
   provider,
   port,
@@ -387,9 +323,6 @@ export async function startTunnel({
   try {
     child = spawn(bin, args, {
       stdio: outputFile ? ['ignore', 'ignore', 'ignore'] : ['ignore', 'pipe', 'pipe'],
-      // Detached: the tunnel outlives this call, exactly like the
-      // supervisor it fronts, and leads its own process group so `stopTunnel`
-      // can signal it without reaching whatever spawned it.
       detached: true,
     });
   } catch (err) {
@@ -456,7 +389,6 @@ export async function startTunnel({
   }
   if (!outputFile) resumeChildPipes(child);
 
-  // Reachable startup proves that the discovered URL forwards traffic.
   if (requireReachable) {
     const reachable = await waitUntilReachable({
       url,
@@ -503,7 +435,6 @@ export type StartTunnelSequenceResult =
     }
   | { failed: true; reason: string };
 
-/** Try the selected providers in order until one returns a public URL. */
 export async function startTunnelSequence({
   providers,
   port,
@@ -612,8 +543,6 @@ export async function terminateChild(
 function describe(err: unknown): string {
   return (err as Error)?.message || String(err);
 }
-
-// --- stopping a tunnel -------------------------------------------------
 
 export interface StopTunnelOptions {
   isAlive?: (pid: number) => boolean;
@@ -826,12 +755,6 @@ function matchesTunnelProcess(record: TunnelRecord, args: readonly string[]): bo
   return sameArgs(commandArgs, tunnelArgv('cloudflared', record.port, null, record.logFile).args);
 }
 
-/**
- * Reap a tunnel `startTunnel` started. Idempotent and never throws: a
- * missing or already-dead pid is `missing`, not an error, and a signal that
- * does not take effect is a returned `failed` status rather than a thrown
- * one (CLAUDE.md item 4's containment rule).
- */
 export async function stopTunnel(
   record: TunnelRecord | null | undefined,
   {

--- a/packages/rn-iso/src/engine/tunnel.ts
+++ b/packages/rn-iso/src/engine/tunnel.ts
@@ -137,6 +137,7 @@ function managedRemoteWorktreeLockRoot(worktreeRoot: string): string {
 async function defaultProbeReachable(url: string, signal: AbortSignal): Promise<boolean> {
   try {
     const res = await fetch(url, { signal, redirect: 'follow' });
+    // Any HTTP response proves the tunnel is routable; only a connection failure means unavailable.
     return res.status > 0;
   } catch {
     return false;

--- a/packages/rn-iso/src/exec.ts
+++ b/packages/rn-iso/src/exec.ts
@@ -2,23 +2,8 @@ import { type ChildProcess, type SpawnOptions, execFileSync, execSync, spawn } f
 
 interface ExecOptions {
   timeoutMs?: number;
-  // The working directory the child runs in. Needed by anything whose
-  // arguments are RELATIVE to a directory this codebase staged -- `zip -0 -r
-  // <apk> assets` writes archive entries at paths relative to the cwd, which
-  // is the whole mechanism engine/apk-swap.js uses to put the bundle back at
-  // assets/index.android.bundle -- and by a tool that resolves its target from
-  // the working directory with no positional for it, which is how `eas sim`
-  // finds the project (unlike `expo config --json <root>`). Unset means
-  // "inherit", exactly as before.
   cwd?: string;
-  // Extra variables for the child, MERGED over process.env rather than
-  // replacing it -- a child handed a bare env loses PATH and cannot find the
-  // tools it shells out to itself. This exists so a credential can be handed
-  // to one child process without being written anywhere: the remote device
-  // passes AGENT_DEVICE_DAEMON_AUTH_TOKEN this way.
   env?: Record<string, string>;
-  // Variables removed from the effective child environment after inherited
-  // and extra variables are combined.
   omitEnv?: readonly string[];
 }
 
@@ -42,9 +27,6 @@ const defaultExecutor: Executor = {
     if (cwd) opts.cwd = cwd;
     return String(execSync(cmd, opts)).trim();
   },
-  // No shell, so an argument carrying a space, a quote, or a `$` reaches the
-  // program as one literal argument. Use this whenever an argument is a path
-  // the user chose rather than a string this codebase composed.
   runFile(file, args = [], { timeoutMs, cwd, env, omitEnv } = {}) {
     const opts: Parameters<typeof execFileSync>[2] = {
       encoding: 'utf-8',

--- a/packages/rn-iso/src/reclaim.ts
+++ b/packages/rn-iso/src/reclaim.ts
@@ -25,19 +25,6 @@ function reapCollectors(root: string): void {
   }
 }
 
-// End the remote session this workspace created, while the workspace still
-// exists.
-//
-// TIMING IS THE WHOLE CONSTRAINT. The session id lives in global workspace
-// state, and `eas simulator:stop` needs a project
-// directory to run in (its contextDefinition includes ProjectDir). Both are
-// gone the moment `git worktree remove` runs, so this must happen HERE, in
-// the shared reclaim that precedes the caller's removal step -- not in the
-// caller afterwards.
-//
-// Unlike a local simulator, a remote session is not occupancy-checked and is
-// never spared: it bills until its max duration, and the project that owned
-// it is going away.
 function reclaimRemoteSession(
   root: string,
   { stopSession = defaultStopSession }: { stopSession?: StopSession } = {},
@@ -48,9 +35,6 @@ function reclaimRemoteSession(
   try {
     result = stopSession(root, sessionId);
   } catch (err) {
-    // Contained for the same reason every teardown here is: a throw would
-    // abort the reclaim before the caller's removal step, and re-running
-    // would hit it forever.
     result = { status: 'failed', reason: String((err as Error)?.message ?? err) };
   }
   if (result.status === 'torn-down') {
@@ -85,17 +69,6 @@ function defaultStopSession(root: string, sessionId: string) {
   return endRecordedSession({ root, sessionId, easBin: resolveEasCliBin(root)?.file ?? null });
 }
 
-// End a tunnel `ios`/`android --remote` started for itself (a managed
-// provider; engine/tunnel.ts), for the same timing reason reclaimRemoteSession
-// runs here rather than in the caller: the record lives in the global
-// workspace directory, which `worktree remove` deletes.
-//
-// Unconditional, like the remote session -- not gated by deleteOwnedDevices.
-// That flag guards DESTROYING a local device, a real choice because a
-// shut-down simulator can be booted again; a tunnel process left running here
-// is simply leaked, since nothing else will ever reap it once its workspace
-// is gone. An Expo-hosted tunnel (kind 'expo') has no process of its own: it
-// dies with the expo child, which stopping the supervisor already ends.
 type StopMetroTunnelFn = (record: ManagedTunnelRecord) => Promise<StopTunnelResult>;
 
 function defaultStopMetroTunnel(record: ManagedTunnelRecord): Promise<StopTunnelResult> {
@@ -112,9 +85,6 @@ async function reclaimMetroTunnel(
   try {
     result = await stopMetroTunnel(record);
   } catch (err) {
-    // Contained for the same reason every teardown here is: a throw would
-    // abort the reclaim before the caller's removal step, and re-running
-    // would hit it forever.
     result = { status: 'failed', reason: String((err as Error)?.message ?? err) };
   }
   if (result.status === 'failed') {
@@ -142,9 +112,6 @@ async function reclaimMetroTunnel(
   return { stopped: record.provider, failed: null };
 }
 
-// A device this function skipped or failed to tear down: reported alongside
-// `deletedDevices` so a caller can tell what happened to every owned device,
-// not just the ones that went cleanly.
 interface SkippedDevice {
   platform: 'ios' | 'android';
   name: string;
@@ -216,11 +183,7 @@ export interface ReclaimResult {
   skippedDevices: SkippedDevice[];
   failedDevices: SkippedDevice[];
   keptEntry: boolean;
-  // The remote session this reclaim ended, if there was one.
   stoppedSession: string | null;
-  // The managed tunnel (ngrok/cloudflared) this reclaim ended, if there was
-  // one -- the provider name. null when there was none, or it was an
-  // Expo-hosted tunnel with no process of its own.
   stoppedTunnel: string | null;
   removedWorkspaceDirs: string[];
   failedWorkspaceDirs: string[];
@@ -249,30 +212,18 @@ export async function reclaimProject(
     failedDevices: SkippedDevice[];
   } = deleteOwnedDevices ? reclaimOwnedDevices(project) : { deletedDevices: [], skippedDevices: [], failedDevices: [] };
 
-  // Always, not only under deleteOwnedDevices. That flag guards DESTROYING a
-  // local device, which is a real choice because a shut-down simulator can be
-  // booted again. A remote session cannot be handed back: the workspace that
-  // holds its id is going away, so the choice is between ending it now and
-  // paying for it until its cap.
   const remote = reclaimRemoteSession(path, { stopSession });
   if (remote.failed) {
     skippedDevices.push(remote.failed);
     failedDevices.push(remote.failed);
   }
 
-  // Same unconditional treatment for a tunnel this workspace started for
-  // itself: it is not a local device deleteOwnedDevices guards, just a
-  // process nothing else will ever reap once the workspace is gone.
   const tunnel = await reclaimMetroTunnel(path, { stopMetroTunnel });
   if (tunnel.failed) {
     skippedDevices.push(tunnel.failed);
     failedDevices.push(tunnel.failed);
   }
 
-  // A Metro started from a deleted directory can outlive it and squat on the
-  // port, so the port is not genuinely free until the process is gone. Killing
-  // by port alone would repeat the Android console-port mistake, so identity is
-  // proven first and an unidentified listener is reported, never killed.
   let killedPid: number | null = null;
   let skippedMetro: string | null = null;
   if (typeof project?.metroPort === 'number') {

--- a/packages/rn-iso/src/reclaim.ts
+++ b/packages/rn-iso/src/reclaim.ts
@@ -25,6 +25,7 @@ function reapCollectors(root: string): void {
   }
 }
 
+// eas simulator:stop needs a project cwd, so end the session before removing the worktree.
 function reclaimRemoteSession(
   root: string,
   { stopSession = defaultStopSession }: { stopSession?: StopSession } = {},

--- a/packages/rn-iso/src/settings.ts
+++ b/packages/rn-iso/src/settings.ts
@@ -90,17 +90,10 @@ export function resolveSettings({
 
 export const REMOTE_DEVICE_BACKENDS: readonly RemoteDeviceBackend[] = ['proxy', 'eas'] as const;
 
-// Which remote backend this workspace's iOS device uses. Kept beside KNOWN_SETTINGS
-// for the reason stated above: the name of a setting and the code that reads
-// it drifting apart is how `worktree.install` became a silent no-op.
-//
-// Settings are Record<string, unknown> because they come from three JSON
-// layers, so the read narrows rather than asserts.
 export function remoteIosSetting(settings: SettingsObject): RemoteDeviceBackend | null {
   return remoteSetting(settings, 'ios');
 }
 
-// The Android half uses the same explicit backend values.
 export function remoteAndroidSetting(settings: SettingsObject): RemoteDeviceBackend | null {
   return remoteSetting(settings, 'android');
 }
@@ -125,10 +118,6 @@ export function remoteDeviceSettingError(settings: SettingsObject): string | nul
   return null;
 }
 
-// engine/metro-reach.ts's TunnelMode, committed once for the whole repo
-// rather than passed per invocation -- there is no `--tunnel` flag. Readers
-// return null for missing or invalid input; commands validate before using the
-// value so invalid input cannot silently select a default.
 export function tunnelModeSetting(settings: SettingsObject): TunnelMode | null {
   const block = settings.metro;
   if (typeof block !== 'object' || block === null) return null;
@@ -155,8 +144,6 @@ export function metroTunnelSettingError(settings: SettingsObject): string | null
   return null;
 }
 
-// An operator-supplied tunnel URL that already exists. planMetroReach uses
-// this in place of starting one of its own, whatever metro.tunnel says.
 export function publicUrlSetting(settings: SettingsObject): string | null {
   const block = settings.metro;
   if (typeof block !== 'object' || block === null) return null;
@@ -164,10 +151,6 @@ export function publicUrlSetting(settings: SettingsObject): string | null {
   return typeof url === 'string' && url.trim() ? url : null;
 }
 
-// A stable URL for a managed ngrok process. It is deliberately scoped to an
-// explicit ngrok selection: `auto` can fall back to cloudflared, where an
-// ngrok-only URL has no meaning. HTTPS is required because remote development
-// clients must not receive a public clear-text origin.
 export function ngrokUrlSetting(settings: SettingsObject): string | null {
   const block = settings.metro;
   if (typeof block !== 'object' || block === null) return null;

--- a/packages/rn-iso/src/supervisor/run.ts
+++ b/packages/rn-iso/src/supervisor/run.ts
@@ -49,8 +49,6 @@ export function parseArgs(argv: string[]): ParsedSupervisorArgs {
       port = argv[++i];
       continue;
     }
-    // `start` decided the Expo dev server should tunnel itself
-    // (metro.tunnel resolved to expo/auto-on-Expo); see server-expo.ts.
     if (arg === '--tunnel') {
       tunnel = true;
       continue;
@@ -84,8 +82,6 @@ type ServerStarter = (opts: {
   port: number;
   logsDir: string;
   writer?: NdjsonWriter | null;
-  // Expo-only; startBareServer ignores both (a bare workspace has no dev
-  // server of its own to hand a `--tunnel` flag to).
   tunnel?: boolean;
   onTunnelUrl?: ((url: string) => void) | null;
 }) => Promise<ServerHandle>;
@@ -93,8 +89,6 @@ type ServerStarter = (opts: {
 export interface RunSupervisorOptions {
   root: string;
   port: number;
-  // `start` decided the Expo dev server should tunnel itself; see
-  // server-expo.ts's `tunnel` option. No effect on the bare path.
   tunnel?: boolean;
   isExpo?: (projectRoot: string) => boolean;
   startBare?: ServerStarter | null;
@@ -128,7 +122,6 @@ export async function runSupervisor({
   const startedAt = new Date(now()).toISOString();
   const record = { pid: process.pid, port, mode, startedAt };
 
-  // ---- the record, first (rule 1) ----
   clearExpoMetroTunnel(root);
   writePidFile(root, process.pid);
   writeWorkspaceState(root, { supervisor: record });

--- a/packages/rn-iso/src/supervisor/server-expo.ts
+++ b/packages/rn-iso/src/supervisor/server-expo.ts
@@ -171,46 +171,12 @@ interface ExpoExitInfo {
   error?: Error;
 }
 
-/**
- * PURE. Tell Expo's dev server its PUBLIC address, when this workspace has
- * one.
- *
- * Expo builds the manifest's `hostUri` and `launchAsset.url` from the request
- * it is answering, taking the hostname from the Host header but the port from
- * ITSELF. Behind a tunnel that produces an address that cannot exist:
- *
- *   "hostUri": "priest-contribute-mysql-leslie.trycloudflare.com:8085"
- *
- * -- the tunnel's hostname with the local Metro port, while the tunnel
- * listens on 443. A remote device follows that manifest and fails, which is
- * observable as a launch that reaches "Loading from Metro..." and then
- * redboxes with "Could not connect to development server". Verified on a real
- * EAS Simulator, and it is NOT fixable from the device side: the manifest
- * wins over the launch URL.
- *
- * EXPO_PACKAGER_PROXY_URL is Expo's own answer, and setting it makes the
- * manifest advertise the tunnel with no port at all.
- *
- * Derived from RN_ISO_METRO_PUBLIC_URL so the two halves cannot disagree:
- * that one variable is already what `ios --remote` points the device at, and
- * requiring a second one to match it by hand is a trap. An explicit
- * EXPO_PACKAGER_PROXY_URL always wins -- a project that sets it has said
- * something more specific than rn-iso can infer.
- */
 export function expoProxyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   if (env.EXPO_PACKAGER_PROXY_URL) return {};
   const publicUrl = env.RN_ISO_METRO_PUBLIC_URL?.trim();
   return publicUrl ? { EXPO_PACKAGER_PROXY_URL: publicUrl.replace(/\/+$/, '') } : {};
 }
 
-// PURE. Expo's own dev server prints `Waiting on <url>` once on a
-// non-interactive stdout -- the shape rn-iso's piped child always is -- for
-// whichever address is active, LAN, localhost, or a tunnel. `cleanLine` has
-// already stripped the ANSI underline Expo wraps the URL in by the time a
-// record reaches this, so the match is plain text.
-//
-// Expo prints a native launch scheme for a tunneled native app. The same
-// host serves Metro over HTTPS, which is the origin the remote gate probes.
 const WAITING_ON_RE = /^Waiting on (\S+)/;
 const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const HTTP_SCHEME_RE = /^https?:\/\//i;
@@ -223,7 +189,6 @@ export function parseExpoWaitingOnUrl(line: unknown): string | null {
   return URL_SCHEME_RE.test(url) ? url.replace(/^[^:]+:/, 'https:') : url;
 }
 
-// The ServerHandle runSupervisor drives, plus the pieces a test reaches for.
 export interface ExpoServerHandle {
   mode: string;
   serverPid: number | null;
@@ -303,9 +268,6 @@ export async function startExpoServer({
   writer?: NdjsonWriter | null;
   spawnFn?: ((cmd: string, args: string[], opts: SpawnOptions) => ChildProcess) | null;
   killTimeoutMs?: number;
-  // `metro.tunnel` resolved to expo (or auto on an Expo project): pass
-  // `--tunnel` and report the URL Expo prints once it comes up. `ios --remote`
-  // cannot add this after the fact, so it has to be decided here, at start.
   tunnel?: boolean;
   onTunnelUrl?: ((url: string) => void) | null;
 }): Promise<ExpoServerHandle> {
@@ -319,9 +281,6 @@ export async function startExpoServer({
   const spawn = spawnFn || ((cmd: string, args: string[], opts: SpawnOptions) => getExecutor().spawn(cmd, args, opts));
 
   const args = tunnel ? ['start', '--port', String(port), '--tunnel'] : ['start', '--port', String(port)];
-  // APPENDED to the caller's environment, never substituted for it: the
-  // NODE_OPTIONS composition inside metroStoreEnv keeps whatever was already
-  // there (a profiler, a --max-old-space-size a big graph needs).
   const storeEnv = resolveMetroStoreInjection(root, { log, env: process.env });
 
   const child = spawn(bin, args, {
@@ -330,23 +289,15 @@ export async function startExpoServer({
     detached: false,
     env: {
       ...process.env,
-      // Colour only makes the log harder to read; it is stripped either way.
       FORCE_COLOR: '0',
       ...expoProxyEnv(process.env),
       ...storeEnv,
-      // Without this, `--tunnel` uses the legacy ws-tunnel session, which is
-      // hardcoded to port 8081 -- fatal here, since rn-iso's whole premise is
-      // a collision-free port per workspace. With it, Expo signs a tunnel URL
-      // for the actual reserved port through the caller's Expo account.
       ...(tunnel ? { EXPO_UNSTABLE_TUNNEL_V2: '1' } : {}),
     },
   });
 
   let lastMsg: string | null = null;
   let lastAt = 0;
-  // Fires at most once: the first "Waiting on <url>" line is Expo reporting
-  // its OWN dev server address, tunnel or not, and later lines (a reload, a
-  // second bundler event) reprint the same one.
   let tunnelUrlSeen = false;
   const emit = (stream: string) => (chunk: unknown) => {
     const record = recordFromLine(chunk, { stream });

--- a/packages/rn-iso/src/supervisor/server-expo.ts
+++ b/packages/rn-iso/src/supervisor/server-expo.ts
@@ -174,6 +174,7 @@ interface ExpoExitInfo {
 export function expoProxyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   if (env.EXPO_PACKAGER_PROXY_URL) return {};
   const publicUrl = env.RN_ISO_METRO_PUBLIC_URL?.trim();
+  // Expo otherwise combines a tunnel host with the local Metro port in its manifest.
   return publicUrl ? { EXPO_PACKAGER_PROXY_URL: publicUrl.replace(/\/+$/, '') } : {};
 }
 
@@ -292,6 +293,7 @@ export async function startExpoServer({
       FORCE_COLOR: '0',
       ...expoProxyEnv(process.env),
       ...storeEnv,
+      // Expo's legacy tunnel uses port 8081; v2 uses this workspace's reserved port.
       ...(tunnel ? { EXPO_UNSTABLE_TUNNEL_V2: '1' } : {}),
     },
   });

--- a/packages/rn-iso/src/supervisor/state.ts
+++ b/packages/rn-iso/src/supervisor/state.ts
@@ -1,11 +1,3 @@
-// src/supervisor/state.ts -- the workspace state + pid helpers, guard-free.
-//
-// Split out of supervisor/run.ts so that the importable state helpers live in a
-// module with NO top-level main() and NO server imports: `ios`, `android`,
-// `start` and the collector all read and write state.json through here, and
-// bundling any of them must never drag the spawnable daemon entry (or Metro)
-// in behind it. run.ts re-exports this surface for callers that still reach for
-// it there.
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { withDirLock } from '../dir-lock.ts';
@@ -19,30 +11,16 @@ export interface WorkspaceState {
   supervisor?: Record<string, unknown>;
   collectors?: Record<string, unknown>;
   lastBuild?: Record<string, unknown>;
-  // Written by `ios --remote` the moment the session exists. The session id
-  // ONLY: the daemon token is never persisted anywhere.
   remoteDevice?: Record<string, unknown>;
-  // The address a remote device reaches this workspace's Metro through, when
-  // rn-iso set one up itself: an Expo-hosted tunnel (`start`, kind 'expo') or
-  // a managed provider (`ios`/`android` --remote, kind 'managed'). Never
-  // written for an operator-supplied metro.publicUrl -- rn-iso only records
-  // what it can also reap.
   metroTunnel?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
-// The Expo dev server tunnelling itself (`expo start --tunnel`). Nothing to
-// reap: the tunnel dies with the expo child, which `stop` already kills.
-// Not exported on its own: nothing names it directly, only through the
-// MetroTunnelRecord union readMetroTunnel returns.
 interface ExpoTunnelRecord {
   kind: 'expo';
   url: string;
 }
 
-// A tunnel rn-iso started and owns the process of (engine/tunnel.ts's
-// TunnelRecord, plus the discriminant). `stop`, `gc` and `worktree remove`
-// reap this one by pid.
 export interface ManagedTunnelRecord {
   kind: 'managed';
   provider: ManagedProvider;
@@ -62,10 +40,6 @@ export interface RemoteSessionRecord {
   startedAt: string | null;
 }
 
-// The tunnel this workspace's Metro is reachable through, if rn-iso set one
-// up. A narrow reader for the same reason readRemoteSessionId is one: every
-// site that reads or reaps this record must agree on its shape and on what a
-// malformed one means.
 export function readMetroTunnel(root: string): MetroTunnelRecord | null {
   const record = readWorkspaceState(root)?.metroTunnel;
   if (!record || typeof record !== 'object') return null;
@@ -97,13 +71,6 @@ export function readMetroTunnel(root: string): MetroTunnelRecord | null {
   return null;
 }
 
-// --- Contract 2: the workspace state file --------------------------------
-//
-// The global workspace state file is written temp+rename so a reader never
-// sees half a file. Merged rather than overwritten: later steps put
-// `lastBuild` beside `supervisor`, and a supervisor shutting down must not
-// take it with it.
-
 export function readWorkspaceState(root: string): WorkspaceState | null {
   try {
     const parsed = JSON.parse(readFileSync(workspaceStateFile(root), 'utf-8'));
@@ -114,13 +81,6 @@ export function readWorkspaceState(root: string): WorkspaceState | null {
   }
 }
 
-// The remote session this workspace created, or null.
-//
-// A narrow reader rather than a raw readWorkspaceState at each call site: the
-// three places that end a session (`stop`, `worktree remove` and `gc`, the
-// last two through reclaim) must all agree on where the id lives and on what
-// a malformed record means, and a session they disagree about is one that
-// keeps billing.
 export function readRemoteSession(root: string): RemoteSessionRecord | null {
   const record = readWorkspaceState(root)?.remoteDevice;
   if (!record || typeof record !== 'object') return null;
@@ -146,15 +106,6 @@ export function clearRemoteSession(root: string, expectedSessionId: string): voi
   });
 }
 
-// Runs `fn` with the state.json lock held (reentrant within this process).
-// EVERY read-modify-write of state.json goes through here so the whole cycle
-// is atomic: the supervisor patches `supervisor`, each collector patches its
-// own `collectors.<platform>`, ios/android patch `lastBuild`, and these run at
-// once (the detached collector registers during the launch-verify window right
-// before writeLastBuild). renameSync stops a torn file, not a lost update --
-// two writers that both read the old state and rename their own version over it
-// drop one side's key, and a dropped `collectors.<platform>` leaks a log stream
-// `stop` can never reap. The lock is the thing that closes that window.
 export function withWorkspaceStateLock<T>(root: string, fn: () => T): T {
   const file = workspaceStateFile(root);
   return withDirLock(workspaceStateLock(root), fn, {
@@ -234,8 +185,6 @@ export function clearWorkspaceStateKeys(root: string, keys: readonly string[]): 
   });
 }
 
-// Removes only the selected key. The file goes when nothing else is left in
-// it, so a stopped workspace has no state.json rather than an empty one.
 function clearWorkspaceStateKey(root: string, key: string, shouldClear: (value: unknown) => boolean): boolean {
   return withWorkspaceStateLock(root, () => {
     const state = readWorkspaceState(root);

--- a/packages/rn-iso/src/types.ts
+++ b/packages/rn-iso/src/types.ts
@@ -103,9 +103,6 @@ export interface IosFacts {
   metroPort?: number | null;
   logs: LogsInfo;
   durationMs?: number;
-  // Only on a remote device that has a browser preview (an EAS Simulator
-  // session). A person cannot see a device in a datacenter; this is how they
-  // watch it.
   webPreviewUrl?: string | null;
 }
 


### PR DESCRIPTION
## Description

The remote-device merge added long comments that restated code and preserved implementation history. The repository policy keeps only comments for external constraints, required directives, public API contracts, or direct issue and RFC links.

## Solution

Remove the narrative comments added after the previous cleanup pass. Keep short comments for external tool behavior, upstream constraints, and live fixture provenance. The diff covers 37 TypeScript files and changes no runtime behavior.

## Test plan

- Compare parsed TypeScript tokens before and after the cleanup. Only formatter layout and one trailing comma differ.
- Run the full suite and confirm all 2,244 tests pass.
