### PR TITLE
Judge gradle-cache storing by new entry names, not net count

### DIFF
--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -273,15 +273,11 @@ export function dirStats(dir) {
   return out;
 }
 
-export function topFileNames(dir) {
+export function topFileNames(dir, { matching } = {}) {
   if (!existsSync(dir)) return [];
-  try {
-    return readdirSync(dir, { withFileTypes: true })
-      .filter((e) => e.isFile())
-      .map((e) => e.name);
-  } catch {
-    return [];
-  }
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && (!matching || matching.test(e.name)))
+    .map((e) => e.name);
 }
 
 export function growth(label, before, after) {

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -273,6 +273,17 @@ export function dirStats(dir) {
   return out;
 }
 
+export function topFileNames(dir) {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isFile())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
 export function growth(label, before, after) {
   return {
     label,

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -148,7 +148,10 @@ async function main() {
   const metroBefore1 = dirStats(storeRoot1 || METRO_CACHE_ROOT);
   const casBefore1 = dirStats(CAS_DIR);
   const gradleBefore1 = dirStats(GRADLE_CACHE_DIR);
-  const gradleNamesBefore1 = new Set(topFileNames(GRADLE_CACHE_DIR));
+  // Gradle cache entries are 32-hex content hashes; the same directory also
+  // holds build-cache-1.lock and gc.properties, which must not count as stores.
+  const GRADLE_ENTRY = /^[0-9a-f]{32}$/;
+  const gradleNamesBefore1 = new Set(topFileNames(GRADLE_CACHE_DIR, { matching: GRADLE_ENTRY }));
 
   const build1 = build(wt1, 'wt1 (cold)');
   assert(
@@ -160,7 +163,8 @@ async function main() {
   const metroAfter1 = await settle(storeRoot1 || METRO_CACHE_ROOT, 'wt1 Metro store');
   const casAfter1 = dirStats(CAS_DIR);
   const gradleAfter1 = dirStats(GRADLE_CACHE_DIR);
-  const gradleNewNames1 = topFileNames(GRADLE_CACHE_DIR).filter((n) => !gradleNamesBefore1.has(n));
+  const gradleNamesAfter1 = new Set(topFileNames(GRADLE_CACHE_DIR, { matching: GRADLE_ENTRY }));
+  const gradleNewNames1 = [...gradleNamesAfter1].filter((n) => !gradleNamesBefore1.has(n));
 
   const wt2 = worktreeCreate('e2e-cache-2', appDir);
   const start2 = startAndAssertMode(wt2);
@@ -300,7 +304,7 @@ async function main() {
 
       const g = growth('Gradle build cache', gradleBefore1, gradleAfter1);
       c.ev(describeGrowth(g));
-      const removed = gradleBefore1.files + gradleNewNames1.length - gradleAfter1.files;
+      const removed = [...gradleNamesBefore1].filter((n) => !gradleNamesAfter1.has(n)).length;
       c.ev(
         `${gradleNewNames1.length} new entry file(s) written by the cold assemble` +
           (removed > 0 ? ` (Gradle's own cleanup removed ${removed} old file(s) in the same window)` : ''),

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -309,9 +309,18 @@ async function main() {
         `${gradleNewNames1.length} new entry file(s) written by the cold assemble` +
           (removed > 0 ? ` (Gradle's own cleanup removed ${removed} old file(s) in the same window)` : ''),
       );
+      // A machine cache already holding this fixture's task outputs (a previous
+      // suite run) stores nothing on a cold workspace: the build LOADS instead.
+      // Either direction proves the cache is engaged.
+      const wt1FromCache = readNdjson(buildLog(wt1))
+        .map((r) => String(r.msg || ''))
+        .filter((m) => /FROM-CACHE/.test(m));
+      if (gradleNewNames1.length === 0) {
+        for (const line of wt1FromCache.slice(0, 3)) c.ev(`wt1 gradle: ${line}`);
+      }
       assert(
-        gradleNewNames1.length > 0,
-        `${GRADLE_CACHE_DIR} gained no NEW entries across a cold assemble. Gradle only creates and fills it when --build-cache is on, so this is engaged-but-not-storing. (Judged by entry-name set difference; a net count drop from Gradle's periodic cleanup of old entries does not fail this check.)`,
+        gradleNewNames1.length > 0 || wt1FromCache.length > 0,
+        `${GRADLE_CACHE_DIR} gained no NEW entries across a cold assemble, and no wt1 task came back FROM-CACHE either. Gradle only creates, fills, or reads it when --build-cache is on, so this is engaged-but-inert. (Judged by entry-name set difference plus the build log; a net count drop from Gradle's periodic cleanup of old entries does not fail this check.)`,
       );
 
       log('forcing gradle to execute in wt2 with --no-build-cache so its task cache can be observed...');
@@ -326,7 +335,11 @@ async function main() {
         `no task in wt2 came back FROM-CACHE, so the second worktree reused none of wt1's task outputs (log: ${buildLog(wt2)})`,
       );
       return c.pass(
-        `--build-cache on the argv; ${gradleNewNames1.length} new cache entries; ${lines.length} FROM-CACHE task(s) in the second worktree`,
+        `--build-cache on the argv; ` +
+          (gradleNewNames1.length > 0
+            ? `${gradleNewNames1.length} new cache entries; `
+            : `warm machine cache reused by wt1 (${wt1FromCache.length} FROM-CACHE); `) +
+          `${lines.length} FROM-CACHE task(s) in the second worktree`,
       );
     });
   } else {

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -165,6 +165,12 @@ async function main() {
   const gradleAfter1 = dirStats(GRADLE_CACHE_DIR);
   const gradleNamesAfter1 = new Set(topFileNames(GRADLE_CACHE_DIR, { matching: GRADLE_ENTRY }));
   const gradleNewNames1 = [...gradleNamesAfter1].filter((n) => !gradleNamesBefore1.has(n));
+  const wt1FromCache =
+    PLATFORM === 'android'
+      ? readNdjson(buildLog(wt1))
+          .map((r) => String(r.msg || ''))
+          .filter((m) => /FROM-CACHE/.test(m))
+      : [];
 
   const wt2 = worktreeCreate('e2e-cache-2', appDir);
   const start2 = startAndAssertMode(wt2);
@@ -311,10 +317,6 @@ async function main() {
       );
       // A machine cache already holding this fixture's task outputs (a previous
       // suite run) stores nothing on a cold workspace: the build LOADS instead.
-      // Either direction proves the cache is engaged.
-      const wt1FromCache = readNdjson(buildLog(wt1))
-        .map((r) => String(r.msg || ''))
-        .filter((m) => /FROM-CACHE/.test(m));
       if (gradleNewNames1.length === 0) {
         for (const line of wt1FromCache.slice(0, 3)) c.ev(`wt1 gradle: ${line}`);
       }
@@ -338,7 +340,7 @@ async function main() {
         `--build-cache on the argv; ` +
           (gradleNewNames1.length > 0
             ? `${gradleNewNames1.length} new cache entries; `
-            : `warm machine cache reused by wt1 (${wt1FromCache.length} FROM-CACHE); `) +
+            : `warm machine cache: wt1 loaded ${wt1FromCache.length} FROM-CACHE, storing not exercised this run; `) +
           `${lines.length} FROM-CACHE task(s) in the second worktree`,
       );
     });

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -20,6 +20,7 @@ import {
   preflight,
   quote,
   readNdjson,
+  topFileNames,
   verifyCleanup,
   workspaceLogsDir,
 } from './harness.mjs';
@@ -147,6 +148,7 @@ async function main() {
   const metroBefore1 = dirStats(storeRoot1 || METRO_CACHE_ROOT);
   const casBefore1 = dirStats(CAS_DIR);
   const gradleBefore1 = dirStats(GRADLE_CACHE_DIR);
+  const gradleNamesBefore1 = new Set(topFileNames(GRADLE_CACHE_DIR));
 
   const build1 = build(wt1, 'wt1 (cold)');
   assert(
@@ -158,6 +160,7 @@ async function main() {
   const metroAfter1 = await settle(storeRoot1 || METRO_CACHE_ROOT, 'wt1 Metro store');
   const casAfter1 = dirStats(CAS_DIR);
   const gradleAfter1 = dirStats(GRADLE_CACHE_DIR);
+  const gradleNewNames1 = topFileNames(GRADLE_CACHE_DIR).filter((n) => !gradleNamesBefore1.has(n));
 
   const wt2 = worktreeCreate('e2e-cache-2', appDir);
   const start2 = startAndAssertMode(wt2);
@@ -297,9 +300,14 @@ async function main() {
 
       const g = growth('Gradle build cache', gradleBefore1, gradleAfter1);
       c.ev(describeGrowth(g));
+      const removed = gradleBefore1.files + gradleNewNames1.length - gradleAfter1.files;
+      c.ev(
+        `${gradleNewNames1.length} new entry file(s) written by the cold assemble` +
+          (removed > 0 ? ` (Gradle's own cleanup removed ${removed} old file(s) in the same window)` : ''),
+      );
       assert(
-        g.added > 0,
-        `${GRADLE_CACHE_DIR} gained no entries across a cold assemble. Gradle only creates and fills it when --build-cache is on, so this is engaged-but-not-storing.`,
+        gradleNewNames1.length > 0,
+        `${GRADLE_CACHE_DIR} gained no NEW entries across a cold assemble. Gradle only creates and fills it when --build-cache is on, so this is engaged-but-not-storing. (Judged by entry-name set difference; a net count drop from Gradle's periodic cleanup of old entries does not fail this check.)`,
       );
 
       log('forcing gradle to execute in wt2 with --no-build-cache so its task cache can be observed...');
@@ -314,7 +322,7 @@ async function main() {
         `no task in wt2 came back FROM-CACHE, so the second worktree reused none of wt1's task outputs (log: ${buildLog(wt2)})`,
       );
       return c.pass(
-        `--build-cache on the argv; cache +${g.added} files; ${lines.length} FROM-CACHE task(s) in the second worktree`,
+        `--build-cache on the argv; ${gradleNewNames1.length} new cache entries; ${lines.length} FROM-CACHE task(s) in the second worktree`,
       );
     });
   } else {


### PR DESCRIPTION
## Description
The `gradle-cache` check in the cache e2e judged storing by comparing the file count of `~/.gradle/caches/build-cache-1` before and after the cold assemble. Gradle's periodic cleanup (entries unused >7 days) can remove more entries than the build adds, so on a lived-in machine the delta goes negative and the check fails as "engaged-but-not-storing" while storing actually worked. Hit during the rc.5 pre-tag QA: net -1104 files, yet 225 entries were created during the window (proven by mtime). CI is unaffected for a simpler reason the review corrected: the e2e workflow restores no Gradle cache at all, so the directory starts empty there.

## Solution
Snapshot the cache's entry basenames before the cold assemble and assert that new names appear afterwards (set difference), which is immune to concurrent deletions. The evidence line now also reports how many old files cleanup removed in the same window, so the next reader of a passing-but-shrinking cache isn't puzzled.

## Test plan
- Helper semantics verified directly: a new entry is detected despite a concurrent removal; a missing dir yields an empty list.
- Real-world validation: a full `caches expo-android` run on the same machine (populated, cleanup-prone gradle cache) that produced the false negative — result to be attached before marking ready.

Fixes #132


---

## Validation evidence (attached per review)

Two full `caches expo-android` runs on the machine that produced the false negative:

1. **First run exposed a third mode the original check also mishandled**: the machine cache already held every one of this fixture's task outputs (from the release-QA run hours earlier), so the cold workspace stored `0` new entries and loaded FROM-CACHE instead -- correct Gradle behavior that the store-only assertion called a failure. The check now accepts either direction (store on a cold machine cache, load on a warm one) and names which it saw.
2. **Rerun with the final check: suite exit 0**, `gradle-cache PASS: --build-cache on the argv; warm machine cache reused by wt1 (89 FROM-CACHE); 89 FROM-CACHE task(s) in the second worktree`.

Review fixes also applied: entries are matched by the 32-hex name shape (`build-cache-1.lock`/`gc.properties` can no longer satisfy the check on a cold directory -- the CI case), an unreadable directory now throws instead of reading as all-new, and the removed-count evidence derives from the same name sets instead of mixing a recursive count with a flat listing.
