### PR TITLE
Fold gc --all into --cache all

### DIFF
--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -65,9 +65,9 @@ cold/warm split deliberately only when it is the behavior under test.
 ## Safety rules (non-negotiable)
 
 - NEVER modify the target repo's main checkout. Worktrees only.
-- NEVER run `gc --delete`, `gc --delete --all`, or `gc --delete --all --cache
-<name>` without the user's explicit approval in this session. Bare `gc`
-  (report) is always fine.
+- NEVER run `gc --delete`, `gc --delete --cache all`, or
+  `gc --delete --cache <name>` without the user's explicit approval in this
+  session. Bare `gc` (report) is always fine.
 - Touch no simulator/emulator except `stim-*` ones YOUR runs created.
 - No raw `simctl recordVideo` (it can wedge a machine with a global lock);
   record only through your device tool's own mechanism, prefer screenshots.

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -110,7 +110,7 @@ Ask the user before these actions:
   when it has no unique commits, and its owned device.
 - `worktree remove --force`, because it also discards uncommitted and untracked
   files.
-- `gc --delete`, because it deletes orphaned resources. `gc --delete --all`
+- `gc --delete`, because it deletes orphaned resources. `gc --delete --cache all`
   also empties shared build caches.
 - `stop` when the workspace owns an EAS session, because it irreversibly ends
   that remote session. For a local device, `stop` shuts it down but does not

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -111,7 +111,7 @@ Ask the user before these actions:
 - `worktree remove --force`, because it also discards uncommitted and untracked
   files.
 - `gc --delete`, because it deletes orphaned resources. `gc --delete --cache all`
-  also empties shared build caches.
+  empties the shared build caches instead; it inspects nothing else.
 - `stop` when the workspace owns an EAS session, because it irreversibly ends
   that remote session. For a local device, `stop` shuts it down but does not
   delete it. An explicit `stop` shuts down a Stim-owned simulator even when

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -54,6 +54,17 @@ describe('selectCaches', () => {
     expect(selectCaches(caches, 'metro-file-map').map((c) => c.name)).toEqual(['Metro file maps']);
   });
 
+  test('all is a reserved name that selects every cache', () => {
+    expect(selectCaches(caches, 'all')).toHaveLength(3);
+    expect(selectCaches(caches, 'ALL')).toHaveLength(3);
+  });
+
+  test('the reserved name wins over a directory that happens to carry it', () => {
+    const withInstall = [...caches, makeCacheDescriptor({ name: 'Vendor cache', dir: '/opt/install/cache' })];
+    expect(selectCaches(withInstall, 'all')).toHaveLength(4);
+    expect(selectCaches(withInstall, 'install').map((c) => c.name)).toEqual(['Vendor cache']);
+  });
+
   test('a name nothing carries selects no cache', () => {
     expect(selectCaches(caches, 'gradle')).toEqual([]);
   });
