### PR TITLE
Stop owned iOS simulator without occupancy checks

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -183,9 +183,7 @@ The one workspace `worktree remove` never destroys is the main checkout: git can
 
 In particular `stop` does not, by design: it shuts the owned device down and leaves it assigned, so returning to a branch costs a boot rather than a create, a provision and a reinstall. There is no `--delete` on it, because an agent reaching for `stop` to reclaim memory must not have one within reach of a typo. Destruction lives in `worktree remove` and `gc`, never here.
 
-**A delete is not occupancy-guarded.** An owned sim goes away even if another tool is still attached to it. It is a device stim-cli created, for a project that is going away, and the process holding it is almost always the caller's own UI-test runner, which has nothing to return to. Skipping occupied sims there leaked booted sims and live `xcodebuild test-without-building` runners out of `worktree remove`, and "left for a later gc" only asked the same question again forever.
-
-`stop` _is_ occupancy-guarded, because the device it spares survives the call and is still there to come back to: an iOS sim actively driven by a foreign UI-test runner is left running and reported instead of shut down. (Android has no occupancy probe, so an owned, identity-verified AVD is always eligible.)
+Device teardown is not occupancy-guarded. An explicit `stop`, `worktree remove`, or `gc --delete` shuts down the Stim-owned device even if another tool still uses it. These commands never shut down an unowned device.
 
 If a delete fails, the failure is reported, the config record is **kept** so the device stays tracked, and the command exits 1. Dropping the record on a failed teardown is exactly what turns it into a simulator nothing references.
 

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -91,7 +91,8 @@ Ask the user before these actions:
   also empties shared build caches.
 - `stop` when the workspace owns an EAS session, because it irreversibly ends
   that remote session. For a local device, `stop` shuts it down but does not
-  delete it.
+  delete it. An explicit `stop` shuts down a Stim-owned simulator even when
+  another process uses it. It never shuts down an unowned simulator.
 
 ## Load advanced guidance only when needed
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -353,6 +353,18 @@ test('exactly one compact skill ships', () => {
   expect(skill).toMatch(/stim doctor/);
 });
 
