### PR TITLE
Install on a connected physical Android device with --device

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,21 +129,29 @@ installed globally. On the website, use synchronized Global and npx tabs with
 Global as the default. Keep the full `npx` form in runnable hooks, release
 checks, and registry remedies, which cannot assume a global install.
 
-### 2. Use only owned devices
+### 2. Create, boot, and delete only owned devices
 
-Stim can use only devices it created, named `stim-<label>` and recorded with
-`owned: true`. Never operate on physical or user-created devices. Keep a device
-record when teardown fails so `gc` can find the device later.
+Stim can create, boot, shut down, or delete only devices it created, named
+`stim-<label>` and recorded with `owned: true`. Never do any of those to a
+user-created emulator or simulator. Keep a device record when teardown fails so
+`gc` can find the device later.
+
+A physical Android device reached through `android --device` is the one device
+Stim uses but does not own. Hardware cannot be created or booted, so that path
+installs, launches, and reads logs, and nothing more. It records no device, so
+`stop`, `gc`, and `teardown.ts` never see it. Keep it that way: a physical
+serial must never enter the project registry.
 
 ### 3. Reimplement; do not reconstruct
 
 Do not infer and rebuild commands from project scripts. Bare React Native hosts
 Metro from the project's dependencies. Expo runs its fixed start command. iOS
-and Android use fixed `xcodebuild` and Gradle arguments. Do not add install or
-physical-device flows.
+and Android use fixed `xcodebuild` and Gradle arguments.
 
 The supported build selectors are `ios --configuration <name>` and
-`android --variant <name>`. Non-Debug iOS configurations and Android variants
+`android --variant <name>`. `android --device [serial]` selects a connected
+physical device; there is no iOS equivalent, because that needs code signing.
+Do not add install flows. Non-Debug iOS configurations and Android variants
 ending in `Release` skip Metro. A release cache hit must inject the current JS
 into a copy of the artifact. A swap failure must run a full build; it must never
 install stale JS. Android swaps require an emitted-asset manifest match, then

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -98,8 +98,13 @@ Follow these rules during the loop:
 
 ## Ownership and deletion
 
