### PR TITLE
Reduce known harmless iOS launch noise

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -138,6 +138,8 @@ describe('ios: log stream ndjson', () => {
 describe('ios: demoting device noise', () => {
   const app =
     '/Users/x/Library/Developer/CoreSimulator/Devices/U/data/Containers/Bundle/Application/ABC/MyApp.app/MyApp';
+  const focusCacheMessage =
+    'RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.';
   const event = (over: Record<string, unknown>): Record<string, unknown> => ({
     eventType: 'logEvent',
     messageType: 'Error',
@@ -246,8 +248,9 @@ describe('ios: demoting device noise', () => {
       [
         'react-native-focus-cache',
         event({
-          eventMessage:
-            'RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.',
+          subsystem: 'com.apple.UIKit',
+          category: 'UIFocus',
+          eventMessage: focusCacheMessage,
         }),
       ],
     ];
@@ -267,6 +270,18 @@ describe('ios: demoting device noise', () => {
       'uiscene-deprecation',
     ]);
     expect(NOISE_RULES.map((r) => r.id).filter((id) => !covered.has(id))).toEqual([]);
+  });
+
+  test('the focus-cache rule requires the exact UIKit focus event', () => {
+    const nearMisses = [
+      event({ subsystem: 'com.apple.UIKit.child', category: 'UIFocus', eventMessage: focusCacheMessage }),
+      event({ subsystem: 'com.apple.UIKit', category: 'default', eventMessage: focusCacheMessage }),
+      event({ subsystem: 'com.apple.UIKit', category: 'UIFocus', eventMessage: `${focusCacheMessage} Extra` }),
+    ];
+    for (const nearMiss of nearMisses) {
+      expect(noiseRuleId(nearMiss)).toBe(null);
+      expect(levelForEvent(nearMiss)).toBe('error');
+    }
   });
 
   test("the app's own error is untouched, and so is an unlisted system one", () => {

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -209,7 +209,7 @@ describe('ios: demoting device noise', () => {
   });
 
   test('the rest of the proven offenders are demoted, each by its own rule', () => {
-    const cases = [
+    const cases: [string, Record<string, unknown>][] = [
       [
         'sectrust',
         event({ subsystem: 'com.apple.securityd', category: 'SecTrust', eventMessage: 'SecTrustEvaluateIfNecessary' }),
@@ -253,7 +253,12 @@ describe('ios: demoting device noise', () => {
     ];
     for (const [id, e] of cases) {
       expect(noiseRuleId(e)).toBe(id);
-      expect(levelForEvent(e)).toBe('info');
+      const record = parseLogStreamLine(JSON.stringify(e));
+      assert(record);
+      expect(record.level).toBe('info');
+      expect(record.msg).toBe(e.eventMessage);
+      expect(record.src).toBe('device');
+      expect(record.proc).toBe('MyApp');
     }
     const covered = new Set([
       ...cases.map(([id]) => id),

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -243,6 +243,13 @@ describe('ios: demoting device noise', () => {
         }),
       ],
       ['coreui-default-subsystem', event({ eventMessage: 'CUICatalog: Invalid asset name supplied: (null)' })],
+      [
+        'react-native-focus-cache',
+        event({
+          eventMessage:
+            'RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.',
+        }),
+      ],
     ];
     for (const [id, e] of cases) {
       expect(noiseRuleId(e)).toBe(id);

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1420,6 +1420,12 @@ describe('verifyLaunch: still bundling', () => {
       level: 'error',
       msg: 'TCP Conn 0x11e8cb020 Failed : error 0:61 [61]',
     };
+    const recovered = {
+      ts: since + 25,
+      src: 'device',
+      level: 'info',
+      msg: 'TCP Conn 0x11e8cb020 complete. fd: 25, err: 0',
+    };
     const applicationError = {
       ts: since + 30,
       src: 'client',
@@ -1433,7 +1439,7 @@ describe('verifyLaunch: still bundling', () => {
       now: clock.now,
       sleep: clock.sleep,
       readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
-      readDeviceRecords: () => [refusal],
+      readDeviceRecords: () => [refusal, recovered],
       readClientRecords: () => [applicationError],
       processAlive: () => true,
     });
@@ -1442,7 +1448,32 @@ describe('verifyLaunch: still bundling', () => {
     expect(refusal.level).toBe('error');
   });
 
-  test.each([false, null])('the transient TCP refusal stays an error when iOS process health is %s', async (alive) => {
+  test.each([true, false, null])(
+    'the TCP refusal stays an error without a later pointer recovery when process health is %s',
+    async (alive) => {
+      const clock = fakeClock();
+      const since = clock.at();
+      const refusal = {
+        ts: since + 20,
+        src: 'device',
+        level: 'error',
+        msg: 'TCP Conn 0x11e8cb020 Failed : error 0:61 [61]',
+      };
+      const result = await verifyLaunch({
+        since,
+        platform: 'ios',
+        now: clock.now,
+        sleep: clock.sleep,
+        readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
+        readDeviceRecords: () => [refusal],
+        processAlive: () => alive,
+      });
+      expect(result.processAlive).toBe(alive);
+      expect(result.errors).toEqual([refusal]);
+    },
+  );
+
+  test('the TCP refusal stays an error when only an earlier or different pointer succeeds', async () => {
     const clock = fakeClock();
     const since = clock.at();
     const refusal = {
@@ -1457,10 +1488,13 @@ describe('verifyLaunch: still bundling', () => {
       now: clock.now,
       sleep: clock.sleep,
       readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
-      readDeviceRecords: () => [refusal],
-      processAlive: () => alive,
+      readDeviceRecords: () => [
+        { ts: since + 15, src: 'device', level: 'info', msg: 'TCP Conn 0x11e8cb020 complete. fd: 24, err: 0' },
+        refusal,
+        { ts: since + 25, src: 'device', level: 'info', msg: 'TCP Conn 0x11e8cb160 complete. fd: 25, err: 0' },
+      ],
+      processAlive: () => true,
     });
-    expect(result.processAlive).toBe(alive);
     expect(result.errors).toEqual([refusal]);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1411,6 +1411,59 @@ describe('verifyLaunch: still bundling', () => {
     expect(result.errors?.[0]?.msg).toBe('console.error during launch');
   });
 
+  test('a healthy iOS launch omits the transient TCP refusal but keeps application errors', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const refusal = {
+      ts: since + 20,
+      src: 'device',
+      level: 'error',
+      msg: 'TCP Conn 0x11e8cb020 Failed : error 0:61 [61]',
+    };
+    const applicationError = {
+      ts: since + 30,
+      src: 'client',
+      event: 'client_log',
+      level: 'error',
+      msg: 'console.error during launch',
+    };
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
+      readDeviceRecords: () => [refusal],
+      readClientRecords: () => [applicationError],
+      processAlive: () => true,
+    });
+    expect(result).toMatchObject({ verified: true, processAlive: true });
+    expect(result.errors).toEqual([applicationError]);
+    expect(refusal.level).toBe('error');
+  });
+
+  test('the transient TCP refusal stays an error when iOS readiness fails', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const refusal = {
+      ts: since + 20,
+      src: 'device',
+      level: 'error',
+      msg: 'TCP Conn 0x11e8cb020 Failed : error 0:61 [61]',
+    };
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
+      readDeviceRecords: () => [refusal],
+      processAlive: () => false,
+    });
+    expect(result).toMatchObject({ verified: false, fatal: true, processAlive: false });
+    expect(result.errors).toEqual([refusal]);
+  });
+
   test('errors before bundle completion are outside the stability window', async () => {
     const clock = fakeClock();
     const since = clock.at();

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1442,7 +1442,7 @@ describe('verifyLaunch: still bundling', () => {
     expect(refusal.level).toBe('error');
   });
 
-  test('the transient TCP refusal stays an error when iOS readiness fails', async () => {
+  test.each([false, null])('the transient TCP refusal stays an error when iOS process health is %s', async (alive) => {
     const clock = fakeClock();
     const since = clock.at();
     const refusal = {
@@ -1458,9 +1458,9 @@ describe('verifyLaunch: still bundling', () => {
       sleep: clock.sleep,
       readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
       readDeviceRecords: () => [refusal],
-      processAlive: () => false,
+      processAlive: () => alive,
     });
-    expect(result).toMatchObject({ verified: false, fatal: true, processAlive: false });
+    expect(result.processAlive).toBe(alive);
     expect(result.errors).toEqual([refusal]);
   });
 

--- a/packages/stim-cli/src/collector/ios.ts
+++ b/packages/stim-cli/src/collector/ios.ts
@@ -47,6 +47,12 @@ export const NOISE_RULES: NoiseRule[] = [
       'migrate to UIScene lifecycle',
     ],
   },
+  {
+    id: 'react-native-focus-cache',
+    messageIncludes: [
+      'RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.',
+    ],
+  },
 ];
 
 interface NoiseRule {

--- a/packages/stim-cli/src/collector/ios.ts
+++ b/packages/stim-cli/src/collector/ios.ts
@@ -49,16 +49,19 @@ export const NOISE_RULES: NoiseRule[] = [
   },
   {
     id: 'react-native-focus-cache',
-    messageIncludes: [
+    exactSubsystem: 'com.apple.UIKit',
+    category: 'UIFocus',
+    messageEquals:
       'RCTScrollViewComponentView implements focusItemsInRect: - caching for linear focus movement is limited as long as this view is on screen.',
-    ],
   },
 ];
 
 interface NoiseRule {
   id: string;
   subsystem?: string;
+  exactSubsystem?: string;
   category?: string;
+  messageEquals?: string;
   messagePrefix?: string[];
   messageIncludes?: string[];
 }
@@ -71,7 +74,9 @@ function ruleMatches(
   { subsystem, category, message }: { subsystem: string; category: string; message: string },
 ): boolean {
   if (rule.subsystem && subsystem !== rule.subsystem && !subsystem.startsWith(`${rule.subsystem}.`)) return false;
+  if (rule.exactSubsystem && subsystem !== rule.exactSubsystem) return false;
   if (rule.category && category !== rule.category) return false;
+  if (rule.messageEquals && message !== rule.messageEquals) return false;
   if (rule.messagePrefix && !rule.messagePrefix.some((p) => message.startsWith(p))) return false;
   if (rule.messageIncludes && !rule.messageIncludes.some((p) => message.includes(p))) return false;
   return true;

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -743,7 +743,8 @@ export async function verifyLaunch({
           waitedMs,
         };
       }
-      return { verified: true, record: proof, errors, processAlive: alive, mode, waitedMs };
+      const actionableErrors = errors.filter((record) => !isConfirmedHealthyLaunchNoise(record, platform));
+      return { verified: true, record: proof, errors: actionableErrors, processAlive: alive, mode, waitedMs };
     }
 
     if (!proof && now() >= bundleDeadline) {
@@ -774,6 +775,16 @@ function after(record: NdjsonRecord, since: number | string | undefined): boolea
 
 function isLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
   return record.level === 'error' || record.level === 'fatal' || isFatalLaunchError(record, platform);
+}
+
+function isConfirmedHealthyLaunchNoise(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
+  return (
+    platform === 'ios' &&
+    record.src === 'device' &&
+    record.level === 'error' &&
+    typeof record.msg === 'string' &&
+    /^TCP Conn 0x[0-9a-f]+ Failed : error 0:61 \[61\]$/i.test(record.msg)
+  );
 }
 
 function isFatalLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -743,7 +743,8 @@ export async function verifyLaunch({
           waitedMs,
         };
       }
-      const actionableErrors = errors.filter((record) => !isConfirmedHealthyLaunchNoise(record, platform));
+      const actionableErrors =
+        alive === true ? errors.filter((record) => !isConfirmedHealthyLaunchNoise(record, platform)) : errors;
       return { verified: true, record: proof, errors: actionableErrors, processAlive: alive, mode, waitedMs };
     }
 

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -743,8 +743,9 @@ export async function verifyLaunch({
           waitedMs,
         };
       }
-      const actionableErrors =
-        alive === true ? errors.filter((record) => !isConfirmedHealthyLaunchNoise(record, platform)) : errors;
+      const actionableErrors = errors.filter(
+        (record) => !isRecoveredIosConnectionRefusal(record, deviceRecords, platform),
+      );
       return { verified: true, record: proof, errors: actionableErrors, processAlive: alive, mode, waitedMs };
     }
 
@@ -778,14 +779,32 @@ function isLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null)
   return record.level === 'error' || record.level === 'fatal' || isFatalLaunchError(record, platform);
 }
 
-function isConfirmedHealthyLaunchNoise(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
-  return (
-    platform === 'ios' &&
-    record.src === 'device' &&
-    record.level === 'error' &&
-    typeof record.msg === 'string' &&
-    /^TCP Conn 0x[0-9a-f]+ Failed : error 0:61 \[61\]$/i.test(record.msg)
-  );
+const TCP_REFUSAL = /^TCP Conn (0x[0-9a-f]+) Failed : error 0:61 \[61\]$/i;
+const TCP_SUCCESS = /^TCP Conn (0x[0-9a-f]+) complete\. fd: \d+, err: 0$/i;
+
+function isRecoveredIosConnectionRefusal(
+  record: NdjsonRecord,
+  deviceRecords: NdjsonRecord[],
+  platform: 'ios' | 'android' | null,
+): boolean {
+  if (platform !== 'ios' || record.src !== 'device' || record.level !== 'error' || typeof record.msg !== 'string') {
+    return false;
+  }
+  const refusal = TCP_REFUSAL.exec(record.msg);
+  const refusalTs = Number(record.ts);
+  if (!refusal?.[1] || !Number.isFinite(refusalTs)) return false;
+  const pointer = refusal[1].toLowerCase();
+  return deviceRecords.some((candidate) => {
+    const success = typeof candidate.msg === 'string' ? TCP_SUCCESS.exec(candidate.msg) : null;
+    return (
+      candidate.src === 'device' &&
+      candidate.proc === record.proc &&
+      candidate.level !== 'error' &&
+      candidate.level !== 'fatal' &&
+      Number(candidate.ts) > refusalTs &&
+      success?.[1]?.toLowerCase() === pointer
+    );
+  });
 }
 
 function isFatalLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {


### PR DESCRIPTION
## Description

Stim can report two harmless device records as iOS launch errors: a transient `TCP Conn ... error 0:61` record and React Native's `RCTScrollViewComponentView` focus-cache notice.

## Solution

The collector records the exact `com.apple.UIKit:UIFocus` focus-cache notice at `info`. Near matches remain errors.

Launch readiness omits the captured TCP refusal only when a later record from the same process shows the same pointer completing with `err: 0`. Bundle failures, process exits, fatal records, and application `console.error` records remain actionable.

The TCP rule can hide one recovered auxiliary refusal from the launch summary. The error remains in `device.ndjson`.

## Test plan

- Run the collector regression and verify only the exact UIKit focus event changes to `info`.
- Run the readiness regressions and verify only a later, same-pointer success suppresses the refusal. Missing, earlier, and different-pointer successes keep it actionable.

Closes #118
