### PR TITLE
Name the compilation cache when a damaged object fails the build

### DIFF
--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -65,8 +65,9 @@ cold/warm split deliberately only when it is the behavior under test.
 ## Safety rules (non-negotiable)
 
 - NEVER modify the target repo's main checkout. Worktrees only.
-- NEVER run `gc --delete` or `gc --delete --all` without the user's explicit
-  approval in this session. Bare `gc` (report) is always fine.
+- NEVER run `gc --delete`, `gc --delete --all`, or `gc --delete --all --cache
+<name>` without the user's explicit approval in this session. Bare `gc`
+  (report) is always fine.
 - Touch no simulator/emulator except `stim-*` ones YOUR runs created.
 - No raw `simctl recordVideo` (it can wedge a machine with a global lock);
   record only through your device tool's own mechanism, prefer screenshots.

--- a/packages/stim-cli/src/__tests__/errors-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-xcode.test.ts
@@ -109,6 +109,28 @@ const REAL_SUCCESS_TAIL = [
   '',
 ].join('\n');
 
+describe('a damaged compilation cache', () => {
+  test('the scan failure carries the remedy that empties that one cache', () => {
+    const transcript = [
+      "error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind (in target 'sqlite3' from project 'Pods')",
+      '** BUILD FAILED **',
+    ].join('\n');
+    const found = extractXcodeDiagnostics(transcript);
+    expect(found.length).toBe(1);
+    expect(found[0]?.remedy).toContain('--cache');
+  });
+
+  test('the module failure that follows the scan failure carries the same remedy', () => {
+    const transcript = [
+      "/usr/include/stdio.h:61:10: error: Could not build module '_DarwinFoundation2' (in target 'nanopb' from project 'Pods')",
+      "error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind (in target 'nanopb' from project 'Pods')",
+      '** BUILD FAILED **',
+    ].join('\n');
+    const remedies = extractXcodeDiagnostics(transcript).map((d) => d.remedy);
+    expect(remedies.some((r) => r?.includes('--cache'))).toBeTruthy();
+  });
+});
+
 describe('real transcripts', () => {
   test('a clang compile failure yields file, line, column and message, and nothing else', () => {
     const found = extractXcodeDiagnostics(REAL_COMPILE_FAILURE);

--- a/packages/stim-cli/src/__tests__/errors-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-xcode.test.ts
@@ -131,6 +131,17 @@ describe('a damaged compilation cache', () => {
     expect(cas?.remedy).toContain('--cache');
   });
 
+  test('the remedy survives the diagnostic cap when the scan failure leads the transcript', () => {
+    const lines = ["error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind (in target 'sqlite3')"];
+    for (let i = 0; i < 40; i += 1) {
+      lines.push(`/usr/include/h${i}.h:1:1: error: Could not build module '_DarwinFoundation1' (in target 'sqlite3')`);
+    }
+    lines.push('** BUILD FAILED **');
+    const all = extractXcodeDiagnostics(lines.join('\n'));
+    expect(all.length).toBeGreaterThan(MAX_DIAGNOSTICS);
+    expect(capDiagnostics(all).diagnostics.find((d) => d.remedy)?.remedy).toContain('--cache');
+  });
+
   test('a CAS scan failure with another cause gets no cache remedy', () => {
     const transcript = [
       "error: CAS-based dependency scan failed: module map not found (in target 'sqlite3' from project 'Pods')",

--- a/packages/stim-cli/src/__tests__/errors-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-xcode.test.ts
@@ -120,14 +120,23 @@ describe('a damaged compilation cache', () => {
     expect(found[0]?.remedy).toContain('--cache');
   });
 
-  test('the module failure that follows the scan failure carries the same remedy', () => {
+  test('a transcript that also carries a module failure still yields the cache remedy', () => {
     const transcript = [
       "/usr/include/stdio.h:61:10: error: Could not build module '_DarwinFoundation2' (in target 'nanopb' from project 'Pods')",
       "error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind (in target 'nanopb' from project 'Pods')",
       '** BUILD FAILED **',
     ].join('\n');
-    const remedies = extractXcodeDiagnostics(transcript).map((d) => d.remedy);
-    expect(remedies.some((r) => r?.includes('--cache'))).toBeTruthy();
+    const found = extractXcodeDiagnostics(transcript);
+    const cas = found.find((d) => d.message.includes('IncludeTreeRoot'));
+    expect(cas?.remedy).toContain('--cache');
+  });
+
+  test('a CAS scan failure with another cause gets no cache remedy', () => {
+    const transcript = [
+      "error: CAS-based dependency scan failed: module map not found (in target 'sqlite3' from project 'Pods')",
+      '** BUILD FAILED **',
+    ].join('\n');
+    expect(extractXcodeDiagnostics(transcript)[0]?.remedy).toBeUndefined();
   });
 });
 

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -29,8 +29,35 @@ import gcCommand, {
   findStaleProjectDevices,
   formatGcReport,
   runGc,
+  selectCaches,
 } from '../commands/gc.ts';
 import { makeConfig, makeIosSim, makeCacheDescriptor, makeBuildLock, makeBuildSlot } from './_factories.ts';
+
+describe('selectCaches', () => {
+  const caches = [
+    makeCacheDescriptor({ name: 'Xcode compilation cache', dir: '/home/.stim/compilation-cache' }),
+    makeCacheDescriptor({ name: 'Build cache', dir: '/home/.stim/build-cache' }),
+    makeCacheDescriptor({ name: 'Metro file maps', dir: '/tmp/metro-file-map-1' }),
+  ];
+
+  test('no name keeps every cache', () => {
+    expect(selectCaches(caches, null)).toHaveLength(3);
+    expect(selectCaches(caches, '')).toHaveLength(3);
+  });
+
+  test('a name selects the caches it appears in, whatever its case', () => {
+    expect(selectCaches(caches, 'compilation cache').map((c) => c.name)).toEqual(['Xcode compilation cache']);
+    expect(selectCaches(caches, 'COMPILATION').map((c) => c.name)).toEqual(['Xcode compilation cache']);
+  });
+
+  test('a directory fragment selects a cache the name does not match', () => {
+    expect(selectCaches(caches, 'metro-file-map').map((c) => c.name)).toEqual(['Metro file maps']);
+  });
+
+  test('a name nothing carries selects no cache', () => {
+    expect(selectCaches(caches, 'gradle')).toEqual([]);
+  });
+});
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -86,7 +86,7 @@ describe('a cache-scoped report', () => {
     expect(lines.some((l) => l.includes('Nothing to reclaim'))).toBeTruthy();
   });
 
-  test('a name no cache carries reports the caches the machine holds', async () => {
+  test('a name no cache carries says so instead of reporting a clean machine', async () => {
     const output = await captureLog(() => runGc({ cache: 'nothing-carries-this-name' }));
     expect(output).toContain('No shared cache carries "nothing-carries-this-name"');
     expect(output).not.toContain('Nothing to reclaim');
@@ -2279,6 +2279,17 @@ test('rejects a non-numeric --older-than instead of silently skipping every entr
   await expect(() => program.parseAsync(['node', 'stim', 'gc', '--older-than', 'lastweek'])).rejects.toThrow(
     /must be a whole number of days/,
   );
+});
+
+test('rejects a blank --cache instead of widening the run', async () => {
+  for (const value of ['', '   ']) {
+    const program = new Command();
+    program.exitOverride();
+    gcCommand(program);
+    await expect(() => program.parseAsync(['node', 'stim', 'gc', '--cache', value])).rejects.toThrow(
+      /must name a cache/,
+    );
+  }
 });
 
 test('describeUnverifiableDevices names Stim devices it cannot verify', () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -59,6 +59,40 @@ describe('selectCaches', () => {
   });
 });
 
+describe('a cache-scoped report', () => {
+  test('carries the scope and inspects nothing else', async () => {
+    const report = await collectGcReport({ cache: 'compilation cache' });
+    expect(report.cacheScope).toBe('compilation cache');
+    expect(report.deadProjects).toEqual([]);
+    expect(report.orphanedDevices).toEqual([]);
+    expect(report.staleDevices).toEqual([]);
+    expect(report.staleDeviceRecords).toEqual([]);
+    expect(report.buildLocks).toEqual({ stale: [], live: [] });
+    expect(report.buildSlots).toEqual({ stale: [], live: [] });
+    expect(report.skipped).toEqual([]);
+    for (const c of report.caches) {
+      expect(`${c.name} ${c.dir}`.toLowerCase()).toContain('compilation cache');
+    }
+  });
+
+  test('the report says what was not inspected instead of claiming a clean machine', () => {
+    const lines = formatGcReport({ cacheScope: 'compilation cache' });
+    expect(lines.some((l) => l.includes('Cache scope: "compilation cache"'))).toBeTruthy();
+    expect(lines.some((l) => l.includes('Nothing to reclaim'))).toBeFalsy();
+  });
+
+  test('an unscoped report still reports a clean machine', () => {
+    const lines = formatGcReport({});
+    expect(lines.some((l) => l.includes('Nothing to reclaim'))).toBeTruthy();
+  });
+
+  test('a name no cache carries reports the caches the machine holds', async () => {
+    const output = await captureLog(() => runGc({ cache: 'nothing-carries-this-name' }));
+    expect(output).toContain('No shared cache carries "nothing-carries-this-name"');
+    expect(output).not.toContain('Nothing to reclaim');
+  });
+});
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 test('names skipped entries and why they were skipped', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -77,7 +77,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--remote'],
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
-    'gc.ts': ['--delete', '--older-than', '--all'],
+    'gc.ts': ['--delete', '--older-than', '--all', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--label', '--force'],
   };
   for (const [file, flags] of Object.entries(advertised)) {
@@ -123,6 +123,8 @@ test('the guide keeps Metro intent separate from the explicit device backend', (
   expect(lifecycle).toMatch(/android\s+[^\n]*--remote <proxy\|eas>/);
   expect(settings).toMatch(/ios\.remote[^\n]*"proxy" or "eas"/);
   expect(settings).toMatch(/android\.remote[^\n]*"proxy" or "eas"/);
+  expect(errors).toContain('not a IncludeTreeRoot node kind');
+  expect(errors).toContain('--cache "compilation cache"');
   expect(errors).toContain('STIM_REMOTE_PROXY_CONFIG');
   expect(errors).toContain('STIM_REMOTE_EAS_UNAVAILABLE');
 });

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -92,6 +92,7 @@ interface GcReport {
 interface CollectGcReportOptions {
   olderThan?: number | null;
   all?: boolean;
+  cache?: string | null;
   now?: number;
   lastTouched?: (path: string) => number;
   unsafeAllowScopedDeviceSweep?: boolean;
@@ -100,6 +101,7 @@ interface CollectGcReportOptions {
 interface RunGcOptions {
   olderThan?: number;
   all?: boolean;
+  cache?: string;
   delete?: boolean;
   unsafeAllowScopedDeviceSweep?: boolean;
 }
@@ -797,6 +799,13 @@ function machineGlobalReason(cache: CacheDescriptor): string | null {
   return `STIM_HOME scopes this config, but ${cache.dir} is outside it and therefore machine-global`;
 }
 
+export function selectCaches(caches: CacheDescriptor[], name: string | null | undefined): CacheDescriptor[] {
+  if (!name) return caches;
+  const wanted = String(name).trim().toLowerCase();
+  if (!wanted) return caches;
+  return caches.filter((c) => c.name.toLowerCase().includes(wanted) || c.dir.toLowerCase().includes(wanted));
+}
+
 function planCacheEmptying(caches: CacheDescriptor[], all: boolean): GcCache[] {
   const annotated = caches.map((c) => Object.assign({}, c, { machineGlobal: machineGlobalReason(c) }));
   if (!all) return annotated;
@@ -868,13 +877,32 @@ export async function collectGcReport(
   {
     olderThan = null,
     all = false,
+    cache = null,
     now = Date.now(),
     lastTouched = projectLastTouched,
     unsafeAllowScopedDeviceSweep = false,
   }: CollectGcReportOptions = {},
   deps: GcDependencies = {},
 ): Promise<GcReport> {
-  const caches = planCacheEmptying(sizeCaches(discoverCaches({ declared: declaredCachePaths() })), all);
+  const selected = selectCaches(discoverCaches({ declared: declaredCachePaths() }), cache);
+  const caches = planCacheEmptying(sizeCaches(selected), all);
+
+  if (cache) {
+    return {
+      skipped: [],
+      deadProjects: [],
+      orphanedDevices: [],
+      staleDevices: [],
+      staleDeviceRecords: [],
+      buildLocks: { stale: [], live: [] },
+      buildSlots: { stale: [], live: [] },
+      deviceSweepNotices: [],
+      easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
+      caches,
+      olderThan,
+      all,
+    };
+  }
 
   const mountedVolumes = listMountedVolumes();
   const cfg = loadConfig();
@@ -1075,14 +1103,23 @@ export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}):
 async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void> {
   const olderThan = typeof opts.olderThan === 'number' ? opts.olderThan : null;
   const all = Boolean(opts.all);
+  const cache = typeof opts.cache === 'string' ? opts.cache : null;
   const report = await collectGcReport(
     {
       olderThan,
       all,
+      cache,
       unsafeAllowScopedDeviceSweep: opts.unsafeAllowScopedDeviceSweep,
     },
     deps,
   );
+  if (cache && report.caches.length === 0) {
+    const names = [...new Set(discoverCaches({ declared: declaredCachePaths() }).map((c) => c.name))];
+    console.log(chalk.yellow(`No shared cache carries "${cache}" in its name or directory.`));
+    if (names.length) console.log(chalk.dim(`Caches on this machine: ${names.join(', ')}`));
+    return;
+  }
+
   for (const line of formatGcReport(report)) console.log(line);
 
   const {
@@ -1449,6 +1486,10 @@ export default function gcCommand(program: Command): void {
     .option(
       '--all',
       'with --delete, empty every shared cache whole rather than trimming it by age -- the only way to clear an index-backed cache. Reaches caches only, never devices or project entries. Caches outside the config dir are refused while STIM_HOME is set.',
+    )
+    .option(
+      '--cache <name>',
+      'act on the shared caches whose name or directory contains <name>, and leave every other cache, device and project entry untouched. Use it with --delete --all to empty one cache, such as --cache "compilation cache".',
     )
     .action(async (opts: RunGcOptions) => {
       await runGc(opts);

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -85,6 +85,7 @@ interface GcReport {
   deviceSweepNotices: string[];
   easSessionSweep: EasSessionSweep;
   caches: GcCache[];
+  cacheScope: string | null;
   olderThan: number | null;
   all: boolean;
 }
@@ -606,6 +607,7 @@ export function formatGcReport({
   deviceSweepNotices = [],
   easSessionSweep = { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
   caches = [],
+  cacheScope = null,
   olderThan = null,
 }: Partial<GcReport>): string[] {
   const lines: string[] = [];
@@ -613,7 +615,9 @@ export function formatGcReport({
   const liveLocks = buildLocks?.live ?? [];
   const staleSlots = buildSlots?.stale ?? [];
 
-  if (
+  if (cacheScope) {
+    lines.push(`Cache scope: "${cacheScope}". Devices, project entries and locks were not inspected.`);
+  } else if (
     deadProjects.length === 0 &&
     orphanedDevices.length === 0 &&
     staleDevices.length === 0 &&
@@ -801,8 +805,7 @@ function machineGlobalReason(cache: CacheDescriptor): string | null {
 
 export function selectCaches(caches: CacheDescriptor[], name: string | null | undefined): CacheDescriptor[] {
   if (!name) return caches;
-  const wanted = String(name).trim().toLowerCase();
-  if (!wanted) return caches;
+  const wanted = name.trim().toLowerCase();
   return caches.filter((c) => c.name.toLowerCase().includes(wanted) || c.dir.toLowerCase().includes(wanted));
 }
 
@@ -899,6 +902,7 @@ export async function collectGcReport(
       deviceSweepNotices: [],
       easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
       caches,
+      cacheScope: cache,
       olderThan,
       all,
     };
@@ -1030,12 +1034,19 @@ export async function collectGcReport(
     deviceSweepNotices,
     easSessionSweep,
     caches,
+    cacheScope: null,
     olderThan,
     all,
   };
 }
 
 export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}): Promise<void> {
+  if (opts.cache) {
+    return runGcCore(opts, {
+      ...deps,
+      precollectedEasSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
+    });
+  }
   let projectRoot: string | null = null;
   try {
     projectRoot = (deps.findProjectRoot ?? findProjectRoot)(process.cwd());
@@ -1489,7 +1500,11 @@ export default function gcCommand(program: Command): void {
     )
     .option(
       '--cache <name>',
-      'act on the shared caches whose name or directory contains <name>, and leave every other cache, device and project entry untouched. Use it with --delete --all to empty one cache, such as --cache "compilation cache".',
+      'act on the shared caches whose name or directory contains <name>. Only those caches are reported and emptied; devices and project entries are not inspected. Use it with --delete --all, such as --cache "compilation cache".',
+      (v: string) => {
+        if (!v.trim()) throw new InvalidArgumentError('must name a cache, e.g. --cache "compilation cache"');
+        return v;
+      },
     )
     .action(async (opts: RunGcOptions) => {
       await runGc(opts);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1079,7 +1079,7 @@ THE OPTION SURFACE, IN FULL
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide; there is no --all)
-  gc              --delete --older-than <days> --all
+  gc              --delete --older-than <days> --all --cache <name>
   worktree create <name> --carry-ignored --base <ref> --label <label>; remove [path] --force
 
   That is the whole surface today, and it is deliberately small. It can grow
@@ -1169,6 +1169,8 @@ THE OPTION SURFACE, IN FULL
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
   gc --delete --all       empties the shared build caches every project uses
+  gc --delete --all --cache <name>
+                          empties only the caches that carry <name>
   worktree remove --force discards uncommitted and untracked work
   stop --force            kills a process Stim could not identify
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -785,6 +785,17 @@ but --base <ref> resolves to <sha>"  (worktree create)
   name, or \`git branch -D worktree-<name>\` and retry. Without --base,
   attaching is still the behaviour: nothing was promised about the tip.
 
+"failed to scan dependencies for source ..." on pods you did not touch  (ios)
+  The compilation cache holds a damaged object. Xcode reports it per source
+  file, so it names whichever targets reach the object first -- often pods such
+  as sqlite3, nanopb or libwebp -- and the list changes between runs. The
+  transcript carries the cause:
+    error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind
+  A cache write that a full disk or a killed build cut short leaves such an
+  object, and upgrading the CLI does not clear it. Empty that one cache with
+  \`gc --delete --all --cache "compilation cache"\`, then build again. The next
+  build is a cold one.
+
 "Carried <dir>/Pods does not match <dir>/Podfile.lock"  (worktree create)
   \`ios/Pods\` is gitignored, so --carry-ignored clones it; \`ios/Podfile.lock\`
   is tracked, so it comes from the branch. When the source worktree's two

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -37,7 +37,15 @@ const SIGNING = [
 
 const NO_SUCH_SCHEME = /does not contain a scheme named/;
 
+// Xcode fails the scan when a compilation cache object has the wrong node
+// kind. A cache write that a full disk or a killed build cut short leaves
+// such an object, and the targets that fail vary with the order they reach it.
+const CAS_CORRUPT = /CAS-based dependency scan failed|not a IncludeTreeRoot node kind/;
+
 function remedyFor(message: string): string | null {
+  if (CAS_CORRUPT.test(message)) {
+    return 'The compilation cache holds a damaged object. Run `stim gc --delete --all --cache "compilation cache"` to empty that cache, then build again. The next build is a cold one.';
+  }
   if (PODS_OUT_OF_SYNC.test(message)) {
     return 'Run `pod install` in ios/ (stim ios does this when Podfile.lock and Pods/Manifest.lock disagree), then build again.';
   }

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -38,8 +38,7 @@ const SIGNING = [
 const NO_SUCH_SCHEME = /does not contain a scheme named/;
 
 // Xcode fails the dependency scan when a compilation cache object has the
-// wrong node kind. A cache write that a full disk or a killed build cut short
-// leaves such an object. See appandflow/stim#138.
+// wrong node kind. See appandflow/stim#138.
 const CAS_CORRUPT = /not a IncludeTreeRoot node kind/;
 
 function remedyFor(message: string): string | null {

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -37,10 +37,10 @@ const SIGNING = [
 
 const NO_SUCH_SCHEME = /does not contain a scheme named/;
 
-// Xcode fails the scan when a compilation cache object has the wrong node
-// kind. A cache write that a full disk or a killed build cut short leaves
-// such an object, and the targets that fail vary with the order they reach it.
-const CAS_CORRUPT = /CAS-based dependency scan failed|not a IncludeTreeRoot node kind/;
+// Xcode fails the dependency scan when a compilation cache object has the
+// wrong node kind. A cache write that a full disk or a killed build cut short
+// leaves such an object. See appandflow/stim#138.
+const CAS_CORRUPT = /not a IncludeTreeRoot node kind/;
 
 function remedyFor(message: string): string | null {
   if (CAS_CORRUPT.test(message)) {


### PR DESCRIPTION
Closes #138.

## Description

A damaged compilation cache fails the build with an error that points at the wrong thing:

```
error: failed to scan dependencies for source '.../Pods/sqlite3/sqlite-src-3500400/sqlite3.c' (in target 'sqlite3')
error: failed to scan dependencies for source '.../Pods/nanopb/pb_encode.c' (in target 'nanopb')
```

The pods are innocent. The transcript carries the line that identifies the cause, which Stim does not surface:

```
error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind (in target 'sqlite3')
error: Could not build module '_DarwinFoundation1'
```

The modules it cannot build are SDK modules, which is what marks the cache rather than the project. The targets it names change from run to run, because they are whichever ones reach the damaged object first, so the failure reads as a pod incompatibility and survives a CLI upgrade.

## Solution

`remedyFor` matches the CAS scan line, so the build names the cache and the command that empties it.

`gc --delete --all` empties every shared cache, which costs the build cache and the Metro caches to recover one damaged cache. `gc --cache <name>` selects the caches whose name or directory carries `<name>`, and reports and empties only those. A name no cache carries reports the caches the machine holds instead of printing "Nothing to reclaim".

A scoped run inspects no device, project entry or lock, so it says so rather than reporting a clean machine it never looked at. It also skips the EAS session sweep, which otherwise shells out to `eas-cli` and takes the EAS project lock to produce a result the scoped report discards.

The failure is documented in the `errors` guide topic, since a user who reads pod names in the error looks there before reading a flag list.

The selector is deliberately a substring over name and directory, not a fixed list of cache ids: `discoverCaches` mixes registered and detected caches whose names come from the manifest, so a fixed list would go stale.

## Risk

`--cache` narrows what `gc` acts on and defaults to today's behavior when absent, so the destructive path only ever gets smaller. A blank value is rejected: an empty string fell through to a full machine-wide run and a whitespace string selected every cache, so both widened what `--delete --all` reaches.

The match is the `not a IncludeTreeRoot node kind` line alone. A CAS scan can fail for other reasons, and telling those users to empty a cache and pay a cold build would be wrong.

## Test plan

Reproduced on a real Expo app (tlon-apps, RN 0.86.3, Xcode 26.5):

- fresh `pod install`, then build with a damaged cache: fails, exit 65, targets vary per run
- empty the compilation cache, rebuild the same tree: succeeds in 201s
- `gc --all --cache "compilation cache"` reports only the two compilation caches, leaving the build cache, Gradle and Metro maps untouched, and reports no devices or projects
- `gc --cache nope` reports the four caches the machine holds
- `gc --all --cache "compilation cache"` states which state it did not inspect
- `gc --cache ""` and `gc --cache "  "` are rejected instead of widening the run

