### PR TITLE
Make warm worktrees easier to discover

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -434,7 +434,13 @@ That carry-over is file-by-file, which suits a handful of small config files but
 
 It is a skip list rather than a copy list on purpose: forgetting to name something you needed shows up months later as a confusing build error, while forgetting to skip something only costs a needless copy.
 
-Each path is cloned with `cp -Rc`, so on APFS the copy is copy-on-write -- a 3.6 GB tree costs roughly 12s and tens of MB of real disk. Off by default because that only holds on APFS, within one volume: elsewhere the clone is refused and the fallback is a real copy of every byte, which `worktree create` warns about.
+Each path is cloned with `cp -Rc`, so on APFS the copy is copy-on-write -- a 3.6 GB tree costs roughly 12s and tens of MB of real disk. Off by default because that only holds on APFS, within one volume: elsewhere the clone is refused and the fallback is a real copy of every byte, which `worktree create` reports separately. The command also reports whether it carried dependencies, CocoaPods, and native build output.
+
+When a plain create detects those warm paths in the source, stderr gives the exact command for the next worktree:
+
+```
+Warm source not carried: dependencies, CocoaPods, native build output. For the next worktree, use: stim worktree create <name> --carry-ignored
+```
 
 Cloned dependencies match the source worktree, not necessarily the new branch's manifests -- the same contract as restoring a CI cache. Reinstall if the branch changes them.
 

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -39,8 +39,8 @@ for isolation or parallel work, carry its installed dependencies and native
 outputs.
 
 ```bash
-# For an agent-created app worktree. By default, it branches from the current
-# HEAD and prints the new absolute path.
+# By default, this branches from the current HEAD. The warm flag carries installed
+# dependencies and native output. The command prints the new absolute path.
 stim worktree create <name> --carry-ignored
 cd <printed-path>
 

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -1,9 +1,15 @@
 import { execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import type { Command } from 'commander';
-import { carriedChangesLine, carryConflictWarning, registerCreate } from '../commands/worktree.ts';
+import {
+  carriedChangesLine,
+  carryConflictWarning,
+  registerCreate,
+  warmCarryCategories,
+  warmCarrySummary,
+} from '../commands/worktree.ts';
 import { resetExecutor } from '../exec.ts';
 import { defaultWorktreeDir } from '../worktree.ts';
 import { findEnclosingWorktreeRoot, getProject, upsertProject } from '../config.ts';
@@ -483,6 +489,113 @@ test('create action: a plain create (no --carry-ignored) is pure HEAD -- no diff
     expect(readFileSync(join(wt, 'app.json'), 'utf-8')).toBe('{"expo":{}}\n');
     expect(execSync('git status --porcelain', { cwd: wt, encoding: 'utf-8' }).trim()).toBe('');
     expect(errs.some((e) => /Carried .* uncommitted|Could not carry/.test(e))).toBe(false);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('warmCarryCategories recognizes dependency, CocoaPods, and native output paths', () => {
+  expect(
+    warmCarryCategories([
+      'apps/mobile/node_modules',
+      'apps/mobile/ios/Pods',
+      'apps/mobile/ios/build',
+      'apps/mobile/android/app/build',
+    ]),
+  ).toEqual({ dependencies: true, pods: true, nativeOutput: true });
+  expect(warmCarrySummary(['node_modules'])).toBe(
+    'Carried warm state: dependencies=yes, CocoaPods=no, native build output=no.',
+  );
+});
+
+test('create action: a plain create reports the exact warm-worktree command when warm state exists', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-warm-hint-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    writeFileSync(join(repo, '.gitignore'), 'node_modules/\nios/Pods/\nios/build/\n');
+    mkdirSync(join(repo, 'ios'), { recursive: true });
+    writeFileSync(join(repo, 'ios', 'Podfile'), "platform :ios, '15.1'\n");
+    git('git add .gitignore ios/Podfile');
+    git('git commit -q -m ignored');
+    for (const rel of ['node_modules/pkg/index.js', 'ios/Pods/Manifest.lock', 'ios/build/generated.cpp']) {
+      mkdirSync(dirname(join(repo, rel)), { recursive: true });
+      writeFileSync(join(repo, rel), 'warm');
+    }
+
+    const { errs } = await runCreateInRepo(repo, 'feat-warm-hint', { base: 'head' });
+
+    expect(errs.some((e) => /Warm source not carried: dependencies, CocoaPods, native build output/.test(e))).toBe(
+      true,
+    );
+    expect(errs.some((e) => /stim worktree create <name> --carry-ignored/.test(e))).toBe(true);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: --carry-ignored reports warm categories and the copy mode', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-warm-summary-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    writeFileSync(join(repo, '.gitignore'), 'node_modules/\nios/Pods/\nios/build/\n');
+    mkdirSync(join(repo, 'ios'), { recursive: true });
+    writeFileSync(join(repo, 'ios', 'Podfile'), "platform :ios, '15.1'\n");
+    git('git add .gitignore ios/Podfile');
+    git('git commit -q -m ignored');
+    for (const rel of ['node_modules/pkg/index.js', 'ios/Pods/Manifest.lock', 'ios/build/generated.cpp']) {
+      mkdirSync(dirname(join(repo, rel)), { recursive: true });
+      writeFileSync(join(repo, rel), 'warm');
+    }
+
+    const { errs } = await runCreateInRepo(repo, 'feat-warm-summary', { base: 'head', carryIgnored: true });
+
+    expect(
+      errs.some((e) => /Carried warm state: dependencies=yes, CocoaPods=yes, native build output=yes/.test(e)),
+    ).toBe(true);
+    expect(errs.some((e) => /Copy mode: (APFS copy-on-write clone|full byte copy)/.test(e))).toBe(true);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a cold plain create does not recommend --carry-ignored', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-cold-hint-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+
+    const { errs } = await runCreateInRepo(repo, 'feat-cold-hint', { base: 'head' });
+
+    expect(errs.some((e) => /Warm source not carried|--carry-ignored/.test(e))).toBe(false);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a cold --carry-ignored create prints one exact dependency remedy', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-cold-carry-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    writeFileSync(join(repo, 'package-lock.json'), '{"lockfileVersion":3}\n');
+    git('git add package-lock.json');
+    git('git commit -q -m lockfile');
+
+    const { errs } = await runCreateInRepo(repo, 'feat-cold-carry', { base: 'head', carryIgnored: true });
+
+    const remedies = errs.filter((e) => /Dependencies were not carried/.test(e));
+    expect(remedies).toHaveLength(1);
+    expect(remedies[0]).toContain('npm ci');
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -6,6 +6,7 @@ import type { Command } from 'commander';
 import {
   carriedChangesLine,
   carryConflictWarning,
+  dependencyInstallCommand,
   registerCreate,
   warmCarryCategories,
   warmCarrySummary,
@@ -509,6 +510,11 @@ test('warmCarryCategories recognizes dependency, CocoaPods, and native output pa
   );
 });
 
+test('dependencyInstallCommand shell-quotes repository paths', () => {
+  expect(dependencyInstallCommand('/tmp/app/$(touch PWNED)')).toBe("cd '/tmp/app/$(touch PWNED)' && npm install");
+  expect(dependencyInstallCommand("/tmp/app/it's-here")).toBe("cd '/tmp/app/it'\\''s-here' && npm install");
+});
+
 test('warmCarryCategories inspects a collapsed ignored directory', () => {
   const root = mkdtempSync(join(tmpdir(), 'stim-cli-test-warm-categories-'));
   try {
@@ -612,6 +618,27 @@ test('create action: a cold --carry-ignored create prints one exact dependency r
   }
 });
 
+test('create action: a cold nested package prints its package manager and directory', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-cold-nested-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    mkdirSync(join(repo, 'apps/mobile'), { recursive: true });
+    writeFileSync(join(repo, 'apps/mobile/yarn.lock'), 'lock\n');
+    git('git add apps/mobile/yarn.lock');
+    git('git commit -q -m nested-lockfile');
+
+    const { errs } = await runCreateInRepo(repo, 'feat-cold-nested', { base: 'head', carryIgnored: true });
+    const target = join(defaultWorktreeDir(repo), 'feat-cold-nested', 'apps/mobile');
+
+    expect(errs.some((line) => line.includes(`cd '${target}' && yarn install`))).toBe(true);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: stale nested dependencies use the nested package manager', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-nested-stale-')));
@@ -633,7 +660,7 @@ test('create action: stale nested dependencies use the nested package manager', 
     const { errs } = await runCreateInRepo(repo, 'feat-nested-stale', { base: oldHead, carryIgnored: true });
     const target = join(defaultWorktreeDir(repo), 'feat-nested-stale', 'apps/mobile');
 
-    expect(errs.some((line) => line.includes(`cd ${JSON.stringify(target)} && yarn install`))).toBe(true);
+    expect(errs.some((line) => line.includes(`cd '${target}' && yarn install`))).toBe(true);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -509,6 +509,16 @@ test('warmCarryCategories recognizes dependency, CocoaPods, and native output pa
   );
 });
 
+test('warmCarryCategories inspects a collapsed ignored directory', () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-cli-test-warm-categories-'));
+  try {
+    for (const rel of ['ios/Pods', 'ios/build']) mkdirSync(join(root, rel), { recursive: true });
+    expect(warmCarryCategories(['ios'], root)).toEqual({ dependencies: false, pods: true, nativeOutput: true });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('create action: a plain create reports the exact warm-worktree command when warm state exists', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-warm-hint-')));
@@ -596,6 +606,34 @@ test('create action: a cold --carry-ignored create prints one exact dependency r
     const remedies = errs.filter((e) => /Dependencies were not carried/.test(e));
     expect(remedies).toHaveLength(1);
     expect(remedies[0]).toContain('npm ci');
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: stale nested dependencies use the nested package manager', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-cli-test-create-nested-stale-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    writeFileSync(join(repo, '.gitignore'), 'apps/mobile/node_modules/\n');
+    mkdirSync(join(repo, 'apps/mobile'), { recursive: true });
+    writeFileSync(join(repo, 'apps/mobile/yarn.lock'), 'version one\n');
+    git('git add .gitignore apps/mobile/yarn.lock');
+    git('git commit -q -m first-lock');
+    const oldHead = git('git rev-parse HEAD').trim();
+    writeFileSync(join(repo, 'apps/mobile/yarn.lock'), 'version two\n');
+    git('git add apps/mobile/yarn.lock');
+    git('git commit -q -m second-lock');
+    mkdirSync(join(repo, 'apps/mobile/node_modules/pkg'), { recursive: true });
+    writeFileSync(join(repo, 'apps/mobile/node_modules/pkg/index.js'), 'warm');
+
+    const { errs } = await runCreateInRepo(repo, 'feat-nested-stale', { base: oldHead, carryIgnored: true });
+    const target = join(defaultWorktreeDir(repo), 'feat-nested-stale', 'apps/mobile');
+
+    expect(errs.some((line) => line.includes(`cd ${JSON.stringify(target)} && yarn install`))).toBe(true);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -725,10 +725,19 @@ but --base <ref> resolves to <sha>"  (worktree create)
   yourself does not fail in its LAST phase with
     error: The sandbox is not in sync with the Podfile.lock
 
-"No node_modules among them"  (worktree create --carry-ignored)
-  The clone can only carry what the source worktree has, and the source has no
-  node_modules. The path count above that line is not evidence of a usable
-  worktree. Install dependencies before building.
+"Warm source not carried: ... For the next worktree, use: stim worktree create
+<name> --carry-ignored"  (worktree create)
+  A plain create found installed dependencies, CocoaPods, or native build output
+  in the source. The new worktree stays clean. Use the printed command for the
+  next worktree to clone that warm state.
+
+"Carried warm state: dependencies=..., CocoaPods=..., native build output=..."
+  The line reports each useful warm category. The following copy-mode line says
+  whether APFS used a copy-on-write clone or Stim made a full byte copy.
+
+"Dependencies were not carried. Run ... before building."
+  The source has no node_modules to clone. Run the printed package-manager
+  command in the new worktree.
 
 "Carried N uncommitted change(s) from the source (...) -- uncommitted here
 too; commit deliberately."  (worktree create --carry-ignored)

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -23,6 +23,7 @@ import {
   isMainWorkingTree,
   isPodInstallChurn,
   listCarryableIgnoredEntries,
+  listTrackedPaths,
   listWorktrees,
   podsOutOfSync,
   readWorktreeExclude,
@@ -103,7 +104,7 @@ export function warmCarrySummary(entries: string[], root?: string): string {
   return `Carried warm state: dependencies=${categories.dependencies ? 'yes' : 'no'}, CocoaPods=${categories.pods ? 'yes' : 'no'}, native build output=${categories.nativeOutput ? 'yes' : 'no'}.`;
 }
 
-function dependencyInstallCommand(target: string, dir = '.'): string {
+export function dependencyInstallCommand(target: string, dir = '.'): string {
   const installRoot = resolve(target, dir);
   let command = 'npm install';
   if (existsSync(resolve(installRoot, 'pnpm-lock.yaml'))) command = 'pnpm install';
@@ -111,7 +112,18 @@ function dependencyInstallCommand(target: string, dir = '.'): string {
   else if (existsSync(resolve(installRoot, 'bun.lock')) || existsSync(resolve(installRoot, 'bun.lockb')))
     command = 'bun install';
   else if (existsSync(resolve(installRoot, 'package-lock.json'))) command = 'npm ci';
-  return `cd ${JSON.stringify(installRoot)} && ${command}`;
+  return `cd '${installRoot.replaceAll("'", "'\\''")}' && ${command}`;
+}
+
+function dependencyInstallCommands(target: string): string[] {
+  const lockfiles = new Set(['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lock', 'bun.lockb']);
+  const dirs = new Set(
+    (listTrackedPaths(target) || [])
+      .filter((path) => lockfiles.has(path.split('/').at(-1) || ''))
+      .map((path) => path.split('/').slice(0, -1).join('/') || '.'),
+  );
+  if (!dirs.size) dirs.add('.');
+  return [...dirs].map((dir) => dependencyInstallCommand(target, dir));
 }
 
 export function registerCreate(worktree: Command): void {
@@ -252,8 +264,11 @@ export function registerCreate(worktree: Command): void {
           );
         }
         if (!carriedDeps) {
+          const remedies = dependencyInstallCommands(target);
           console.error(
-            chalk.yellow(`Dependencies were not carried. Run \`${dependencyInstallCommand(target)}\` before building.`),
+            chalk.yellow(
+              `Dependencies were not carried. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
+            ),
           );
         }
         for (const f of res.failed) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -22,6 +22,7 @@ import {
   hasUncommittedWork,
   isMainWorkingTree,
   isPodInstallChurn,
+  listCarryableIgnoredEntries,
   listWorktrees,
   podsOutOfSync,
   readWorktreeExclude,
@@ -44,6 +45,45 @@ interface WorktreeSettings {
     include?: string[];
     exclude?: string[];
   };
+}
+
+export interface WarmCarryCategories {
+  dependencies: boolean;
+  pods: boolean;
+  nativeOutput: boolean;
+}
+
+export function warmCarryCategories(entries: string[]): WarmCarryCategories {
+  return {
+    dependencies: entries.some((rel) => rel === 'node_modules' || rel.endsWith('/node_modules')),
+    pods: entries.some((rel) => rel === 'Pods' || rel.endsWith('/Pods')),
+    nativeOutput: entries.some(
+      (rel) =>
+        /(?:^|\/)ios\/build(?:\/|$)/.test(rel) || /(?:^|\/)android\/(?:.*\/)?(?:build|\.gradle)(?:\/|$)/.test(rel),
+    ),
+  };
+}
+
+function warmCategoryNames(categories: WarmCarryCategories): string[] {
+  const names: string[] = [];
+  if (categories.dependencies) names.push('dependencies');
+  if (categories.pods) names.push('CocoaPods');
+  if (categories.nativeOutput) names.push('native build output');
+  return names;
+}
+
+export function warmCarrySummary(entries: string[]): string {
+  const categories = warmCarryCategories(entries);
+  return `Carried warm state: dependencies=${categories.dependencies ? 'yes' : 'no'}, CocoaPods=${categories.pods ? 'yes' : 'no'}, native build output=${categories.nativeOutput ? 'yes' : 'no'}.`;
+}
+
+function dependencyInstallCommand(target: string): string {
+  let command = 'npm install';
+  if (existsSync(resolve(target, 'pnpm-lock.yaml'))) command = 'pnpm install';
+  else if (existsSync(resolve(target, 'yarn.lock'))) command = 'yarn install';
+  else if (existsSync(resolve(target, 'bun.lock')) || existsSync(resolve(target, 'bun.lockb'))) command = 'bun install';
+  else if (existsSync(resolve(target, 'package-lock.json'))) command = 'npm ci';
+  return `cd ${JSON.stringify(target)} && ${command}`;
 }
 
 export function registerCreate(worktree: Command): void {
@@ -165,35 +205,38 @@ export function registerCreate(worktree: Command): void {
 
       let carriedIgnored = false;
       let carriedDeps = false;
+      let warmSource: string[] = [];
       if (opts.carryIgnored) {
         const excluded = readWorktreeExclude(root);
         const skip = excluded && excluded.length ? excluded : settings?.worktree?.exclude || [];
         const res = cloneIgnoredEntries({ root, target, patterns: skip });
         carriedIgnored = res.copied.length > 0;
         carriedDeps = res.copied.some((rel) => rel === 'node_modules' || rel.endsWith('/node_modules'));
-        if (res.copied.length) console.error(chalk.dim(`Cloned ${res.copied.length} gitignored path(s).`));
-        if (carriedIgnored && !carriedDeps) {
+        if (res.copied.length) {
+          console.error(chalk.dim(`Cloned ${res.copied.length} gitignored path(s).`));
+          console.error(chalk.dim(warmCarrySummary(res.copied)));
           console.error(
-            chalk.yellow(
-              'No node_modules among them -- the source worktree has none. Install dependencies before building.',
+            chalk.dim(
+              res.cloned
+                ? 'Copy mode: APFS copy-on-write clone.'
+                : 'Copy mode: full byte copy. APFS copy-on-write clone was unavailable.',
             ),
           );
         }
-        if (!res.cloned) {
+        if (!carriedDeps) {
           console.error(
-            chalk.yellow(
-              'Copy-on-write clone unavailable (not APFS, or a different volume) -- these are full copies using real disk.',
-            ),
+            chalk.yellow(`Dependencies were not carried. Run \`${dependencyInstallCommand(target)}\` before building.`),
           );
         }
         for (const f of res.failed) {
           console.error(chalk.yellow(`Failed to clone ${f.file}: ${f.error}`));
         }
