### PR TITLE
Skip nested worktrees during ignored-file carry-over

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -427,13 +427,16 @@ Only files that are both gitignored and pattern-matched are copied -- tracked fi
 
 #### `--carry-ignored`
 
-That carry-over is file-by-file, which suits a handful of small config files but not the multi-gigabyte trees a worktree needs in order to build without reinstalling. `worktree create --carry-ignored` instead clones **every** gitignored path -- `node_modules`, `ios/Pods`, `ios/build` (React Native codegen output, without which `xcodebuild` fails on a missing `States.cpp` until `pod install` regenerates it) -- minus:
+That carry-over is file-by-file, which suits a handful of small config files but not the multi-gigabyte trees a worktree needs in order to build without reinstalling. `worktree create --carry-ignored` instead clones **every safe** gitignored path -- `node_modules`, `ios/Pods`, `ios/build` (React Native codegen output, without which `xcodebuild` fails on a missing `States.cpp` until `pod install` regenerates it) -- minus:
 
+- every registered Git worktree nested below the source checkout. If Git reports an ignored parent as one collapsed entry, Stim skips that parent instead of recursively copying the nested worktree;
 - anything matching `.worktreeexclude` at the repo root, same gitignore-style syntax as `.worktreeinclude`, e.g.:
   ```
   bench/results/logs
   ```
 - or the `worktree.exclude` setting, if no `.worktreeexclude` file exists.
