### PR TITLE
Report Xcode compilation-cache activity

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -95,6 +95,7 @@ Each command takes `--json` and then prints exactly one line of JSON on stdout, 
   "cacheKey": "...",
   "cacheHit": "local",
   "cacheSkipped": false,
+  "compilationCache": { "status": "not-run", "hits": null, "cacheableTasks": null, "hitRatePercent": null },
   "appPath": "/...",
   "bundleId": "com.example.app",
   "launched": true,
@@ -105,6 +106,8 @@ Each command takes `--json` and then prints exactly one line of JSON on stdout, 
 ```
 
 `cacheHit` is a LEVEL, not a boolean: `"local"` (this machine's shared cache), `"remote"` (the project's own Expo `buildCacheProvider`, whose artifact is copied into the local cache on the way past) or `false` (it was compiled). `cacheSkipped` is true only when `--no-build-cache` was passed, which is "nothing was looked up" rather than "nothing was found".
+
+`compilationCache` reports Xcode's compilation-cache summary when Xcode builds the app. Its status is `"not-run"` when the artifact cache supplies the app. Its status is `"unavailable"` when Xcode does not report reliable statistics.
 
 In a different worktree of the same app, the same two commands get a _different_ owned sim and Metro port, so both run side by side.
 

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -9,6 +9,7 @@ import type { NdjsonRecord, NdjsonWriter } from '../ndjson.ts';
 import { createNdjsonWriter, parseNdjsonText } from '../ndjson.ts';
 import { workspaceDerivedData, workspaceLogsDir } from '../paths.ts';
 import { readManifest } from '../cache-manifest.ts';
+import type { CompilationCacheActivity } from '../types.ts';
 import {
   buildIos,
   ccacheEnabled,
@@ -18,6 +19,7 @@ import {
   findAppBundle,
   listSchemes,
   parseBundleId,
+  parseCompilationCacheActivity,
   parseSchemeList,
   prefixMapping,
   readPodfileProperties,
@@ -32,6 +34,17 @@ import {
   tailLines,
   xcodebuildArgs,
 } from '../engine/xcode.ts';
+
+test('parseCompilationCacheActivity reads Xcode 26 compilation-cache metrics from a fixture', () => {
+  const fixture = readFileSync(new URL('./fixtures/xcode-compilation-cache.txt', import.meta.url), 'utf-8');
+  expect(parseCompilationCacheActivity(fixture)).toEqual({
+    status: 'reported',
+    hits: 1394,
+    cacheableTasks: 1520,
+    hitRatePercent: 91.7,
+  });
+  expect(parseCompilationCacheActivity('Cache hit')).toBe(null);
+});
 
 const REAL_PROJECT_LIST_JSON = `{
   "project" : {
@@ -124,6 +137,7 @@ type BuildIosResultLike = {
     remedy?: string;
     [key: string]: unknown;
   }>;
+  compilationCache?: CompilationCacheActivity;
 };
 
 function asResult(value: unknown): BuildIosResultLike {
@@ -792,6 +806,43 @@ describe('buildIos with a mocked executor', () => {
     makeProduct(dd);
     child.emit('close', 0, null);
     await promise;
+  });
+
+  test('streams and returns the Xcode compilation-cache summary', async () => {
+    const child = fakeChild();
+    harness(tmp, { child });
+    const writer = recordingWriter();
+    const notes: string[] = [];
+    const dd = join(tmp, 'dd');
+    const promise = buildIos({
+      root: tmp,
+      udid: 'u',
+      logWriter: writer,
+      derivedDataPath: dd,
+      compilationCache: ['COMPILATION_CACHE_ENABLE_CACHING=YES'],
+      onNote: (line) => notes.push(line),
+    });
+
+    child.stdout.emit('data', 'CompilationCacheMetrics\nnote: 1394 hits / 1520 cacheable tasks (91.7%)\n');
+    makeProduct(dd);
+    child.emit('close', 0, null);
+    const result = asResult(await promise);
+
+    expect(result.compilationCache).toEqual({
+      status: 'reported',
+      hits: 1394,
+      cacheableTasks: 1520,
+      hitRatePercent: 91.7,
+    });
+    expect(notes).toEqual(['compilation cache 1394/1520 hits (91.7%)']);
+    expect(writer.records).toContainEqual(
+      expect.objectContaining({
+        event: 'compilation_cache',
+        hits: 1394,
+        cacheableTasks: 1520,
+        hitRatePercent: 91.7,
+      }),
+    );
   });
 
   test('a line left unterminated by a dying child is still recorded', async () => {

--- a/packages/stim-cli/src/__tests__/fixtures/xcode-compilation-cache.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/xcode-compilation-cache.txt
@@ -1,0 +1,2 @@
+CompilationCacheMetrics
+note: 1394 hits / 1520 cacheable tasks (91.7%)

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -39,6 +39,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'cacheKey',
       'cacheHit',
       'cacheSkipped',
+      'compilationCache',
       'waitedForBuild',
       'appPath',
       'bundleId',

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1475,6 +1475,7 @@ describe('success output', () => {
     expect(logs[0]).toContain(phaseLine('app', 'com.example.app'));
     expect(logs[0]).toContain(phaseLine('metro', 'running on port 8082'));
     expect(logs[0]).toContain(phaseLine('cache', 'built'));
+    expect(logs[0]).toContain(phaseLine('compilation cache', 'unavailable; Xcode did not report reliable statistics'));
     expect(logs[0]).toContain(phaseLine('logs', workspaceLogsDir(root)));
     const text = errs.join('\n');
     expect(text).toMatch(/^  device {6}stim-cli-fixture \(BF2A\.\.\) booted \(\d+ms\)$/m);
@@ -1496,6 +1497,12 @@ describe('success output', () => {
     expect(facts.fingerprint).toBe(FINGERPRINT);
     expect(facts.cacheKey).toMatch(new RegExp(`^${FINGERPRINT}-debug-sim$`));
     expect(facts.cacheHit).toBe(false);
+    expect(facts.compilationCache).toEqual({
+      status: 'unavailable',
+      hits: null,
+      cacheableTasks: null,
+      hitRatePercent: null,
+    });
     expect(facts.appPath).toBe(appPath);
     expect(facts.bundleId).toBe('com.example.app');
     expect(facts.launched).toBe(true);
@@ -1860,6 +1867,7 @@ describe('iosFacts', () => {
       cacheKey: 'abc-debug-sim',
       cacheHit: 'local',
       cacheSkipped: false,
+      compilationCache: { status: 'not-run', hits: null, cacheableTasks: null, hitRatePercent: null },
       waitedForBuild: null,
       appPath: '/a/b.app',
       bundleId: 'com.x',

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -62,6 +62,12 @@ other line goes to stderr, so it is always safe to pipe.
                   the device; it is a page, not a deep link.
   cacheSkipped    true only when --no-build-cache was passed: "nothing was
                   looked up", which is a different fact from "nothing was found"
+  compilationCache
+                  Xcode compilation-cache activity for a compiled iOS app:
+                    { status: "reported", hits, cacheableTasks, hitRatePercent }
+                  status is "not-run" when the artifact cache supplied the app.
+                  status is "unavailable" when Xcode did not print reliable
+                  statistics. This field is separate from cacheHit
   waitedForBuild  { pid, ms } when ANOTHER workspace was already compiling this
                   exact fingerprint and this run waited for its artifact instead
                   of compiling a second copy (see \`guide lifecycle\`, "one

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -70,9 +70,15 @@ import {
   type LoadProjectProviderResult,
 } from '../engine/remote-cache.ts';
 import { swapJsBundle } from '../engine/js-swap.ts';
-import { buildIos, readBundleId } from '../engine/xcode.ts';
+import {
+  buildIos,
+  compilationCacheActivityLine,
+  COMPILATION_CACHE_NOT_RUN,
+  COMPILATION_CACHE_UNAVAILABLE,
+  readBundleId,
+} from '../engine/xcode.ts';
 import { getExecutor } from '../exec.ts';
-import type { CacheHitLevel, IosFacts, RemoteDeviceBackend } from '../types.ts';
+import type { CacheHitLevel, CompilationCacheActivity, IosFacts, RemoteDeviceBackend } from '../types.ts';
 import { NOT_OURS_FOREIGN_CWD, isPidAlive, resolveProjectMetro } from '../metro.ts';
 import { createNdjsonWriter, type NdjsonWriter } from '../ndjson.ts';
 import { ensureWorkspaceStorage, workspaceLogsDir } from '../paths.ts';
@@ -160,6 +166,7 @@ interface BuildIosResultLike {
   exitCode?: number | null;
   appPath?: string;
   bundleId?: string;
+  compilationCache?: CompilationCacheActivity;
 }
 
 interface VerifyLaunchResultLike {
@@ -482,6 +489,7 @@ export function iosFacts({
   cacheKey,
   cacheHit,
   cacheSkipped = false,
+  compilationCache = COMPILATION_CACHE_NOT_RUN,
   waitedForBuild = null,
   appPath,
   bundleId,
@@ -498,6 +506,7 @@ export function iosFacts({
   cacheKey?: string | null;
   cacheHit?: boolean | string;
   cacheSkipped?: boolean;
+  compilationCache?: CompilationCacheActivity;
   waitedForBuild?: WaitedForBuild | null;
   appPath?: string | null;
   bundleId?: string | null;
@@ -516,6 +525,7 @@ export function iosFacts({
     cacheKey,
     cacheHit: cacheLevel(cacheHit),
     cacheSkipped: Boolean(cacheSkipped),
+    compilationCache,
     waitedForBuild: waitedForBuild ? { pid: waitedForBuild.pid ?? null, ms: waitedForBuild.ms ?? 0 } : null,
     appPath,
     bundleId,
@@ -943,6 +953,7 @@ interface ReportIosResultArgs {
   storeHash: string;
   storeKey: string;
   cacheHit: CacheHitLevel;
+  compilationCache: CompilationCacheActivity;
   useBuildCache: boolean;
   waitedForBuild: WaitedForBuild | null;
   launchState: boolean | string;
@@ -969,6 +980,7 @@ function reportIosResult({
   storeHash,
   storeKey,
   cacheHit,
+  compilationCache,
   useBuildCache,
   waitedForBuild,
   launchState,
@@ -1001,6 +1013,7 @@ function reportIosResult({
     configuration,
     cacheKey: storeKey,
     cacheHit,
+    compilationCache,
     cacheSkipped: !useBuildCache,
     waitedForBuild,
     appPath,
@@ -1040,6 +1053,7 @@ function reportIosResult({
         phaseLine('app', bundleId),
         phaseLine('metro', metroResult),
         phaseLine('cache', cacheResult),
+        phaseLine('compilation cache', compilationCacheActivityLine(compilationCache)),
         phaseLine('logs', logsDir),
       ].join('\n'),
     );
@@ -1080,6 +1094,7 @@ interface FinishIosRunArgs {
   storeHash: string;
   storeKey: string;
   cacheHit: CacheHitLevel;
+  compilationCache: CompilationCacheActivity;
   useBuildCache: boolean;
   waitedForBuild: WaitedForBuild | null;
   closeWriter: () => void;
@@ -1117,6 +1132,7 @@ async function finishIosRun({
   storeHash,
   storeKey,
   cacheHit,
+  compilationCache,
   useBuildCache,
   waitedForBuild,
   closeWriter,
@@ -1240,6 +1256,7 @@ async function finishIosRun({
     storeHash,
     storeKey,
     cacheHit,
+    compilationCache,
     useBuildCache,
     waitedForBuild,
     launchState,
@@ -1427,6 +1444,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   let appPath: string | null = null;
   let bundleId: string | null = null;
   let cacheHit: CacheHitLevel = false;
+  let compilationCache: CompilationCacheActivity = COMPILATION_CACHE_NOT_RUN;
   let remote: LoadProjectProviderResult | null = null;
   let abandonedRemote = false;
   let uploadPending: Promise<RemoteUploadLike> | null = null;
@@ -1854,6 +1872,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             });
             return false;
           }
+          compilationCache = result.compilationCache ?? COMPILATION_CACHE_UNAVAILABLE;
           phase('build', `ok (${formatDuration(result.durationMs)})`);
           appPath = result.appPath ?? null;
           bundleId = result.bundleId ?? null;
@@ -1923,6 +1942,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     storeHash,
     storeKey,
     cacheHit,
+    compilationCache,
     useBuildCache,
     waitedForBuild,
     closeWriter: () => writer?.close?.(),

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -9,6 +9,7 @@ import { sharedCompilationCache, workspaceDerivedData } from '../paths.ts';
 import { createLineReader } from '../process-output.ts';
 import { capDiagnostics, describeDiagnostic, type Diagnostic, extractXcodeDiagnostics } from './errors-xcode.ts';
 import { cleanLine } from '../supervisor/server-expo.ts';
+import type { CompilationCacheActivity } from '../types.ts';
 
 const IOS_DIR = 'ios';
 
@@ -446,7 +447,42 @@ export type BuildIosResult = {
   productsDir?: string;
   durationMs: number;
   transcriptLines: number;
+  compilationCache?: CompilationCacheActivity;
 };
+
+export const COMPILATION_CACHE_UNAVAILABLE: CompilationCacheActivity = {
+  status: 'unavailable',
+  hits: null,
+  cacheableTasks: null,
+  hitRatePercent: null,
+};
+
+export const COMPILATION_CACHE_NOT_RUN: CompilationCacheActivity = {
+  status: 'not-run',
+  hits: null,
+  cacheableTasks: null,
+  hitRatePercent: null,
+};
+
+export function parseCompilationCacheActivity(line: unknown): CompilationCacheActivity | null {
+  if (typeof line !== 'string') return null;
+  const match = line.match(/(?:note:\s*)?(\d+) hits \/ (\d+) cacheable tasks \((\d+(?:\.\d+)?)%\)/);
+  if (!match) return null;
+  return {
+    status: 'reported',
+    hits: Number(match[1]),
+    cacheableTasks: Number(match[2]),
+    hitRatePercent: Number(match[3]),
+  };
+}
+
+export function compilationCacheActivityLine(activity: CompilationCacheActivity): string {
+  if (activity.status === 'reported') {
+    return `${activity.hits}/${activity.cacheableTasks} hits (${activity.hitRatePercent}%)`;
+  }
+  if (activity.status === 'not-run') return 'not run; artifact cache supplied the app';
+  return 'unavailable; Xcode did not report reliable statistics';
+}
 
 export async function buildIos({
   root,
@@ -558,6 +594,7 @@ export async function buildIos({
   });
 
   const transcript: string[] = [];
+  let compilationCacheActivity: CompilationCacheActivity = COMPILATION_CACHE_UNAVAILABLE;
   let lastTranscriptLine = '';
   const onLine = (line: unknown) => {
     const msg = cleanLine(line);
@@ -565,6 +602,20 @@ export async function buildIos({
     if (msg.trim() === '') return;
     lastTranscriptLine = msg;
     logWriter.write({ src: 'build', level: 'debug', msg });
+    const activity = parseCompilationCacheActivity(msg);
+    if (activity) {
+      compilationCacheActivity = activity;
+      logWriter.write({
+        src: 'build',
+        level: 'info',
+        msg: compilationCacheActivityLine(activity),
+        event: 'compilation_cache',
+        hits: activity.hits,
+        cacheableTasks: activity.cacheableTasks,
+        hitRatePercent: activity.hitRatePercent,
+      });
+      onNote(`compilation cache ${compilationCacheActivityLine(activity)}`);
+    }
   };
 
   let child: ChildProcess;
@@ -701,5 +752,6 @@ export async function buildIos({
     derivedDataPath: dd,
     productsDir: products,
     transcriptLines: transcript.length,
+    compilationCache: compilationCacheActivity,
   };
 }

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -88,6 +88,13 @@ interface LogsInfo {
   dir?: string;
 }
 
+export interface CompilationCacheActivity {
+  status: 'reported' | 'unavailable' | 'not-run';
+  hits: number | null;
+  cacheableTasks: number | null;
+  hitRatePercent: number | null;
+}
+
 export interface IosFacts {
   platform: string;
   udid: string;
@@ -97,6 +104,7 @@ export interface IosFacts {
   cacheKey?: string | null;
   cacheHit: CacheHitLevel;
   cacheSkipped: boolean;
+  compilationCache: CompilationCacheActivity;
   waitedForBuild: { pid: number | null; ms: number } | null;
   appPath?: string | null;
   bundleId?: string | null;

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -40,6 +40,7 @@ Each command takes `--json` and then prints exactly one line of JSON on stdout, 
   "cacheKey": "...",
   "cacheHit": "local",
   "cacheSkipped": false,
+  "compilationCache": { "status": "not-run", "hits": null, "cacheableTasks": null, "hitRatePercent": null },
   "appPath": "/...",
   "bundleId": "com.example.app",
   "launched": true,
@@ -50,6 +51,8 @@ Each command takes `--json` and then prints exactly one line of JSON on stdout, 
 ```
 
 `cacheHit` is a LEVEL, not a boolean: `"local"` (this machine's shared cache), `"remote"` (the project's own Expo `buildCacheProvider`, whose artifact is copied into the local cache on the way past) or `false` (it was compiled). `cacheSkipped` is true only when `--no-build-cache` was passed, which is "nothing was looked up" rather than "nothing was found".
+
+`compilationCache` reports Xcode's compilation-cache summary when Xcode builds the app. Its status is `"not-run"` when the artifact cache supplies the app. Its status is `"unavailable"` when Xcode does not report reliable statistics.
 
 In a different worktree of the same app, the same two commands get a _different_ owned sim and Metro port, so both run side by side.
 


### PR DESCRIPTION
Closes #117.

## Summary

- Parse the Xcode 26 `CompilationCacheMetrics` summary during iOS builds.
- Stream a concise hit summary while `stim ios` runs.
- Add `compilationCache` to the plain result and the JSON facts.
- Distinguish `reported`, `not-run`, and `unavailable` states.
- Keep Xcode compilation-cache facts separate from Stim artifact-cache facts.

## Verification

- `pnpm run format`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm test` (2,347 tests)
- `pnpm run test:e2e` (12 tests)
- Focused iOS tests (268 tests)
