### PR TITLE
Make tunnel cleanup test deterministic on Node 22

### DIFF
--- a/packages/stim-cli/src/__tests__/tunnel.test.ts
+++ b/packages/stim-cli/src/__tests__/tunnel.test.ts
@@ -458,7 +458,14 @@ describe('startTunnel: nothing here throws -- every failure is a returned value'
   });
 
   test('a process whose start token cannot be captured is cleaned up and not returned as owned', async () => {
-    const child = makeChildProcess();
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    const child = makeChildProcess({
+      kill(signal) {
+        signals.push(signal);
+        child.emit('exit', null, signal);
+        return true;
+      },
+    });
     const promise = startTunnel({
       provider: 'ngrok',
       port: 8081,
@@ -469,6 +476,7 @@ describe('startTunnel: nothing here throws -- every failure is a returned value'
     child.stdout?.emit('data', `${JSON.stringify({ url: 'https://x.ngrok-free.app' })}\n`);
     const result = await promise;
     expect(result).toEqual({ failed: true, reason: expect.stringContaining('process identity token') });
+    expect(signals).toEqual(['SIGTERM']);
   });
 });
 


### PR DESCRIPTION
## Description

On Node 22 Linux, the process identity failure test uses stub PID `4242`. The stub did not emit an `exit` event when cleanup signaled it, so cleanup fell back to probing the host PID table. An unrelated live PID `4242` could add `cleanupFailed: true` and make the suite flaky.

Fixes #124.

## Solution

The fake child now records `SIGTERM` and emits its `exit` event. The assertion proves cleanup signaled the child. Production cleanup code and its failure contract remain unchanged.

## Test plan

- Ran the focused test 50 consecutive times in the official `node:22-bookworm-slim` image. All 50 runs passed.
