### PR TITLE
chore: prepare 1.0.0-rc.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           # Node 24 bundles an npm new enough for OIDC trusted publishing.
           runtime: node@24
-          cache: true
+          # Release installs must not restore a package-manager cache.
+          cache: false
           install: false
       - name: Install (lifecycle scripts stay blocked)
         run: pnpm install --frozen-lockfile
@@ -49,9 +50,7 @@ jobs:
           if npm view "@stim-cli/core@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/core@$version is already published"
           else
-            tag=latest
-            if [[ "$version" == *-* ]]; then tag=next; fi
-            npm publish --provenance --access public --tag "$tag"
+            npm publish --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/metro
         working-directory: packages/metro
@@ -60,9 +59,7 @@ jobs:
           if npm view "@stim-cli/metro@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/metro@$version is already published"
           else
-            tag=latest
-            if [[ "$version" == *-* ]]; then tag=next; fi
-            npm publish --provenance --access public --tag "$tag"
+            npm publish --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/expo-build-cache
         working-directory: packages/expo-build-cache
@@ -71,9 +68,7 @@ jobs:
           if npm view "@stim-cli/expo-build-cache@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/expo-build-cache@$version is already published"
           else
-            tag=latest
-            if [[ "$version" == *-* ]]; then tag=next; fi
-            npm publish --provenance --access public --tag "$tag"
+            npm publish --provenance --access public --tag latest
           fi
       - name: Publish stim-cli
         working-directory: packages/stim-cli
@@ -82,9 +77,7 @@ jobs:
           if npm view "stim-cli@$version" version >/dev/null 2>&1; then
             echo "stim-cli@$version is already published"
           else
-            tag=latest
-            if [[ "$version" == *-* ]]; then tag=next; fi
-            npm publish --provenance --access public --tag "$tag"
+            npm publish --provenance --access public --tag latest
           fi
       - name: Smoke-test the registry
         run: |

--- a/docs/releases/1.0.0-rc.1.md
+++ b/docs/releases/1.0.0-rc.1.md
@@ -1,0 +1,59 @@
+# stim-cli 1.0.0-rc.1 - clearer launches and safer cleanup
+
+This release candidate makes the normal agent loop easier to follow and more
+reliable. Plain output now streams each phase and finishes with the complete
+device, app, Metro, cache, and log facts. JSON output remains available for
+scripts that need a stable payload.
+
+## Install and run
+
+```bash
+npx skills add appandflow/stim-cli
+
+npx --package=stim-cli stim doctor
+npx --package=stim-cli stim start
+npx --package=stim-cli stim ios              # or: npx --package=stim-cli stim android
+npx --package=stim-cli stim logs --errors
+npx --package=stim-cli stim stop
+```
+
+## Launch readiness
+
+`stim ios` and `stim android` wait for Metro to finish the bundle before the
+launch stability window starts. The commands then observe the app for three
+seconds and check that its process remains alive.
+
+The final output reports whether the app is ready, still bundling, unverified,
+or failed. A Metro bundle failure or an exited app process fails the command.
+Errors observed during the launch window are printed for the agent to assess,
+even when the app remains alive.
+
+## Plain agent output
+
+The platform commands stream the important build and launch phases as they
+happen. Their final plain-text summary includes:
+
+- the full simulator UDID or emulator serial;
+- the app ID;
+- the Metro port and state;
+- the native build cache result;
+- the log directory.
+
+The bundled skill recommends plain output for interactive agent work. It uses
+JSON only when another program must parse the result.
+
+## Owned simulator cleanup
+
+An explicit `stim stop` shuts down a Stim-owned iOS simulator even when a
+device automation session is still active. Stim verifies ownership before the
+shutdown and never shuts down an unowned simulator.
+
+This lets an agent keep its Agent Device session active through visual proof,
+run `stim stop`, and then close the automation session.
+
+## Error reporting
+
+Native prebuild failures now appear in `stim logs --errors`. Bare React Native
+Metro logs also retain more launch context for diagnosis.
+
+All four packages use version `1.0.0-rc.1` and are released together.

--- a/docs/trailhead-agent-benchmark.md
+++ b/docs/trailhead-agent-benchmark.md
@@ -30,7 +30,7 @@ output in the coordinator report.
 
 1. Build the merged Stim candidate and install that exact candidate locally.
    Install Agent Device 0.20.10. Record both versions and the candidate commit.
