### PR TITLE
Keep the shared Gradle cache report-only (#84)

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -258,11 +258,14 @@ Resolution order: the project layer, then the repo layer, then that committed fi
 
 Everything `gc` reclaims is _dead_: a project entry whose directory no longer
 exists belongs to nobody, and a `stim-cli-*` simulator nothing references is
-never coming back. Shared build caches are the opposite -- alive by design,
-shared by every project on the machine, and pruned by nothing:
+never coming back. Shared build caches are the opposite -- alive by design and
+shared by projects on the machine:
 
 - **Metro's `FileStore`** has no eviction logic whatsoever.
 - **Xcode's compilation cache** has no size cap.
+- **Gradle's build cache** applies Gradle's own retention policy and is shared by
+  every Gradle build under the Gradle user home, including builds that did not
+  use stim-cli. stim-cli reports it but never deletes from it.
 - **Metro file maps** accumulate one file per project root ever served.
 
 So every `gc` run reports them -- in their own bucket, tagged _registered_ or
@@ -286,6 +289,12 @@ Xcode's compilation cache is the exception. It is an LLVM CAS whose `v4.actions`
 index references its `v9.*.leaf` data files, so removing leaves individually
 would leave the index pointing at data that is gone. `--older-than` reports it
 as left alone; it can only be emptied whole, which is what `--all` does.
+
+Gradle's build cache is report-only. stim-cli enables it with `--build-cache`,
+so `gc` detects and sizes `caches/build-cache-1` under `GRADLE_USER_HOME`
+(default `~/.gradle`). Because that directory is shared with every other Gradle
+build on the machine, stim-cli never prunes or empties it, even with
+`--delete --older-than` or `--delete --all`.
 
 Emptying is a performance decision, not cleanup: the next build in every
 project pays to refill what you removed. The summary says so.

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -119,7 +119,7 @@ Also normal: `npx` may re-download stim-cli on every invocation (`npm warn exec 
 
 **stim-cli needs no setup edits to run.** Runtime state, logs, pidfiles and Xcode DerivedData live under `$STIM_CLI_HOME/workspaces/<project>--<digest>/` (default `~/.stim-cli/workspaces/...`). Gradle keeps its normal project build directories but uses the shared build cache via stim-cli's command line. stim-cli supplies its caches on its own command lines, and `npx stim-cli doctor` reports the handful of things it cannot handle.
 
-These caches never evict themselves. Every `npx stim-cli gc` run reports what they have grown to -- each one tagged _registered_ or _detected_ -- and `gc --delete --older-than <days>` trims the entries nothing has used. Trim rather than empty: `gc --delete --all` empties them whole -- the only way to clear an index-backed cache like Xcode's CAS -- and costs the next build in every project the time the cache was saving.
+These caches can grow substantially. Every `npx stim-cli gc` run reports what they have grown to -- each one tagged _registered_ or _detected_ -- and `gc --delete --older-than <days>` trims the entries nothing has used. Trim rather than empty: `gc --delete --all` empties them whole -- the only way to clear an index-backed cache like Xcode's CAS -- and costs the next build in every project the time the cache was saving. The Gradle build cache under `GRADLE_USER_HOME` (default `~/.gradle`) has Gradle's own retention policy and is report-only to stim-cli: stim-cli reports its size because `--build-cache` contributes to it, but never prunes or empties that directory under any `gc` flags because every Gradle build on the machine shares it.
 
 ## Runtime workspace and fingerprint dependencies
 

--- a/packages/stim-cli/src/__tests__/caches.test.ts
+++ b/packages/stim-cli/src/__tests__/caches.test.ts
@@ -1,4 +1,13 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync, realpathSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  utimesSync,
+  existsSync,
+  realpathSync,
+  symlinkSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setExecutor, resetExecutor } from '../exec.ts';
@@ -56,19 +65,21 @@ test('metro file maps are reported as an explicit file list, never as a director
   }
 });
 
-test('discoverCaches reports the Gradle build cache from GRADLE_USER_HOME', () => {
+test('discoverCaches reports the Gradle build cache from GRADLE_USER_HOME as report-only', () => {
   const gradleHome = mkdtempSync(join(tmpdir(), 'stim-cli-gradle-home-'));
   const previous = process.env.GRADLE_USER_HOME;
   const buildCache = join(gradleHome, 'caches', 'build-cache-1');
   mkdirSync(buildCache, { recursive: true });
   try {
     process.env.GRADLE_USER_HOME = gradleHome;
-    const found = discoverCaches().find((c) => c.name === 'Gradle build cache');
+    const caches = discoverCaches({ declared: [buildCache] });
+    const found = caches.find((c) => c.name === 'Gradle build cache');
     expect(found).toMatchObject({
       dir: buildCache,
-      prune: 'entries',
+      prune: 'report-only',
       source: 'detected',
     });
+    expect(caches.filter((c) => c.dir === buildCache)).toHaveLength(1);
   } finally {
     if (previous === undefined) delete process.env.GRADLE_USER_HOME;
     else process.env.GRADLE_USER_HOME = previous;
@@ -76,27 +87,52 @@ test('discoverCaches reports the Gradle build cache from GRADLE_USER_HOME', () =
   }
 });
 
-test('Gradle cache pruning keeps its lock and metadata files', () => {
-  const gradleHome = mkdtempSync(join(tmpdir(), 'stim-cli-gradle-prune-'));
+test('a registration cannot make the shared Gradle build cache deletable', () => {
+  const gradleHome = mkdtempSync(join(tmpdir(), 'stim-cli-gradle-registered-'));
   const previous = process.env.GRADLE_USER_HOME;
   const buildCache = join(gradleHome, 'caches', 'build-cache-1');
+  const alias = join(gradleHome, 'build-cache-alias');
+  const entry = join(buildCache, 'entry');
   mkdirSync(buildCache, { recursive: true });
-  const entry = join(buildCache, '0123456789abcdef0123456789abcdef');
-  const lock = join(buildCache, 'build-cache-1.lock');
-  const metadata = join(buildCache, 'gc.properties');
-  for (const file of [entry, lock, metadata]) {
-    writeFileSync(file, 'x');
-    age(file);
-  }
+  symlinkSync(buildCache, alias, 'dir');
+  writeFileSync(entry, 'x');
+  age(entry);
   try {
     process.env.GRADLE_USER_HOME = gradleHome;
-    const cache = discoverCaches().find((c) => c.name === 'Gradle build cache');
-    assert(cache);
-    const result = pruneCache(cache, { olderThanDays: 30 });
-    expect(result.removed).toBe(1);
-    expect(existsSync(entry)).toBe(false);
-    expect(existsSync(lock)).toBe(true);
-    expect(existsSync(metadata)).toBe(true);
+    register({ dir: alias, name: 'Registered Gradle cache', prune: 'entries' });
+    register({ dir: buildCache, name: 'Duplicate real Gradle cache', prune: 'atomic' });
+    const caches = discoverCaches();
+    const found = caches.find((c) => realpathSync(c.dir) === realpathSync(buildCache));
+    assert(found);
+    expect(found.prune).toBe('report-only');
+    expect(pruneCache(found, { olderThanDays: 30 }).skipped).toMatch(/report-only/);
+    expect(existsSync(entry)).toBe(true);
+    expect(caches.filter((c) => realpathSync(c.dir) === realpathSync(buildCache))).toHaveLength(1);
+  } finally {
+    if (previous === undefined) delete process.env.GRADLE_USER_HOME;
+    else process.env.GRADLE_USER_HOME = previous;
+    rmSync(gradleHome, { recursive: true, force: true });
+  }
+});
+
+test('a declared ancestor cannot delete its protected Gradle build-cache child', () => {
+  const gradleHome = mkdtempSync(join(tmpdir(), 'stim-cli-gradle-parent-'));
+  const previous = process.env.GRADLE_USER_HOME;
+  const cachesRoot = join(gradleHome, 'caches');
+  const buildCache = join(cachesRoot, 'build-cache-1');
+  const entry = join(buildCache, 'entry');
+  mkdirSync(buildCache, { recursive: true });
+  writeFileSync(entry, 'x');
+  age(entry);
+  try {
+    process.env.GRADLE_USER_HOME = gradleHome;
+    const caches = discoverCaches({ declared: [cachesRoot] });
+    const found = caches.find((c) => realpathSync(c.dir) === realpathSync(cachesRoot));
+    assert(found);
+    expect(found.prune).toBe('report-only');
+    expect(pruneCache(found, { olderThanDays: 30 }).skipped).toMatch(/report-only/);
+    expect(existsSync(entry)).toBe(true);
+    expect(caches.some((c) => realpathSync(c.dir) === realpathSync(buildCache))).toBe(false);
   } finally {
     if (previous === undefined) delete process.env.GRADLE_USER_HOME;
     else process.env.GRADLE_USER_HOME = previous;

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -1881,6 +1881,35 @@ test('--delete on its own never touches a shared cache', async () => {
   expect(existsSync(entry)).toBeTruthy();
 });
 
+test('gc reports but never deletes the shared Gradle build cache under any deletion mode', async () => {
+  const previous = process.env.GRADLE_USER_HOME;
+  const gradleHome = join(fakeHome, 'gradle-home');
+  const cachesRoot = join(gradleHome, 'caches');
+  const cacheDir = join(cachesRoot, 'build-cache-1');
+  const cacheAlias = join(gradleHome, 'caches-alias');
+  const entry = join(cacheDir, 'entry-a');
+  mkdirSync(cacheDir, { recursive: true });
+  symlinkSync(cachesRoot, cacheAlias, 'dir');
+  writeFileSync(entry, 'x'.repeat(1000));
+  const old = new Date(Date.now() - 400 * DAY_MS);
+  utimesSync(entry, old, old);
+  process.env.GRADLE_USER_HOME = gradleHome;
+  saveConfig({ version: 2, projects: {}, repos: {} });
+  register({ dir: cacheAlias, name: 'Gradle build cache', prune: 'entries' });
+  installExecutor();
+
+  try {
+    for (const args of [['--delete'], ['--delete', '--older-than', '30'], ['--delete', '--all']]) {
+      const output = await captureLog(() => cli(args));
+      expect(output).toMatch(/Gradle build cache/);
+      expect(existsSync(entry)).toBeTruthy();
+    }
+  } finally {
+    if (previous === undefined) delete process.env.GRADLE_USER_HOME;
+    else process.env.GRADLE_USER_HOME = previous;
+  }
+});
+
 test('--delete --older-than trims the cache entries nothing has touched', async () => {
   const cacheDir = join(fakeHome, 'my-cache');
   const oldEntry = join(cacheDir, 'entry-old');

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -177,6 +177,14 @@ test('the cleanup guide documents fail-closed EAS orphan recovery', () => {
   expect(cleanup).not.toMatch(/EAS session and local claim stay/i);
 });
 
+test('the cleanup guide documents that the shared Gradle build cache is report-only', () => {
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+
+  expect(cleanup).toMatch(/Gradle build cache[\s\S]*report-only/i);
+  expect(cleanup).toMatch(/never[^.]*prunes[^.]*empties/i);
+});
+
 test('the guide distinguishes local stop behavior from EAS session teardown', () => {
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);

--- a/packages/stim-cli/src/caches.ts
+++ b/packages/stim-cli/src/caches.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync, rmSync, statSync } from 'fs';
+import { existsSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
-import { basename, join, resolve } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import { directorySize } from './fs-util.ts';
 import { registeredCaches } from './cache-manifest.ts';
 import { findProjectRoot } from './project.ts';
@@ -10,10 +10,9 @@ import { gitCommonDir, repoRoot } from './worktree.ts';
 export interface CacheDescriptor {
   name: string;
   dir: string;
-  prune: 'atomic' | 'entries';
+  prune: 'atomic' | 'entries' | 'report-only';
   note: string;
   entriesDepth?: number;
-  entryNamePattern?: RegExp;
   files?: string[];
   bytes?: number;
   source?: 'registered' | 'detected';
@@ -36,14 +35,13 @@ function compilationCache(): CacheDescriptor | null {
 
 function gradleBuildCache(): CacheDescriptor | null {
   const gradleHome = process.env.GRADLE_USER_HOME || join(homedir(), '.gradle');
-  const dir = join(gradleHome, 'caches', 'build-cache-1');
+  const dir = resolve(gradleHome, 'caches', 'build-cache-1');
   if (!existsSync(dir)) return null;
   return {
     name: 'Gradle build cache',
     dir,
-    prune: 'entries',
-    entryNamePattern: /^[0-9a-f]{32}$/,
-    note: 'shared Gradle task outputs enabled by stim-cli --build-cache',
+    prune: 'report-only',
+    note: 'shared with every Gradle build; report only, never pruned or emptied by stim-cli',
   };
 }
 
@@ -92,20 +90,89 @@ export function declaredCachePaths(cwd: string = process.cwd()): string[] {
 }
 
 export function discoverCaches({ declared = [] }: { declared?: string[] } = {}): CacheDescriptor[] {
-  const registered: CacheDescriptor[] = registeredCaches().map((c): CacheDescriptor =>
+  const gradle = gradleBuildCache();
+  const gradleDir = gradle ? canonicalCacheDir(gradle.dir) : null;
+  const registered = registeredCaches().map((c): CacheDescriptor =>
     Object.assign({}, c, {
       name: c.name ?? c.dir,
       note: c.note ?? 'registered',
-      prune: c.prune as 'atomic' | 'entries',
+      prune: c.prune,
       source: 'registered' as const,
     }),
   );
-  const seen = new Set(registered.map((c) => c.dir));
-  const detected = [compilationCache(), gradleBuildCache(), metroFileMaps(), ...declaredCaches(declared)]
+  const detected = [compilationCache(), gradle, metroFileMaps(), ...declaredCaches(declared)]
     .filter((c): c is CacheDescriptor => Boolean(c))
-    .filter((c) => !seen.has(c.dir))
     .map((c): CacheDescriptor => Object.assign({}, c, { source: 'detected' as const }));
-  return [...registered, ...detected];
+  return mergeCacheDescriptors([...registered, ...detected], gradleDir);
+}
+
+function mergeCacheDescriptors(caches: CacheDescriptor[], gradleDir: string | null): CacheDescriptor[] {
+  const merged: CacheDescriptor[] = [];
+  for (const cache of caches) {
+    const descriptor = protectGradleCache(cache, gradleDir);
+    const dir = canonicalCacheDir(descriptor.dir);
+    const exact = merged.findIndex((candidate) => canonicalCacheDir(candidate.dir) === dir);
+    if (exact !== -1) {
+      const current = merged[exact] as CacheDescriptor;
+      if (pruneStrength(descriptor.prune) > pruneStrength(current.prune)) {
+        merged[exact] = Object.assign({}, current, { prune: descriptor.prune, note: descriptor.note });
+      }
+      continue;
+    }
+
+    if (gradleDir && isGradleProtectedDescriptor(descriptor, gradleDir)) {
+      const protectedAncestor = merged.some((candidate) => {
+        const candidateDir = canonicalCacheDir(candidate.dir);
+        return isGradleProtectedDescriptor(candidate, gradleDir) && cachePathContains(candidateDir, dir);
+      });
+      if (protectedAncestor) continue;
+      for (let i = merged.length - 1; i >= 0; i--) {
+        const candidate = merged[i] as CacheDescriptor;
+        const candidateDir = canonicalCacheDir(candidate.dir);
+        if (isGradleProtectedDescriptor(candidate, gradleDir) && cachePathContains(dir, candidateDir)) {
+          merged.splice(i, 1);
+        }
+      }
+    }
+    merged.push(descriptor);
+  }
+  return merged;
+}
+
+function protectGradleCache(cache: CacheDescriptor, gradleDir: string | null): CacheDescriptor {
+  if (cache.files) return cache;
+  if (!gradleDir || !cachePathsOverlap(canonicalCacheDir(cache.dir), gradleDir)) return cache;
+  return Object.assign({}, cache, {
+    prune: 'report-only' as const,
+    note: 'shared with every Gradle build; report only, never pruned or emptied by stim-cli',
+  });
+}
+
+function isGradleProtectedDescriptor(cache: CacheDescriptor, gradleDir: string): boolean {
+  return cache.prune === 'report-only' && cachePathsOverlap(canonicalCacheDir(cache.dir), gradleDir);
+}
+
+function pruneStrength(prune: CacheDescriptor['prune']): number {
+  if (prune === 'report-only') return 3;
+  if (prune === 'atomic') return 2;
+  return 1;
+}
+
+function cachePathsOverlap(left: string, right: string): boolean {
+  return cachePathContains(left, right) || cachePathContains(right, left);
+}
+
+function cachePathContains(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function canonicalCacheDir(dir: string): string {
+  try {
+    return realpathSync(dir);
+  } catch {
+    return resolve(dir);
+  }
 }
 
 export function sizeCaches(caches: CacheDescriptor[]): CacheDescriptor[] {
@@ -122,13 +189,15 @@ export function pruneCache(
 ): { removed: number; bytes: number; skipped: string | null } {
   const cutoff = now - (olderThanDays as number) * 24 * 60 * 60 * 1000;
 
+  if (cache.prune === 'report-only') {
+    return { removed: 0, bytes: 0, skipped: 'report-only shared cache; stim-cli never deletes it' };
+  }
+
   if (cache.prune === 'atomic') {
     return { removed: 0, bytes: 0, skipped: 'index-backed; empty it whole or not at all' };
   }
 
-  const entries = (cache.files ?? entriesAtDepth(cache.dir, cache.entriesDepth ?? 1)).filter(
-    (entry) => !cache.entryNamePattern || cache.entryNamePattern.test(basename(entry)),
-  );
+  const entries = cache.files ?? entriesAtDepth(cache.dir, cache.entriesDepth ?? 1);
   let removed = 0;
   let bytes = 0;
   for (const entry of entries) {

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -773,6 +773,12 @@ function planCacheEmptying(caches: CacheDescriptor[], all: boolean): GcCache[] {
   const annotated = caches.map((c) => Object.assign({}, c, { machineGlobal: machineGlobalReason(c) }));
   if (!all) return annotated;
   return annotated.map((c) => {
+    if (c.prune === 'report-only') {
+      return Object.assign({}, c, {
+        willEmpty: false,
+        emptySkipped: 'report-only shared cache; stim-cli never deletes it',
+      });
+    }
     if (c.machineGlobal) {
       return Object.assign({}, c, { willEmpty: false, emptySkipped: c.machineGlobal });
     }
@@ -804,6 +810,9 @@ function emptyCache(cache: CacheDescriptor): {
   skipped: string | null;
   failed?: number;
 } {
+  if (cache.prune === 'report-only') {
+    return { removed: 0, bytes: 0, skipped: 'report-only shared cache; stim-cli never deletes it' };
+  }
   if (cache.prune !== 'atomic') {
     return pruneCache(cache, { olderThanDays: 0, now: Date.now() + DAY_MS });
   }

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1189,6 +1189,9 @@ SHARED BUILD CACHES
     stim-cli gc --delete --older-than 30   # trim entries nothing has used
     stim-cli gc --delete --all             # empty them whole, index-backed ones
                                          # (the Xcode CAS) included
+  The Gradle build cache under GRADLE_USER_HOME (default ~/.gradle) is
+  report-only because every Gradle build shares it. stim-cli reports its size
+  but never prunes or empties it, including with --older-than or --all.
   Trim rather than empty. Emptying costs the next build in every project the
   time the cache was saving.`,
   },


### PR DESCRIPTION
## Description

`stim-cli android` enables Gradle's shared build cache, but `stim-cli gc` did not safely account for the resulting `GRADLE_USER_HOME/caches/build-cache-1` footprint. The initial implementation on `main` made individual Gradle entries eligible for deletion, even though this cache is shared by every Gradle build on the machine.

Closes #84.

## Solution

- Keep detecting and sizing the standard Gradle build-cache directory, including under a custom `GRADLE_USER_HOME`, but classify it as report-only.
- Ensure `gc --delete`, `--older-than`, and `--all` never remove its contents.
- Canonicalize cache paths, deduplicate aliases, and preserve report-only safety when the Gradle cache or one of its parent directories is declared or registered.
- Document the ownership boundary in the README, shipped skill, and `guide` output.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (2,256 tests)
- `pnpm run test:e2e` (8 tests)
- Focused cache/gc/guide tests (144 tests)
- Verify a custom Gradle cache is reported and its sentinel survives every deletion mode.
- Verify registration through a symlink alias cannot downgrade report-only safety or duplicate the cache.