+test('the skill and guide shut down owned simulators without an occupancy check', () => {
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+
+  expect(skill).toMatch(/explicit `stop` shuts down a Stim-owned simulator even when[\s\S]*another process uses it/i);
+  expect(skill).toMatch(/never shuts down an unowned simulator/i);
+  expect(cleanup).toMatch(/do not check simulator occupancy/i);
+  expect(cleanup).toMatch(/never shuts down an unowned simulator/i);
+  expect(skill).not.toContain('agent-device close --shutdown');
+});
+
 test('the skill still carries the rules an agent must not have to look up', () => {
   const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
   for (const must of [

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -77,16 +77,30 @@ test('teardownOwnedIosSim reports missing without erroring', () => {
   expect(teardownOwnedIosSim('U1', { del: true })).toEqual({ status: 'missing' });
 });
 
-test('teardownOwnedIosSim skips an occupied sim it is only shutting down', () => {
+test('teardownOwnedIosSim shuts down an owned sim without checking occupancy', () => {
   const exec = iosExecutor({
     sims: [OWNED],
     occupied: '\t123\t0\tUIKitApplication:com.example.thing.xctrunner[0x1][rb-legacy]\n',
   });
   setExecutor(exec);
   const r = teardownOwnedIosSim('U1', { del: false });
-  expect(r.status).toBe('skipped');
-  expect(r.reason).toMatch(/occupied/);
-  expect(!exec.calls.some((c) => /simctl shutdown|simctl delete/.test(c))).toBeTruthy();
+  expect(r.status).toBe('torn-down');
+  expect(exec.calls.some((c) => /simctl shutdown U1/.test(c))).toBeTruthy();
+  expect(exec.calls.some((c) => /launchctl list/.test(c))).toBe(false);
+});
+
+test('teardownOwnedIosSim does not check occupancy or shut down a sim that is not owned', () => {
+  const exec = iosExecutor({
+    sims: [{ ...OWNED, name: 'My Real Sim' }],
+    occupied: '\t123\t0\tUIKitApplication:com.callstack.agentdevice.runner.uitests.xctrunner[0x1][rb-legacy]\n',
+  });
+  setExecutor(exec);
+
+  const r = teardownOwnedIosSim('U1', { del: false });
+
+  expect(r.kind).toBe('not-owned');
+  expect(exec.calls.some((c) => /launchctl list/.test(c))).toBe(false);
+  expect(exec.calls.some((c) => /simctl shutdown/.test(c))).toBe(false);
 });
 
 test('teardownOwnedIosSim deletes an occupied sim anyway, without needing force', () => {
@@ -184,13 +198,9 @@ test('teardownOwnedAvd contains a throw instead of propagating it', () => {
   expect(r.reason).toMatch(/boom/);
 });
 
-test('skip outcomes carry a machine-readable kind, so callers need not match prose', () => {
+test('ownership skip outcomes carry a machine-readable kind', () => {
   setExecutor(iosExecutor({ sims: [{ ...OWNED, name: 'My Real Sim' }] }));
   expect(teardownOwnedIosSim('U1', { del: true }).kind).toBe('not-owned');
-  resetExecutor();
-
-  setExecutor(iosExecutor({ sims: [OWNED], occupied: '\t1\t0\tUIKitApplication:com.x.xctrunner[0x1]\n' }));
-  expect(teardownOwnedIosSim('U1', { del: false }).kind).toBe('occupied');
   resetExecutor();
 
   setExecutor(androidExecutor({ avds: ['Pixel_6'], adb: 'List of devices attached\n' }));

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1113,10 +1113,9 @@ ON THE MAIN CHECKOUT
   A registered project directory that is not a git repo at all gets the same
   environment reclaim -- there is nothing else remove could mean there.
 
-Neither delete path checks occupancy: a device being deleted goes away even if
-something is still driving it, because it is one stim-cli created for a project
-that is going away. \`stop\` DOES spare an occupied sim, because there the
-device survives the call.
+The delete paths and \`stop\` do not check simulator occupancy. An explicit
+\`stim stop\` shuts down this workspace's Stim-owned simulator, including a
+simulator used by a UI-test runner. It never shuts down an unowned simulator.
 
 If a delete fails, the device's config record is KEPT and the command reports
 it. A record is what makes the device findable again, so it outlives a failed

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -1,4 +1,4 @@
-import { occupyingApps, resolveOwnedIosSim, shutdownIosSim, deleteIosSim } from './sim/ios.ts';
+import { resolveOwnedIosSim, shutdownIosSim, deleteIosSim } from './sim/ios.ts';
 import { resolveOwnedAvdSerial, shutdownAndroidEmulator, deleteAvd } from './sim/android.ts';
 
 export interface TeardownOutcome {
@@ -24,17 +24,6 @@ export function teardownOwnedIosSim(
       };
     }
     if (resolved.missing) return { status: 'missing' };
-    if (!del) {
-      const apps = occupyingApps(udid);
-      if (apps === null || apps.length > 0) {
-        return {
-          status: 'skipped',
-          kind: 'occupied',
-          reason: 'in use by another process (occupied)',
-          ...(apps ? { holders: apps } : {}),
-        };
-      }
-    }
     shutdownIosSim(udid);
     if (del) deleteIosSim(udid);
     return { status: 'torn-down', label: label ?? resolved.sim?.name ?? udid };
@@ -43,8 +32,6 @@ export function teardownOwnedIosSim(
   }
 }
 
-// Android has no occupancy probe, so an owned, identity-verified AVD is always
-// eligible: there is no equivalent of the iOS occupancy skip here.
 export function teardownOwnedAvd(avdName: string, { del = false }: { del?: boolean } = {}): TeardownOutcome {
   try {
     const resolved = resolveOwnedAvdSerial(avdName);


### PR DESCRIPTION
## Description

`stim stop` preserves an owned iOS simulator when any process occupies it. The simulator belongs to the current Stim workspace, so an explicit stop can shut it down safely.

## Solution

- Remove the occupancy probe from owned iOS simulator teardown.
- Shut down the current workspace-owned simulator during `stim stop`.
- Preserve unowned and missing simulators.
- Document the ownership rule in the skill and guide.

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm format:check`
- `pnpm test:runtime`
- `pnpm build`
- Real teardown while Agent Device uses the owned simulator

Closes #104