-   Use Codex CLI 0.142.0, model `gpt-5.6-sol`, reasoning effort `high`, and
+   Use Codex CLI 0.151.0, model `gpt-5.6-sol`, reasoning effort `high`, and
    service tier `priority` for both timed arms.
 2. Archive the first benchmark artifacts. Do not reuse its worktrees, branches,
    simulators, logs, or Metro processes.
@@ -48,7 +48,18 @@ output in the coordinator report.
    result, and log directory.
 7. Build the same main checkout with
    `npx expo run:ios --device <udid> --no-bundler`, using the simulator from step 6. This warms Xcode's normal DerivedData path for the control arm.
-8. Run `stim stop`. Confirm that the main checkout is still clean.
+8. Create one disposable validation worktree for each arm from the fixed commit.
+   Install dependencies with the same commands that the timed agents will use.
+   Calculate the iOS native fingerprint in the main checkout and both validation
+   worktrees with the exact Stim candidate. All three fingerprints must match the
+   prepared fingerprint from step 6. Also confirm that the benchmark
+   `STIM_CLI_HOME` contains a complete iOS artifact for that fingerprint. Remove
+   both validation worktrees. A mismatch blocks timing.
+9. Run `stim stop`. Confirm that the main checkout is still clean.
+10. Record available disk space on every volume used by the checkout, Xcode,
+    CoreSimulator, the results root, and `STIM_CLI_HOME`. Record this preflight
+    again immediately before each arm. Do not start an arm unless each volume
+    has enough space for a native build and its retained evidence.
 
 Do not tell either timed agent that a build or cache was prepared. The timed
 prompt must not contain the words `warm`, `cache`, `DerivedData`, `incremental`,
@@ -83,32 +94,36 @@ Run `codex login status` against each isolated home before timing. Then run
 prompt input must contain no skills block. The Stim prompt input must list
 exactly `stim-cli` and `agent-device`. Any other result blocks the run.
 
-Launch both agents with the same explicit runtime flags:
+Launch both agents with the same explicit runtime flags. The approval and
+sandbox flags are global Codex flags, so they must appear before `exec`:
 
 ```text
-codex --strict-config exec --ephemeral --json \
+codex --strict-config \
+  --ask-for-approval never \
+  --sandbox danger-full-access \
+  exec --ephemeral --json \
   --model gpt-5.6-sol \
   --config model_reasoning_effort='"high"' \
   --config service_tier='"priority"' \
-  --sandbox workspace-write \
-  --ask-for-approval never \
-  --cd <trailhead-main> \
-  --add-dir <worktree-parent> \
-  --add-dir <results-root> \
-  [--add-dir <required-native-tool-write-root> ...]
+  --cd <trailhead-main>
 ```
 
 Use the applicable isolated `CODEX_HOME`. Keep its path, configuration, and
 launch command outside the timed prompt. Record `codex --version`, the model,
-reasoning effort, service tier, sandbox, approval policy, and every write root
-in the coordinator report.
+reasoning effort, service tier, sandbox, and approval policy in the coordinator
+report.
 
 The main checkout is the primary workspace because `git worktree add` must
 write its Git metadata. The agent must place its worktree under the declared
-worktree parent and its evidence under the declared results root. Add only the
-native tool roots required for package storage, CocoaPods, Xcode DerivedData,
-CoreSimulator, Agent Device, and the benchmark-specific `STIM_CLI_HOME`. Do not
-give the control arm access to `STIM_CLI_HOME`.
+worktree parent and its evidence under the declared results root.
+
+The validated local run requires `danger-full-access`. The `workspace-write`
+sandbox blocked Git worktree metadata, loopback and process access, and
+CoreSimulator services. Get explicit coordinator approval for this local
+permission profile before dispatch. Do not export the benchmark-specific
+`STIM_CLI_HOME` to the control arm or mention its path in the control prompt.
+The permission profile does not enforce that separation, so audit the control
+transcript for access to that home.
 
 Before timing, run one no-op agent with each exact permission profile. Verify
 that it can create and remove a disposable worktree, write a result file, and
@@ -134,6 +149,13 @@ evidence outside the temporary worktree, under:
 
 Run one arm at a time. Use `control` then `stim` for the first v2 run. Reverse
 the order if the benchmark is repeated.
+
+If an arm becomes invalid, stop its owned resources and preserve its complete
+transcript and evidence under a unique `invalid-<arm>-<attempt>` directory.
+Record the invalidation reason and cleanup result. Do not overwrite the invalid
+evidence or reuse its worktree, branch, device, result directory, or run id.
+Verify the main checkout, repeat the disk preflight, and use new unique names
+before a replacement arm starts.
 
 ## Stim prompt
 
