### PR TITLE
Report full agent facts in plain command output

### DIFF
--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -28,8 +28,9 @@ later. If `npx` returns E401 or E404 in a repo with a private registry, use:
 npx --registry=https://registry.npmjs.org stim-cli <command>
 ```
 
-Prefer `--json` when another command or device tool needs a port, UDID, serial,
-bundle ID, or path.
+Prefer plain output for agent workflows. It streams each phase and ends with the
+full device ID, app ID, Metro state, cache result, and log path. Use `--json`
+only when a script must parse a stable payload.
 
 ## Normal workflow
 
@@ -43,7 +44,7 @@ cd <printed-path>
 
 stim start
 stim ios                    # or: stim android
-stim logs --errors --json
+stim logs --errors
 
 # Edit JavaScript or TypeScript. Fast Refresh applies the change.
 stim logs --since 30s --level error
@@ -62,17 +63,20 @@ Follow these rules during the loop:
   change does not need another native build.
 - A cold native build can outlive a shell timeout. Run the same build command
   again. The second call joins the active build or returns its result.
-- Target only the UDID, serial, and Metro port from this workspace's current
-  JSON output. Never assume that the device named `booted` is yours. Never
-  hardcode a Metro port.
-- `launched: true` proves the launch. `launched: "bundling"` means Metro still
-  builds the bundle. Wait and query the logs. For `launched: "unverified"`,
-  follow the printed remedy before you claim success.
+- Target only the full UDID, serial, app ID, and Metro port from this
+  workspace's current output. Never assume that the device named `booted` is
+  yours. Never hardcode a Metro port.
+- An `OK` summary with no launch qualifier proves the launch. When the summary
+  says `bundle requested, still building`, Metro has not completed the bundle;
+  wait and query the logs. For `launch UNVERIFIED`, follow the printed remedy
+  before you claim success. JSON reports these states as `true`, `"bundling"`,
+  and `"unverified"` in `launched`.
 - Empty output from `logs --errors` with exit code 0 is the pass condition.
   Do not read the NDJSON files directly.
-- Use `stim status` to find this workspace's device, port, server state,
-  and last build. Use `stim doctor` when a build is unexpectedly slow
-  or the environment looks incomplete.
+- Use `stim status` when resuming a workspace or recovering missing device,
+  port, server, or build facts. A normal `start` and platform run already print
+  the facts needed for the next step. Use `stim doctor` when a build is
+  unexpectedly slow or the environment looks incomplete.
 
 ## Ownership and deletion
 

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -934,7 +934,7 @@ describe('a cache hit', () => {
     expect(labelled(h.stderr, 'build').length).toBe(0);
   });
 
-  test("prints the phases the spec's worked example prints, and one line on stdout", async () => {
+  test('prints the phases and one complete agent-facts block on stdout', async () => {
     const h = harness({ resolveCached: () => '/cache/app-debug.apk', build: never('the build') });
     await h.run();
 
@@ -948,6 +948,11 @@ describe('a cache hit', () => {
     expect(labelled(h.stderr, 'launch')[0]).toMatch(/\(\d+m?\d*s\)$/);
     expect(h.stdout.length).toBe(1);
     expect(h.stdout[0]).toMatch(/OK: com\.example\.app launched on emulator-5584/);
+    expect(h.stdout[0]).toContain(phaseLine('device', 'stim-cli-app-412 (emulator-5584)'));
+    expect(h.stdout[0]).toContain(phaseLine('app', 'com.example.app'));
+    expect(h.stdout[0]).toContain(phaseLine('metro', 'running on port 8082'));
+    expect(h.stdout[0]).toContain(phaseLine('cache', 'cache hit'));
+    expect(h.stdout[0]).toContain(phaseLine('logs', workspaceLogsDir(root)));
     expect(h.stderr.length <= 9).toBeTruthy();
   });
 
@@ -994,7 +999,8 @@ describe('a cache miss', () => {
     expect(h.calls.storeCached[0]?.slice(0, 2)).toEqual(['android', CACHE_KEY]);
     expect(h.calls.install[0]?.apkPath).toBe(h.calls.storeCached[0]?.[2]);
     expect(labelled(h.stderr, 'fingerprint')[0]).toMatch(/miss/);
-    expect(labelled(h.stderr, 'build')[0]).toMatch(/app-debug\.apk \(2m41s\)/);
+    expect(labelled(h.stderr, 'build')[0]).toMatch(/compiling debug with Gradle/);
+    expect(labelled(h.stderr, 'build')[1]).toMatch(/app-debug\.apk \(2m41s\)/);
     assert(result.facts);
     expect(result.facts.cacheHit).toBe(false);
   });
@@ -1208,6 +1214,7 @@ describe('metro is verified before any build work', () => {
     expect(result.ok).toBe(true);
     expect(labelled(h.stderr, 'metro')[0]).toMatch(/not checked/);
     expect(h.calls.launch[0]?.metroPort).toBe(8082);
+    expect(h.stdout[0]).toContain(phaseLine('metro', 'check skipped on port 8082'));
   });
 
   test('in --json mode a refusal is the error contract, on stdout, alone', async () => {
@@ -1409,7 +1416,8 @@ describe('a failed build', () => {
     expect(result.ok).toBe(false);
     assert(result.error);
     expect(result.error.code).toBe(BUILD_ERROR);
-    expect(labelled(h.stderr, 'build')[0]).toMatch(/FAILED after 2m41s/);
+    expect(labelled(h.stderr, 'build')[0]).toMatch(/compiling debug with Gradle/);
+    expect(labelled(h.stderr, 'build')[1]).toMatch(/FAILED after 2m41s/);
     const errors = labelled(h.stderr, 'error');
     expect(errors.some((l) => /MainActivity\.kt:23:9: Unresolved reference 'Foo'\./.test(l))).toBeTruthy();
     expect(errors.some((l) => /and 3 more diagnostic/.test(l))).toBeTruthy();
@@ -2178,6 +2186,7 @@ describe('launch verification', () => {
     expect(text).toMatch(/adb -s emulator-5584 shell monkey -p com\.example\.app 1/);
     expect(text).not.toMatch(/simctl/);
     expect(h.stdout.join('\n')).toMatch(/UNVERIFIED/);
+    expect(h.stdout[0]).toContain(phaseLine('metro', 'state unverified on port 8082'));
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -333,11 +333,12 @@ describe('the Metro gate', () => {
 
   test('--no-metro-check proceeds without probing the port at all', async () => {
     reserve();
-    const { exitCode, calls } = await run({ metroCheck: false });
+    const { exitCode, calls, logs } = await run({ metroCheck: false });
     expect(exitCode).toBe(null);
     expect(!calls.order.includes('resolveProjectMetro')).toBeTruthy();
     expect(calls.order.includes('buildIos')).toBeTruthy();
     expect(calls.args.launchIosApp.metroPort).toBe(8082);
+    expect(logs[0]).toContain(phaseLine('metro', 'check skipped on port 8082'));
   });
 
   test('--no-metro-check with no reservation still wires the app to 8081', async () => {
@@ -548,6 +549,7 @@ describe('launch verification', () => {
     reserve();
     const { logs } = await run({}, { verifyLaunch: async () => ({ verified: false, timedOut: true }) });
     expect(logs[0]).toMatch(/UNVERIFIED/);
+    expect(logs[0]).toContain(phaseLine('metro', 'state unverified on port 8082'));
   });
 });
 
@@ -1463,15 +1465,21 @@ describe('failure output', () => {
 });
 
 describe('success output', () => {
-  test('the phase lines are stderr and the summary is the only line on stdout', async () => {
+  test('the phase lines stream on stderr and the final stdout block has complete agent facts', async () => {
     reserve();
     const { logs, errs, exitCode } = await run({});
     expect(exitCode).toBe(null);
     expect(logs.length).toBe(1);
     expect(logs[0]).toMatch(/^OK: com\.example\.app on stim-cli-fixture \(BF2A\.\.\), Metro port 8082/);
+    expect(logs[0]).toContain(phaseLine('device', `stim-cli-fixture (${UDID})`));
+    expect(logs[0]).toContain(phaseLine('app', 'com.example.app'));
+    expect(logs[0]).toContain(phaseLine('metro', 'running on port 8082'));
+    expect(logs[0]).toContain(phaseLine('cache', 'built'));
+    expect(logs[0]).toContain(phaseLine('logs', workspaceLogsDir(root)));
     const text = errs.join('\n');
     expect(text).toMatch(/^  device {6}stim-cli-fixture \(BF2A\.\.\) booted \(\d+ms\)$/m);
     expect(text).toMatch(/^  fingerprint a3f9b1\.\. miss \(\d+ms\)$/m);
+    expect(text).toMatch(/^  build {7}compiling Debug with xcodebuild$/m);
     expect(text).toMatch(/^  build {7}ok \(2m41s\)$/m);
     expect(text).toMatch(/^  install {5}-> stim-cli-fixture \(BF2A\.\.\) \(\d+ms\)$/m);
     expect(text).toMatch(/^  launch {6}com\.example\.app \(\d+ms\)$/m);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -833,6 +833,7 @@ interface ReportAndroidResultArgs {
   useBuildCache: boolean;
   variant: string | null;
   release: boolean;
+  metroCheck: boolean;
   metroPort: number | null;
   logsDir: string | null;
   serial: string;
@@ -854,6 +855,7 @@ function reportAndroidResult({
   useBuildCache,
   variant,
   release,
+  metroCheck,
   metroPort,
   logsDir,
   serial,
@@ -897,12 +899,30 @@ function reportAndroidResult({
       `OK: ${androidPackage} launched on ${serial}, ` +
       `${release ? `${variant} (embedded JS, no Metro)` : `Metro port ${metroPort}`} ` +
       `(${cacheOutcome(record.cacheHit, remote?.name)})`;
-    emit(
+    const outcome =
       launchState === LAUNCH_UNVERIFIED
         ? chalk.yellow(`${summary} -- launch UNVERIFIED`)
         : launchState === LAUNCH_BUNDLING
           ? chalk.green(`${summary} -- bundle requested, still building`)
-          : chalk.green(summary),
+          : chalk.green(summary);
+    const deviceName = record.avdName || record.deviceName || serial;
+    const cacheResult = useBuildCache ? cacheOutcome(record.cacheHit, remote?.name) : 'bypassed; built';
+    const metroResult = release
+      ? `embedded (${variant})`
+      : !metroCheck
+        ? `check skipped on port ${metroPort}`
+        : launchState === LAUNCH_UNVERIFIED
+          ? `state unverified on port ${metroPort}`
+          : `running on port ${metroPort}`;
+    emit(
+      [
+        outcome,
+        phaseLine('device', `${deviceName} (${serial})`),
+        phaseLine('app', androidPackage),
+        phaseLine('metro', metroResult),
+        phaseLine('cache', cacheResult),
+        phaseLine('logs', logsDir || 'unavailable (remote device)'),
+      ].join('\n'),
     );
   }
   return facts;
@@ -1162,6 +1182,7 @@ async function finishAndroidRun({
     useBuildCache,
     variant,
     release,
+    metroCheck,
     metroPort,
     logsDir: remoteRelease ? null : logsDir,
     serial,
@@ -1964,6 +1985,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         }
 
         if (!apkPath) {
+          phase('build', `compiling ${variant || 'debug'} with Gradle`);
           const built: BuildAndroidResultLike = await build({ root, logWriter: writer, variant });
           if (built.failed) {
             const diagnostics = built.diagnostics || [];

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -931,6 +931,7 @@ interface ReportIosResultArgs {
   json: boolean;
   release: boolean;
   configuration: string | null;
+  metroCheck: boolean;
   metroPort: number | null;
   logsDir: string;
   device: DeviceLike;
@@ -956,6 +957,7 @@ function reportIosResult({
   json,
   release,
   configuration,
+  metroCheck,
   metroPort,
   logsDir,
   device,
@@ -1016,12 +1018,30 @@ function reportIosResult({
       `OK: ${bundleId} on ${deviceLabel(device, udid)}, ` +
       (release ? `${configuration} (embedded JS, no Metro)` : `Metro port ${metroPort}`) +
       ` (${cacheDescription(cacheHit, remote?.name)}, ${formatDuration(durationMs)})`;
-    console.log(
+    const outcome =
       launchState === LAUNCH_UNVERIFIED
         ? chalk.yellow(`${summary} -- launch UNVERIFIED`)
         : launchState === LAUNCH_BUNDLING
           ? chalk.green(`${summary} -- bundle requested, still building`)
-          : chalk.green(summary),
+          : chalk.green(summary);
+    const deviceName = device?.deviceName ?? device?.name ?? udid;
+    const cacheResult = useBuildCache ? cacheDescription(cacheHit, remote?.name) : 'bypassed; built';
+    const metroResult = release
+      ? `embedded (${configuration})`
+      : !metroCheck
+        ? `check skipped on port ${metroPort}`
+        : launchState === LAUNCH_UNVERIFIED
+          ? `state unverified on port ${metroPort}`
+          : `running on port ${metroPort}`;
+    console.log(
+      [
+        outcome,
+        phaseLine('device', `${deviceName} (${udid})`),
+        phaseLine('app', bundleId),
+        phaseLine('metro', metroResult),
+        phaseLine('cache', cacheResult),
+        phaseLine('logs', logsDir),
+      ].join('\n'),
     );
     if (facts.webPreviewUrl) console.error(chalk.dim(`Watch this device: ${facts.webPreviewUrl}`));
   }
@@ -1208,6 +1228,7 @@ async function finishIosRun({
     json,
     release,
     configuration,
+    metroCheck,
     metroPort,
     logsDir,
     device,
@@ -1812,6 +1833,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         }
 
         if (!appPath) {
+          phase('build', `compiling ${configuration || 'Debug'} with xcodebuild`);
           const result: BuildIosResultLike = await d.buildIos({
             root,
             udid,


### PR DESCRIPTION
## Description

Plain platform output omits facts that an agent needs after a run. Agents must call `stim status` or request JSON to recover the full device ID, app ID, Metro state, cache result, and log path.

## Solution

- Print a complete agent-facts block after successful iOS and Android runs.
- Stream a compiler-start phase before long Xcode and Gradle builds.
- Recommend plain output for agent workflows and keep JSON for stable script parsing.

## Test plan

- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm test:runtime`
- Skill validation

Closes #101