-Stim operates only on devices it created. Owned devices use the
-`stim-<label>` name. Never use Stim on physical or user-created devices.
+Stim creates, boots, and deletes only devices it created. Owned devices use
+the `stim-<label>` name. Never point Stim at a user-created emulator or
+simulator.
+
+`stim android --device [serial]` installs on a connected physical device. Stim
+never creates, boots, or deletes hardware, and records nothing about it, so
+`stop` and `gc` leave it alone.
 
 Treat a refusal as an ownership or state mismatch. Read its code and remedy.
 Do not add `--force` as a first response.

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -3398,6 +3398,7 @@ describe('--device (a physical Android device)', () => {
       device: true,
       listDevices: () => CONNECTED,
       deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
       checkCapacity: never('the device-capacity check'),
       ensureDevice: never('the owned-device path'),
       ensureDeviceBooted: never('the emulator boot'),
@@ -3468,6 +3469,7 @@ describe('--device (a physical Android device)', () => {
       remoteDevice: 'proxy',
       listDevices: () => CONNECTED,
       deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
       fingerprint: never('the fingerprint'),
       resolveRemoteDeviceContext: never('the remote session'),
     });
@@ -3481,4 +3483,93 @@ describe('--device (a physical Android device)', () => {
     await h.run();
     expect(labelled(h.stdout.join('\n').split('\n'), 'device').join(' ')).toMatch(/SM-G996W.*RFCR7081Q9L/);
   });
+});
+
+describe('--device refusals found in review', () => {
+  const CONNECTED2 = { emulators: [], physical: [{ serial: 'RFCR7081Q9L' }], unhealthy: [] };
+
+  test('an empty --device value is refused, never silently run on the emulator', async () => {
+    const h = harness({
+      device: '',
+      listDevices: () => CONNECTED2,
+      deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
+      checkCapacity: never('the device-capacity check'),
+      ensureDevice: never('the owned-device path'),
+      ensureDeviceBooted: never('the emulator boot'),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_BAD_ARG');
+    expect(result.error?.message).toMatch(/--device/);
+  });
+
+  test('an explicit --device wins over the android.remote setting instead of refusing', async () => {
+    setProjectSetting(root, 'android', { remote: 'proxy' });
+    const h = harness({
+      device: true,
+      listDevices: () => CONNECTED2,
+      deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
+      checkCapacity: never('the device-capacity check'),
+      ensureDevice: never('the owned-device path'),
+      ensureDeviceBooted: never('the emulator boot'),
+      resolveRemoteDeviceContext: never('the remote session'),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe('RFCR7081Q9L');
+  });
+
+  test('--device with an explicit --remote is a bad-argument refusal', async () => {
+    const h = harness({
+      device: true,
+      remoteDevice: 'proxy',
+      listDevices: () => CONNECTED2,
+      deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
+      fingerprint: never('the fingerprint'),
+      resolveRemoteDeviceContext: never('the remote session'),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_BAD_ARG');
+  });
+
+  test('a physical run leaves no serial in the workspace state either', async () => {
+    const h = harness({
+      device: true,
+      listDevices: () => CONNECTED2,
+      deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
+      checkCapacity: never('the device-capacity check'),
+      ensureDevice: never('the owned-device path'),
+      ensureDeviceBooted: never('the emulator boot'),
+    });
+    await h.run();
+    const state = JSON.stringify(readState());
+    expect(state).not.toContain('RFCR7081Q9L');
+    expect(loadConfig()?.projects?.[root]?.platforms?.android).toBeUndefined();
+  });
+});
+
+test('a signature conflict on install names the conflict instead of blaming the cable', async () => {
+  const h = harness({
+    device: true,
+    listDevices: () => ({ emulators: [], physical: [{ serial: 'RFCR7081Q9L' }], unhealthy: [] }),
+    deviceModel: () => 'SM-G996W',
+    isEmulatorDevice: () => false,
+    checkCapacity: never('the device-capacity check'),
+    ensureDevice: never('the owned-device path'),
+    ensureDeviceBooted: never('the emulator boot'),
+    install: () => ({
+      failed: true,
+      code: 'STIM_INSTALL_FAILED',
+      reason: 'adb install failed for app.apk: INSTALL_FAILED_UPDATE_INCOMPATIBLE',
+    }),
+  });
+  const result = await h.run();
+  expect(result.ok).toBe(false);
+  expect(result.error?.remedy).toMatch(/signer|uninstall/i);
+  expect(result.error?.remedy).not.toMatch(/still connected/);
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { setProjectSetting, upsertProject } from '../config.ts';
+import { loadConfig, setProjectSetting, upsertProject } from '../config.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { emulatorLogFile, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import { writeWorkspaceState } from '../supervisor/run.ts';
@@ -128,6 +128,7 @@ interface InstallArgs {
   apkPath?: string | null;
   packageName?: string | null;
   allowUninstall?: boolean;
+  serial?: string;
 }
 interface SwapArgs {
   root?: string;
@@ -140,6 +141,8 @@ interface LaunchArgs {
   metroPort?: string | number;
   devClientScheme?: string | null;
   packageName?: string;
+  serial?: string;
+  physical?: boolean;
 }
 interface RemoteBuildArgs {
   platform?: string | null;
@@ -3369,5 +3372,113 @@ describe('the project cache provider', () => {
     expect((await h.run()).ok).toBe(true);
     expect(uploads.length).toBe(1);
     expect(uploads[0]).toMatchObject({ overwrite: true });
+  });
+});
+
+function parseDeviceOption(args: string[]): unknown {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {} });
+  registerAndroid(program);
+  const command = program.commands[0];
+  assert(command);
+  command.parseOptions(args);
+  return command.opts().device;
+}
+
+describe('--device (a physical Android device)', () => {
+  const CONNECTED = {
+    emulators: [],
+    physical: [{ serial: 'RFCR7081Q9L' }],
+    unhealthy: [],
+  };
+
+  function physicalHarness(overrides: Record<string, unknown> = {}) {
+    return harness({
+      device: true,
+      listDevices: () => CONNECTED,
+      deviceModel: () => 'SM-G996W',
+      checkCapacity: never('the device-capacity check'),
+      ensureDevice: never('the owned-device path'),
+      ensureDeviceBooted: never('the emulator boot'),
+      ...overrides,
+    });
+  }
+
+  test('the CLI parser accepts --device bare and with a serial', () => {
+    expect(parseDeviceOption(['--device'])).toBe(true);
+    expect(parseDeviceOption(['--device', 'RFCR7081Q9L'])).toBe('RFCR7081Q9L');
+    expect(parseDeviceOption([])).toBeUndefined();
+  });
+
+  test('a physical run installs and launches on the resolved serial', async () => {
+    const h = physicalHarness();
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe('RFCR7081Q9L');
+    expect(h.calls.launch[0]?.serial).toBe('RFCR7081Q9L');
+  });
+
+  test('a physical run launches against localhost, not the emulator loopback', async () => {
+    const h = physicalHarness();
+    await h.run();
+    expect(h.calls.launch[0]?.physical).toBe(true);
+  });
+
+  test('an emulator run still launches against the emulator loopback', async () => {
+    const h = harness();
+    await h.run();
+    expect(h.calls.launch[0]?.physical).toBeFalsy();
+  });
+
+  test('a physical run honours an explicit serial', async () => {
+    const h = physicalHarness({
+      device: 'RFCR7081Q9L',
+      listDevices: () => ({
+        emulators: [],
+        physical: [{ serial: 'OTHER' }, { serial: 'RFCR7081Q9L' }],
+        unhealthy: [],
+      }),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe('RFCR7081Q9L');
+  });
+
+  test('a physical run refuses with the resolver error and remedy when no device is connected', async () => {
+    const h = physicalHarness({
+      listDevices: () => ({ emulators: [], physical: [], unhealthy: [] }),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(NO_DEVICE);
+    expect(result.error?.message).toMatch(/No physical Android device is connected/);
+    expect(result.error?.remedy).toMatch(/USB debugging/);
+  });
+
+  test('a physical run records no device in the global config, so gc and stop cannot reach it', async () => {
+    const h = physicalHarness();
+    await h.run();
+    expect(loadConfig()?.projects?.[root]?.platforms?.android).toBeUndefined();
+  });
+
+  test('--device and --remote together are refused before any build work', async () => {
+    const h = harness({
+      device: true,
+      remoteDevice: 'proxy',
+      listDevices: () => CONNECTED,
+      deviceModel: () => 'SM-G996W',
+      fingerprint: never('the fingerprint'),
+      resolveRemoteDeviceContext: never('the remote session'),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toMatch(/--device.*--remote|--remote.*--device/);
+  });
+
+  test('the summary names the device model and marks it physical', async () => {
+    const h = physicalHarness();
+    await h.run();
+    expect(labelled(h.stdout.join('\n').split('\n'), 'device').join(' ')).toMatch(/SM-G996W.*RFCR7081Q9L/);
   });
 });

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1625,3 +1625,59 @@ describe('verifyLaunch: still bundling', () => {
     expect(result).toMatchObject({ verified: false, fatal: true, processAlive: false });
   });
 });
+
+describe('the Metro host for a physical device', () => {
+  test('writeDebugHttpHost points a physical device at localhost, which adb reverse serves', () => {
+    const calls: string[][] = [];
+    const exec = {
+      runFile: (cmd: string, args: string[]) => {
+        calls.push([cmd, ...args]);
+        return '';
+      },
+    } as unknown as Executor;
+    const r = writeDebugHttpHost(
+      { serial: 'RFCR7081Q9L', packageName: 'com.x', metroPort: 8082, physical: true },
+      { exec },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.host).toBe('localhost:8082');
+    const argv = calls[0];
+    assert(argv);
+    expect(argv[8]).toMatch(/localhost:8082/);
+    expect(argv[8]).not.toMatch(/10\.0\.2\.2/);
+  });
+
+  test('writeDebugHttpHost still points an emulator at the emulator loopback', () => {
+    const exec = { runFile: () => '' } as unknown as Executor;
+    const r = writeDebugHttpHost(
+      { serial: 'emulator-5554', packageName: 'com.x', metroPort: 8082, physical: false },
+      { exec },
+    );
+    expect(r.host).toBe('10.0.2.2:8082');
+  });
+
+  test('the dev-client url targets localhost on a physical device', () => {
+    expect(androidDevClientUrl('exp+app', 8085, true)).toBe(
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085',
+    );
+    expect(androidDevClientUrl('exp+app', 8085, false)).toBe(
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085',
+    );
+  });
+
+  test('launchAndroidApp sends the localhost deep link when the device is physical', () => {
+    const exec = recordingExec();
+    const result: LaunchResult = launchAndroidApp(
+      {
+        serial: 'RFCR7081Q9L',
+        packageName: 'com.example.app',
+        metroPort: 8082,
+        devClientScheme: 'exp+app',
+        physical: true,
+      },
+      { exec },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.devClientUrl).toBe('exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082');
+  });
+});

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -781,7 +781,7 @@ describe('ensureOwnedDevice: android', () => {
       expect(run.some((c) => c.includes('R5CT10'))).toBe(false);
       expect(result.avdName).toBe('stim-app');
       expect(result.owned).toBe(true);
-      expect(notes.some((n) => /no longer supports physical devices/i.test(n))).toBeTruthy();
+      expect(notes.some((n) => /stored assignment to physical device R5CT10/i.test(n))).toBeTruthy();
       expect(readFileSync(join(process.env.ANDROID_AVD_HOME!, 'stim-app.avd', 'config.ini'), 'utf8')).toContain(
         'disk.dataPartition.size=8589934592',
       );

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -74,7 +74,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
   const advertised = {
     'start.ts': ['--json', '--wait', '--remote'],
     'ios.ts': ['--json', '--no-metro-check', '--no-build-cache', '--configuration', '--remote'],
-    'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--remote'],
+    'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--device', '--remote'],
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
     'gc.ts': ['--delete', '--older-than', '--all'],

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -33,6 +33,7 @@ import {
   ownedAvdDirectory,
   deleteAvd,
   resolveOwnedAvdSerial,
+  physicalDeviceModel,
   resolvePhysicalDevice,
   waitForBoot,
   withAvdConfigOverrides,
@@ -838,4 +839,52 @@ test('resolvePhysicalDevice reports an offline requested device instead of calli
   const result = resolvePhysicalDevice('RFCR7081Q9L', adb);
   expect(result.serial).toBeUndefined();
   expect(result.error).toMatch(/RFCR7081Q9L is connected but offline/);
+});
+
+test('physicalDeviceModel passes the serial as an argument, never through a shell string', () => {
+  const calls: { file: string; args: string[] }[] = [];
+  setExecutor({
+    runFile: (file: string, args: string[] = []) => {
+      calls.push({ file, args });
+      return 'SM-G996W\n';
+    },
+    run: () => {
+      throw new Error('a shell string must not be built from a device serial');
+    },
+    runQuiet: () => {
+      throw new Error('a shell string must not be built from a device serial');
+    },
+  } as never);
+  expect(physicalDeviceModel('RFCR7081Q9L')).toBe('SM-G996W');
+  expect(calls[0]?.args).toEqual(['-s', 'RFCR7081Q9L', 'shell', 'getprop', 'ro.product.model']);
+  resetExecutor();
+});
+
+test('physicalDeviceModel returns null when adb cannot answer', () => {
+  setExecutor({
+    runFile: () => {
+      throw new Error('device offline');
+    },
+  } as never);
+  expect(physicalDeviceModel('RFCR7081Q9L')).toBeNull();
+  resetExecutor();
+});
+
+test('resolvePhysicalDevice refuses a network-attached emulator that adb reports as physical', () => {
+  const adb = parseAdbDevices(`List of devices attached\n192.168.56.101:5555\tdevice\n`);
+  const result = resolvePhysicalDevice(null, adb, () => true);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/is an emulator/);
+});
+
+test('resolvePhysicalDevice accepts a genuine device over adb-over-TCP', () => {
+  const adb = parseAdbDevices(`List of devices attached\n192.168.1.5:5555\tdevice\n`);
+  expect(resolvePhysicalDevice(null, adb, () => false)).toEqual({ serial: '192.168.1.5:5555' });
+});
+
+test('resolvePhysicalDevice reports the whole adb status, not its first word', () => {
+  const adb = parseAdbDevices(`List of devices attached\n1234567890\tno permissions; see [http://x]\n`);
+  const result = resolvePhysicalDevice(null, adb);
+  expect(result.error).toMatch(/no permissions/);
+  expect(result.error).not.toMatch(/but no,/);
 });

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -33,6 +33,7 @@ import {
   ownedAvdDirectory,
   deleteAvd,
   resolveOwnedAvdSerial,
+  resolvePhysicalDevice,
   waitForBoot,
   withAvdConfigOverrides,
   withAvdDataPartitionSize,
@@ -774,4 +775,67 @@ test('emulatorFailureRemedy answers the disk case with free-space instructions',
     /Fix what the emulator reported above/,
   );
   expect(emulatorFailureRemedy([])).toMatch(/Fix what the emulator reported above/);
+});
+
+test('resolvePhysicalDevice picks the only connected physical device when none is requested', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n`);
+  expect(resolvePhysicalDevice(null, adb)).toEqual({ serial: 'RFCR7081Q9L' });
+});
+
+test('resolvePhysicalDevice ignores emulators when picking the only physical device', () => {
+  const adb = parseAdbDevices(`List of devices attached\nemulator-5554\tdevice\nRFCR7081Q9L\tdevice\n`);
+  expect(resolvePhysicalDevice(null, adb)).toEqual({ serial: 'RFCR7081Q9L' });
+});
+
+test('resolvePhysicalDevice refuses when no physical device is connected', () => {
+  const adb = parseAdbDevices(`List of devices attached\nemulator-5554\tdevice\n`);
+  const result = resolvePhysicalDevice(null, adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/No physical Android device is connected/);
+  expect(result.remedy).toMatch(/adb devices/);
+});
+
+test('resolvePhysicalDevice refuses an ambiguous choice and names every candidate', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n0123456789ABCDEF\tdevice\n`);
+  const result = resolvePhysicalDevice(null, adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toContain('RFCR7081Q9L');
+  expect(result.error).toContain('0123456789ABCDEF');
+  expect(result.remedy).toMatch(/--device <serial>/);
+});
+
+test('resolvePhysicalDevice accepts a requested serial that is connected', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n0123456789ABCDEF\tdevice\n`);
+  expect(resolvePhysicalDevice('0123456789ABCDEF', adb)).toEqual({ serial: '0123456789ABCDEF' });
+});
+
+test('resolvePhysicalDevice refuses a requested serial that is not connected', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n`);
+  const result = resolvePhysicalDevice('NOPE', adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/NOPE is not connected/);
+  expect(result.error).toContain('RFCR7081Q9L');
+});
+
+test('resolvePhysicalDevice refuses an emulator serial', () => {
+  const adb = parseAdbDevices(`List of devices attached\nemulator-5554\tdevice\n`);
+  const result = resolvePhysicalDevice('emulator-5554', adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/emulator-5554 is an emulator/);
+  expect(result.remedy).toMatch(/without --device/);
+});
+
+test('resolvePhysicalDevice reports an unauthorized device instead of calling it absent', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tunauthorized\n`);
+  const result = resolvePhysicalDevice(null, adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/RFCR7081Q9L is connected but unauthorized/);
+  expect(result.remedy).toMatch(/USB debugging/);
+});
+
+test('resolvePhysicalDevice reports an offline requested device instead of calling it absent', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\toffline\n`);
+  const result = resolvePhysicalDevice('RFCR7081Q9L', adb);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toMatch(/RFCR7081Q9L is connected but offline/);
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -84,6 +84,7 @@ import {
   unverifiedLaunchLines,
   verifyAndroidReleaseLaunch,
   androidAppProcess,
+  installConflictKind,
   verifyLaunch,
 } from '../engine/app-install.ts';
 import {
@@ -94,6 +95,7 @@ import {
   findBuildTool,
   listAdbDevices,
   physicalDeviceModel,
+  probeEmulatorSerial,
   resolvePhysicalDevice,
 } from '../sim/android.ts';
 import { checkDeviceCapacity, ensureBooted, ensureOwnedDevice } from '../engine/device.ts';
@@ -632,6 +634,7 @@ interface RunAndroidOptions {
   device?: string | boolean | null;
   listDevices?: typeof listAdbDevices;
   deviceModel?: typeof physicalDeviceModel;
+  isEmulatorDevice?: typeof probeEmulatorSerial;
   readApkPackage?: (apkPath: string | null) => string | null;
   remoteDevice?: RemoteDeviceBackend | null;
   resolveSettingsFor?: typeof resolveSettings;
@@ -716,6 +719,7 @@ interface VerifyAndroidRunArgs {
   launchedAt: number;
   metroPort: number | null;
   isExpo: boolean;
+  physical: boolean;
   scheme?: string | null;
   phase: (label: unknown, text: string) => void;
 }
@@ -733,6 +737,7 @@ async function verifyAndroidRun({
   launchedAt,
   metroPort,
   isExpo,
+  physical,
   scheme,
   phase,
 }: VerifyAndroidRunArgs): Promise<boolean | string> {
@@ -825,7 +830,7 @@ async function verifyAndroidRun({
     waitedMs: verification?.waitedMs,
     bundleId: androidPackage,
     serial,
-    devClientUrl: scheme ? androidDevClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT) : null,
+    devClientUrl: scheme ? androidDevClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT, physical) : null,
     mode: isExpo ? MODE_EXPO : MODE_BARE,
   }))
     phase('', chalk.yellow(line));
@@ -1090,12 +1095,13 @@ async function finishAndroidRun({
     allowUninstall: release,
   });
   if (installed.failed) {
-    return fail(
-      installed.code || INSTALL_FAILED,
-      installed.reason,
-      `Check that ${serial} is still connected (\`adb devices\`) and has room for the APK.`,
-      { lastBuildStatus: true },
-    );
+    const conflict = installConflictKind(installed.reason);
+    const installRemedy = conflict
+      ? `${androidPackage} is already installed on ${serial} ` +
+        (conflict === 'signature' ? 'with a different signer' : 'at a higher versionCode') +
+        `. Uninstall it first (\`adb -s ${serial} uninstall ${androidPackage}\`); its data goes with it.`
+      : `Check that ${serial} is still connected (\`adb devices\`) and has room for the APK.`;
+    return fail(installed.code || INSTALL_FAILED, installed.reason, installRemedy, { lastBuildStatus: true });
   }
   phase('install', `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} ${installTimer()}`);
   if (installed.note) {
@@ -1207,6 +1213,7 @@ async function finishAndroidRun({
     launchedAt,
     metroPort,
     isExpo,
+    physical,
     scheme,
     phase,
   });
@@ -1266,6 +1273,7 @@ function resolveRunAndroidOptions(
     device: deviceFlag = null,
     listDevices = listAdbDevices,
     deviceModel = physicalDeviceModel,
+    isEmulatorDevice = probeEmulatorSerial,
     readApkPackage = (apkPath: string | null) => apkPackage(dumpApkManifest(apkPath)),
     getLimits = getConcurrencyLimits,
     checkCapacity = checkDeviceCapacity,
@@ -1329,6 +1337,7 @@ function resolveRunAndroidOptions(
     deviceFlag,
     listDevices,
     deviceModel,
+    isEmulatorDevice,
     readApkPackage,
     getLimits,
     checkCapacity,
@@ -1394,6 +1403,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     deviceFlag,
     listDevices,
     deviceModel,
+    isEmulatorDevice,
     readApkPackage,
     getLimits,
     checkCapacity,
@@ -1562,16 +1572,23 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   const variant = resolveVariant(variantFlag, settings);
   const release = isReleaseVariant(variant);
   const isExpo = detectIsExpo(root);
-  const remoteBackend = commandRemoteBackend ?? remoteAndroidSetting(settings);
-  const physical = Boolean(deviceFlag);
-  const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
-  if (physical && remoteBackend) {
+  const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;
+  if (physical && deviceFlag === '') {
     return fail(
-      NO_DEVICE,
+      'STIM_BAD_ARG',
+      '--device was given an empty serial.',
+      'Pass `--device` on its own to use the one connected device, or `--device <serial>` to name one.',
+    );
+  }
+  if (physical && commandRemoteBackend) {
+    return fail(
+      'STIM_BAD_ARG',
       '--device installs on a device connected to this machine, and --remote installs on a remote one.',
       'Pass only one of --device and --remote.',
     );
   }
+  const remoteBackend = physical ? null : (commandRemoteBackend ?? remoteAndroidSetting(settings));
+  const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
   let androidPackage = detectAndroidPackage(root);
   record.bundleId = androidPackage;
   const registerProject = () =>
@@ -1673,7 +1690,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let bootPromise: Promise<AndroidBootLike>;
 
   if (physical) {
-    const resolved = resolvePhysicalDevice(requestedSerial, listDevices());
+    const resolved = resolvePhysicalDevice(requestedSerial, listDevices(), isEmulatorDevice);
     if (!resolved.serial) return fail(NO_DEVICE, resolved.error!, resolved.remedy!);
     device = {
       serial: resolved.serial,

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -92,6 +92,9 @@ import {
   emulatorFailureRemedy,
   extractEmulatorFailure,
   findBuildTool,
+  listAdbDevices,
+  physicalDeviceModel,
+  resolvePhysicalDevice,
 } from '../sim/android.ts';
 import { checkDeviceCapacity, ensureBooted, ensureOwnedDevice } from '../engine/device.ts';
 import {
@@ -218,6 +221,7 @@ interface AndroidCommandOptions {
   buildCache?: boolean;
   variant?: string;
   remote?: RemoteDeviceBackend;
+  device?: string | boolean;
 }
 
 interface FailExtra {
@@ -587,6 +591,11 @@ export function registerAndroid(program: Command): void {
       'Gradle variant to assemble and install (e.g. productionDebug on a flavored project); overrides the android.variant setting. A variant ending in Release embeds the JS bundle and skips Metro entirely. Default: debug',
     )
     .option(
+      '--device [serial]',
+      "Install and launch on a connected physical device instead of this workspace's owned emulator. " +
+        'With no serial, the one connected device is used. Stim never creates, boots, or deletes a physical device.',
+    )
+    .option(
       '--remote <backend>',
       'Install and launch on a remote device with proxy or EAS. The build still happens here.',
       (value) => {
@@ -608,6 +617,7 @@ export function registerAndroid(program: Command): void {
         useBuildCache: opts.buildCache !== false,
         variant: opts.variant ?? null,
         remoteDevice: opts.remote ?? null,
+        device: opts.device ?? null,
       });
       if (!result.ok) process.exit(1);
     });
@@ -619,6 +629,9 @@ interface RunAndroidOptions {
   metroCheck?: boolean;
   useBuildCache?: boolean;
   variant?: string | null;
+  device?: string | boolean | null;
+  listDevices?: typeof listAdbDevices;
+  deviceModel?: typeof physicalDeviceModel;
   readApkPackage?: (apkPath: string | null) => string | null;
   remoteDevice?: RemoteDeviceBackend | null;
   resolveSettingsFor?: typeof resolveSettings;
@@ -958,6 +971,7 @@ interface FinishAndroidRunArgs {
   logsDir: string;
   emuLog: string;
   device: OwnedDeviceRecord;
+  physical: boolean;
   remoteDevice: ReturnType<typeof remoteAndroidDeps> | null;
   bootPromise: Promise<AndroidBootLike>;
   bootDuration: () => string;
@@ -1010,6 +1024,7 @@ async function finishAndroidRun({
   logsDir,
   emuLog,
   device,
+  physical,
   remoteDevice,
   bootPromise,
   bootDuration,
@@ -1052,6 +1067,7 @@ async function finishAndroidRun({
       reason: booted.reason ?? 'The emulator did not boot.',
       logFile: emuLog,
       remedy: 'Run `stim status` to see what Stim thinks it owns; re-running `stim android` creates a fresh owned AVD.',
+      localEmulator: !physical,
     });
     return fail(NO_DEVICE, diag.message, diag.remedy, {
       lines: diag.lines,
@@ -1059,7 +1075,12 @@ async function finishAndroidRun({
     });
   }
   const serial = booted.serial!;
-  phase('device', `${device.avdName || serial} (${serial}) booted ${bootDuration()}`);
+  phase(
+    'device',
+    physical
+      ? `${device.deviceName || serial} (${serial}) connected, not owned by Stim`
+      : `${device.avdName || serial} (${serial}) booted ${bootDuration()}`,
+  );
 
   const installTimer = stepTimer(now);
   const installed: InstallResultLike = install({
@@ -1115,6 +1136,7 @@ async function finishAndroidRun({
         packageName: androidPackage,
         metroPort: metroPort ?? DEFAULT_METRO_PORT,
         devClientScheme: scheme,
+        physical,
       });
   if (launched.failed) {
     return fail(
@@ -1241,6 +1263,9 @@ function resolveRunAndroidOptions(
     metroCheck = true,
     useBuildCache = true,
     variant: variantFlag = null,
+    device: deviceFlag = null,
+    listDevices = listAdbDevices,
+    deviceModel = physicalDeviceModel,
     readApkPackage = (apkPath: string | null) => apkPackage(dumpApkManifest(apkPath)),
     getLimits = getConcurrencyLimits,
     checkCapacity = checkDeviceCapacity,
@@ -1301,6 +1326,9 @@ function resolveRunAndroidOptions(
     metroCheck,
     useBuildCache,
     variantFlag,
+    deviceFlag,
+    listDevices,
+    deviceModel,
     readApkPackage,
     getLimits,
     checkCapacity,
@@ -1363,6 +1391,9 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     metroCheck,
     useBuildCache,
     variantFlag,
+    deviceFlag,
+    listDevices,
+    deviceModel,
     readApkPackage,
     getLimits,
     checkCapacity,
@@ -1532,6 +1563,15 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   const release = isReleaseVariant(variant);
   const isExpo = detectIsExpo(root);
   const remoteBackend = commandRemoteBackend ?? remoteAndroidSetting(settings);
+  const physical = Boolean(deviceFlag);
+  const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
+  if (physical && remoteBackend) {
+    return fail(
+      NO_DEVICE,
+      '--device installs on a device connected to this machine, and --remote installs on a remote one.',
+      'Pass only one of --device and --remote.',
+    );
+  }
   let androidPackage = detectAndroidPackage(root);
   record.bundleId = androidPackage;
   const registerProject = () =>
@@ -1626,68 +1666,81 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     launch = remoteDevice.launch;
   }
 
-  const limits = getLimits();
-  const capacity = checkCapacity({
-    platform: PLATFORM,
-    project,
-    max: limits.maxDevices,
-  });
-  if (capacity) return fail(capacity.code, capacity.message, capacity.remedy);
-
   const emuLog = emulatorLogFile(root);
+  const limits = getLimits();
   let device: OwnedDeviceRecord;
-  try {
-    device = await ensureDevice({
+  let bootDuration = '';
+  let bootPromise: Promise<AndroidBootLike>;
+
+  if (physical) {
+    const resolved = resolvePhysicalDevice(requestedSerial, listDevices());
+    if (!resolved.serial) return fail(NO_DEVICE, resolved.error!, resolved.remedy!);
+    device = {
+      serial: resolved.serial,
+      deviceName: deviceModel(resolved.serial) ?? resolved.serial,
+      owned: false,
+    };
+    bootPromise = Promise.resolve({ ok: true, serial: resolved.serial });
+  } else {
+    const capacity = checkCapacity({
       platform: PLATFORM,
       project,
-      projectPath: root,
-      settingsRoot,
-      label,
-      settings,
-      flags: {},
-      note: out,
-      out,
-      logFile: emuLog,
+      max: limits.maxDevices,
     });
-  } catch (err) {
-    const diag = noDeviceDiagnostic({
-      reason: `Could not ensure an owned Android emulator: ${(err as Error)?.message || err}`,
-      logFile: emuLog,
-      remedy:
-        'Check that JAVA_HOME and ANDROID_HOME are set correctly, and that an arm64 system image is installed (`sdkmanager "system-images;android-36;google_apis;arm64-v8a"`).',
-    });
-    return fail(NO_DEVICE, diag.message, diag.remedy, {
-      lines: diag.lines,
-      logPath: diag.logPath ? displayPath(root, diag.logPath) : null,
+    if (capacity) return fail(capacity.code, capacity.message, capacity.remedy);
+
+    try {
+      device = await ensureDevice({
+        platform: PLATFORM,
+        project,
+        projectPath: root,
+        settingsRoot,
+        label,
+        settings,
+        flags: {},
+        note: out,
+        out,
+        logFile: emuLog,
+      });
+    } catch (err) {
+      const diag = noDeviceDiagnostic({
+        reason: `Could not ensure an owned Android emulator: ${(err as Error)?.message || err}`,
+        logFile: emuLog,
+        remedy:
+          'Check that JAVA_HOME and ANDROID_HOME are set correctly, and that an arm64 system image is installed (`sdkmanager "system-images;android-36;google_apis;arm64-v8a"`).',
+      });
+      return fail(NO_DEVICE, diag.message, diag.remedy, {
+        lines: diag.lines,
+        logPath: diag.logPath ? displayPath(root, diag.logPath) : null,
+      });
+    }
+
+    const bootTimer = stepTimer(now);
+    const boot = (): Promise<AndroidBootLike> =>
+      Promise.resolve(ensureDeviceBooted({ platform: PLATFORM, device, out, logFile: emuLog })).catch((e) => ({
+        failed: true as const,
+        reason: String((e as Error)?.message || e),
+        serial: undefined,
+      }));
+    bootPromise = (
+      remoteDevice?.ctx.backend === 'eas'
+        ? ensureRemoteOwned({
+            root,
+            platform: PLATFORM,
+            sessionName: ownedSessionName(remoteDevice.ctx.label),
+            startedAt,
+            boot,
+            createdSessionId: remoteDevice.createdSessionId,
+            abandonCreatedSession: remoteDevice.abandonCreatedSession,
+            writeState,
+            register: registerProject,
+          })
+        : boot()
+    ).then((result) => {
+      bootDuration = bootTimer();
+      return result;
     });
   }
-
-  const bootTimer = stepTimer(now);
-  let bootDuration = '';
-  const boot = (): Promise<AndroidBootLike> =>
-    Promise.resolve(ensureDeviceBooted({ platform: PLATFORM, device, out, logFile: emuLog })).catch((e) => ({
-      failed: true as const,
-      reason: String((e as Error)?.message || e),
-      serial: undefined,
-    }));
-  const bootPromise: Promise<AndroidBootLike> = (
-    remoteDevice?.ctx.backend === 'eas'
-      ? ensureRemoteOwned({
-          root,
-          platform: PLATFORM,
-          sessionName: ownedSessionName(remoteDevice.ctx.label),
-          startedAt,
-          boot,
-          createdSessionId: remoteDevice.createdSessionId,
-          abandonCreatedSession: remoteDevice.abandonCreatedSession,
-          writeState,
-          register: registerProject,
-        })
-      : boot()
-  ).then((result) => {
-    bootDuration = bootTimer();
-    return result;
-  });
 
   if (remoteDevice) {
     const booted = await bootPromise;
@@ -2124,6 +2177,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     logsDir,
     emuLog,
     device,
+    physical,
     remoteDevice,
     bootPromise,
     bootDuration: () => bootDuration,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -148,8 +148,9 @@ other line goes to stderr, so it is always safe to pipe.
                   the remedies all target -- read from the BUILT APK's
                   manifest, which on a flavored project is the flavor's
                   applicationId, not what the project files say
-  debugHttpHost   "10.0.2.2:<port>" when the app's SharedPreferences were
-                  pointed at this workspace's Metro, null when they were not
+  debugHttpHost   "10.0.2.2:<port>" on an emulator, "localhost:<port>" on a
+                  physical device, when the app's SharedPreferences were
+                  pointed at this workspace's Metro; null when they were not
                   (Contract 6's Android half; the adb reverse still covers
                   the app's compiled-in 8081)
   debugHttpHostNote
@@ -175,8 +176,9 @@ RULES
     (agent-device, xcrun simctl, adb -s, idb).
   - Never assume "booted" is your simulator. Other agents have theirs booted
     too.
-  - There is no physical-device support. Every device Stim touches is one
-    Stim created, named stim-<label>.`,
+  - Every device Stim creates or boots is one Stim created, named
+    stim-<label>. The exception is \`android --device\`, which installs on a
+    connected physical device Stim never creates, boots, or deletes.`,
   },
 
   metro: {
@@ -1075,7 +1077,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
 THE OPTION SURFACE, IN FULL
   start           --json --wait <seconds> --remote
   ios             --json --no-metro-check --no-build-cache --configuration <name> --remote <proxy|eas>
-  android         --json --no-metro-check --no-build-cache --variant <name> --remote <proxy|eas>
+  android         --json --no-metro-check --no-build-cache --variant <name> --device [serial] --remote <proxy|eas>
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide; there is no --all)
@@ -1094,6 +1096,18 @@ THE OPTION SURFACE, IN FULL
   setting (see \`guide settings\`), which is the repo-level default; unset,
   the plain \`assembleDebug\` flow is unchanged. The --json payload's
   \`variant\` field reports what was built (null for the default).
+
+  \`android --device [serial]\` installs and launches on a physical device
+  connected to this machine instead of this workspace's owned emulator. With
+  no serial it uses the one connected device, and refuses with the candidate
+  list when adb reports several. It cannot be combined with --remote.
+
+  The build, the fingerprint, the build cache and the Metro port gate are
+  unchanged. What is skipped is everything that manages an owned device:
+  no capacity check, no AVD creation, no boot wait, and no device record --
+  so \`stop\` and \`gc\` never touch the phone. The app is pointed at
+  localhost:<port>, which the adb reverse serves, instead of the emulator's
+  10.0.2.2. Stim never creates, boots, shuts down, or deletes hardware.
 
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second
@@ -1145,7 +1159,8 @@ THE OPTION SURFACE, IN FULL
   uninstalls the package once and retries, printing a note -- the app's data
   goes with it, which is why only release runs do this.
 
-  Local emulator installs only. Store signing, physical devices and
+  Local installs only, onto an owned emulator or, with
+  \`android --device\`, a connected physical device. Store signing and
   distribution stay out of scope.
 
   \`ios --configuration <name>\` selects the Xcode configuration --

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -339,7 +339,7 @@ export function reverseMetroPorts(
 const EMULATOR_HOST_LOOPBACK = '10.0.2.2';
 const PHYSICAL_HOST_LOOPBACK = 'localhost';
 
-export function androidMetroHost(physical: boolean): string {
+function androidMetroHost(physical: boolean): string {
   return physical ? PHYSICAL_HOST_LOOPBACK : EMULATOR_HOST_LOOPBACK;
 }
 

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -337,6 +337,11 @@ export function reverseMetroPorts(
 }
 
 const EMULATOR_HOST_LOOPBACK = '10.0.2.2';
+const PHYSICAL_HOST_LOOPBACK = 'localhost';
+
+export function androidMetroHost(physical: boolean): string {
+  return physical ? PHYSICAL_HOST_LOOPBACK : EMULATOR_HOST_LOOPBACK;
+}
 
 export function deviceShellArg(text: unknown): string {
   return `'${String(text).replace(/'/g, "'\\''")}'`;
@@ -366,11 +371,16 @@ export function debugHttpHostScript({
 }
 
 export function writeDebugHttpHost(
-  { serial, packageName, metroPort }: { serial: string; packageName: string; metroPort: number | string },
+  {
+    serial,
+    packageName,
+    metroPort,
+    physical = false,
+  }: { serial: string; packageName: string; metroPort: number | string; physical?: boolean },
   { exec = null }: ExecOpt = {},
 ): { ok: boolean; host?: string; reason?: string } {
   const e = exec || getExecutor();
-  const host = `${EMULATOR_HOST_LOOPBACK}:${metroPort}`;
+  const host = `${androidMetroHost(physical)}:${metroPort}`;
   const script = debugHttpHostScript({ packageName, host });
   try {
     e.runFile('adb', ['-s', serial, 'shell', 'run-as', packageName, 'sh', '-c', deviceShellArg(script)]);
@@ -380,8 +390,8 @@ export function writeDebugHttpHost(
   }
 }
 
-export function androidDevClientUrl(scheme: string, metroPort: number | string): string {
-  return devClientUrl(scheme, metroPort, EMULATOR_HOST_LOOPBACK);
+export function androidDevClientUrl(scheme: string, metroPort: number | string, physical = false): string {
+  return devClientUrl(scheme, metroPort, androidMetroHost(physical));
 }
 
 export function amStartError(text: unknown): string | null {
@@ -425,13 +435,20 @@ export function launchAndroidApp(
     packageName,
     metroPort,
     devClientScheme = null,
-  }: { serial: string; packageName: string; metroPort: number | string; devClientScheme?: string | null },
+    physical = false,
+  }: {
+    serial: string;
+    packageName: string;
+    metroPort: number | string;
+    devClientScheme?: string | null;
+    physical?: boolean;
+  },
   { exec = null }: ExecOpt = {},
 ): AndroidLaunchResult {
   const e = exec || getExecutor();
   const reversed = reverseMetroPorts({ serial, metroPort }, { exec: e });
   if (reversed.failed) return reversed;
-  const prefs = writeDebugHttpHost({ serial, packageName, metroPort }, { exec: e });
+  const prefs = writeDebugHttpHost({ serial, packageName, metroPort, physical }, { exec: e });
   const wiring = {
     reversed: reversed.reversed,
     debugHttpHost: prefs.ok ? prefs.host : null,
@@ -440,7 +457,7 @@ export function launchAndroidApp(
 
   let devClientNote = null;
   if (devClientScheme) {
-    const url = androidDevClientUrl(devClientScheme, metroPort);
+    const url = androidDevClientUrl(devClientScheme, metroPort, physical);
     const opened = openAndroidDevClientUrl({ serial, url }, { exec: e });
     if (opened.ok) return { ok: true, mode: 'deep-link', devClientUrl: url, ...wiring };
     devClientNote = `${opened.reason}; fell back to the launcher activity`;

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -373,10 +373,10 @@ async function ensureOwnedAndroidDevice({
   } else if (record?.serial) {
     note(
       chalk.yellow(
-        `Note: this project is assigned physical device ${record.serial}, and Stim no longer supports physical devices.`,
+        `Note: this project has a stored assignment to physical device ${record.serial}, which Stim no longer keeps.`,
       ),
     );
-    note(chalk.dim('Creating an owned emulator instead. The serial is not touched, connected or not.'));
+    note(chalk.dim('Creating an owned emulator instead. Pass `--device` to build for a connected device.'));
   }
 
   let created: { avdName: string };

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -265,6 +265,68 @@ export function listAdbDevices(): AdbDevices {
   return parseAdbDevices(getExecutor().run(`${androidTool('adb')} devices`));
 }
 
+export function physicalDeviceModel(serial: string): string | null {
+  try {
+    const out = getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} shell getprop ro.product.model`);
+    return String(out ?? '').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResolvedPhysicalDevice {
+  serial?: string;
+  error?: string;
+  remedy?: string;
+}
+
+function unreachableDeviceRefusal(entry: AdbUnhealthyEntry): ResolvedPhysicalDevice {
+  return {
+    error: `${entry.serial} is connected but ${entry.status}, so adb cannot talk to it.`,
+    remedy:
+      entry.status === 'unauthorized'
+        ? 'Unlock the device, accept the USB debugging prompt, then retry.'
+        : 'Reconnect the device or run `adb reconnect`, then retry.',
+  };
+}
+
+export function resolvePhysicalDevice(requested: string | null, adb: AdbDevices): ResolvedPhysicalDevice {
+  const physical = adb?.physical ?? [];
+  const emulators = adb?.emulators ?? [];
+  const unhealthy = adb?.unhealthy ?? [];
+  if (requested) {
+    if (physical.some((p) => p.serial === requested)) return { serial: requested };
+    if (emulators.some((e) => e.serial === requested) || /^emulator-\d+$/.test(requested)) {
+      return {
+        error: `${requested} is an emulator, not a physical device.`,
+        remedy: "Run `stim android` without --device to use this workspace's owned emulator.",
+      };
+    }
+    const unreachable = unhealthy.find((u) => u.serial === requested);
+    if (unreachable) return unreachableDeviceRefusal(unreachable);
+    const connected = physical.map((p) => p.serial);
+    return {
+      error: connected.length
+        ? `${requested} is not connected. adb reports these physical devices: ${connected.join(', ')}.`
+        : `${requested} is not connected, and adb reports no physical device at all.`,
+      remedy: 'Check the cable and `adb devices`, then retry with a serial adb lists.',
+    };
+  }
+  if (physical.length === 1) return { serial: physical[0]!.serial };
+  if (physical.length > 1) {
+    return {
+      error: `Several physical devices are connected: ${physical.map((p) => p.serial).join(', ')}.`,
+      remedy: 'Name the one to build for with `stim android --device <serial>`.',
+    };
+  }
+  const unreachable = unhealthy.find((u) => u.kind === 'physical');
+  if (unreachable) return unreachableDeviceRefusal(unreachable);
+  return {
+    error: 'No physical Android device is connected.',
+    remedy: 'Plug the device in, accept the USB debugging prompt, then check `adb devices`.',
+  };
+}
+
 export function nextConsolePort(claimedPorts: number[]): number {
   if (claimedPorts.length === 0) return 5554;
   const max = Math.max(...claimedPorts);

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -236,8 +236,10 @@ export function parseAdbDevices(text: string): AdbDevices {
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const [serial, status] = trimmed.split(/\s+/);
-    if (!serial || !status) continue;
+    const match = trimmed.match(/^(\S+)\s+(.+)$/);
+    if (!match) continue;
+    const serial = match[1]!;
+    const status = match[2]!.trim();
     const m = serial.match(/^emulator-(\d+)$/);
     if (m) {
       const consolePort = parseInt(m[1]!, 10);
@@ -265,13 +267,44 @@ export function listAdbDevices(): AdbDevices {
   return parseAdbDevices(getExecutor().run(`${androidTool('adb')} devices`));
 }
 
-export function physicalDeviceModel(serial: string): string | null {
+const ADB_PROP_TIMEOUT_MS = 5000;
+const EMULATOR_HARDWARE = new Set(['ranchu', 'goldfish', 'vbox86', 'vbox86p']);
+
+function adbProp(serial: string, name: string): string | null {
   try {
-    const out = getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} shell getprop ro.product.model`);
+    const out = getExecutor().runFile(androidToolPath('adb'), ['-s', serial, 'shell', 'getprop', name], {
+      timeoutMs: ADB_PROP_TIMEOUT_MS,
+    });
     return String(out ?? '').trim() || null;
   } catch {
     return null;
   }
+}
+
+export function physicalDeviceModel(serial: string): string | null {
+  return adbProp(serial, 'ro.product.model');
+}
+
+function looksLikeEmulator({
+  kernelQemu,
+  hardware,
+}: {
+  kernelQemu?: string | null;
+  hardware?: string | null;
+}): boolean {
+  if (String(kernelQemu ?? '').trim() === '1') return true;
+  return EMULATOR_HARDWARE.has(
+    String(hardware ?? '')
+      .trim()
+      .toLowerCase(),
+  );
+}
+
+export function probeEmulatorSerial(serial: string): boolean {
+  return looksLikeEmulator({
+    kernelQemu: adbProp(serial, 'ro.kernel.qemu'),
+    hardware: adbProp(serial, 'ro.hardware'),
+  });
 }
 
 export interface ResolvedPhysicalDevice {
@@ -290,18 +323,25 @@ function unreachableDeviceRefusal(entry: AdbUnhealthyEntry): ResolvedPhysicalDev
   };
 }
 
-export function resolvePhysicalDevice(requested: string | null, adb: AdbDevices): ResolvedPhysicalDevice {
+function emulatorRefusal(serial: string): ResolvedPhysicalDevice {
+  return {
+    error: `${serial} is an emulator, not a physical device.`,
+    remedy: "Run `stim android` without --device to use this workspace's owned emulator.",
+  };
+}
+
+export function resolvePhysicalDevice(
+  requested: string | null,
+  adb: AdbDevices,
+  isEmulator: (serial: string) => boolean = probeEmulatorSerial,
+): ResolvedPhysicalDevice {
   const physical = adb?.physical ?? [];
-  const emulators = adb?.emulators ?? [];
   const unhealthy = adb?.unhealthy ?? [];
   if (requested) {
-    if (physical.some((p) => p.serial === requested)) return { serial: requested };
-    if (emulators.some((e) => e.serial === requested) || /^emulator-\d+$/.test(requested)) {
-      return {
-        error: `${requested} is an emulator, not a physical device.`,
-        remedy: "Run `stim android` without --device to use this workspace's owned emulator.",
-      };
+    if (physical.some((p) => p.serial === requested)) {
+      return isEmulator(requested) ? emulatorRefusal(requested) : { serial: requested };
     }
+    if (/^emulator-\d+$/.test(requested)) return emulatorRefusal(requested);
     const unreachable = unhealthy.find((u) => u.serial === requested);
     if (unreachable) return unreachableDeviceRefusal(unreachable);
     const connected = physical.map((p) => p.serial);
@@ -312,7 +352,10 @@ export function resolvePhysicalDevice(requested: string | null, adb: AdbDevices)
       remedy: 'Check the cable and `adb devices`, then retry with a serial adb lists.',
     };
   }
-  if (physical.length === 1) return { serial: physical[0]!.serial };
+  if (physical.length === 1) {
+    const only = physical[0]!.serial;
+    return isEmulator(only) ? emulatorRefusal(only) : { serial: only };
+  }
   if (physical.length > 1) {
     return {
       error: `Several physical devices are connected: ${physical.map((p) => p.serial).join(', ')}.`,

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -74,7 +74,7 @@ Simulator targets only.
 ## `android`
 
 ```text
-stim android [--variant <name>] [--remote <proxy|eas>]
+stim android [--variant <name>] [--device [serial]] [--remote <proxy|eas>]
              [--no-metro-check] [--no-build-cache] [--json]
 ```
 

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -5,8 +5,13 @@ description: 'Owned local and remote devices with safe teardown'
 ---
 
 Stim creates and records every local simulator or emulator it uses. Local device
-names start with `stim-`. Stim does not operate on physical devices or devices
-created by another tool.
+names start with `stim-`. Stim does not create, boot, or delete a simulator or
+emulator that another tool made.
+
+`stim android --device [serial]` is the one device Stim uses without owning it.
+It installs, launches, and reads logs on a connected physical device, and never
+creates, boots, shuts down, or deletes it. Stim records nothing about the device,
+so `stim stop` and `stim gc` leave it alone.
 
 Each workspace keeps its device assignment. A later run can boot and reuse the
 same device.

--- a/website/docs/why.md
+++ b/website/docs/why.md
@@ -50,7 +50,9 @@ noise means less waiting and fewer tokens.
 ## Owned resources and cleanup
 
 Stim records the ports, processes, build output, devices, and remote sessions it
-creates. It does not operate on physical devices or user-created simulators.
+creates. It does not create, boot, or delete a user-created simulator or
+emulator. A physical device reached with `android --device` is used but never
+owned, and never recorded.
 
 `stim stop` releases a live environment without deleting its local device.
 `stim worktree remove` reclaims the worktree environment. `stim gc --delete`


### PR DESCRIPTION
Closes #140

## Description

`stim android` could only install on the owned emulator, so anything needing real hardware meant leaving Stim and driving Gradle and adb by hand.

Physical-device support was removed deliberately, in [32b96b2](https://github.com/appandflow/stim/commit/32b96b2daaf14a80311932d58bd706b10b09852e), which deleted the old `--serial` flag and wrote the ban into invariants 2 and 3 of `AGENTS.md`. That was right about ownership -- Stim must not create, boot, shut down, or delete somebody's phone -- but it conflated owning a device with installing on one. This PR keeps the ownership half and drops the rest, so those two invariants are rewritten rather than ignored.

## Solution

`stim android --device [serial]` builds as usual, then installs and launches on a connected physical device. With no serial it uses the one connected device, and refuses with the candidate list when adb reports several. It cannot be combined with `--remote`.

**`debug_http_host` and the dev-client deep link now resolve to `localhost` on a physical device instead of `10.0.2.2`.** This is a fix, not a preference: the emulator host loopback is not routable from a phone, so without it the app finds no bundler and loads no JS at all. The `adb reverse` that already ran serves `localhost`. Emulators keep `10.0.2.2`.

Stim never records the phone as a device, so `stop`, `gc`, and `teardown.ts` -- all of which act on the project's device record -- have nothing to act on. The physical branch also skips the device-capacity check, AVD creation, and the boot wait, but keeps the build-slot cap, since the build runs locally either way.

A device that reports itself as an emulator is refused. Genymotion and
`adb connect` emulators appear to adb as `host:port` rather than `emulator-N`, so
serial shape alone would have let `--device` install on a user-created emulator.
`ro.kernel.qemu` and `ro.hardware` settle it.

`--variant` is unchanged; a flavored project still needs it, physical or not.

## One device, many workspaces

Every workspace gets its own emulator, but they all share the one phone, so it is
worth being precise about what does and does not collide.

Two `adb reverse` pairs are registered: `<port> -> <port>`, which is what an app
with `debug_http_host` written actually uses, and `8081 -> <port>`, the fallback
for an app whose prefs write failed. Only the first is per-workspace. Two
workspaces on 8082 and 8083 therefore do not interfere: each app follows its own
`debug_http_host` to its own Metro. Registering a device port replaces any
previous mapping for it, so the shared `8081` entry does belong to whichever
workspace ran last -- but that only decides where an app lands when its prefs
write failed, which is already a warned, degraded state.

**Known limitation:** two workspaces building the same `applicationId` overwrite
each other's install, because that is one package name and one device. The last
`--device` run wins. Emulator isolation does not extend to hardware, and this PR
does not pretend otherwise.

## Risk

Contained. Nothing changes for an emulator run: the physical work is behind `--device`, and the host selection defaults to the existing `10.0.2.2`. The one shared edit is the new `physical` parameter threaded through `writeDebugHttpHost`, `androidDevClientUrl`, and `launchAndroidApp`, all defaulting to `false`.

The exposure worth naming is that Stim now issues `adb install`, `am start`, and `run-as` against hardware it does not own. Each is scoped to a serial adb already reports as `device`, and the destructive-uninstall retry on a signature conflict is still gated on release variants only, as before. No new adb verb reaches a physical device that did not already reach an emulator.

## Test plan

Verified end to end against a physical Samsung SM-G996W (`RFCR7081Q9L`), building tlon-apps `develop`:

```
device      SM-G996W (RFCR7081Q9L) connected, not owned by Stim
install     app-preview-debug.apk (37.9s)
launch      io.tlon.groups.preview (expo-dev-client deep link)
wired       debug_http_host localhost:8082 + adb reverse tcp:8081 -> tcp:8082
verify      ready: bundle loaded, stable for 3s, process alive (3s total)
```

`verify ready: bundle loaded` is the load-bearing line -- it is Metro actually serving the phone over the reverse, which is what the `10.0.2.2` to `localhost` change buys.

After the run, the project's entry in `~/.stim/config.json` has no `platforms` record at all and `stim status` prints no android line, so `stop` and `gc` have nothing to act on.

Also exercised the real `adb -s <serial> shell getprop ro.product.model` call behind `physicalDeviceModel`, per invariant 9, and confirmed real `adb devices` output parses to the fixtures the unit tests use.