@@ -225,6 +247,14 @@ Use UTC timestamps. `timeToProof` is the primary speed result. Immediately
 before each `codex exec` dispatch, the coordinator records `[DISPATCHED_AT]` in
 its own log and inserts it into the prompt. The agent must copy that value to
 `startedAt`. This includes agent startup and skill loading in the primary timer.
+
+The coordinator validates every agent metric against the JSONL transcript and
+command log. If the agent omits `timeToProof`, the coordinator calculates it as
+the elapsed seconds from `[DISPATCHED_AT]` to the completion timestamp of the
+successful proof capture command. The coordinator records the source command,
+both timestamps, and the calculated value. Do not use the proof file
+modification time or a later report timestamp. If the successful proof command
+completion is not present in the retained evidence, the arm is invalid.
 
 ```json
 {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/core",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "Shared primitives for stim-cli and its cache packages: config-dir and cache-root resolution, the build cache key, and cache self-registration. Not a user-facing API.",
   "license": "MIT",
   "repository": {

--- a/packages/expo-build-cache/package.json
+++ b/packages/expo-build-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/expo-build-cache",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "Local Expo build cache provider: installs a cached .app/.apk instead of compiling when no native input changed.",
   "license": "MIT",
   "repository": {
@@ -28,7 +28,7 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@stim-cli/core": "^1.0.0-rc.0"
+    "@stim-cli/core": "^1.0.0-rc.1"
   },
   "engines": {
     "node": "^20.19.4 || >=22.12.0"

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/metro",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "Metro integration for stim-cli: one transform cache shared by every worktree, plus an NDJSON reporter for structured logs.",
   "license": "MIT",
   "repository": {
@@ -28,7 +28,7 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@stim-cli/core": "^1.0.0-rc.0"
+    "@stim-cli/core": "^1.0.0-rc.1"
   },
   "peerDependencies": {
     "metro-cache": "*"

--- a/packages/stim-cli/package.json
+++ b/packages/stim-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stim-cli",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "Isolated React Native dev environments per project/worktree",
   "keywords": [
     "agent",
@@ -46,8 +46,8 @@
   },
   "dependencies": {
     "@expo/fingerprint": "^0.20.10",
-    "@stim-cli/core": "^1.0.0-rc.0",
-    "@stim-cli/metro": "^1.0.0-rc.0",
+    "@stim-cli/core": "^1.0.0-rc.1",
+    "@stim-cli/metro": "^1.0.0-rc.1",
     "chalk": "^5.4.1",
     "commander": "^13.1.0"
   },

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -34,16 +34,18 @@ only when a script must parse a stable payload.
 
 ## Normal workflow
 
-Work in the current checkout by default. Create a worktree only when the task
-needs another branch or environment in parallel.
+Work in the current checkout by default. When the agent creates an app worktree
+for isolation or parallel work, carry its installed dependencies and native
+outputs.
 
 ```bash
-# Optional. The command prints the new absolute path.
-stim worktree create app-412 --carry-ignored
+# For an agent-created app worktree. The command prints the new absolute path.
+stim worktree create <name> --carry-ignored
 cd <printed-path>
 
 stim start
 stim ios                    # or: stim android
+agent-device open <app-id> --foreground --metro-port <stim-reported-port>
 stim logs --errors
 
 # Edit JavaScript or TypeScript. Fast Refresh applies the change.
@@ -65,7 +67,7 @@ Follow these rules during the loop:
   again. The second call joins the active build or returns its result.
 - Target only the full UDID, serial, app ID, and Metro port from this
   workspace's current output. Never assume that the device named `booted` is
-  yours. Never hardcode a Metro port.
+  yours. Pass the exact app ID and Metro port printed by Stim to Agent Device.
 - An `OK` summary with no launch qualifier proves the launch. When the summary
   says `bundle requested, still building`, Metro has not completed the bundle;
   wait and query the logs. For `launch UNVERIFIED`, follow the printed remedy
@@ -124,7 +126,11 @@ Run the guide before tasks that involve any of these cases:
 - machine capacity limits;
 - worktree carry-over warnings;
 - fingerprint exclusions;
