### PR TITLE
Tolerate a slow first simulator boot instead of dying on ETIMEDOUT

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -92,6 +92,36 @@ describe('ensureBooted: ios', () => {
     expect(commands.indexOf('xcrun simctl boot U1')).toBeLessThan(commands.indexOf('xcrun simctl bootstatus U1 -b'));
   });
 
+  test('an explicit ensureBooted timeout bounds the whole iOS boot wait', async () => {
+    setExecutor({
+      run: (cmd) => {
+        if (cmd.includes('list devices')) {
+          return simList([{ udid: 'U1', name: 'stim-app', state: 'Booting', isAvailable: true }]);
+        }
+        if (cmd.includes('bootstatus')) {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+          const e = new Error('spawnSync /bin/sh ETIMEDOUT') as Error & { code?: string };
+          e.code = 'ETIMEDOUT';
+          throw e;
+        }
+        return '';
+      },
+      runQuiet: () => '',
+      runFile: () => '',
+      spawn: () => null,
+    });
+
+    const result = await ensureBooted({
+      platform: 'ios',
+      device: { deviceUdid: 'U1', owned: true },
+      timeoutMs: 1200,
+      pollMs: 5,
+    });
+
+    expect(result.ok).toBeUndefined();
+    expect(result.reason).toMatch(/did not finish booting within 1s/);
+  });
+
   test('reports boot setup failures instead of treating the Booted state as ready', async () => {
     setExecutor({
       run: (cmd) => {

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -12,6 +12,7 @@ import {
   ownedSimName,
   deleteIosSim,
   occupyingApps,
+  bootIosSim,
 } from '../sim/ios.ts';
 import assert from 'node:assert';
 
@@ -342,4 +343,101 @@ test('ownedSimName does not double the ownership prefix', () => {
   expect(ownedSimName('feat-a/tlon-mobile')).toBe('stim-feat-a-tlon-mobile');
   expect(ownedSimName('stim-x').startsWith('stim-')).toBeTruthy();
   expect(ownedSimName('Stim').startsWith('stim-')).toBeTruthy();
+});
+
+function timedOut(): Error {
+  const e = new Error('spawnSync /bin/sh ETIMEDOUT') as Error & { code?: string };
+  e.code = 'ETIMEDOUT';
+  return e;
+}
+
+function bootSimList(state: string) {
+  return JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [{ udid: 'UDID-A', name: 'stim-app', state, isAvailable: true }],
+    },
+  });
+}
+
+test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is still Booting', () => {
+  const commands: string[] = [];
+  let bootstatusCalls = 0;
+  setExecutor({
+    run: (cmd) => {
+      commands.push(cmd);
+      if (cmd.includes('bootstatus')) {
+        bootstatusCalls += 1;
+        if (bootstatusCalls === 1) throw timedOut();
+        return '';
+      }
+      if (cmd.includes('list devices')) return bootSimList('Booting');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  bootIosSim('UDID-A');
+  expect(bootstatusCalls).toBe(2);
+});
+
+test('bootIosSim treats a timed-out attempt as success when the sim reports Booted', () => {
+  let bootstatusCalls = 0;
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) {
+        bootstatusCalls += 1;
+        throw timedOut();
+      }
+      if (cmd.includes('list devices')) return bootSimList('Booted');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  bootIosSim('UDID-A');
+  expect(bootstatusCalls).toBe(1);
+});
+
+test('bootIosSim names the udid and the wait when the deadline expires while Booting', () => {
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) throw timedOut();
+      if (cmd.includes('list devices')) return bootSimList('Booting');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  expect(() => bootIosSim('UDID-A', { timeoutMs: 25 })).toThrow(/UDID-A did not finish booting within \d+s/);
+});
+
+test('bootIosSim reports a sim that left the boot path instead of retrying forever', () => {
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) throw timedOut();
+      if (cmd.includes('list devices')) return bootSimList('Shutdown');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  expect(() => bootIosSim('UDID-A')).toThrow(/UDID-A reports "Shutdown"/);
+});
+
+test('bootIosSim rethrows a bootstatus failure that is not a timeout', () => {
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) throw new Error('CoreLocationMigrator failed');
+      if (cmd.includes('list devices')) return bootSimList('Booting');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  expect(() => bootIosSim('UDID-A')).toThrow(/CoreLocationMigrator failed/);
 });

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -360,11 +360,10 @@ function bootSimList(state: string) {
 }
 
 test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is still Booting', () => {
