### PR TITLE
Verify app readiness after Metro bundling

### DIFF
--- a/packages/metro/__tests__/reporter.test.ts
+++ b/packages/metro/__tests__/reporter.test.ts
@@ -109,6 +109,26 @@ test('bundle_build_failed is a marker too, written before the bundling_error it 
   });
 });
 
+test('overlapping bundle records keep their build id and platform', () => {
+  withDir((dir) => {
+    const reporter = ndjsonReporter({ dir });
+    reporter.update({ type: 'bundle_build_started', buildID: 'ios_1', bundleDetails: { platform: 'ios' } });
+    reporter.update({ type: 'bundle_build_started', buildID: 'android_1', bundleDetails: { platform: 'android' } });
+    reporter.update({ type: 'bundle_build_done', buildID: 'android_1' });
+    reporter.update({ type: 'bundle_build_failed', buildID: 'ios_1' });
+    reporter.update({ type: 'bundling_error', error: new Error('Unable to resolve module ./ios-only') });
+
+    const lines = records(dir, 'metro.ndjson');
+    expect(lines.map((record) => [record.event, record.buildID, record.platform])).toEqual([
+      ['bundle_build_started', 'ios_1', 'ios'],
+      ['bundle_build_started', 'android_1', 'android'],
+      ['bundle_build_done', 'android_1', 'android'],
+      ['bundle_build_failed', 'ios_1', 'ios'],
+      ['bundling_error', 'ios_1', 'ios'],
+    ]);
+  });
+});
+
 test('unstable_server_log carries its own level', () => {
   withDir((dir) => {
     const reporter = ndjsonReporter({ dir });

--- a/packages/metro/index.ts
+++ b/packages/metro/index.ts
@@ -22,6 +22,7 @@ interface MetroEvent {
   error?: unknown;
   stack?: string;
   buildID?: string;
+  bundleDetails?: { platform?: string | null };
 }
 
 interface LogRecord {
@@ -32,6 +33,8 @@ interface LogRecord {
   event?: string;
   stack?: string;
   marker?: boolean;
+  buildID?: string;
+  platform?: string;
 }
 
 export interface NdjsonReporter {
@@ -142,6 +145,8 @@ export function ndjsonReporter({ dir }: { dir?: string } = {}): NdjsonReporter {
   const logDir = dir || workspaceLogDir(process.cwd());
   let ensured = false;
   let drops = 0;
+  const builds = new Map<string, string | null>();
+  let failedBuild: { buildID: string; platform: string | null } | null = null;
 
   function write(file: string, record: LogRecord): void {
     try {
@@ -161,6 +166,25 @@ export function ndjsonReporter({ dir }: { dir?: string } = {}): NdjsonReporter {
       const type = event && typeof event.type === 'string' ? event.type : '';
       const record: LogRecord = { ts: Date.now(), src: 'metro', level: 'debug', msg: '' };
       if (type) record.event = type;
+
+      if (type !== 'bundling_error') failedBuild = null;
+
+      if (type === 'bundle_build_started' && event.buildID) {
+        const platform = event.bundleDetails?.platform || null;
+        builds.set(event.buildID, platform);
+        record.buildID = event.buildID;
+        if (platform) record.platform = platform;
+      } else if ((type === 'bundle_build_done' || type === 'bundle_build_failed') && event.buildID) {
+        const platform = builds.get(event.buildID) || null;
+        record.buildID = event.buildID;
+        if (platform) record.platform = platform;
+        builds.delete(event.buildID);
+        if (type === 'bundle_build_failed') failedBuild = { buildID: event.buildID, platform };
+      } else if (type === 'bundling_error' && failedBuild) {
+        record.buildID = failedBuild.buildID;
+        if (failedBuild.platform) record.platform = failedBuild.platform;
+        failedBuild = null;
+      }
 
       if (type === 'client_log') {
         record.src = 'client';

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -160,6 +160,7 @@ interface VerifyArgs {
   logsDir?: string;
   since?: string | number;
   metroPort?: string | number | null;
+  platform?: string | null;
 }
 
 interface Calls {
@@ -2161,7 +2162,8 @@ describe('launch verification', () => {
     expect(result.facts.launched).toBe(true);
     expect(h.calls.verify[0]?.logsDir).toBe(workspaceLogsDir(root));
     expect(Number.isFinite(h.calls.verify[0]?.since)).toBeTruthy();
-    expect(h.stderr.some((l) => /verify.*bundle requested from Metro port 8082/.test(l))).toBeTruthy();
+    expect(h.calls.verify[0]?.platform).toBe('android');
+    expect(h.stderr.some((l) => /verify.*bundle loaded, stable for 3s/.test(l))).toBeTruthy();
   });
 
   test('the picker: no bundle request makes it launched: "unverified", still exit ok', async () => {
@@ -2627,16 +2629,28 @@ describe('release skips Metro entirely', () => {
     expect(h.stdout[0]).toMatch(/productionRelease \(embedded JS, no Metro\)/);
   });
 
-  test('a dead app process is launched: "unverified", with the device-log pointer', async () => {
+  test('a dead app process fails the readiness check with the device-log pointer', async () => {
     const h = harness({
       variant: 'productionRelease',
       verifyReleaseLaunched: async () => ({ verified: false, reason: 'exited', waitedMs: 3000, pid: null }),
     });
     const result = await h.run();
-    assert(result.facts);
-    expect(result.facts.launched).toBe('unverified');
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_CLI_LAUNCH_FAILED');
     expect(h.stderr.join('\n')).toMatch(/UNVERIFIED: no com\.example\.app process/);
     expect(h.stderr.join('\n')).toMatch(/stim logs --errors/);
+  });
+
+  test('a failed release process probe stays unverified without claiming an exit', async () => {
+    const h = harness({
+      variant: 'productionRelease',
+      verifyReleaseLaunched: async () => ({ verified: false, reason: 'probe-failed', waitedMs: 3000 }),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(result.facts?.launched).toBe('unverified');
+    expect(h.stderr.join('\n')).toMatch(/UNVERIFIED: the app process check failed/);
+    expect(h.stderr.join('\n')).not.toMatch(/no com\.example\.app process/);
   });
 
   test('the android.variant setting is the repo default, and the flag overrides it back to debug', async () => {

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -191,6 +191,16 @@ describe('ios: demoting device noise', () => {
     );
     assert(record);
     expect(record.level).toBe('info');
+    const simulatorRecord = parseLogStreamLine(
+      JSON.stringify(
+        event({
+          messageType: 'Fault',
+          eventMessage: '`UIScene` lifecycle will soon be required. Failure to adopt will result in an assert.',
+        }),
+      ),
+    );
+    assert(simulatorRecord);
+    expect(simulatorRecord.level).toBe('info');
     expect(
       noiseRuleId(
         JSON.parse(JSON.stringify(event({ eventMessage: 'The app must migrate to UIScene lifecycle before iOS 27.' }))),

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -238,9 +238,11 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
     assert(first);
     expect(first.msg).toMatch(/LocationProvider/);
     expect(first.proc).toBe('locationd');
+    expect(first.platform).toBe('ios');
     const firstLog = deviceLog()[0];
     assert(firstLog);
     expect(firstLog.event).toBe('collector_started');
+    expect(firstLog.platform).toBe('ios');
 
     process.kill(childPid(child), 'SIGTERM');
     const result = await exited(child);
@@ -396,6 +398,7 @@ describe('runCollector seams', () => {
     assert(failed);
     expect(failed.msg).toMatch(/no process appeared/);
     expect(failed.level).toBe('error');
+    expect(failed.platform).toBe('android');
     expect('collectors' in (state() || {})).toBe(false);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_METRO_PORT,
   INSTALL_ERROR,
   LAUNCH_ERROR,
+  STABILITY_WINDOW_MS,
   VERIFY_TIMEOUT_MS,
   devClientUrl,
   isBundleProof,
@@ -17,12 +18,14 @@ import {
   unverifiedLaunchLines,
   verifyLaunch,
   amStartError,
+  androidAppProcess,
   androidDevClientUrl,
   debugHttpHostScript,
   deviceShellArg,
   installAndroidApp,
   installConflictKind,
   installIosApp,
+  iosAppProcess,
   iosSchemeApprovalKeys,
   launchAndroidReleaseApp,
   parsePidof,
@@ -243,6 +246,26 @@ describe('ios', () => {
     expect(parseLaunchedPid('something went wrong')).toBe(null);
     expect(parseLaunchedPid(null)).toBe(null);
     expect(parseLaunchedPid('com.example.app: 0')).toBe(null);
+  });
+
+  test('iosAppProcess finds the app pid in the simulator launchctl list', () => {
+    const exec = recordingExec({
+      outputs: {
+        'launchctl list': '-\t0\tcom.apple.foo\n4242\t0\tUIKitApplication:com.example.app[abcd][rb-legacy]\n',
+      },
+    });
+    expect(iosAppProcess('U1', 'com.example.app', { exec })).toBe(4242);
+    expect(exec.calls[0]).toEqual(['xcrun', 'simctl', 'spawn', 'U1', 'launchctl', 'list']);
+  });
+
+  test('iosAppProcess returns null when the app is not running', () => {
+    const exec = recordingExec({ outputs: { 'launchctl list': '-\t0\tcom.apple.foo\n' } });
+    expect(iosAppProcess('U1', 'com.example.app', { exec })).toBe(null);
+  });
+
+  test('iosAppProcess returns undefined when the process probe fails', () => {
+    const exec = recordingExec({ fail: 'launchctl list' });
+    expect(iosAppProcess('U1', 'com.example.app', { exec })).toBeUndefined();
   });
 });
 
@@ -487,6 +510,9 @@ describe('isBundleProof', () => {
     ).toBe(true);
     expect(isBundleActivityLine('Android Bundling failed 91ms')).toBe(true);
     expect(isBundleProof({ ts: 150, src: 'metro', msg: 'Android Bundling failed 91ms' }, 100)).toBe(true);
+    expect(isBundleProof({ ts: 150, src: 'metro', msg: 'Android Bundled 91ms' }, 100, 'ios')).toBe(false);
+    expect(isBundleProof({ ts: 150, src: 'metro', msg: 'iOS Bundled 91ms' }, 100, 'ios')).toBe(true);
+    expect(isBundleProof({ ts: 150, event: 'bundle_build_done', platform: 'android' }, 100, 'ios')).toBe(false);
   });
 
   test('a record from BEFORE the launch is not proof of this launch', () => {
@@ -506,7 +532,7 @@ describe('isBundleProof', () => {
 });
 
 describe('verifyLaunch', () => {
-  test('verified: the poll returns as soon as a bundle request lands', async () => {
+  test('verified: the stability window starts after bundle completion', async () => {
     const clock = fakeClock();
     const records: NdjsonRecord[] = [];
     let reads = 0;
@@ -516,14 +542,14 @@ describe('verifyLaunch', () => {
       sleep: clock.sleep,
       readRecords: () => {
         reads += 1;
-        if (reads === 3) records.push({ ts: clock.at(), event: 'bundle_build_started' });
+        if (reads === 3) records.push({ ts: clock.at(), event: 'bundle_build_done' });
         return records;
       },
     });
     expect(result.verified).toBe(true);
     assert(result.record);
-    expect(result.record.event).toBe('bundle_build_started');
-    expect(result.waitedMs > 0 && result.waitedMs < VERIFY_TIMEOUT_MS).toBeTruthy();
+    expect(result.record.event).toBe('bundle_build_done');
+    expect(result.waitedMs).toBeGreaterThanOrEqual(STABILITY_WINDOW_MS);
   });
 
   test('the picker: an app that fetches nothing times out as UNVERIFIED, not as a failure', async () => {
@@ -577,13 +603,13 @@ describe('verifyLaunch', () => {
       writeFileSync(
         join(dir, 'metro.ndjson'),
         `${JSON.stringify({ ts: clock.at() - 5, event: 'bundle_build_done' })}\n` +
-          `${JSON.stringify({ ts: clock.at() + 10, event: 'bundle_build_started' })}\n` +
+          `${JSON.stringify({ ts: clock.at() + 10, event: 'bundle_build_done' })}\n` +
           '{"ts":123,"event":"half-writ',
       );
       const result = await verifyLaunch({ logsDir: dir, since: clock.at(), now: clock.now, sleep: clock.sleep });
       expect(result.verified).toBe(true);
       assert(result.record);
-      expect(result.record.ts).toBe(clock.at() + 10);
+      expect(result.record.ts).toBe(1010);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -1083,6 +1109,18 @@ describe('the android release process proof', () => {
     expect(result.reason).toBe('exited');
     expect(result.pid).toBe(null);
   });
+
+  test('a failed process probe is unverified without claiming the app exited', async () => {
+    const exec = recordingExec({ fail: 'adb' });
+    expect(androidAppProcess('emulator-5584', 'com.example.app', { exec })).toBeUndefined();
+    const result = await verifyAndroidReleaseLaunch({
+      serial: 'emulator-5584',
+      packageName: 'com.example.app',
+      exec,
+      sleep: async () => {},
+    });
+    expect(result).toMatchObject({ verified: false, reason: 'probe-failed' });
+  });
 });
 
 describe('isBundleRequestProof', () => {
@@ -1109,6 +1147,22 @@ describe('isBundleRequestProof', () => {
     ).toBe(false);
   });
 
+  test("another platform's device request is not proof", () => {
+    expect(
+      isBundleRequestProof(
+        {
+          ts: 150,
+          src: 'device',
+          platform: 'android',
+          msg: 'Loading http://10.0.2.2:8082/index.bundle?platform=android',
+        },
+        100,
+        8082,
+        'ios',
+      ),
+    ).toBe(false);
+  });
+
   test('an error-level line naming the same URL is a request that FAILED, not one in flight', () => {
     expect(
       isBundleRequestProof(
@@ -1132,6 +1186,21 @@ describe('isBundleRequestProof', () => {
 });
 
 describe('verifyLaunch: still bundling', () => {
+  test('a bundle that only started reports requested after the readiness window', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      metroPort: 8082,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_started' }],
+      readDeviceRecords: () => [],
+    });
+    expect(result).toMatchObject({ verified: false, timedOut: true, requested: true });
+    expect(result.record?.event).toBe('bundle_build_started');
+  });
+
   test('a timeout with a device-log request reports requested, not a bare unverified', async () => {
     const clock = fakeClock();
     const since = clock.at();
@@ -1166,7 +1235,7 @@ describe('verifyLaunch: still bundling', () => {
     expect(result.timedOut).toBe(true);
   });
 
-  test('a bundle that actually built still verifies: the device log is only consulted on a timeout', async () => {
+  test('a completed bundle verifies after stability-window device logs are checked', async () => {
     const clock = fakeClock();
     let deviceReads = 0;
     const result = await verifyLaunch({
@@ -1174,13 +1243,259 @@ describe('verifyLaunch: still bundling', () => {
       metroPort: 8082,
       now: clock.now,
       sleep: clock.sleep,
-      readRecords: () => [{ ts: clock.at(), event: 'bundle_build_started' }],
+      readRecords: () => [{ ts: clock.at(), event: 'bundle_build_done' }],
       readDeviceRecords: () => {
         deviceReads += 1;
         return [];
       },
     });
     expect(result.verified).toBe(true);
-    expect(deviceReads).toBe(0);
+    expect(deviceReads).toBe(1);
+    expect(result.waitedMs).toBe(STABILITY_WINDOW_MS);
+  });
+
+  test('a delayed bundle completion starts a fresh stability window', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    let processChecks = 0;
+    const result = await verifyLaunch({
+      since,
+      timeoutMs: 10000,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => (clock.at() >= since + 5000 ? [{ ts: since + 5000, event: 'bundle_build_done' }] : []),
+      readDeviceRecords: () => [],
+      processAlive: () => {
+        processChecks += 1;
+        return true;
+      },
+    });
+    expect(result).toMatchObject({ verified: true, processAlive: true, waitedMs: 8000 });
+    expect(processChecks).toBe(1);
+  });
+
+  test('overlapping native bundles wait for the requested platform', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const iosStarted = { ts: since, event: 'bundle_build_started', buildID: 'ios_1', platform: 'ios' };
+    const androidStarted = {
+      ts: since,
+      event: 'bundle_build_started',
+      buildID: 'android_1',
+      platform: 'android',
+    };
+    const androidDone = {
+      ts: since + 1000,
+      event: 'bundle_build_done',
+      buildID: 'android_1',
+      platform: 'android',
+    };
+    const iosDone = { ts: since + 5000, event: 'bundle_build_done', buildID: 'ios_1', platform: 'ios' };
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      timeoutMs: 10000,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => {
+        const records = [iosStarted, androidStarted];
+        if (clock.at() >= since + 1000) records.push(androidDone);
+        if (clock.at() >= since + 5000) records.push(iosDone);
+        return records;
+      },
+      readDeviceRecords: () => [],
+    });
+    expect(result).toMatchObject({ verified: true, waitedMs: 8000 });
+    expect(result.record).toMatchObject({ buildID: 'ios_1', platform: 'ios' });
+  });
+
+  test("another platform's bundle failure does not fail this launch", async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [
+        {
+          ts: since + 10,
+          event: 'bundle_build_failed',
+          buildID: 'android_1',
+          platform: 'android',
+          level: 'error',
+          msg: 'Android failed',
+        },
+        {
+          ts: since + 11,
+          event: 'bundling_error',
+          buildID: 'android_1',
+          platform: 'android',
+          level: 'error',
+          msg: 'Unable to resolve AndroidOnly',
+        },
+        { ts: since + 20, event: 'bundle_build_done', buildID: 'ios_1', platform: 'ios' },
+      ],
+      readDeviceRecords: () => [],
+      processAlive: () => true,
+    });
+    expect(result).toMatchObject({ verified: true, processAlive: true });
+    expect(result.errors).toEqual([]);
+  });
+
+  test('Expo text markers match their named platform', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      timeoutMs: 10000,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => {
+        const records = [{ ts: since, src: 'metro', event: 'expo_stdout', msg: 'Android Bundled 80ms index.js' }];
+        if (clock.at() >= since + 2000) {
+          records.push({ ts: since + 2000, src: 'metro', event: 'expo_stdout', msg: 'iOS Bundled 90ms index.js' });
+        }
+        return records;
+      },
+      readDeviceRecords: () => [],
+    });
+    expect(result).toMatchObject({ verified: true, waitedMs: 5000 });
+    expect(result.record?.msg).toMatch(/^iOS Bundled/);
+  });
+
+  test('the stability window starts at the Metro completion timestamp', async () => {
+    const clock = fakeClock(5000);
+    const result = await verifyLaunch({
+      since: 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: 2000, event: 'bundle_build_done' }],
+      readDeviceRecords: () => [],
+    });
+    expect(result).toMatchObject({ verified: true, waitedMs: 0 });
+  });
+
+  test('a second bundle completion does not shorten the first stability window', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const first = { ts: since, event: 'bundle_build_done', msg: 'first bundle' };
+    const second = { ts: since + 2500, event: 'bundle_build_done', msg: 'second bundle' };
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => (clock.at() >= since + 2500 ? [first, second] : [first]),
+      readDeviceRecords: () => [],
+    });
+    expect(result).toMatchObject({ verified: true, waitedMs: STABILITY_WINDOW_MS });
+    expect(result.record?.msg).toBe('first bundle');
+  });
+
+  test('a client console error is returned with a live, verified app', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_done' }],
+      readDeviceRecords: () => [],
+      readClientRecords: () => [
+        { ts: since + 20, src: 'client', event: 'client_log', level: 'error', msg: 'console.error during launch' },
+      ],
+      processAlive: () => true,
+    });
+    expect(result).toMatchObject({ verified: true, processAlive: true });
+    expect(result.errors?.[0]?.msg).toBe('console.error during launch');
+  });
+
+  test('errors before bundle completion are outside the stability window', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 100, event: 'bundle_build_done' }],
+      readDeviceRecords: () => [
+        { ts: since + 50, level: 'error', msg: 'pre-bundle warning' },
+        { ts: since + 200, level: 'error', msg: 'post-bundle warning' },
+      ],
+      processAlive: () => true,
+    });
+    expect(result.errors?.map((record) => record.msg)).toEqual(['post-bundle warning']);
+  });
+
+  test('a bundle failure is fatal and includes its error text', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [
+        { ts: since + 10, level: 'error', event: 'bundle_build_failed', msg: 'Unable to resolve module X' },
+      ],
+      readDeviceRecords: () => [],
+      processAlive: () => true,
+    });
+    expect(result).toMatchObject({ verified: false, fatal: true, processAlive: true });
+    expect(result.errors?.[0]?.msg).toBe('Unable to resolve module X');
+  });
+
+  test('an Expo text bundle failure is fatal', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [
+        { ts: since + 10, src: 'metro', event: 'expo_stderr', level: 'error', msg: 'iOS Bundling failed 893ms' },
+        {
+          ts: since + 11,
+          src: 'metro',
+          event: 'expo_stderr',
+          level: 'error',
+          msg: 'Unable to resolve module Missing from App.tsx',
+        },
+      ],
+      readDeviceRecords: () => [],
+      processAlive: () => true,
+    });
+    expect(result).toMatchObject({ verified: false, fatal: true, processAlive: true });
+    expect(result.errors?.map((record) => record.msg)).toEqual([
+      'iOS Bundling failed 893ms',
+      'Unable to resolve module Missing from App.tsx',
+    ]);
+  });
+
+  test('an unknown process state does not fail a verified bundle', async () => {
+    const clock = fakeClock();
+    const result = await verifyLaunch({
+      since: clock.at(),
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: clock.at(), event: 'bundle_build_done' }],
+      readDeviceRecords: () => [],
+      processAlive: () => null,
+    });
+    expect(result).toMatchObject({ verified: true, processAlive: null });
+  });
+
+  test('a process exit during the readiness window is fatal', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const result = await verifyLaunch({
+      since,
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_done' }],
+      readDeviceRecords: () => [],
+      processAlive: () => false,
+    });
+    expect(result).toMatchObject({ verified: false, fatal: true, processAlive: false });
   });
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -121,7 +121,7 @@ interface RecordedArgs {
   readBundleId: unknown;
   storeBuild: { options?: unknown; platform?: unknown; path?: unknown; key?: unknown };
   resolveBuild: { key?: unknown };
-  verifyLaunch: { since?: unknown; logsDir?: unknown };
+  verifyLaunch: { since?: unknown; logsDir?: unknown; platform?: unknown };
   uploadRemote: { fingerprintHash?: unknown; buildPath?: unknown };
   resolveRemote: { projectRoot?: unknown; platform?: unknown; fingerprintHash?: unknown };
   replaceCollector: { udid?: unknown; bundleId?: unknown; appName?: unknown };
@@ -477,9 +477,10 @@ describe('launch verification', () => {
     const { logs, errs, exitCode, calls } = await run({ json: true });
     expect(exitCode).toBe(null);
     expect(parseFirst(logs).launched).toBe(true);
-    expect(errs.join('\n')).toMatch(/verify.*bundle requested from Metro port 8082/);
+    expect(errs.join('\n')).toMatch(/verify.*bundle loaded, stable for 3s/);
     expect(calls.args.verifyLaunch.logsDir).toBe(workspaceLogsDir(root));
     expect(Number.isFinite(calls.args.verifyLaunch.since)).toBeTruthy();
+    expect(calls.args.verifyLaunch.platform).toBe('ios');
   });
 
   test('the picker: an unverified launch is launched: "unverified", exit 0, and a loud warning', async () => {
@@ -2375,14 +2376,15 @@ describe('release skips Metro entirely', () => {
     expect(facts.cacheKey).toBe(`${FINGERPRINT}-release-sim`);
   });
 
-  test('a dead app process is launched: "unverified", with the device-log pointer', async () => {
-    const { logs, errs } = await run(
+  test('a dead app process fails the readiness check with the device-log pointer', async () => {
+    const { logs, errs, exitCode } = await run(
       { configuration: 'Release', json: true },
       {
         verifyReleaseLaunch: async () => ({ verified: false, reason: 'exited', waitedMs: 3000 }),
       },
     );
-    expect(parseFirst(logs).launched).toBe('unverified');
+    expect(exitCode).toBe(1);
+    expect(parseFirst(logs).code).toBe('STIM_CLI_LAUNCH_FAILED');
     expect(errs.join('\n')).toMatch(/process exited within/);
     expect(errs.join('\n')).toMatch(/stim logs --errors/);
   });

--- a/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
@@ -230,6 +230,23 @@ describe('loadNdjsonReporter', () => {
     };
     expect(loadNdjsonReporter(root, { requireFrom: nothing })).toBe(null);
   });
+
+  test('prefers the reporter bundled with this CLI over an older project copy', () => {
+    const projectPackage = join(root, 'package.json');
+    const bundled = () => ({ update() {} });
+    const projectLocal = () => ({ update() {} });
+    const seen: string[] = [];
+    const factory = loadNdjsonReporter(root, {
+      requireFrom: (from) => {
+        seen.push(from);
+        return asRequire(() => ({ ndjsonReporter: from === projectPackage ? projectLocal : bundled }));
+      },
+    });
+
+    expect(factory).toBe(bundled);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).not.toBe(projectPackage);
+  });
 });
 
 describe('startBareServer wiring', () => {

--- a/packages/stim-cli/src/collector/ios.ts
+++ b/packages/stim-cli/src/collector/ios.ts
@@ -42,6 +42,7 @@ export const NOISE_RULES: NoiseRule[] = [
     id: 'uiscene-deprecation',
     messageIncludes: [
       'UIScene lifecycle will soon be required',
+      '`UIScene` lifecycle will soon be required',
       'must migrate to UIScene',
       'migrate to UIScene lifecycle',
     ],

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -156,7 +156,7 @@ export async function runCollector({
     if (finished) return;
     finished = true;
     watcher?.stop();
-    writer.write({ src: 'device', level, event, msg });
+    writer.write({ src: 'device', platform, level, event, msg });
     try {
       unregisterCollector(root, platform);
     } catch {}
@@ -199,6 +199,7 @@ export async function runCollector({
 
   writer.write({
     src: 'device',
+    platform,
     level: 'info',
     event: 'collector_started',
     msg:
@@ -210,7 +211,7 @@ export async function runCollector({
   const parse = platform === 'ios' ? parseLogStreamLine : parseLogcatLine;
   const onLine = (line: string) => {
     const record = parse(line, { now });
-    if (record) writer.write(record);
+    if (record) writer.write({ ...record, platform });
   };
 
   const attach = (streamPid: number | null): ChildProcess => {
@@ -222,7 +223,9 @@ export async function runCollector({
     const outReader = createLineReader(onLine);
     const errReader = createLineReader((line: string) => {
       const text = String(line).trimEnd();
-      if (text.trim()) writer.write({ src: 'device', level: 'debug', raw: true, event: 'collector_stderr', msg: text });
+      if (text.trim()) {
+        writer.write({ src: 'device', platform, level: 'debug', raw: true, event: 'collector_stderr', msg: text });
+      }
     });
     flushReaders = () => {
       outReader.flush();
@@ -259,6 +262,7 @@ export async function runCollector({
     child = null;
     writer.write({
       src: 'device',
+      platform,
       level: 'info',
       event: 'collector_reattached',
       msg: `${why}: ${packageName} is now pid ${nextPid} on ${serial} (was ${previous}); reattaching the log stream`,

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -61,6 +61,7 @@ import { MODE_BARE, MODE_EXPO, readWorkspaceState, writeWorkspaceState } from '.
 import {
   DEFAULT_METRO_PORT,
   LAUNCH_BUNDLING,
+  LAUNCH_FATAL,
   LAUNCH_UNVERIFIED,
   androidDevClientUrl,
   installAndroidApp,
@@ -68,6 +69,7 @@ import {
   launchAndroidReleaseApp,
   unverifiedLaunchLines,
   verifyAndroidReleaseLaunch,
+  androidAppProcess,
   verifyLaunch,
 } from '../engine/app-install.ts';
 import {
@@ -190,6 +192,9 @@ interface VerifyLaunchResultLike {
   verified?: boolean;
   skipped?: boolean;
   requested?: boolean;
+  fatal?: boolean;
+  processAlive?: boolean | null;
+  errors?: Array<{ msg?: unknown }>;
   waitedMs?: number;
 }
 
@@ -715,6 +720,10 @@ async function verifyAndroidRun({
       );
       return true;
     }
+    if (processCheck?.reason === 'probe-failed') {
+      phase('verify', chalk.yellow('UNVERIFIED: the app process check failed'));
+      return LAUNCH_UNVERIFIED;
+    }
     phase(
       'verify',
       chalk.yellow(
@@ -727,14 +736,40 @@ async function verifyAndroidRun({
         'A release app that dies at startup usually crashed loading its embedded bundle; `stim logs --errors` has the device log that says why.',
       ),
     );
-    return LAUNCH_UNVERIFIED;
+    return LAUNCH_FATAL;
   }
 
   const verification: VerifyLaunchResultLike = metroCheck
-    ? await verifyLaunched({ logsDir, since: launchedAt, metroPort, mode: isExpo ? MODE_EXPO : MODE_BARE })
+    ? await verifyLaunched({
+        logsDir,
+        since: launchedAt,
+        metroPort,
+        platform: 'android',
+        mode: isExpo ? MODE_EXPO : MODE_BARE,
+        processAlive: () => {
+          const pid = androidAppProcess(serial, androidPackage);
+          return pid === undefined ? null : pid !== null;
+        },
+      })
     : { verified: false, skipped: true };
+  if (verification?.fatal) {
+    const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
+    phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
+    for (const record of verification.errors ?? []) {
+      if (record.msg) phase('', chalk.red(String(record.msg)));
+    }
+    return LAUNCH_FATAL;
+  }
   if (verification?.verified) {
-    phase('verify', `bundle requested from Metro port ${metroPort} (${formatDuration(verification.waitedMs ?? 0)})`);
+    phase(
+      'verify',
+      `ready: bundle loaded, stable for 3s` +
+        (verification.processAlive === true ? ', process alive' : '') +
+        ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
+    );
+    for (const record of verification.errors ?? []) {
+      if (record.msg) phase('launch err', chalk.yellow(String(record.msg)));
+    }
     return true;
   }
   if (verification?.skipped) {
@@ -1110,6 +1145,14 @@ async function finishAndroidRun({
     scheme,
     phase,
   });
+  if (launchState === LAUNCH_FATAL) {
+    return fail(
+      LAUNCH_FAILED,
+      'The app failed its launch readiness check.',
+      `Read the launch error above or run \`stim logs --errors\`. The full timeline is in ${logsDir}.`,
+      { lastBuildStatus: true, logPath: displayPath(root, logsDir) },
+    );
+  }
   writer.write(
     launchOutcomeRecord({ launchState, release, bundleId: androidPackage, configuration: variant, metroPort }),
   );

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -74,10 +74,14 @@ other line goes to stderr, so it is always safe to pipe.
   bundleId        the iOS bundle id that was launched
   launched        true, "bundling", or "unverified". THE THREE ARE DIFFERENT
                   FACTS and only the last one is a problem.
-                    true         a bundle request from this app reached this
-                                 workspace's Metro within ~20s of the launch
+                    true         Metro finished the bundle, then the app stayed
+                                 alive through a three-second stability window.
+                                 The command checks process liveness when the
+                                 platform exposes it. Errors from that window
+                                 are printed even when the app stays alive; the
+                                 agent decides whether a nonfatal error matters
                     "bundling"   the request DID arrive and Metro was still
-                                 building the bundle when the window closed.
+                                 building when the bundle timeout closed.
                                  The wiring is proven; the JS has simply not
                                  run yet (a cold bundle of ~10k modules takes
                                  longer than the window). Nothing to do --
@@ -100,9 +104,9 @@ other line goes to stderr, so it is always safe to pipe.
                   with no dev server at all. There, \`launched\` is verified
                   by the app process staying alive after launch (a bad
                   embedded bundle crashes within seconds), not by a bundle
-                  request -- "unverified" means the process died or could not
-                  be checked, and \`stim logs --errors\` has the device
-                  log that says why
+                  request. A process that exits fails the command. An iOS
+                  launch with no process id is "unverified", and
+                  \`stim logs --errors\` has the device log that says why
   logs            { dir }
   durationMs      wall time for the whole run
 
@@ -130,8 +134,8 @@ other line goes to stderr, so it is always safe to pipe.
                   There, \`launched\` is verified by the app PROCESS being
                   alive on the device a moment after launch (\`pidof\`, then
                   \`ps -A\`), not by a bundle request -- "unverified" means
-                  no process was found, and \`stim logs --errors\` has the
-                  device log that says why
+                  no process was found fails the command, and
+                  \`stim logs --errors\` has the device log that says why
   bundleId        the ANDROID PACKAGE NAME the launch, the port wiring and
                   the remedies all target -- read from the BUILT APK's
                   manifest, which on a flavored project is the flavor's

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -22,9 +22,11 @@ import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import {
   DEFAULT_METRO_PORT,
   LAUNCH_BUNDLING,
+  LAUNCH_FATAL,
   LAUNCH_UNVERIFIED,
   devClientUrl,
   installIosApp,
+  iosAppProcess,
   launchIosApp,
   unverifiedLaunchLines,
   verifyLaunch,
@@ -164,6 +166,9 @@ interface VerifyLaunchResultLike {
   verified?: boolean;
   skipped?: boolean;
   requested?: boolean;
+  fatal?: boolean;
+  processAlive?: boolean | null;
+  errors?: Array<{ msg?: unknown }>;
   waitedMs?: number;
 }
 
@@ -817,14 +822,43 @@ async function verifyIosRun({
         ),
       ),
     );
-    return LAUNCH_UNVERIFIED;
+    return processCheck?.reason === 'exited' ? LAUNCH_FATAL : LAUNCH_UNVERIFIED;
   }
 
   const verification: VerifyLaunchResultLike = metroCheck
-    ? await d.verifyLaunch({ logsDir, since: launchedAt, metroPort, mode: isExpo ? MODE_EXPO : MODE_BARE })
+    ? await d.verifyLaunch({
+        logsDir,
+        since: launchedAt,
+        metroPort,
+        platform: 'ios',
+        mode: isExpo ? MODE_EXPO : MODE_BARE,
+        processAlive: remoteDevice
+          ? null
+          : () => {
+              if (launched?.pid) return d.isPidAlive(launched.pid);
+              const pid = iosAppProcess(udid, bundleId);
+              return pid === undefined ? null : pid !== null;
+            },
+      })
     : { verified: false, skipped: true };
+  if (verification?.fatal) {
+    const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
+    phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
+    for (const record of verification.errors ?? []) {
+      if (record.msg) note(chalk.red(phaseLine('', String(record.msg))));
+    }
+    return LAUNCH_FATAL;
+  }
   if (verification?.verified) {
-    phase('verify', `bundle requested from Metro port ${metroPort} (${formatDuration(verification.waitedMs ?? 0)})`);
+    phase(
+      'verify',
+      `ready: bundle loaded, stable for 3s` +
+        (verification.processAlive === true ? ', process alive' : '') +
+        ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
+    );
+    for (const record of verification.errors ?? []) {
+      if (record.msg) note(chalk.yellow(phaseLine('launch err', String(record.msg))));
+    }
     return true;
   }
   if (verification?.skipped) {
@@ -1156,6 +1190,15 @@ async function finishIosRun({
     remoteDevice: Boolean(remoteDevice),
     metroOrigin: typeof launched?.jsLocation === 'string' ? launched.jsLocation : null,
   });
+  if (launchState === LAUNCH_FATAL) {
+    return fail({
+      code: 'STIM_CLI_LAUNCH_FAILED',
+      message: 'The app failed its launch readiness check.',
+      remedy: `Read the launch error above or run \`stim logs --errors\`. The full timeline is in ${logsDir}.`,
+      logPath: logsDir,
+      build: { ...buildFailure, appPath, bundleId },
+    });
+  }
   logWriter().write(launchOutcomeRecord({ launchState, release, bundleId, configuration, metroPort }));
 
   const uploadWasAbandoned = await finishIosUpload(uploadPending, remote, phase, note);

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -119,6 +119,27 @@ export function parseLaunchedPid(text: unknown): number | null {
   return Number.isInteger(pid) && pid > 0 ? pid : null;
 }
 
+export function iosAppProcess(
+  udid: string,
+  bundleId: string,
+  { exec = null }: ExecOpt = {},
+): number | null | undefined {
+  const e = exec || getExecutor();
+  let out = '';
+  try {
+    out = e.runFile('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'list']);
+  } catch {
+    return undefined;
+  }
+  const label = `UIKitApplication:${bundleId}[`;
+  for (const line of out.split('\n')) {
+    if (!line.includes(label)) continue;
+    const pid = Number(line.trim().split(/\s+/)[0]);
+    if (Number.isInteger(pid) && pid > 0) return pid;
+  }
+  return null;
+}
+
 export function launchIosApp(
   {
     udid,
@@ -467,6 +488,9 @@ function describe(err: unknown) {
 export type VerifyLaunchResult = {
   verified: boolean;
   record?: NdjsonRecord;
+  errors?: NdjsonRecord[];
+  fatal?: boolean;
+  processAlive?: boolean | null;
   timedOut?: boolean;
   requested?: boolean;
   mode: string | null;
@@ -477,7 +501,7 @@ const RELEASE_VERIFY_WAIT_MS = 3000;
 
 export type ReleaseVerifyResult = {
   verified: boolean;
-  reason?: 'no-pid' | 'exited';
+  reason?: 'no-pid' | 'exited' | 'probe-failed';
   waitedMs: number;
 };
 
@@ -520,6 +544,23 @@ export function parsePsPid(text: unknown, packageName: string): number | null {
   return null;
 }
 
+export function androidAppProcess(
+  serial: string,
+  packageName: string,
+  { exec = null }: ExecOpt = {},
+): number | null | undefined {
+  const e = exec || getExecutor();
+  try {
+    const pid = parsePidof(e.runFile('adb', ['-s', serial, 'shell', 'pidof', packageName]));
+    if (pid !== null) return pid;
+  } catch {}
+  try {
+    return parsePsPid(e.runFile('adb', ['-s', serial, 'shell', 'ps', '-A']), packageName);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function verifyAndroidReleaseLaunch({
   serial,
   packageName,
@@ -538,20 +579,9 @@ export async function verifyAndroidReleaseLaunch({
   const e = exec || getExecutor();
   const startedAt = now();
   await sleep(Math.max(0, waitMs));
-  let pid: number | null = null;
-  try {
-    pid = parsePidof(e.runFile('adb', ['-s', serial, 'shell', 'pidof', packageName]));
-  } catch {
-    pid = null;
-  }
-  if (pid === null) {
-    try {
-      pid = parsePsPid(e.runFile('adb', ['-s', serial, 'shell', 'ps', '-A']), packageName);
-    } catch {
-      pid = null;
-    }
-  }
+  const pid = androidAppProcess(serial, packageName, { exec: e });
   const waitedMs = now() - startedAt;
+  if (pid === undefined) return { verified: false, reason: 'probe-failed', waitedMs };
   return pid === null ? { verified: false, reason: 'exited', waitedMs, pid: null } : { verified: true, waitedMs, pid };
 }
 
@@ -568,7 +598,10 @@ export const LAUNCH_UNVERIFIED = 'unverified';
 
 export const LAUNCH_BUNDLING = 'bundling';
 
+export const LAUNCH_FATAL = 'fatal';
+
 export const VERIFY_TIMEOUT_MS = 20000;
+export const STABILITY_WINDOW_MS = 3000;
 const VERIFY_POLL_MS = 500;
 
 const BUNDLE_EVENTS = new Set([
@@ -579,11 +612,16 @@ const BUNDLE_EVENTS = new Set([
   'transformer_error',
 ]);
 
-export function isBundleProof(record: unknown, since: number | string = 0): boolean {
+export function isBundleProof(
+  record: unknown,
+  since: number | string = 0,
+  platform: 'ios' | 'android' | null = null,
+): boolean {
   if (!record || typeof record !== 'object') return false;
   const rec = record as NdjsonRecord;
   const ts = Number(rec.ts);
   if (!Number.isFinite(ts) || ts < Number(since || 0)) return false;
+  if (platform && recordPlatform(rec) !== platform) return false;
   if (typeof rec.event === 'string' && BUNDLE_EVENTS.has(rec.event)) return true;
   if (rec.src === 'metro' && typeof rec.msg === 'string' && expoBundleLine(rec.msg)) return true;
   return false;
@@ -595,6 +633,7 @@ export function isBundleRequestProof(
   record: unknown,
   since: number | string = 0,
   port: number | string | null = null,
+  platform: 'ios' | 'android' | null = null,
 ): boolean {
   if (!record || typeof record !== 'object' || !port) return false;
   const rec = record as NdjsonRecord;
@@ -602,6 +641,8 @@ export function isBundleRequestProof(
   if (!Number.isFinite(ts) || ts < Number(since || 0)) return false;
   if (typeof rec.msg !== 'string') return false;
   if (rec.level === 'error' || rec.level === 'fatal') return false;
+  const sourcePlatform = recordPlatform(rec);
+  if (platform && sourcePlatform && sourcePlatform !== platform) return false;
   const digits = String(port).replace(/[^0-9]/g, '');
   if (!digits) return false;
   if (!new RegExp(`:${digits}\\b`).test(rec.msg)) return false;
@@ -616,54 +657,172 @@ export async function verifyLaunch({
   logsDir,
   since,
   metroPort = null,
+  platform = null,
   mode = null,
   timeoutMs = VERIFY_TIMEOUT_MS,
+  stabilityMs = STABILITY_WINDOW_MS,
   pollMs = VERIFY_POLL_MS,
   readRecords = null,
   readDeviceRecords = null,
+  readClientRecords = null,
+  processAlive = null,
   now = Date.now,
   sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
 }: {
   logsDir?: string;
   since?: number | string;
   metroPort?: number | string | null;
+  platform?: 'ios' | 'android' | null;
   mode?: string | null;
   timeoutMs?: number;
+  stabilityMs?: number;
   pollMs?: number;
   readRecords?: (() => NdjsonRecord[]) | null;
   readDeviceRecords?: (() => NdjsonRecord[]) | null;
+  readClientRecords?: (() => NdjsonRecord[]) | null;
+  processAlive?: (() => boolean | null) | null;
   now?: () => number;
   sleep?: (ms: number) => Promise<unknown>;
 } = {}): Promise<VerifyLaunchResult> {
   const read = readRecords || (() => readMetroRecords(logsDir));
   const readDevice = readDeviceRecords || (() => readNdjson(logsDir, 'device.ndjson'));
+  const readClient = readClientRecords || (() => readNdjson(logsDir, 'client.ndjson'));
   const startedAt = now();
-  const deadline = startedAt + Math.max(0, timeoutMs);
+  const bundleDeadline = startedAt + Math.max(0, timeoutMs);
+  let proof: NdjsonRecord | null = null;
+  let activity: NdjsonRecord | null = null;
+  let stabilityDeadline: number | null = null;
   while (true) {
-    for (const record of read()) {
-      if (isBundleProof(record, since)) {
-        return { verified: true, record, mode, waitedMs: now() - startedAt };
+    const metroRecords = read().filter((record) => after(record, since));
+    for (const record of metroRecords) {
+      if (isBundleProof(record, since, platform)) activity = record;
+      if (!proof && isBundleReadyProof(record, since, platform)) {
+        proof = record;
+        stabilityDeadline = Number(record.ts) + Math.max(0, stabilityMs);
       }
     }
-    if (now() >= deadline) {
-      const requested = findBundleRequest(readDevice(), since, metroPort);
+    const bundleErrors = metroRecords.filter((record) => isFatalLaunchError(record, platform));
+    if (bundleErrors.length) {
+      const alive = processAlive ? processAlive() : null;
+      const fatalRecord = bundleErrors[bundleErrors.length - 1];
+      const fatalAt = Number(fatalRecord?.ts ?? since ?? 0);
+      const errors = metroRecords.filter(
+        (record) =>
+          after(record, fatalAt) && recordCouldBelongToPlatform(record, platform) && isLaunchError(record, platform),
+      );
+      return {
+        verified: false,
+        fatal: true,
+        errors,
+        processAlive: alive,
+        record: fatalRecord,
+        mode,
+        waitedMs: now() - startedAt,
+      };
+    }
+
+    if (proof && stabilityDeadline !== null && now() >= stabilityDeadline) {
+      const errorSince = Number(proof.ts ?? since ?? 0);
+      const deviceRecords = readDevice().filter((record) => after(record, errorSince));
+      const clientRecords = readClient().filter((record) => after(record, errorSince));
+      const errors = [
+        ...metroRecords.filter((record) => after(record, errorSince) && recordCouldBelongToPlatform(record, platform)),
+        ...deviceRecords.filter((record) => recordCouldBelongToPlatform(record, platform)),
+        ...clientRecords,
+      ].filter((record) => isLaunchError(record, platform));
+      const alive = processAlive ? processAlive() : null;
       const waitedMs = now() - startedAt;
-      if (requested) return { verified: false, timedOut: true, requested: true, record: requested, mode, waitedMs };
+      if (alive === false) {
+        return {
+          verified: false,
+          fatal: true,
+          errors,
+          processAlive: alive,
+          record: proof,
+          mode,
+          waitedMs,
+        };
+      }
+      return { verified: true, record: proof, errors, processAlive: alive, mode, waitedMs };
+    }
+
+    if (!proof && now() >= bundleDeadline) {
+      const deviceRecords = readDevice().filter((record) => after(record, since));
+      const requested = findBundleRequest(deviceRecords, since, metroPort, platform) ?? activity;
+      const waitedMs = now() - startedAt;
+      if (requested) {
+        return {
+          verified: false,
+          timedOut: true,
+          requested: true,
+          record: requested,
+          mode,
+          waitedMs,
+        };
+      }
       return { verified: false, timedOut: true, mode, waitedMs };
     }
+    const deadline = stabilityDeadline ?? bundleDeadline;
     await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
   }
+}
+
+function after(record: NdjsonRecord, since: number | string | undefined): boolean {
+  const ts = Number(record.ts);
+  return Number.isFinite(ts) && ts >= Number(since ?? 0);
+}
+
+function isLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
+  return record.level === 'error' || record.level === 'fatal' || isFatalLaunchError(record, platform);
+}
+
+function isFatalLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
+  if (platform && recordPlatform(record) !== platform) return false;
+  return (
+    record.event === 'bundle_build_failed' ||
+    record.event === 'bundling_error' ||
+    record.event === 'transformer_error' ||
+    ((record.event === 'expo_stdout' || record.event === 'expo_stderr') &&
+      typeof record.msg === 'string' &&
+      /\bBundling failed\b/.test(record.msg))
+  );
+}
+
+function isBundleReadyProof(
+  record: unknown,
+  since: number | string = 0,
+  platform: 'ios' | 'android' | null = null,
+): boolean {
+  if (!isBundleProof(record, since, platform)) return false;
+  const rec = record as NdjsonRecord;
+  if (rec.event === 'bundle_build_done') return true;
+  return rec.src === 'metro' && typeof rec.msg === 'string' && /\bBundled\b/.test(rec.msg);
 }
 
 function findBundleRequest(
   records: NdjsonRecord[],
   since: number | string | undefined,
   port: number | string | null,
+  platform: 'ios' | 'android' | null,
 ): NdjsonRecord | null {
   for (const record of records) {
-    if (isBundleRequestProof(record, since ?? 0, port)) return record;
+    if (isBundleRequestProof(record, since ?? 0, port, platform)) return record;
   }
   return null;
+}
+
+function recordCouldBelongToPlatform(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
+  if (!platform) return true;
+  const sourcePlatform = recordPlatform(record);
+  return sourcePlatform === null || sourcePlatform === platform;
+}
+
+function recordPlatform(record: NdjsonRecord): 'ios' | 'android' | null {
+  if (record.platform === 'ios' || record.platform === 'android') return record.platform;
+  if (typeof record.msg !== 'string') return null;
+  const match = record.msg.match(/\b(iOS|Android)\s+Bundl(?:ed|ing)\b/i);
+  if (!match) return null;
+  return match[1]!.toLowerCase() === 'ios' ? 'ios' : 'android';
 }
 
 export function readMetroRecords(logsDir: string | undefined): NdjsonRecord[] {

--- a/packages/stim-cli/src/supervisor/server-bare.ts
+++ b/packages/stim-cli/src/supervisor/server-bare.ts
@@ -106,7 +106,7 @@ export function loadNdjsonReporter(
   root: string,
   { requireFrom = createRequire }: { requireFrom?: (id: string) => NodeJS.Require } = {},
 ): ((opts: { dir: string }) => BareModule) | null {
-  for (const from of [join(root, 'package.json'), import.meta.url]) {
+  for (const from of [import.meta.url, join(root, 'package.json')]) {
     try {
       const factory = requireFrom(from)('@stim-cli/metro').ndjsonReporter;
       if (typeof factory === 'function') return factory;


### PR DESCRIPTION
## Description

The iOS and Android commands can exit before Metro finishes the JavaScript bundle. A successful native launch does not prove that the app is ready or still alive.

## Solution

- Wait for Metro to report bundle completion.
- Correlate completion and failure records by Metro build ID and platform.
- Start a three-second stability window after bundle completion.
- Check process liveness and collect launch errors after the window.
- Fail immediately for Metro bundle errors and confirmed process exit.
- Keep explicit `bundling` and `unverified` states when readiness cannot be proven.

## Test plan

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm format:check`
- `pnpm test:runtime`
- Live Trailhead launch with a native cache hit

Closes #103