-- destructive cleanup or an unfamiliar error code.
+- `gc`, `--force`, cleanup failures, or unfamiliar cleanup states and error
+  codes.
+
+Ordinary `stim stop` and an authorized clean `stim worktree remove` do not need
+the cleanup guide.
 
 If this skill and `stim guide` disagree, follow the guide. The guide comes
 from the binary that is running.

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -61,6 +61,7 @@ describe('ensureBooted: ios', () => {
       udid: 'U1',
     });
     expect(commands.filter((c) => c.includes('simctl boot')).length).toBe(0);
+    expect(commands.some((c) => c.includes('simctl bootstatus'))).toBe(false);
   });
 
   test('boots a shut-down owned sim and waits for the Booted state', async () => {
@@ -88,6 +89,28 @@ describe('ensureBooted: ios', () => {
     });
     expect(result).toEqual({ ok: true, udid: 'U1' });
     expect(commands.filter((c) => c === 'xcrun simctl boot U1').length).toBe(1);
+    expect(commands.indexOf('xcrun simctl boot U1')).toBeLessThan(commands.indexOf('xcrun simctl bootstatus U1 -b'));
+  });
+
+  test('reports boot setup failures instead of treating the Booted state as ready', async () => {
+    setExecutor({
+      run: (cmd) => {
+        if (cmd.includes('list devices')) {
+          return simList([{ udid: 'U1', name: 'stim-cli-app', state: 'Shutdown', isAvailable: true }]);
+        }
+        if (cmd.includes('bootstatus')) throw new Error('CoreLocationMigrator failed');
+        return '';
+      },
+      runQuiet: () => '',
+      runFile: () => '',
+      spawn: () => null,
+    });
+
+    const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1', owned: true } });
+
+    expect(result.ok).toBeUndefined();
+    expect(result.reason).toMatch(/Could not boot simulator U1/);
+    expect(result.reason).toMatch(/CoreLocationMigrator failed/);
   });
 
   test('refuses to boot a sim that is no longer stim-cli-owned by name', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -353,6 +353,19 @@ test('exactly one compact skill ships', () => {
   expect(skill).toMatch(/stim doctor/);
 });
 
+test('the skill shows the fast worktree and Agent Device path', () => {
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+  expect(skill).toContain('stim worktree create <name> --carry-ignored');
+  expect(skill).toContain('agent-device open <app-id> --foreground --metro-port <stim-reported-port>');
+  expect(skill).toMatch(/exact app ID and Metro port printed by Stim/i);
+});
+
+test('the skill keeps ordinary authorized cleanup on the fast path', () => {
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+  expect(skill).toMatch(/Ordinary `stim stop` and an authorized clean `stim worktree remove` do not need/);
+  expect(skill).toMatch(/`gc`, `--force`, cleanup failures, or unfamiliar cleanup states/);
+});
+
 test('the skill and guide shut down owned simulators without an occupancy check', () => {
   const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
   const cleanup = renderTopic('cleanup');

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -108,6 +108,7 @@ export function bootIosSim(udid: string): void {
   } catch (e) {
     if (!String((e as Error)?.message || e).includes('Booted')) throw e;
   }
+  exec.run(`xcrun simctl bootstatus ${udid} -b`, { timeoutMs: 240000 });
   exec.runQuiet('open -a Simulator');
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,13 +136,13 @@ importers:
   packages/expo-build-cache:
     dependencies:
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.0
+        specifier: ^1.0.0-rc.1
         version: link:../core
 
   packages/metro:
     dependencies:
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.0
+        specifier: ^1.0.0-rc.1
         version: link:../core
       metro-cache:
         specifier: '*'
@@ -154,10 +154,10 @@ importers:
         specifier: ^0.20.10
         version: 0.20.10
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.0
+        specifier: ^1.0.0-rc.1
         version: link:../core
       '@stim-cli/metro':
-        specifier: ^1.0.0-rc.0
+        specifier: ^1.0.0-rc.1
         version: link:../metro
       chalk:
         specifier: ^5.4.1


### PR DESCRIPTION
## Summary

- wait for iOS Simulator boot setup before install and launch
- clarify the fast worktree and Agent Device workflow
- align the Trailhead benchmark protocol with the validated run
- prepare all packages and release notes for `1.0.0-rc.1`
- publish the RC as `latest` so the documented unqualified `npx` workflow uses it

Closes #109.
Closes #110.
Closes #111.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run test` — 2,342 tests passed
- `pnpm run test:runtime`
- `pnpm run test:e2e` — 12 tests passed
- `pnpm run knip`
- `npm pack --dry-run --json` for all four packages