+
+The project exclusions add to Stim's safety exclusions. They cannot make Stim copy a registered nested worktree. This rule covers tool-managed locations and custom worktree locations without a hardcoded path list.
 
 It is a skip list rather than a copy list on purpose: forgetting to name something you needed shows up months later as a confusing build error, while forgetting to skip something only costs a needless copy.
 

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -21,6 +21,7 @@ import {
   isPodInstallChurn,
   listGitignoredEntries,
   listGitignoredFiles,
+  listCarryableIgnoredEntries,
   listTrackedPaths,
   addWorktree,
   removeWorktree,
@@ -326,6 +327,82 @@ test('listGitignoredEntries keeps collapsed directories and does not exclude nod
   expect(listGitignoredEntries('/repo')).toEqual(['node_modules', 'ios/Pods', 'ios/.xcode.env.local']);
   expect(capturedCmd).toMatch(/--directory/);
   expect(capturedCmd).not.toMatch(/exclude,glob/);
+});
+
+test('listCarryableIgnoredEntries skips a collapsed ignored parent that contains a registered worktree', () => {
+  setExecutor({
+    run: () => '',
+    runQuiet: (cmd) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return 'worktree /repo\nbranch refs/heads/main\n\nworktree /repo/.claude/worktrees/task\nbranch refs/heads/task\n';
+      }
+      if (cmd.includes('ls-files --others --ignored')) return '.claude/\nnode_modules/\nios/Pods/';
+      return '';
+    },
+    spawn: () => {},
+  });
+
+  expect(listCarryableIgnoredEntries('/repo', [])).toEqual(['node_modules', 'ios/Pods']);
+});
+
+test('listCarryableIgnoredEntries skips entries inside a registered nested worktree', () => {
+  setExecutor({
+    run: () => '',
+    runQuiet: (cmd) => {
+      if (cmd.includes('worktree list --porcelain')) {
+        return 'worktree /repo\nbranch refs/heads/main\n\nworktree /repo/tools/tasks/one\nbranch refs/heads/one\n';
+      }
+      if (cmd.includes('ls-files --others --ignored')) {
+        return 'tools/tasks/one/node_modules/\ntools/shared-cache/\n';
+      }
+      return '';
+    },
+    spawn: () => {},
+  });
+
+  expect(listCarryableIgnoredEntries('/repo', [])).toEqual(['tools/shared-cache']);
+});
+
+test('listCarryableIgnoredEntries fails closed when Git cannot list worktrees', () => {
+  setExecutor({
+    run: () => '',
+    runQuiet: (cmd) => (cmd.includes('worktree list --porcelain') ? null : 'node_modules/'),
+    spawn: () => {},
+  });
+
+  expect(() => listCarryableIgnoredEntries('/repo', [])).toThrow(
+    'Could not list Git worktrees. Refusing to carry ignored files.',
+  );
+});
+
+test('cloneIgnoredEntries does not copy a registered worktree nested under an ignored parent', () => {
+  const base = mkdtempSync(join(tmpdir(), 'stim-cli-test-nested-worktree-'));
+  const root = join(base, 'repo');
+  const target = join(base, 'target');
+  try {
+    mkdirSync(root, { recursive: true });
+    mkdirSync(target, { recursive: true });
+    const git = (cmd: string) => execSync(cmd, { cwd: root, encoding: 'utf-8' });
+    git('git init -q');
+    git('git config user.email test@example.com');
+    git('git config user.name test');
+    writeFileSync(join(root, 'README.md'), 'hello');
+    writeFileSync(join(root, '.gitignore'), '.claude/\nnode_modules/\n');
+    git('git add README.md .gitignore');
+    git('git commit -q -m init');
+    git('git worktree add -q -b nested-task .claude/worktrees/task');
+    mkdirSync(join(root, 'node_modules/pkg'), { recursive: true });
+    writeFileSync(join(root, 'node_modules/pkg/index.js'), 'module.exports = true');
+
+    const { copied, failed } = cloneIgnoredEntries({ root, target, patterns: [] });
+
+    expect(copied).toEqual(['node_modules']);
+    expect(failed).toEqual([]);
+    expect(existsSync(join(target, 'node_modules/pkg/index.js'))).toBe(true);
+    expect(existsSync(join(target, '.claude'))).toBe(false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test('cloneIgnoredEntries skips excluded paths and reports a clone that fell back to a real copy', () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1358,7 +1358,9 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
   worktree.baseRef      "head" (current HEAD) or "fresh" (origin/HEAD).
                         Unset means "head".
   worktree.include      carry-over patterns, same role as .worktreeinclude
-  worktree.exclude      --carry-ignored skip list, same role as .worktreeexclude
+  worktree.exclude      additional --carry-ignored skip list, same role as
+                        .worktreeexclude. Registered nested Git worktrees are
+                        always skipped.
   caches                extra shared-cache paths for \`gc\` to report. A JSON
                         array; every path is treated as a flat store.
 

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -137,7 +137,7 @@ export function registerCreate(worktree: Command): void {
     .option('--label <label>', 'stim-cli shortcut for the worktree (defaults to the worktree name)')
     .option(
       '--carry-ignored',
-      "clone the source's working state: every gitignored path (node_modules, Pods, build output) except those in .worktreeexclude, plus its uncommitted tracked changes (applied when they fit this base)",
+      "clone the source's working state: every safe gitignored path (node_modules, Pods, build output) except nested Git worktrees and paths in .worktreeexclude, plus its uncommitted tracked changes (applied when they fit this base)",
     )
     .action(async (name, opts) => {
       if (!/^[A-Za-z0-9._-]+$/.test(name)) {

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -1,6 +1,16 @@
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
 
 const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
@@ -97,6 +107,36 @@ export function listGitignoredFiles(root: string): string[] {
     .filter((f) => !f.endsWith('/'));
 }
 
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function nestedWorktreePaths(root: string): string[] {
+  const source = canonicalPath(root);
+  const paths = new Set<string>();
+  const out = getExecutor().runQuiet(`git -C "${root}" worktree list --porcelain`);
+  if (out === null) {
+    throw new Error('Could not list Git worktrees. Refusing to carry ignored files.');
+  }
+  for (const entry of parseWorktrees(out)) {
+    const rel = relative(source, canonicalPath(entry.path));
+    if (!rel || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) continue;
+    paths.add(rel.split(sep).join('/'));
+  }
+  return [...paths];
+}
+
+function overlapsNestedWorktree(rel: string, nestedPaths: string[]): boolean {
+  const path = String(rel).replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/$/, '');
+  return nestedPaths.some(
+    (nested) => path === nested || path.startsWith(`${nested}/`) || nested.startsWith(`${path}/`),
+  );
+}
+
 export function listTrackedPaths(dir: string): string[] | null {
   const out = getExecutor().runQuiet(`git -C "${dir}" ls-files -z`);
   if (out === null) return null;
@@ -153,8 +193,10 @@ export function carryOverFiles({
   const skipped: SkippedEntry[] = [];
   const failed: FailedEntry[] = [];
   const guard = trackedGuard(target);
+  const nested = nestedWorktreePaths(root);
   for (const rel of listGitignoredFiles(root)) {
     if (isCarrySkipped(rel)) continue;
+    if (overlapsNestedWorktree(rel, nested)) continue;
     if (!matchesInclude(rel, patterns)) continue;
     const from = join(root, rel);
     const to = join(target, rel);
@@ -186,7 +228,10 @@ export function listGitignoredEntries(root: string): string[] {
 }
 
 export function listCarryableIgnoredEntries(root: string, patterns: string[] | null | undefined): string[] {
-  return listGitignoredEntries(root).filter((rel) => !isCarrySkipped(rel) && !matchesInclude(rel, patterns));
+  const nested = nestedWorktreePaths(root);
+  return listGitignoredEntries(root).filter(
+    (rel) => !isCarrySkipped(rel) && !overlapsNestedWorktree(rel, nested) && !matchesInclude(rel, patterns),
+  );
 }
 
 interface CloneResult extends CarryResult {
@@ -486,9 +531,7 @@ export interface WorktreeEntry {
   branch?: string;
 }
 
-export function listWorktrees(cwd: string): WorktreeEntry[] {
-  const out = getExecutor().runQuiet(`git -C "${cwd}" worktree list --porcelain`);
-  if (!out) return [];
+function parseWorktrees(out: string): WorktreeEntry[] {
   const entries: WorktreeEntry[] = [];
   let current: Partial<WorktreeEntry> = {};
   for (const line of out.split('\n')) {
@@ -501,6 +544,11 @@ export function listWorktrees(cwd: string): WorktreeEntry[] {
   }
   if (current.path) entries.push(current as WorktreeEntry);
   return entries;
+}
+
+export function listWorktrees(cwd: string): WorktreeEntry[] {
+  const out = getExecutor().runQuiet(`git -C "${cwd}" worktree list --porcelain`);
+  return out ? parseWorktrees(out) : [];
 }
 
 export function resolveBaseRef(cwd: string, baseRef: string): string {


### PR DESCRIPTION
## Description

`--carry-ignored` can see a nested Git worktree as one ignored directory. A recursive clone can then copy another complete worktree into the new worktree.

## Solution

Stim reads the repository's registered worktrees before carry-over. It skips an ignored entry when the entry contains, equals, or sits inside a nested worktree. This uses Git's worktree registry, so Claude, Codex, and custom locations need no hardcoded path list.

Registered worktrees always stay excluded. If Git reports only an ignored parent, Stim excludes the full parent, which can also omit unrelated ignored files beneath it. `.worktreeexclude` and `worktree.exclude` remain available for additional project exclusions.

## Test plan

- Create a real worktree at `.claude/worktrees/task` under an ignored `.claude/` parent.
- Run the ignored-path clone with `node_modules` also present.
- Verify that `node_modules` reaches the destination and `.claude` does not.
- Verify direct entries inside a registered nested worktree and collapsed parent entries are both filtered.