-  const commands: string[] = [];
+  const quiet: string[] = [];
   let bootstatusCalls = 0;
   setExecutor({
     run: (cmd) => {
-      commands.push(cmd);
       if (cmd.includes('bootstatus')) {
         bootstatusCalls += 1;
         if (bootstatusCalls === 1) throw timedOut();
@@ -373,12 +372,16 @@ test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is
       if (cmd.includes('list devices')) return bootSimList('Booting');
       return '';
     },
-    runQuiet: () => '',
+    runQuiet: (cmd) => {
+      quiet.push(cmd);
+      return '';
+    },
     runFile: () => '',
     spawn: () => null,
   });
   bootIosSim('UDID-A');
   expect(bootstatusCalls).toBe(2);
+  expect(quiet).toContain('open -a Simulator');
 });
 
 test('bootIosSim treats a timed-out attempt as success when the sim reports Booted', () => {
@@ -400,10 +403,17 @@ test('bootIosSim treats a timed-out attempt as success when the sim reports Boot
   expect(bootstatusCalls).toBe(1);
 });
 
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 test('bootIosSim names the udid and the wait when the deadline expires while Booting', () => {
   setExecutor({
     run: (cmd) => {
-      if (cmd.includes('bootstatus')) throw timedOut();
+      if (cmd.includes('bootstatus')) {
+        sleepSync(300);
+        throw timedOut();
+      }
       if (cmd.includes('list devices')) return bootSimList('Booting');
       return '';
     },
@@ -411,7 +421,38 @@ test('bootIosSim names the udid and the wait when the deadline expires while Boo
     runFile: () => '',
     spawn: () => null,
   });
-  expect(() => bootIosSim('UDID-A', { timeoutMs: 25 })).toThrow(/UDID-A did not finish booting within \d+s/);
+  expect(() => bootIosSim('UDID-A', { timeoutMs: 1200 })).toThrow(/UDID-A did not finish booting within 1s/);
+});
+
+test('bootIosSim reports a sim that vanished from the device list', () => {
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) throw timedOut();
+      if (cmd.includes('list devices')) return JSON.stringify({ devices: {} });
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  expect(() => bootIosSim('UDID-A')).toThrow(/UDID-A reports "missing"/);
+});
+
+test('bootIosSim keeps waiting through a failing device list and still hits the deadline', () => {
+  setExecutor({
+    run: (cmd) => {
+      if (cmd.includes('bootstatus')) {
+        sleepSync(300);
+        throw timedOut();
+      }
+      if (cmd.includes('list devices')) throw new Error('CoreSimulatorService connection interrupted');
+      return '';
+    },
+    runQuiet: () => '',
+    runFile: () => '',
+    spawn: () => null,
+  });
+  expect(() => bootIosSim('UDID-A', { timeoutMs: 1200 })).toThrow(/UDID-A did not finish booting within 1s/);
 });
 
 test('bootIosSim reports a sim that left the boot path instead of retrying forever', () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -560,6 +560,9 @@ STIM_NO_DEVICE
   state. \`stim doctor\` checks the toolchain; \`stim status\` says what
   Stim thinks it owns. Re-running the command creates a fresh owned device
   when the recorded one is gone.
+  On iOS a slow first boot is waited out for up to ten minutes while the
+  simulator still reports Booting -- a long silent wait on a loaded machine
+  is patience, not a hang. The failure names the udid and the wait.
   On Android the emulator's own stdio is captured to
   the global workspace logs/emulator.log (truncated per boot), and when it printed a
   \`FATAL |\` / \`ERROR |\` / \`PANIC:\` line THAT is the message and the remedy

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -8,7 +8,14 @@ import {
   type ProjectRecord,
 } from '../config.ts';
 import { isPidAlive } from '../metro.ts';
-import { bootIosSim, createOwnedIosSim, listAllIosSims, listIosDeviceTypes, resolveOwnedIosSim } from '../sim/ios.ts';
+import {
+  bootIosSim,
+  createOwnedIosSim,
+  IOS_BOOT_TIMEOUT_MS,
+  listAllIosSims,
+  listIosDeviceTypes,
+  resolveOwnedIosSim,
+} from '../sim/ios.ts';
 import {
   bootAndroidEmulator,
   configureNewOwnedAvd,
@@ -611,7 +618,7 @@ interface BootResult {
 export async function ensureBooted({
   platform,
   device,
-  timeoutMs = 240000,
+  timeoutMs,
   pollMs = BOOT_POLL_MS,
   out = () => {},
   logFile = null,
@@ -625,8 +632,9 @@ export async function ensureBooted({
     out: Notify;
   } & EmulatorLogging
 > = {}): Promise<BootResult> {
-  if (platform === 'ios') return ensureIosBooted({ device, timeoutMs, pollMs, out });
-  if (platform === 'android') return ensureAndroidBooted({ device, timeoutMs, out, logFile, alive });
+  if (platform === 'ios') return ensureIosBooted({ device, timeoutMs: timeoutMs ?? IOS_BOOT_TIMEOUT_MS, pollMs, out });
+  if (platform === 'android')
+    return ensureAndroidBooted({ device, timeoutMs: timeoutMs ?? 240000, out, logFile, alive });
   return { failed: true, reason: `Unknown platform "${platform}".` };
 }
 
@@ -666,13 +674,15 @@ async function ensureIosBooted({
   if (sim.state === 'Booted') return { ok: true, udid };
 
   out(chalk.dim(`Booting sim ${sim.name} (${udid})...`));
+  const bootDeadline = Date.now() + timeoutMs;
   try {
-    bootIosSim(udid);
+    bootIosSim(udid, { timeoutMs });
   } catch (e) {
     return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
   }
 
-  const deadline = Date.now() + timeoutMs;
+  // A boot that consumed the whole budget still gets a couple of verification polls.
+  const deadline = Math.max(bootDeadline, Date.now() + 2 * pollMs);
   while (Date.now() < deadline) {
     await sleep(pollMs);
     let state = null;

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -681,13 +681,12 @@ async function ensureIosBooted({
     return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
   }
 
-  // A boot that consumed the whole budget still gets a couple of verification polls.
   const deadline = Math.max(bootDeadline, Date.now() + 2 * pollMs);
   while (Date.now() < deadline) {
     await sleep(pollMs);
     let state = null;
     try {
-      state = listAllIosSims().find((s) => s.udid === udid)?.state ?? null;
+      state = listAllIosSims({ timeoutMs: 30000 }).find((s) => s.udid === udid)?.state ?? null;
     } catch {}
     if (state === 'Booted') return { ok: true, udid };
   }

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -103,6 +103,8 @@ export function parseRuntimeVersion(runtimeId: string): string {
 
 export const IOS_BOOT_TIMEOUT_MS: number = 600000;
 const BOOTSTATUS_ATTEMPT_MS = 240000;
+const BOOTSTATUS_ATTEMPT_FLOOR_MS = 1000;
+const BOOT_STATE_LIST_TIMEOUT_MS = 30000;
 
 export function bootIosSim(udid: string, { timeoutMs = IOS_BOOT_TIMEOUT_MS }: { timeoutMs?: number } = {}): void {
   const exec = getExecutor();
@@ -114,25 +116,31 @@ export function bootIosSim(udid: string, { timeoutMs = IOS_BOOT_TIMEOUT_MS }: { 
   const deadline = Date.now() + timeoutMs;
   // `simctl bootstatus -b` blocks until the boot finishes, and a first boot on a
   // CPU-starved host (a CI runner sharing cores with xcodebuild) can legitimately
-  // outlast one attempt. An expired attempt while the device still reports
-  // Booting is a slow boot, not a failed one -- re-enter until the deadline.
+  // outlast one attempt (#128).
   for (;;) {
     const remaining = deadline - Date.now();
     if (remaining > 0) {
       try {
-        exec.run(`xcrun simctl bootstatus ${udid} -b`, { timeoutMs: Math.min(remaining, BOOTSTATUS_ATTEMPT_MS) });
+        exec.run(`xcrun simctl bootstatus ${udid} -b`, {
+          timeoutMs: Math.min(Math.max(remaining, BOOTSTATUS_ATTEMPT_FLOOR_MS), BOOTSTATUS_ATTEMPT_MS),
+        });
         break;
       } catch (e) {
         if ((e as NodeJS.ErrnoException)?.code !== 'ETIMEDOUT') throw e;
       }
     }
-    const state = listAllIosSims().find((s) => s.udid === udid)?.state ?? null;
+    let state: string | null | undefined;
+    try {
+      state = listAllIosSims({ timeoutMs: BOOT_STATE_LIST_TIMEOUT_MS }).find((s) => s.udid === udid)?.state ?? null;
+    } catch {
+      state = undefined;
+    }
     if (state === 'Booted') break;
     const waited = Math.round((timeoutMs - Math.max(0, deadline - Date.now())) / 1000);
-    if (state !== 'Booting') {
+    if (state !== 'Booting' && state !== undefined) {
       throw new Error(`Simulator ${udid} reports "${state ?? 'missing'}" after ${waited}s of boot wait.`);
     }
-    if (remaining <= 0) {
+    if (deadline - Date.now() <= 0) {
       throw new Error(`Simulator ${udid} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`);
     }
   }

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -101,14 +101,41 @@ export function parseRuntimeVersion(runtimeId: string): string {
   return minor ? `${major}.${minor}` : major;
 }
 
-export function bootIosSim(udid: string): void {
+export const IOS_BOOT_TIMEOUT_MS: number = 600000;
+const BOOTSTATUS_ATTEMPT_MS = 240000;
+
+export function bootIosSim(udid: string, { timeoutMs = IOS_BOOT_TIMEOUT_MS }: { timeoutMs?: number } = {}): void {
   const exec = getExecutor();
   try {
     exec.run(`xcrun simctl boot ${udid}`);
   } catch (e) {
     if (!String((e as Error)?.message || e).includes('Booted')) throw e;
   }
-  exec.run(`xcrun simctl bootstatus ${udid} -b`, { timeoutMs: 240000 });
+  const deadline = Date.now() + timeoutMs;
+  // `simctl bootstatus -b` blocks until the boot finishes, and a first boot on a
+  // CPU-starved host (a CI runner sharing cores with xcodebuild) can legitimately
+  // outlast one attempt. An expired attempt while the device still reports
+  // Booting is a slow boot, not a failed one -- re-enter until the deadline.
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining > 0) {
+      try {
+        exec.run(`xcrun simctl bootstatus ${udid} -b`, { timeoutMs: Math.min(remaining, BOOTSTATUS_ATTEMPT_MS) });
+        break;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException)?.code !== 'ETIMEDOUT') throw e;
+      }
+    }
+    const state = listAllIosSims().find((s) => s.udid === udid)?.state ?? null;
+    if (state === 'Booted') break;
+    const waited = Math.round((timeoutMs - Math.max(0, deadline - Date.now())) / 1000);
+    if (state !== 'Booting') {
+      throw new Error(`Simulator ${udid} reports "${state ?? 'missing'}" after ${waited}s of boot wait.`);
+    }
+    if (remaining <= 0) {
+      throw new Error(`Simulator ${udid} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`);
+    }
+  }
   exec.runQuiet('open -a Simulator');
 }
 


### PR DESCRIPTION
## Description
Both iOS jobs of the nightly Native E2E failed with `Could not ensure an owned iOS simulator: spawnSync /bin/sh ETIMEDOUT` -> `STIM_NO_DEVICE`. Every CI run creates a fresh owned sim, and its first boot runs `simctl bootstatus -b` under a hard 240s exec timeout. On a three-core runner sharing CPU with xcodebuild the boot can legitimately take longer, and the raw Node timeout error becomes the whole failure message.

## Solution
`bootIosSim` treats an expired bootstatus attempt as "still booting" rather than fatal: while the device reports `Booting`, it re-enters `bootstatus` against a 600s overall deadline.

- Deadline exhausted, or the sim leaves the boot path: fails with the udid and the elapsed wait, still under `STIM_NO_DEVICE`.
- Non-timeout bootstatus failures rethrow unchanged.
- **All three call sites share the fix** (fresh create, recorded-sim reboot, the parallel ensure path).

## Test plan
- Unit tests: re-entry while `Booting`; timeout with `Booted` treated as success; deadline expiry names the udid and wait; a sim that left the boot path fails instead of retrying; non-timeout errors rethrow.
- The simctl argv is unchanged (`simctl boot`, `simctl bootstatus <udid> -b`), so no new tool-call shapes against the real tool.
- Tonight's scheduled Native E2E run is the real-world verification.

Fixes #128