-        for (const d of depsOutOfSync(root, target, res.copied)) {
-          const where = d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`;
+        const staleDeps = depsOutOfSync(root, target, res.copied);
+        if (staleDeps.length) {
+          const manifests = staleDeps.map((d) => (d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`)).join(', ');
           console.error(
             chalk.yellow(
-              `Carried ${d.dir === '.' ? 'node_modules' : `${d.dir}/node_modules`} was installed for a different ${d.lockfile} than this branch's ${where}. Reinstall dependencies before building, or the dev server can die on a module the branch added.`,
+              `Carried dependencies do not match ${manifests}. Run \`${dependencyInstallCommand(target)}\` before building.`,
             ),
           );
         }
@@ -213,6 +256,10 @@ export function registerCreate(worktree: Command): void {
         } else if (changes?.conflicted) {
           console.error(chalk.yellow(carryConflictWarning(changes.files)));
         }
+      } else {
+        const excluded = readWorktreeExclude(root);
+        const skip = excluded && excluded.length ? excluded : settings?.worktree?.exclude || [];
+        warmSource = warmCategoryNames(warmCarryCategories(listCarryableIgnoredEntries(root, skip)));
       }
 
       const mainRoot = listWorktrees(root).find((candidate) => isMainWorkingTree(candidate.path))?.path || root;