@@ -782,7 +793,7 @@ describe('EAS orphan session sweep', () => {
 
     try {
       await runGc(
-        { delete: true, all: true },
+        { delete: true },
         {
           ...harness.deps,
           easLedgerRoot: join(fakeHome, 'machine-eas'),
@@ -2035,7 +2046,7 @@ test('gc reports but never deletes the shared Gradle build cache under any delet
   installExecutor();
 
   try {
-    for (const args of [['--delete'], ['--delete', '--older-than', '30'], ['--delete', '--all']]) {
+    for (const args of [['--delete'], ['--delete', '--older-than', '30'], ['--delete', '--cache', 'all']]) {
       const output = await captureLog(() => cli(args));
       expect(output).toMatch(/Gradle build cache/);
       expect(existsSync(entry)).toBeTruthy();
@@ -2163,7 +2174,7 @@ test('--delete --older-than keeps a current Metro store that is also a current o
   expect(existsSync(childTransform)).toBe(true);
 });
 
-test('--delete --all empties an index-backed cache that --older-than cannot trim', async () => {
+test('--delete --cache all empties an index-backed cache that --older-than cannot trim', async () => {
   const casDir = join(tmpHome, 'compilation-cache');
   const leaf = join(casDir, 'v9.data.leaf');
   const index = join(casDir, 'v4.actions');
@@ -2174,18 +2185,18 @@ test('--delete --all empties an index-backed cache that --older-than cannot trim
   saveConfig({ version: 2, projects: {}, repos: {} });
   installExecutor();
 
-  const report = await collectGcReport({ all: true });
+  const report = await collectGcReport({ cache: 'all' });
   expect(report.caches.some((c) => c.prune === 'atomic' && c.willEmpty)).toBeTruthy();
 
   await captureLog(() => cli(['--delete', '--older-than', '30']));
   expect(existsSync(leaf)).toBeTruthy();
 
-  await captureLog(() => cli(['--delete', '--all']));
+  await captureLog(() => cli(['--delete', '--cache', 'all']));
   expect(existsSync(leaf)).toBe(false);
   expect(existsSync(index)).toBe(false);
 });
 
-test('--delete --all empties an entries-style cache including entries used today', async () => {
+test('--delete --cache all empties an entries-style cache including entries used today', async () => {
   const cacheDir = join(tmpHome, 'my-cache');
   const freshEntry = join(cacheDir, 'entry-fresh');
   mkdirSync(freshEntry, { recursive: true });
@@ -2194,13 +2205,13 @@ test('--delete --all empties an entries-style cache including entries used today
   saveConfig({ version: 2, projects: {}, repos: {} });
   installExecutor();
 
-  await captureLog(() => cli(['--delete', '--all']));
+  await captureLog(() => cli(['--delete', '--cache', 'all']));
 
   expect(existsSync(freshEntry)).toBe(false);
   expect(existsSync(cacheDir)).toBeTruthy();
 });
 
-test('--all without --delete reports what would be emptied and writes nothing', async () => {
+test('--cache all without --delete reports what would be emptied and writes nothing', async () => {
   const casDir = join(tmpHome, 'compilation-cache');
   const leaf = join(casDir, 'v9.data.leaf');
   mkdirSync(casDir, { recursive: true });
@@ -2210,7 +2221,7 @@ test('--all without --delete reports what would be emptied and writes nothing', 
   installExecutor();
   const before = loadConfig();
 
-  const output = await captureLog(() => cli(['--all']));
+  const output = await captureLog(() => cli(['--cache', 'all']));
 
   expect(output).toMatch(/Xcode compilation cache/);
   expect(output).toMatch(/empt/i);
@@ -2218,7 +2229,7 @@ test('--all without --delete reports what would be emptied and writes nothing', 
   expect(loadConfig()).toEqual(before);
 });
 
-test('--delete --all under a scoped home refuses machine-global caches', async () => {
+test('--delete --cache all under a scoped home refuses machine-global caches', async () => {
   const globalCas = join(fakeHome, 'Library', 'Developer', 'Xcode', 'DerivedData', 'CompilationCache.noindex');
   const leaf = join(globalCas, 'v9.data.leaf');
   mkdirSync(globalCas, { recursive: true });
@@ -2226,7 +2237,7 @@ test('--delete --all under a scoped home refuses machine-global caches', async (
   saveConfig({ version: 2, projects: {}, repos: {} });
   installExecutor();
 
-  const output = await captureLog(() => cli(['--delete', '--all']));
+  const output = await captureLog(() => cli(['--delete', '--cache', 'all']));
 
   expect(existsSync(leaf)).toBeTruthy();
   expect(output).toMatch(/STIM_HOME/);
@@ -2262,7 +2273,7 @@ test('--all reaches caches only: never a device, never a project entry', async (
   const execCalls: string[] = [];
   installDeviceExecutor({ devices: [{ udid: 'UDID-LIVE', name: 'stim-live' }], execCalls });
 
-  await captureLog(() => sweepingGc({ delete: true, all: true }));
+  await captureLog(() => sweepingGc({ delete: true, cache: 'all' }));
 
   expect(execCalls.some((c) => c.startsWith('xcrun simctl shutdown'))).toBe(false);
   expect(execCalls.some((c) => c.startsWith('xcrun simctl delete'))).toBe(false);

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -2257,7 +2257,7 @@ test('--delete --older-than under a scoped home refuses machine-global caches', 
   expect(output).toMatch(/machine-global/);
 });
 
-test('--all reaches caches only: never a device, never a project entry', async () => {
+test('--cache all reaches caches only: never a device, never a project entry', async () => {
   const livePath = join(fakeHome, 'live-project');
   mkdirSync(livePath, { recursive: true });
   saveConfig({

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -77,7 +77,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--remote'],
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
-    'gc.ts': ['--delete', '--older-than', '--all', '--cache'],
+    'gc.ts': ['--delete', '--older-than', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--label', '--force'],
   };
   for (const [file, flags] of Object.entries(advertised)) {
@@ -125,6 +125,7 @@ test('the guide keeps Metro intent separate from the explicit device backend', (
   expect(settings).toMatch(/android\.remote[^\n]*"proxy" or "eas"/);
   expect(errors).toContain('not a IncludeTreeRoot node kind');
   expect(errors).toContain('--cache "compilation cache"');
+  expect(errors).not.toContain('--delete --all');
   expect(errors).toContain('STIM_REMOTE_PROXY_CONFIG');
   expect(errors).toContain('STIM_REMOTE_EAS_UNAVAILABLE');
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -80,6 +80,15 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'gc.ts': ['--delete', '--older-than', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--label', '--force'],
   };
+  const retired: Record<string, string[]> = { 'gc.ts': ['--all'] };
+  for (const [file, flags] of Object.entries(retired)) {
+    const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');
+    for (const flag of flags) {
+      const mention = new RegExp(`${flag}(?![\\w-])`);
+      expect(mention.test(src)).toBeFalsy();
+      for (const name of topicNames()) expect(mention.test(renderTopic(name) ?? '')).toBeFalsy();
+    }
+  }
   for (const [file, flags] of Object.entries(advertised)) {
     const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');
     for (const flag of flags) {

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -92,7 +92,6 @@ interface GcReport {
 
 interface CollectGcReportOptions {
   olderThan?: number | null;
-  all?: boolean;
   cache?: string | null;
   now?: number;
   lastTouched?: (path: string) => number;
@@ -101,7 +100,6 @@ interface CollectGcReportOptions {
 
 interface RunGcOptions {
   olderThan?: number;
-  all?: boolean;
   cache?: string;
   delete?: boolean;
   unsafeAllowScopedDeviceSweep?: boolean;
@@ -727,14 +725,14 @@ export function formatGcReport({
       lines.push(`  ${formatBytes(c.bytes ?? 0).padStart(10)}  ${c.name}${tag}`);
       lines.push(`              ${c.dir}`);
       if (c.note) lines.push(`              ${c.note}`);
-      if (c.willEmpty) lines.push('              --all would EMPTY this cache');
-      else if (c.emptySkipped) lines.push(`              --all skips this cache: ${c.emptySkipped}`);
+      if (c.willEmpty) lines.push('              would be EMPTIED');
+      else if (c.emptySkipped) lines.push(`              would be left alone: ${c.emptySkipped}`);
     }
     lines.push(`  total: ${formatBytes(total)}`);
     const doomed = caches.filter((c) => c.willEmpty);
     if (doomed.length) {
       const doomedBytes = doomed.reduce((n, c) => n + (c.bytes ?? 0), 0);
-      lines.push(`  --all would empty ${doomed.length} of these (${formatBytes(doomedBytes)})`);
+      lines.push(`  would empty ${doomed.length} of these (${formatBytes(doomedBytes)})`);
     }
   }
 
@@ -803,9 +801,12 @@ function machineGlobalReason(cache: CacheDescriptor): string | null {
   return `STIM_HOME scopes this config, but ${cache.dir} is outside it and therefore machine-global`;
 }
 
+export const EVERY_CACHE = 'all';
+
 export function selectCaches(caches: CacheDescriptor[], name: string | null | undefined): CacheDescriptor[] {
   if (!name) return caches;
   const wanted = name.trim().toLowerCase();
+  if (wanted === EVERY_CACHE) return caches;
   return caches.filter((c) => c.name.toLowerCase().includes(wanted) || c.dir.toLowerCase().includes(wanted));
 }
 
@@ -879,7 +880,6 @@ function emptyCache(cache: CacheDescriptor): {
 export async function collectGcReport(
   {
     olderThan = null,
-    all = false,
     cache = null,
     now = Date.now(),
     lastTouched = projectLastTouched,
@@ -887,6 +887,7 @@ export async function collectGcReport(
   }: CollectGcReportOptions = {},
   deps: GcDependencies = {},
 ): Promise<GcReport> {
+  const all = cache !== null && olderThan === null;
   const selected = selectCaches(discoverCaches({ declared: declaredCachePaths() }), cache);
   const caches = planCacheEmptying(sizeCaches(selected), all);
 
@@ -1113,12 +1114,11 @@ export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}):
 
 async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void> {
   const olderThan = typeof opts.olderThan === 'number' ? opts.olderThan : null;
-  const all = Boolean(opts.all);
   const cache = typeof opts.cache === 'string' ? opts.cache : null;
+  const all = cache !== null && olderThan === null;
   const report = await collectGcReport(
     {
       olderThan,
-      all,
       cache,
       unsafeAllowScopedDeviceSweep: opts.unsafeAllowScopedDeviceSweep,
     },
@@ -1154,11 +1154,13 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     ((olderThan !== null || all) && caches.length > 0);
 
   if (!opts.delete) {
-    if (all) console.log(chalk.dim('\nDry run. Re-run with --delete --all to empty the caches above.'));
+    if (all) console.log(chalk.dim('\nDry run. Re-run with --delete to empty the caches above.'));
     else if (actionable) console.log(chalk.dim('\nDry run. Re-run with --delete to reclaim.'));
     else if (caches.length) {
       console.log(
-        chalk.dim('\nPass --delete --older-than <days> to trim the caches above, or --delete --all to empty them.'),
+        chalk.dim(
+          '\nPass --delete --cache all to empty the caches above, or --delete --older-than <days> to trim them.',
+        ),
       );
     }
     return;
@@ -1411,7 +1413,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
   if (olderThan === null) {
     if (caches.length) {
       console.log(
-        chalk.dim('Shared caches left alone: pass --older-than <days> to trim them, or --all to empty them.'),
+        chalk.dim('Shared caches left alone: pass --cache all to empty them, or --older-than <days> to trim them.'),
       );
     }
     return;
@@ -1495,12 +1497,8 @@ export default function gcCommand(program: Command): void {
       },
     )
     .option(
-      '--all',
-      'with --delete, empty every shared cache whole rather than trimming it by age -- the only way to clear an index-backed cache. Reaches caches only, never devices or project entries. Caches outside the config dir are refused while STIM_HOME is set.',
-    )
-    .option(
       '--cache <name>',
-      'act on the shared caches whose name or directory contains <name>. Only those caches are reported and emptied; devices and project entries are not inspected. Use it with --delete --all, such as --cache "compilation cache".',
+      'act on the shared caches whose name or directory contains <name>, or every cache with --cache all. With --delete they are emptied whole, which is the only way to clear an index-backed cache; add --older-than <days> to trim them by age instead. Only those caches are reported; devices and project entries are not inspected. Caches outside the config dir are refused while STIM_HOME is set.',
       (v: string) => {
         if (!v.trim()) throw new InvalidArgumentError('must name a cache, e.g. --cache "compilation cache"');
         return v;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -801,7 +801,7 @@ function machineGlobalReason(cache: CacheDescriptor): string | null {
   return `STIM_HOME scopes this config, but ${cache.dir} is outside it and therefore machine-global`;
 }
 
-export const EVERY_CACHE = 'all';
+const EVERY_CACHE = 'all';
 
 export function selectCaches(caches: CacheDescriptor[], name: string | null | undefined): CacheDescriptor[] {
   if (!name) return caches;
@@ -887,11 +887,12 @@ export async function collectGcReport(
   }: CollectGcReportOptions = {},
   deps: GcDependencies = {},
 ): Promise<GcReport> {
-  const all = cache !== null && olderThan === null;
-  const selected = selectCaches(discoverCaches({ declared: declaredCachePaths() }), cache);
+  const scope = typeof cache === 'string' && cache.trim() ? cache : null;
+  const all = scope !== null && olderThan === null;
+  const selected = selectCaches(discoverCaches({ declared: declaredCachePaths() }), scope);
   const caches = planCacheEmptying(sizeCaches(selected), all);
 
-  if (cache) {
+  if (scope) {
     return {
       skipped: [],
       deadProjects: [],
@@ -903,7 +904,7 @@ export async function collectGcReport(
       deviceSweepNotices: [],
       easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
       caches,
-      cacheScope: cache,
+      cacheScope: scope,
       olderThan,
       all,
     };
@@ -1114,8 +1115,7 @@ export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}):
 
 async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void> {
   const olderThan = typeof opts.olderThan === 'number' ? opts.olderThan : null;
-  const cache = typeof opts.cache === 'string' ? opts.cache : null;
-  const all = cache !== null && olderThan === null;
+  const cache = typeof opts.cache === 'string' && opts.cache.trim() ? opts.cache : null;
   const report = await collectGcReport(
     {
       olderThan,
@@ -1130,6 +1130,8 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     if (names.length) console.log(chalk.dim(`Caches on this machine: ${names.join(', ')}`));
     return;
   }
+
+  const all = report.all;
 
   for (const line of formatGcReport(report)) console.log(line);
 
@@ -1498,7 +1500,7 @@ export default function gcCommand(program: Command): void {
     )
     .option(
       '--cache <name>',
-      'act on the shared caches whose name or directory contains <name>, or every cache with --cache all. With --delete they are emptied whole, which is the only way to clear an index-backed cache; add --older-than <days> to trim them by age instead. Only those caches are reported; devices and project entries are not inspected. Caches outside the config dir are refused while STIM_HOME is set.',
+      'act on the shared caches whose name or directory contains <name>, or every cache with --cache all, a reserved name that never selects a single cache. With --delete they are emptied whole, which is the only way to clear an index-backed cache; add --older-than <days> to trim them by age instead. Only those caches are reported; devices and project entries are not inspected. Caches outside the config dir are refused while STIM_HOME is set.',
       (v: string) => {
         if (!v.trim()) throw new InvalidArgumentError('must name a cache, e.g. --cache "compilation cache"');
         return v;

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1089,7 +1089,7 @@ THE OPTION SURFACE, IN FULL
   android         --json --no-metro-check --no-build-cache --variant <name> --remote <proxy|eas>
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
-  status          --json          (already machine-wide; there is no --all)
+  status          --json          (already machine-wide)
   gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --label <label>; remove [path] --force
 
@@ -1334,11 +1334,11 @@ SHARED BUILD CACHES
   each row tagged (registered) or (detected), with its size:
     stim gc                            # report, caches included
     stim gc --delete --older-than 30   # trim entries nothing has used
-    stim gc --delete --all             # empty them whole, index-backed ones
+    stim gc --delete --cache all       # empty them whole, index-backed ones
                                          # (the Xcode CAS) included
   The Gradle build cache under GRADLE_USER_HOME (default ~/.gradle) is
   report-only because every Gradle build shares it. Stim reports its size
-  but never prunes or empties it, including with --older-than or --all.
+  but never prunes or empties it, including with --older-than or --cache all.
   Trim rather than empty. Emptying costs the next build in every project the
   time the cache was saving.`,
   },
@@ -1607,7 +1607,7 @@ FileStore shards across 256 directories, a build cache is keyed
 <platform>/<key> -- or 'gc --delete --older-than N' removes a whole shard or
 platform instead of one entry. Pass prune: 'atomic' for a cache whose index
 references its own data (an LLVM CAS): it is then left alone by --older-than
-and emptied whole only by 'gc --delete --all'.
+and emptied whole only by 'gc --delete --cache all'.
 Registration is idempotent and keyed on the directory.`,
   },
 };

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -793,7 +793,7 @@ but --base <ref> resolves to <sha>"  (worktree create)
     error: CAS-based dependency scan failed: not a IncludeTreeRoot node kind
   A cache write that a full disk or a killed build cut short leaves such an
   object, and upgrading the CLI does not clear it. Empty that one cache with
-  \`gc --delete --all --cache "compilation cache"\`, then build again. The next
+  \`gc --delete --cache "compilation cache"\`, then build again. The next
   build is a cold one.
 
 "Carried <dir>/Pods does not match <dir>/Podfile.lock"  (worktree create)
@@ -1090,7 +1090,7 @@ THE OPTION SURFACE, IN FULL
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide; there is no --all)
-  gc              --delete --older-than <days> --all --cache <name>
+  gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --label <label>; remove [path] --force
 
   That is the whole surface today, and it is deliberately small. It can grow
@@ -1179,8 +1179,8 @@ THE OPTION SURFACE, IN FULL
 
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
-  gc --delete --all       empties the shared build caches every project uses
-  gc --delete --all --cache <name>
+  gc --delete --cache all empties the shared build caches every project uses
+  gc --delete --cache <name>
                           empties only the caches that carry <name>
   worktree remove --force discards uncommitted and untracked work
   stop --force            kills a process Stim could not identify

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -43,7 +43,7 @@ const CAS_CORRUPT = /not a IncludeTreeRoot node kind/;
 
 function remedyFor(message: string): string | null {
   if (CAS_CORRUPT.test(message)) {
-    return 'The compilation cache holds a damaged object. Run `stim gc --delete --all --cache "compilation cache"` to empty that cache, then build again. The next build is a cold one.';
+    return 'The compilation cache holds a damaged object. Run `stim gc --delete --cache "compilation cache"` to empty that cache, then build again. The next build is a cold one.';
   }
   if (PODS_OUT_OF_SYNC.test(message)) {
     return 'Run `pod install` in ios/ (stim ios does this when Podfile.lock and Pods/Manifest.lock disagree), then build again.';

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -50,11 +50,13 @@ from the source checkout.
 ```bash
 stim gc
 stim gc --delete --older-than 30
-stim gc --delete --all
+stim gc --delete --cache all
 ```
 
 The first command only reports sizes. Age-based cleanup removes unused entries.
-`--all` empties managed caches and makes future builds cold.
+`--cache all` empties managed caches and makes future builds cold; it reaps
+nothing, so `gc --delete` on its own remains the way to prune stale entries.
+`--cache "compilation cache"` empties one cache instead of every one.
 
 Set `STIM_BUILD_CACHE` or `STIM_METRO_CACHE` to place the shared caches on a
 different volume. The same values can live in the machine config under

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -154,7 +154,7 @@ environment. `--force` permits removal with uncommitted or unpushed work.
 ## `gc`
 
 ```text
-stim gc [--delete] [--older-than <days>] [--all]
+stim gc [--delete] [--older-than <days>] [--cache <name|all>]
 ```
 
 Reports stale workspace entries, orphaned owned devices and remote sessions,
@@ -162,7 +162,9 @@ stale locks, and shared cache sizes. It does not change anything without
 `--delete`.
 
 - `--older-than <days>` also selects old devices and unused cache entries.
-- `--all` with `--delete` empties every managed cache.
+- `--cache <name|all>` with `--delete` empties the caches whose name or directory
+  carries `<name>` whole, or every cache with `all`. Devices and project entries
+  are not inspected, so a scoped run empties caches and reaps nothing.
 
 ## `guide`
 


### PR DESCRIPTION
Closes #143.

## Description

`--all` named a scope but set a depth. It meant "empty the cache whole rather than trim it by age", and it reached caches only, never devices or project entries. Beside `--cache`, which does name a scope, the two read as if they contradict each other:

```
gc --delete --all --cache "compilation cache"
```

## Solution

`--cache` carries the scope, with `all` as the reserved name for every cache:

```
gc --delete --cache all                   empty every cache whole
gc --delete --cache "compilation cache"   empty the matching caches whole
gc --delete --cache all --older-than 30   trim those entries by age
gc --delete                               caches untouched
```

Emptying whole is what `--cache` does, since that is what naming a cache asks for, and `--older-than` still asks for trimming. `all` is matched before the substring search, so a declared cache directory carrying `install` cannot answer to `--cache all`.

`collectGcReport` derives "empty whole" from the same rule the CLI uses, so the internal API cannot disagree with the flags.

## Behavior change

`gc --delete --all` emptied every cache **and** reaped devices, dead project entries and stale locks. `gc --delete --cache all` empties caches and inspects nothing else; the reaping stays with bare `gc --delete`. Running both is two commands now, and each does one thing.

This split is what keeps the compilation-cache remedy safe: a user recovering a broken build runs `gc --delete --cache "compilation cache"`, and that must not also delete their simulators.

One flag combination also inverts. `gc --delete --all --older-than 30` emptied, because the old `--all` branch ran ahead of the trim branch. `gc --delete --cache all --older-than 30` trims, which is what asking for an age filter should mean.

A bare `gc --delete` still leaves every cache alone, which is the property that separates the safe tier from the destructive one in `skill/SKILL.md` and `docs/field-test-protocol.md`.

## Risk

`--all` is removed rather than deprecated, so a script carrying it now fails with `unknown option '--all'` instead of doing something different quietly. The CLI is pre-1.0 and the flag is documented only in this repo.

## Test plan

- `gc --cache all` reports every cache and states that devices and project entries were not inspected
- `gc --all` exits with `unknown option '--all'`
- `gc` alone still reports without touching caches
- `selectCaches` covers `all`, its case-insensitivity, and a `/opt/install/cache` directory that must not answer to it
- `guide cleanup` and `guide settings` print `--cache all`, and the guide contract test now fails if a retired flag reappears in any topic (verified by reintroducing the old text)

