### PR TITLE
Reverse 8081 only when the debug_http_host write fails

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -336,7 +336,7 @@ function harness(overrides = {}) {
         mode: 'am-start',
         component: 'com.example.app/.MainActivity',
         devClientNote: null,
-        reversed: ['tcp:8081->tcp:8082', 'tcp:8082->tcp:8082'],
+        reversed: ['tcp:8082->tcp:8082'],
         debugHttpHost: '10.0.2.2:8082',
         debugHttpHostNote: null,
       };
@@ -2218,7 +2218,7 @@ describe('the port wiring is reported', () => {
     const h = harness();
     const result = await h.run();
     expect(labelled(h.stderr, 'wired')[0]).toMatch(
-      /debug_http_host 10\.0\.2\.2:8082 \+ adb reverse tcp:8081 -> tcp:8082/,
+      /debug_http_host 10\.0\.2\.2:8082 \+ adb reverse tcp:8082->tcp:8082/,
     );
     assert(result.facts);
     expect(result.facts.debugHttpHost).toBe('10.0.2.2:8082');
@@ -2239,7 +2239,7 @@ describe('the port wiring is reported', () => {
     expect(result.ok).toBe(true);
     const wired = labelled(h.stderr, 'wired')[0];
     expect(wired).toMatch(/not debuggable/);
-    expect(wired).toMatch(/adb reverse tcp:8081 -> tcp:8082/);
+    expect(wired).toMatch(/adb reverse tcp:8081->tcp:8082/);
     assert(result.facts);
     expect(result.facts.debugHttpHost).toBe(null);
     expect(result.facts.debugHttpHostNote).toMatch(/relying on adb reverse/);
@@ -3572,4 +3572,23 @@ test('a signature conflict on install names the conflict instead of blaming the 
   expect(result.ok).toBe(false);
   expect(result.error?.remedy).toMatch(/signer|uninstall/i);
   expect(result.error?.remedy).not.toMatch(/still connected/);
+});
+
+test('the wired line reports the reverses that were actually registered', async () => {
+  const h = harness({
+    launch: (args: LaunchArgs = {}) => ({
+      ok: true,
+      mode: 'am-start',
+      component: 'com.example.app/.MainActivity',
+      devClientNote: null,
+      reversed: ['tcp:8082->tcp:8082'],
+      debugHttpHost: '10.0.2.2:8082',
+      debugHttpHostNote: null,
+      ...args,
+    }),
+  });
+  await h.run();
+  const wired = labelled(h.stderr, 'wired').join(' ');
+  expect(wired).toContain('tcp:8082->tcp:8082');
+  expect(wired).not.toContain('tcp:8081');
 });

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -378,14 +378,17 @@ describe('android: install and launch', () => {
     expect(exec.calls).toEqual([['adb', '-s', 'emulator-5554', 'install', '-r', apkPath]]);
   });
 
-  test('reverseMetroPorts maps 8081 to the reserved port AND keeps the same-port reverse', () => {
+  test('reverseMetroPorts maps only the reserved port to itself', () => {
     const exec = recordingExec();
     const result = reverseMetroPorts({ serial: 'emulator-5554', metroPort: 8082 }, { exec });
     expect(result.ok).toBe(true);
-    expect(exec.calls).toEqual([
-      ['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8081', 'tcp:8082'],
-      ['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8082', 'tcp:8082'],
-    ]);
+    expect(exec.calls).toEqual([['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8082', 'tcp:8082']]);
+  });
+
+  test('reverseMetroPorts maps an explicit device port to the reserved one', () => {
+    const exec = recordingExec();
+    reverseMetroPorts({ serial: 'emulator-5554', metroPort: 8082, devicePorts: [8081] }, { exec });
+    expect(exec.calls).toEqual([['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8081', 'tcp:8082']]);
   });
 
   test('a workspace that actually reserved 8081 gets one reverse, not a duplicate', () => {
@@ -404,9 +407,8 @@ describe('android: install and launch', () => {
     );
     expect(result.mode).toBe('am-start');
     expect(exec.calls).toEqual([
-      ['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8081', 'tcp:8082'],
       ['adb', '-s', 'emulator-5554', 'reverse', 'tcp:8082', 'tcp:8082'],
-      exec.calls[2],
+      exec.calls[1],
       [
         'adb',
         '-s',
@@ -422,7 +424,7 @@ describe('android: install and launch', () => {
       ],
       ['adb', '-s', 'emulator-5554', 'shell', 'am', 'start', '-n', 'com.example.app/.MainActivity'],
     ]);
-    const httpHostCall = exec.calls[2];
+    const httpHostCall = exec.calls[1];
     assert(httpHostCall);
     expect(httpHostCall.slice(0, 6)).toEqual(['adb', '-s', 'emulator-5554', 'shell', 'run-as', 'com.example.app']);
     expect(httpHostCall.at(-1)).toMatch(/debug_http_host.*10\.0\.2\.2:8082/);
@@ -884,7 +886,7 @@ describe('the Android dev-client deep link', () => {
     ]);
     expect(!exec.calls.some((c: string[]) => c.includes('resolve-activity'))).toBeTruthy();
     expect(result.debugHttpHost).toBe('10.0.2.2:8082');
-    expect(result.reversed).toEqual(['tcp:8081->tcp:8082', 'tcp:8082->tcp:8082']);
+    expect(result.reversed).toEqual(['tcp:8082->tcp:8082']);
   });
 
   test('am start exits 0 on an intent it could not resolve, so the OUTPUT is read', () => {
@@ -1679,5 +1681,59 @@ describe('the Metro host for a physical device', () => {
     );
     expect(result.ok).toBe(true);
     expect(result.devClientUrl).toBe('exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082');
+  });
+});
+
+describe('the 8081 adb reverse is a fallback, not a default', () => {
+  function execRecording(prefsOk: boolean) {
+    const calls: string[][] = [];
+    return {
+      calls,
+      exec: {
+        runFile: (cmd: string, args: string[]) => {
+          calls.push([cmd, ...args]);
+          if (!prefsOk && args.includes('run-as')) throw new Error('run-as: package not debuggable');
+          if (args.includes('resolve-activity')) return 'com.example.app/.MainActivity';
+          return '';
+        },
+      } as unknown as Executor,
+    };
+  }
+  const reverses = (calls: string[][]) => calls.filter((c) => c.includes('reverse')).map((c) => c.slice(-2).join(' '));
+
+  test('a successful prefs write leaves only the same-port mapping', () => {
+    const { calls, exec } = execRecording(true);
+    const result: LaunchResult = launchAndroidApp(
+      { serial: 'RFCR7081Q9L', packageName: 'com.example.app', metroPort: 8082, physical: true },
+      { exec },
+    );
+    expect(result.ok).toBe(true);
+    expect(reverses(calls)).toEqual(['tcp:8082 tcp:8082']);
+    expect(result.debugHttpHost).toBe('localhost:8082');
+  });
+
+  test('a failed prefs write adds the 8081 fallback so the app still finds Metro', () => {
+    const { calls, exec } = execRecording(false);
+    const result: LaunchResult = launchAndroidApp(
+      { serial: 'RFCR7081Q9L', packageName: 'com.example.app', metroPort: 8082, physical: true },
+      { exec },
+    );
+    expect(result.ok).toBe(true);
+    expect(reverses(calls)).toEqual(['tcp:8082 tcp:8082', 'tcp:8081 tcp:8082']);
+    expect(result.debugHttpHost).toBeNull();
+    expect(result.debugHttpHostNote).toMatch(/relying on adb reverse/);
+  });
+
+  test('the same-port mapping is registered before the prefs write, so the app can never race ahead of it', () => {
+    const { calls, exec } = execRecording(true);
+    launchAndroidApp({ serial: 'emulator-5554', packageName: 'com.example.app', metroPort: 8082 }, { exec });
+    const order = calls.map((c) => (c.includes('reverse') ? 'reverse' : c.includes('run-as') ? 'prefs' : 'other'));
+    expect(order.indexOf('reverse')).toBeLessThan(order.indexOf('prefs'));
+  });
+
+  test('a workspace on the default port still gets its one mapping', () => {
+    const { calls, exec } = execRecording(true);
+    launchAndroidApp({ serial: 'emulator-5554', packageName: 'com.example.app', metroPort: 8081 }, { exec });
+    expect(reverses(calls)).toEqual(['tcp:8081 tcp:8081']);
   });
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1164,17 +1164,13 @@ async function finishAndroidRun({
   const launchMode = launched.mode === 'deep-link' ? 'expo-dev-client deep link' : launched.mode;
   phase('launch', `${launchMode ? `${androidPackage} (${launchMode})` : androidPackage} ${launchTimer()}`);
 
+  const reversedSummary = (launched.reversed ?? []).join(', ') || `tcp:${metroPort}->tcp:${metroPort}`;
   if (!release && launched.debugHttpHost) {
-    phase(
-      'wired',
-      `debug_http_host ${launched.debugHttpHost} + adb reverse tcp:${DEFAULT_METRO_PORT} -> tcp:${metroPort}`,
-    );
+    phase('wired', `debug_http_host ${launched.debugHttpHost} + adb reverse ${reversedSummary}`);
   } else if (!release) {
     phase(
       'wired',
-      chalk.yellow(
-        `adb reverse tcp:${DEFAULT_METRO_PORT} -> tcp:${metroPort}; ${launched.debugHttpHostNote || 'debug_http_host not written'}`,
-      ),
+      chalk.yellow(`adb reverse ${reversedSummary}; ${launched.debugHttpHostNote || 'debug_http_host not written'}`),
     );
     writer.write({
       src: 'build',

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -150,9 +150,11 @@ other line goes to stderr, so it is always safe to pipe.
                   applicationId, not what the project files say
   debugHttpHost   "10.0.2.2:<port>" on an emulator, "localhost:<port>" on a
                   physical device, when the app's SharedPreferences were
-                  pointed at this workspace's Metro; null when they were not
-                  (Contract 6's Android half; the adb reverse still covers
-                  the app's compiled-in 8081)
+                  pointed at this workspace's Metro; null when they were not.
+                  A healthy run reverses only <port> -> <port>, which is what
+                  that host resolves to. Only when the write fails does Stim
+                  also reverse 8081 -> <port>, so the app's compiled-in
+                  default still finds this workspace's Metro
   debugHttpHostNote
                   why the write did not land, when it did not. A launch
                   survives it -- this is the difference between the two

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -316,12 +316,15 @@ function resolveLaunchActivity(serial: string, packageName: string, { exec = nul
 }
 
 export function reverseMetroPorts(
-  { serial, metroPort }: { serial: string; metroPort: number | string },
+  {
+    serial,
+    metroPort,
+    devicePorts = null,
+  }: { serial: string; metroPort: number | string; devicePorts?: (number | string)[] | null },
   { exec = null }: ExecOpt = {},
 ): { ok?: boolean; reversed?: string[]; failed?: boolean; code?: string; reason?: string } {
   const e = exec || getExecutor();
-  const pairs = [[DEFAULT_METRO_PORT, metroPort]];
-  if (Number(metroPort) !== DEFAULT_METRO_PORT) pairs.push([metroPort, metroPort]);
+  const pairs = (devicePorts ?? [metroPort]).map((device) => [device, metroPort]);
   for (const [device, host] of pairs) {
     try {
       e.runFile('adb', ['-s', serial, 'reverse', `tcp:${device}`, `tcp:${host}`]);
@@ -449,8 +452,14 @@ export function launchAndroidApp(
   const reversed = reverseMetroPorts({ serial, metroPort }, { exec: e });
   if (reversed.failed) return reversed;
   const prefs = writeDebugHttpHost({ serial, packageName, metroPort, physical }, { exec: e });
+  let reversedPairs = reversed.reversed ?? [];
+  if (!prefs.ok && Number(metroPort) !== DEFAULT_METRO_PORT) {
+    const fallback = reverseMetroPorts({ serial, metroPort, devicePorts: [DEFAULT_METRO_PORT] }, { exec: e });
+    if (fallback.failed) return fallback;
+    reversedPairs = [...reversedPairs, ...(fallback.reversed ?? [])];
+  }
   const wiring = {
-    reversed: reversed.reversed,
+    reversed: reversedPairs,
     debugHttpHost: prefs.ok ? prefs.host : null,
     debugHttpHostNote: prefs.ok ? null : prefs.reason,
   };


### PR DESCRIPTION
Closes #142

## Description

`launchAndroidApp` registered two `adb reverse` pairs before writing `debug_http_host`:

```
tcp:8081        -> tcp:<metroPort>
tcp:<metroPort> -> tcp:<metroPort>
```

Once the prefs write lands the app asks for `<host>:<metroPort>`, which the second pair serves. The first is unused. I checked rather than assumed: deleting `tcp:8081` from under a running app on a physical device and triggering a full reload, the app re-bundled and came back with only `tcp:8082 -> tcp:8082` present.

That matters because `tcp:8081` is the one device port every workspace competes for, and re-registering a device port silently replaces the previous entry -- no error, no warning. A run that does not need the mapping should not be entering that contention, and an unused cross-port entry in `adb reverse --list` is a misleading thing to find when debugging.

## Solution

Register `tcp:8081 -> tcp:<port>` only when the `debug_http_host` write fails, which is exactly when the app is left asking for its compiled-in default.

Removing it outright would have been wrong. The write goes through `run-as`, which fails on a non-debuggable app and under a secondary Android user. Today that is a warning and the app still loads; with no fallback at all it would become "the app loads no JS", and the existing `relying on adb reverse` note would be false. Ordering the fallback behind the failure keeps that degraded path working while taking it off the healthy one.

`reverseMetroPorts` now takes the device ports to map rather than deriving them from `metroPort`, so the fallback is one explicit call instead of a flag that re-registers the same-port pair.

The `wired` line printed a fixed `tcp:8081 -> tcp:<port>` string regardless of what was registered, so it would have started lying after this change. It now reports what `launchAndroidApp` actually returned.

## Risk

The behavior change is that a healthy run no longer registers `tcp:8081`. Anything outside Stim that assumed the app is reachable on device port 8081 -- a hand-run `curl`, another tool's expectation -- loses that on a healthy run. Nothing in Stim depends on it: the app follows `debug_http_host`, and the collector and launch verification go through the serial, not the port.

Reverting is a one-file change.

## Test plan

Verified on a physical Samsung SM-G996W with `stim android --device --variant previewDebug`, after clearing every mapping with `adb reverse --remove-all`:

```
wired       debug_http_host localhost:8082 + adb reverse tcp:8082->tcp:8082
verify      ready: bundle loaded, stable for 3s, process alive (4.5s total)

$ adb -s RFCR7081Q9L reverse --list
UsbFfs tcp:8082 tcp:8082
```

One mapping, same port both sides, and the app still bundles. The failed-write path is covered by a unit test that makes `run-as` throw and asserts the `8081` fallback is then registered and the existing note is emitted.