@@ -231,6 +278,13 @@ export function registerCreate(worktree: Command): void {
             : 'Worktree ready. Install dependencies yourself before building.',
         ),
       );
+      if (warmSource.length) {
+        console.error(
+          chalk.yellow(
+            `Warm source not carried: ${warmSource.join(', ')}. For the next worktree, use: stim worktree create <name> --carry-ignored`,
+          ),
+        );
+      }
 
       console.log(target);
     });

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from 'fs';
+import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
@@ -53,8 +53,8 @@ export interface WarmCarryCategories {
   nativeOutput: boolean;
 }
 
-export function warmCarryCategories(entries: string[]): WarmCarryCategories {
-  return {
+export function warmCarryCategories(entries: string[], root?: string): WarmCarryCategories {
+  const categories = {
     dependencies: entries.some((rel) => rel === 'node_modules' || rel.endsWith('/node_modules')),
     pods: entries.some((rel) => rel === 'Pods' || rel.endsWith('/Pods')),
     nativeOutput: entries.some(
@@ -62,6 +62,32 @@ export function warmCarryCategories(entries: string[]): WarmCarryCategories {
         /(?:^|\/)ios\/build(?:\/|$)/.test(rel) || /(?:^|\/)android\/(?:.*\/)?(?:build|\.gradle)(?:\/|$)/.test(rel),
     ),
   };
+  if (!root || (categories.dependencies && categories.pods && categories.nativeOutput)) return categories;
+
+  const inspect = (rel: string): void => {
+    if (categories.dependencies && categories.pods && categories.nativeOutput) return;
+    if (rel === 'node_modules' || rel.endsWith('/node_modules')) {
+      categories.dependencies = true;
+      return;
+    }
+    if (rel === 'Pods' || rel.endsWith('/Pods')) {
+      categories.pods = true;
+      return;
+    }
+    if (/(?:^|\/)ios\/build(?:\/|$)/.test(rel) || /(?:^|\/)android\/(?:.*\/)?(?:build|\.gradle)(?:\/|$)/.test(rel)) {
+      categories.nativeOutput = true;
+      return;
+    }
+    try {
+      for (const entry of readdirSync(resolve(root, rel), { withFileTypes: true })) {
+        if (entry.isDirectory()) inspect(rel ? `${rel}/${entry.name}` : entry.name);
+      }
+    } catch {
+      // A copied entry can disappear while the summary is generated.
+    }
+  };
+  for (const rel of entries) inspect(rel);
+  return categories;
 }
 
 function warmCategoryNames(categories: WarmCarryCategories): string[] {
@@ -72,18 +98,20 @@ function warmCategoryNames(categories: WarmCarryCategories): string[] {
   return names;
 }
 
-export function warmCarrySummary(entries: string[]): string {
-  const categories = warmCarryCategories(entries);
+export function warmCarrySummary(entries: string[], root?: string): string {
+  const categories = warmCarryCategories(entries, root);
   return `Carried warm state: dependencies=${categories.dependencies ? 'yes' : 'no'}, CocoaPods=${categories.pods ? 'yes' : 'no'}, native build output=${categories.nativeOutput ? 'yes' : 'no'}.`;
 }
 
-function dependencyInstallCommand(target: string): string {
+function dependencyInstallCommand(target: string, dir = '.'): string {
+  const installRoot = resolve(target, dir);
   let command = 'npm install';
-  if (existsSync(resolve(target, 'pnpm-lock.yaml'))) command = 'pnpm install';
-  else if (existsSync(resolve(target, 'yarn.lock'))) command = 'yarn install';
-  else if (existsSync(resolve(target, 'bun.lock')) || existsSync(resolve(target, 'bun.lockb'))) command = 'bun install';
-  else if (existsSync(resolve(target, 'package-lock.json'))) command = 'npm ci';
-  return `cd ${JSON.stringify(target)} && ${command}`;
+  if (existsSync(resolve(installRoot, 'pnpm-lock.yaml'))) command = 'pnpm install';
+  else if (existsSync(resolve(installRoot, 'yarn.lock'))) command = 'yarn install';
+  else if (existsSync(resolve(installRoot, 'bun.lock')) || existsSync(resolve(installRoot, 'bun.lockb')))
+    command = 'bun install';
+  else if (existsSync(resolve(installRoot, 'package-lock.json'))) command = 'npm ci';
+  return `cd ${JSON.stringify(installRoot)} && ${command}`;
 }
 
 export function registerCreate(worktree: Command): void {
@@ -211,10 +239,10 @@ export function registerCreate(worktree: Command): void {
         const skip = excluded && excluded.length ? excluded : settings?.worktree?.exclude || [];
         const res = cloneIgnoredEntries({ root, target, patterns: skip });
         carriedIgnored = res.copied.length > 0;
-        carriedDeps = res.copied.some((rel) => rel === 'node_modules' || rel.endsWith('/node_modules'));
+        carriedDeps = warmCarryCategories(res.copied, target).dependencies;
         if (res.copied.length) {
           console.error(chalk.dim(`Cloned ${res.copied.length} gitignored path(s).`));
-          console.error(chalk.dim(warmCarrySummary(res.copied)));
+          console.error(chalk.dim(warmCarrySummary(res.copied, target)));
           console.error(
             chalk.dim(
               res.cloned
@@ -234,9 +262,12 @@ export function registerCreate(worktree: Command): void {
         const staleDeps = depsOutOfSync(root, target, res.copied);
         if (staleDeps.length) {
           const manifests = staleDeps.map((d) => (d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`)).join(', ');
+          const remedies = [
+            ...new Set(staleDeps.map((dependency) => dependencyInstallCommand(target, dependency.dir))),
+          ];
           console.error(
             chalk.yellow(
-              `Carried dependencies do not match ${manifests}. Run \`${dependencyInstallCommand(target)}\` before building.`,
+              `Carried dependencies do not match ${manifests}. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
             ),
           );
         }
@@ -259,7 +290,7 @@ export function registerCreate(worktree: Command): void {
       } else {
         const excluded = readWorktreeExclude(root);
         const skip = excluded && excluded.length ? excluded : settings?.worktree?.exclude || [];
-        warmSource = warmCategoryNames(warmCarryCategories(listCarryableIgnoredEntries(root, skip)));
+        warmSource = warmCategoryNames(warmCarryCategories(listCarryableIgnoredEntries(root, skip), root));
       }
 
       const mainRoot = listWorktrees(root).find((candidate) => isMainWorkingTree(candidate.path))?.path || root;

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -185,6 +185,10 @@ export function listGitignoredEntries(root: string): string[] {
     .map((e) => (e.endsWith('/') ? e.slice(0, -1) : e));
 }
 
+export function listCarryableIgnoredEntries(root: string, patterns: string[] | null | undefined): string[] {
+  return listGitignoredEntries(root).filter((rel) => !isCarrySkipped(rel) && !matchesInclude(rel, patterns));
+}
+
 interface CloneResult extends CarryResult {
   cloned: boolean;
 }
@@ -203,9 +207,7 @@ export function cloneIgnoredEntries({
   const failed: FailedEntry[] = [];
   let cloned = true;
   const guard = trackedGuard(target);
-  for (const rel of listGitignoredEntries(root)) {
-    if (isCarrySkipped(rel)) continue;
-    if (matchesInclude(rel, patterns)) continue;
+  for (const rel of listCarryableIgnoredEntries(root, patterns)) {
     const from = join(root, rel);
     const to = join(target, rel);
     let isDir = false;

--- a/test/e2e/worktree-warm.e2e.js
+++ b/test/e2e/worktree-warm.e2e.js
@@ -1,0 +1,77 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const CLI = join(REPO, 'packages', 'stim-cli', 'bin', 'cli.ts');
+const ctx = {};
+
+before(() => {
+  ctx.home = realpathSync(mkdtempSync(join(tmpdir(), 'stim-cli-warm-e2e-home-')));
+  ctx.tmp = realpathSync(mkdtempSync(join(tmpdir(), 'stim-cli-warm-e2e-')));
+  ctx.repo = join(ctx.tmp, 'app');
+  mkdirSync(ctx.repo, { recursive: true });
+  writeFileSync(join(ctx.repo, 'package.json'), '{"name":"warm-fixture","private":true}\n');
+  writeFileSync(join(ctx.repo, '.gitignore'), 'node_modules/\nios/Pods/\nios/build/\n');
+  mkdirSync(join(ctx.repo, 'ios'), { recursive: true });
+  writeFileSync(join(ctx.repo, 'ios', 'Podfile'), "platform :ios, '15.1'\n");
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'e2e@example.com']);
+  git(['config', 'user.name', 'stim-cli e2e']);
+  git(['config', 'commit.gpgsign', 'false']);
+  git(['add', '-A']);
+  git(['commit', '-m', 'fixture']);
+});
+
+after(() => {
+  for (const dir of [ctx.home, ctx.tmp]) {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cold and warm worktree creation report different guidance', () => {
+  const cold = create('cold');
+  assert.equal(cold.status, 0, cold.stderr);
+  assert.doesNotMatch(cold.stderr, /Warm source not carried|--carry-ignored/);
+
+  write('node_modules/pkg/index.js', 'dependency');
+  write('ios/Pods/Manifest.lock', 'pods');
+  write('ios/build/generated.cpp', 'native');
+
+  const plainWarm = create('plain-warm');
+  assert.equal(plainWarm.status, 0, plainWarm.stderr);
+  assert.match(plainWarm.stderr, /Warm source not carried: dependencies, CocoaPods, native build output/);
+  assert.match(plainWarm.stderr, /stim worktree create <name> --carry-ignored/);
+
+  const carried = create('carried', ['--carry-ignored']);
+  assert.equal(carried.status, 0, carried.stderr);
+  assert.match(carried.stderr, /Carried warm state: dependencies=yes, CocoaPods=yes, native build output=yes/);
+  assert.match(carried.stderr, /Copy mode: (APFS copy-on-write clone|full byte copy)/);
+  const carriedPath = carried.stdout.trim();
+  assert.ok(existsSync(join(carriedPath, 'node_modules', 'pkg', 'index.js')));
+  assert.ok(existsSync(join(carriedPath, 'ios', 'Pods', 'Manifest.lock')));
+  assert.ok(existsSync(join(carriedPath, 'ios', 'build', 'generated.cpp')));
+});
+
+function create(name, extra = []) {
+  return spawnSync(process.execPath, [CLI, 'worktree', 'create', name, '--base', 'head', ...extra], {
+    cwd: ctx.repo,
+    env: { ...process.env, STIM_CLI_HOME: ctx.home },
+    encoding: 'utf-8',
+  });
+}
+
+function git(args) {
+  return execFileSync('git', ['-C', ctx.repo, ...args], { encoding: 'utf-8' });
+}
+
+function write(rel, contents) {
+  const path = join(ctx.repo, rel);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -46,7 +46,13 @@ That carry-over is file-by-file, which suits a handful of small config files but
 
 It is a skip list rather than a copy list on purpose: forgetting to name something you needed shows up months later as a confusing build error, while forgetting to skip something only costs a needless copy.
 
-Each path is cloned with `cp -Rc`, so on APFS the copy is copy-on-write -- a 3.6 GB tree costs roughly 12s and tens of MB of real disk. Off by default because that only holds on APFS, within one volume: elsewhere the clone is refused and the fallback is a real copy of every byte, which `worktree create` warns about.
+Each path is cloned with `cp -Rc`, so on APFS the copy is copy-on-write -- a 3.6 GB tree costs roughly 12s and tens of MB of real disk. Off by default because that only holds on APFS, within one volume: elsewhere the clone is refused and the fallback is a real copy of every byte, which `worktree create` reports separately. The command also reports whether it carried dependencies, CocoaPods, and native build output.
+
+When a plain create detects those warm paths in the source, stderr gives the exact command for the next worktree:
+
+```
+Warm source not carried: dependencies, CocoaPods, native build output. For the next worktree, use: stim worktree create <name> --carry-ignored
+```
 
 Cloned dependencies match the source worktree, not necessarily the new branch's manifests -- the same contract as restoring a CI cache. Reinstall if the branch changes them.
 


### PR DESCRIPTION
## Summary

- warn when a plain worktree skips installed dependencies, CocoaPods, or native output, and show the warm command
- print one package-manager command when dependencies are missing or stale
- report copied categories and whether APFS cloning or a full byte copy was used
- keep the bundled skill on the `--carry-ignored` warm path

## Test plan

- new real Git coverage verifies cold, plain-warm, and carried-warm creation

Closes #116
