### PR TITLE
Run pods through bundler when the project pins them

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -127,6 +127,30 @@ test('checkMainCheckout runs its expensive probes only when their preconditions 
   }
 });
 
+test('the CocoaPods remedy uses bundler only when the lockfile resolves cocoapods (#137)', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-source-gemfile-'));
+  try {
+    mkdirSync(join(project, 'ios'), { recursive: true });
+    writeFileSync(join(project, 'ios', 'Podfile.lock'), 'pods\n');
+    writeFileSync(join(project, 'Gemfile'), "gem 'fastlane'\n");
+    writeFileSync(join(project, 'Gemfile.lock'), 'GEM\n  specs:\n    fastlane (2.219.0)\n');
+
+    const fastlane = checkMainCheckout(project, { brokenPods: [], upstream: null }).find((f) =>
+      /CocoaPods state/.test(f.title),
+    );
+    expect(fastlane?.fix).toMatch(/&& pod install/);
+    expect(fastlane?.fix).not.toMatch(/bundle exec/);
+
+    writeFileSync(join(project, 'Gemfile.lock'), 'GEM\n  specs:\n    cocoapods (1.15.2)\n');
+    const pinned = checkMainCheckout(project, { brokenPods: [], upstream: null }).find((f) =>
+      /CocoaPods state/.test(f.title),
+    );
+    expect(pinned?.fix).toMatch(/bundle exec pod install/);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('checkMainCheckout reports broken CocoaPods links even when lockfiles match', () => {
   const project = mkdtempSync(join(tmpdir(), 'stim-doctor-source-broken-pods-'));
   try {

--- a/packages/stim-cli/src/__tests__/engine-bundler.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-bundler.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { bundlerPin, podInstallCommand } from '../engine/bundler.ts';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'stim-bundler-'));
+  writeFileSync(join(root, 'Gemfile'), "source 'https://rubygems.org'\n");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function lock(text: string) {
+  writeFileSync(join(root, 'Gemfile.lock'), text);
+}
+
+const GEM_SPECS = ['GEM', '  remote: https://rubygems.org/', '  specs:'];
+
+test('a resolved cocoapods spec pins the pods toolchain', () => {
+  lock([...GEM_SPECS, '    activesupport (7.2.3.2)', '    cocoapods (1.15.2)', ''].join('\n'));
+  expect(bundlerPin(root)).toEqual({ gemfile: join(root, 'Gemfile'), lockfile: join(root, 'Gemfile.lock') });
+});
+
+test('a CRLF lockfile pins it too, because the match is anchored at the line start', () => {
+  lock([...GEM_SPECS, '    cocoapods (1.15.2)', ''].join('\r\n'));
+  expect(bundlerPin(root)).not.toBe(null);
+});
+
+test('cocoapods as another gem dependency, with no spec of its own, is NOT a pin', () => {
+  lock([...GEM_SPECS, '    cocoapods-catalyst-support (0.2.1)', '      cocoapods (>= 1.10)', ''].join('\n'));
+  expect(bundlerPin(root)).toBe(null);
+});
+
+test('a CHECKSUMS entry alone is NOT a pin: those lines are indented two spaces', () => {
+  lock(
+    [
+      ...GEM_SPECS,
+      '    fastlane (2.219.0)',
+      '',
+      'CHECKSUMS',
+      '  cocoapods (1.15.2) sha256=0d1e2f',
+      '',
+      'DEPENDENCIES',
+      '  fastlane',
+      '',
+    ].join('\n'),
+  );
+  expect(bundlerPin(root)).toBe(null);
+});
+
+test('a cocoapods spec resolved from a GIT source pins it', () => {
+  lock(
+    [
+      'GIT',
+      '  remote: https://github.com/CocoaPods/CocoaPods.git',
+      '  revision: 7f0c3c1e',
+      '  specs:',
+      '    cocoapods (1.16.2)',
+      '',
+    ].join('\n'),
+  );
+  expect(bundlerPin(root)).not.toBe(null);
+});
+
+test('a missing Gemfile, a missing lockfile, and a lockfile that is a directory are all unpinned', () => {
+  expect(bundlerPin(root)).toBe(null);
+  mkdirSync(join(root, 'Gemfile.lock'));
+  expect(bundlerPin(root)).toBe(null);
+  rmSync(join(root, 'Gemfile.lock'), { recursive: true });
+  lock([...GEM_SPECS, '    cocoapods (1.15.2)', ''].join('\n'));
+  rmSync(join(root, 'Gemfile'));
+  expect(bundlerPin(root)).toBe(null);
+});
+
+test('podInstallCommand follows the pin and keeps the extra pod flags', () => {
+  lock([...GEM_SPECS, '    fastlane (2.219.0)', ''].join('\n'));
+  expect(podInstallCommand(root)).toBe('pod install');
+  expect(podInstallCommand(root, '--clean-install')).toBe('pod install --clean-install');
+
+  lock([...GEM_SPECS, '    cocoapods (1.15.2)', ''].join('\n'));
+  expect(podInstallCommand(root)).toBe('bundle exec pod install');
+  expect(podInstallCommand(root, '--clean-install')).toBe('bundle exec pod install --clean-install');
+});

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -280,6 +280,205 @@ describe('runPodInstall', () => {
   });
 });
 
+describe('runPodInstall through bundler (#137)', () => {
+  function pinnedProject({ lock = true }: { lock?: boolean } = {}) {
+    mkdirSync(join(root, 'ios'), { recursive: true });
+    writeFileSync(join(root, 'Gemfile'), "source 'https://rubygems.org'\ngem 'cocoapods'\n");
+    if (lock) writeFileSync(join(root, 'Gemfile.lock'), 'DEPENDENCIES\n  cocoapods\n');
+  }
+
+  function router(
+    calls: SpawnCall[],
+    replies: Record<string, () => ReturnType<typeof fakePodChild>>,
+  ): (cmd: string, args: string[], opts: Record<string, unknown>) => ReturnType<typeof fakePodChild> {
+    return (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      const key = [cmd, ...args].join(' ');
+      const reply = replies[key];
+      if (!reply) throw new Error(`unexpected spawn: ${key}`);
+      return reply();
+    };
+  }
+
+  const ok = () => fakePodChild({ lines: ['Pod installation complete!'] });
+
+  test('a Gemfile with a Gemfile.lock checks the bundle, then pods through bundler', async () => {
+    pinnedProject();
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, {
+        'bundle check --dry-run': () => fakePodChild({ lines: ['The Gemfile dependencies are satisfied'] }),
+        'bundle exec pod install': ok,
+      }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('bundle exec pod install');
+    expect(calls.map((c) => [c.cmd, ...c.args].join(' '))).toEqual([
+      'bundle check --dry-run',
+      'bundle exec pod install',
+    ]);
+    expect(calls[0]?.opts.cwd).toBe(root);
+    expect(calls[1]?.opts.cwd).toBe(join(root, 'ios'));
+  });
+
+  test('bundler never gets to write the lockfile: --dry-run on check, BUNDLE_FROZEN on every spawn', async () => {
+    pinnedProject();
+    const calls: SpawnCall[] = [];
+    await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, {
+        'bundle check --dry-run': () => fakePodChild({ code: 1, lines: ['The following gems are missing'] }),
+        'bundle install': ok,
+        'bundle exec pod install': ok,
+      }),
+    });
+    expect(calls.map((c) => [c.cmd, ...c.args].join(' '))).toEqual([
+      'bundle check --dry-run',
+      'bundle install',
+      'bundle exec pod install',
+    ]);
+    for (const call of calls) {
+      const env = call.opts.env as NodeJS.ProcessEnv;
+      expect(env.BUNDLE_FROZEN).toBe('true');
+      expect(env.BUNDLE_GEMFILE).toBe(join(root, 'Gemfile'));
+      expect(env.LANG).toBe('en_US.UTF-8');
+      expect(env.FORCE_COLOR).toBe('0');
+    }
+  });
+
+  test('a missing-gems check installs the bundle at the Gemfile, with `gems` heartbeats', async () => {
+    pinnedProject();
+    const beats: string[] = [];
+    const child = makeChildProcess({ pid: 99 });
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': () => {
+          setImmediate(() => child.stdout?.emit('data', 'Fetching cocoapods 1.16.2\n'));
+          setTimeout(() => child.emit('exit', 0, null), 120);
+          return child;
+        },
+        'bundle exec pod install': ok,
+      }),
+      heartbeatMs: 25,
+      onHeartbeat: (l: string) => beats.push(l),
+    });
+    expect(result.ok).toBe(true);
+    expect(calls[1]?.opts.cwd).toBe(root);
+    expect(beats[0]).toMatch(/^gems\s+still running \(/);
+    expect(beats[0]).toMatch(/Fetching cocoapods/);
+  });
+
+  test('a Gemfile with no Gemfile.lock stays on plain `pod install`, so nothing writes a lockfile', async () => {
+    pinnedProject({ lock: false });
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, { 'pod install': ok }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('pod install');
+    expect(calls.map((c) => c.cmd)).toEqual(['pod']);
+  });
+
+  test('no `bundle` on PATH falls back to plain `pod install` with a note, not a failure', async () => {
+    pinnedProject();
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: (cmd, args, opts) => {
+        calls.push({ cmd, args, opts });
+        if (cmd === 'bundle') throw makeError('spawn bundle ENOENT', { code: 'ENOENT' });
+        return ok();
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('pod install');
+    expect(result.failed).toBe(undefined);
+    expect(result.notes?.join('\n')).toMatch(/`bundle` is not on PATH/);
+    expect(calls.map((c) => c.cmd)).toEqual(['bundle', 'pod']);
+  });
+
+  test('a failed `bundle install` fails the run with STIM_DEPS_FAILED and never runs pods', async () => {
+    pinnedProject();
+    writeFileSync(join(root, '.ruby-version'), 'ruby-3.4.1\n');
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': () =>
+          fakePodChild({ code: 5, lines: ["Could not find gem 'activesupport (= 7.1.3)' in locally installed gems."] }),
+      }),
+    });
+    expect(result.failed).toBe(true);
+    expect(result.code).toBe(DEPS_ERROR);
+    expect(result.reason).toMatch(/`bundle install` failed \(exit code 5\)/);
+    expect(result.remedy).toMatch(/ruby 3\.4\.1/);
+    expect(result.remedy).toMatch(/bundle install/);
+    assert(result.lastLines);
+    expect(result.lastLines.join('\n')).toMatch(/Could not find gem/);
+    expect(calls.map((c) => c.cmd)).toEqual(['bundle', 'bundle']);
+  });
+
+  test('a lockfile bundler refuses to rewrite is reported as frozen mode, not as a missing gem', async () => {
+    pinnedProject();
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': () =>
+          fakePodChild({
+            code: 16,
+            lines: [
+              "The dependencies in your gemfile changed, but the lockfile can't be updated because frozen mode is set",
+              'You have added to the Gemfile:',
+              '* json',
+            ],
+          }),
+      }),
+    });
+    expect(result.failed).toBe(true);
+    expect(result.remedy).toMatch(/BUNDLE_FROZEN/);
+    expect(result.remedy).toMatch(new RegExp(`cd ${root} && bundle install`.replace(/[$^*+?.()|[\]{}\\]/g, '\\$&')));
+  });
+
+  test('a frozen-mode refusal from `bundle exec pod install` gets the same remedy', async () => {
+    pinnedProject();
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ lines: ['satisfied'] }),
+        'bundle exec pod install': () =>
+          fakePodChild({
+            code: 1,
+            lines: [
+              "definition.rb:469:in 'ensure_equivalent_gemfile_and_lockfile': the lockfile can't be updated because frozen mode is set (Bundler::ProductionError)",
+            ],
+          }),
+      }),
+    });
+    expect(result.failed).toBe(true);
+    expect(result.command).toBe('bundle exec pod install');
+    expect(result.reason).toMatch(/`bundle exec pod install` failed \(exit code 1\)/);
+    expect(result.remedy).toMatch(/BUNDLE_FROZEN/);
+  });
+
+  test('a Gemfile that does not bundle cocoapods explains why bundler has no pod to exec', async () => {
+    pinnedProject();
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ lines: ['satisfied'] }),
+        'bundle exec pod install': () =>
+          fakePodChild({
+            code: 1,
+            lines: [
+              "can't find executable pod for gem cocoapods. cocoapods is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)",
+            ],
+          }),
+      }),
+    });
+    expect(result.failed).toBe(true);
+    expect(result.remedy).toMatch(/does not include cocoapods/);
+    expect(result.remedy).toMatch(/gem 'cocoapods'/);
+  });
+});
+
 describe('extractPodDiagnostics', () => {
   test('a fatal [!] mid-transcript beats the deferred warnings flushed after it (case 1)', () => {
     const warnings = ['expo-sensors', 'expo-splash-screen', 'expo-store-review', 'expo-system-ui', 'expo-video'].map(

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -340,8 +340,8 @@ describe('runPodInstall through bundler (#137)', () => {
       const env = call.opts.env as NodeJS.ProcessEnv;
       expect(env.BUNDLE_FROZEN).toBe('true');
       expect(env.BUNDLE_GEMFILE).toBe(join(root, 'Gemfile'));
-      expect(env.LANG).toBe('en_US.UTF-8');
       expect(env.FORCE_COLOR).toBe('0');
+      expect(env.CLICOLOR).toBe('0');
     }
   });
 

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -281,10 +281,35 @@ describe('runPodInstall', () => {
 });
 
 describe('runPodInstall through bundler (#137)', () => {
-  function pinnedProject({ lock = true }: { lock?: boolean } = {}) {
+  const COCOAPODS_LOCK = [
+    'GEM',
+    '  remote: https://rubygems.org/',
+    '  specs:',
+    '    activesupport (7.2.3.2)',
+    '    cocoapods (1.15.2)',
+    '      cocoapods-core (= 1.15.2)',
+    '    cocoapods-core (1.15.2)',
+    '',
+    'DEPENDENCIES',
+    '  cocoapods (~> 1.15)',
+    '',
+  ].join('\n');
+
+  const FASTLANE_LOCK = [
+    'GEM',
+    '  remote: https://rubygems.org/',
+    '  specs:',
+    '    fastlane (2.219.0)',
+    '',
+    'DEPENDENCIES',
+    '  fastlane',
+    '',
+  ].join('\n');
+
+  function pinnedProject({ lock = COCOAPODS_LOCK }: { lock?: string | null } = {}) {
     mkdirSync(join(root, 'ios'), { recursive: true });
     writeFileSync(join(root, 'Gemfile'), "source 'https://rubygems.org'\ngem 'cocoapods'\n");
-    if (lock) writeFileSync(join(root, 'Gemfile.lock'), 'DEPENDENCIES\n  cocoapods\n');
+    if (lock !== null) writeFileSync(join(root, 'Gemfile.lock'), lock);
   }
 
   function router(
@@ -370,7 +395,7 @@ describe('runPodInstall through bundler (#137)', () => {
   });
 
   test('a Gemfile with no Gemfile.lock stays on plain `pod install`, so nothing writes a lockfile', async () => {
-    pinnedProject({ lock: false });
+    pinnedProject({ lock: null });
     const calls: SpawnCall[] = [];
     const result = await runPodInstall(root, collectingWriter(), {
       spawnFn: router(calls, { 'pod install': ok }),
@@ -378,6 +403,54 @@ describe('runPodInstall through bundler (#137)', () => {
     expect(result.ok).toBe(true);
     expect(result.command).toBe('pod install');
     expect(calls.map((c) => c.cmd)).toEqual(['pod']);
+  });
+
+  test('a lockfile that pins fastlane but no pods stays on plain `pod install`, with no note', async () => {
+    pinnedProject({ lock: FASTLANE_LOCK });
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, { 'pod install': ok }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('pod install');
+    expect(result.notes).toEqual([]);
+    expect(calls.map((c) => c.cmd)).toEqual(['pod']);
+  });
+
+  test('cocoapods pulled in as a transitive spec still counts as pinned', async () => {
+    pinnedProject({
+      lock: [
+        'GEM',
+        '  specs:',
+        '    cocoapods-bin (0.8.0)',
+        '      cocoapods (>= 1.10)',
+        '    cocoapods (1.15.2)',
+        '',
+      ].join('\n'),
+    });
+    const calls: SpawnCall[] = [];
+    await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, { 'bundle check --dry-run': ok, 'bundle exec pod install': ok }),
+    });
+    expect(calls.map((c) => c.cmd)).toEqual(['bundle', 'bundle']);
+  });
+
+  test('an unreadable or malformed Gemfile.lock falls back to plain `pod install` instead of throwing', async () => {
+    pinnedProject({ lock: '\u0000 not a lockfile' });
+    const calls: SpawnCall[] = [];
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router(calls, { 'pod install': ok }),
+    });
+    expect(result.ok).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(['pod']);
+
+    rmSync(join(root, 'Gemfile.lock'), { force: true });
+    mkdirSync(join(root, 'Gemfile.lock'));
+    const second = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], { 'pod install': ok }),
+    });
+    expect(second.ok).toBe(true);
+    expect(second.command).toBe('pod install');
   });
 
   test('no `bundle` on PATH falls back to plain `pod install` with a note, not a failure', async () => {

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -598,6 +598,36 @@ describe('runPodInstall through bundler (#137)', () => {
       }),
     });
     expect(outside.notes).toEqual([]);
+
+    writeFileSync(join(root, '.bundle', 'config'), 'BUNDLE_PATH: "~/gems-probe"\n');
+    const home = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': ok,
+        'bundle exec pod install': ok,
+      }),
+    });
+    expect(home.notes).toEqual([]);
+  });
+
+  test('a BUNDLE_PATH from the environment is reported as the environment, not as a config file', async () => {
+    pinnedProject();
+    const previous = process.env.BUNDLE_PATH;
+    process.env.BUNDLE_PATH = 'vendor/bundle';
+    try {
+      const result = await runPodInstall(root, collectingWriter(), {
+        spawnFn: router([], {
+          'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+          'bundle install': ok,
+          'bundle exec pod install': ok,
+        }),
+      });
+      expect(result.notes?.join('\n')).toMatch(/BUNDLE_PATH environment variable/);
+      expect(result.notes?.join('\n')).not.toMatch(/\.bundle\/config/);
+    } finally {
+      if (previous === undefined) delete process.env.BUNDLE_PATH;
+      else process.env.BUNDLE_PATH = previous;
+    }
   });
 });
 

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -415,6 +415,10 @@ describe('runPodInstall through bundler (#137)', () => {
     expect(result.command).toBe('pod install');
     expect(result.notes).toEqual([]);
     expect(calls.map((c) => c.cmd)).toEqual(['pod']);
+    const env = calls[0]?.opts.env as NodeJS.ProcessEnv;
+    expect(env.BUNDLE_FROZEN).toBe(undefined);
+    expect(env.BUNDLE_GEMFILE).toBe(undefined);
+    expect(env.FORCE_COLOR).toBe('0');
   });
 
   test('cocoapods pulled in as a transitive spec still counts as pinned', async () => {
@@ -468,6 +472,9 @@ describe('runPodInstall through bundler (#137)', () => {
     expect(result.failed).toBe(undefined);
     expect(result.notes?.join('\n')).toMatch(/`bundle` is not on PATH/);
     expect(calls.map((c) => c.cmd)).toEqual(['bundle', 'pod']);
+    const podEnvOnly = calls[1]?.opts.env as NodeJS.ProcessEnv;
+    expect(podEnvOnly.BUNDLE_FROZEN).toBe(undefined);
+    expect(podEnvOnly.BUNDLE_GEMFILE).toBe(undefined);
   });
 
   test('a failed `bundle install` fails the run with STIM_DEPS_FAILED and never runs pods', async () => {
@@ -532,7 +539,7 @@ describe('runPodInstall through bundler (#137)', () => {
     expect(result.remedy).toMatch(/BUNDLE_FROZEN/);
   });
 
-  test('a Gemfile that does not bundle cocoapods explains why bundler has no pod to exec', async () => {
+  test('a bundle without the pinned pod binary points at the bundle that is actually loaded', async () => {
     pinnedProject();
     const result = await runPodInstall(root, collectingWriter(), {
       spawnFn: router([], {
@@ -547,8 +554,50 @@ describe('runPodInstall through bundler (#137)', () => {
       }),
     });
     expect(result.failed).toBe(true);
-    expect(result.remedy).toMatch(/does not include cocoapods/);
-    expect(result.remedy).toMatch(/gem 'cocoapods'/);
+    expect(result.remedy).toMatch(/resolves cocoapods/);
+    expect(result.remedy).toMatch(/belong to a different Gemfile/);
+    expect(result.remedy).toMatch(/bundle exec pod --version/);
+    expect(result.remedy).not.toMatch(/remove .*Gemfile\.lock/);
+  });
+
+  test('an ENOENT at the pod step in the bundler branch names `bundle`, not CocoaPods', async () => {
+    pinnedProject();
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: (_cmd, args) => {
+        if (args[0] === 'check') return fakePodChild({ lines: ['satisfied'] });
+        throw makeError('spawn bundle ENOENT', { code: 'ENOENT' });
+      },
+    });
+    expect(result.failed).toBe(true);
+    expect(result.code).toBe(DEPS_ERROR);
+    expect(result.reason).toMatch(/Bundler is not installed/);
+    expect(result.reason).not.toMatch(/CocoaPods is not installed/);
+    expect(result.remedy).toMatch(/gem install bundler/);
+  });
+
+  test('`bundle install` reports the project-local BUNDLE_PATH it filled, and only that', async () => {
+    pinnedProject();
+    mkdirSync(join(root, '.bundle'), { recursive: true });
+    writeFileSync(join(root, '.bundle', 'config'), 'BUNDLE_PATH: "vendor/bundle"\nBUNDLE_FORCE_RUBY_PLATFORM: 1\n');
+    const withPath = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': ok,
+        'bundle exec pod install': ok,
+      }),
+    });
+    expect(withPath.notes?.join('\n')).toMatch(/gems in vendor\/bundle\//);
+    expect(withPath.notes?.join('\n')).toMatch(/Gemfile\.lock itself is never written/);
+
+    writeFileSync(join(root, '.bundle', 'config'), 'BUNDLE_PATH: "/opt/gems"\n');
+    const outside = await runPodInstall(root, collectingWriter(), {
+      spawnFn: router([], {
+        'bundle check --dry-run': () => fakePodChild({ code: 1 }),
+        'bundle install': ok,
+        'bundle exec pod install': ok,
+      }),
+    });
+    expect(outside.notes).toEqual([]);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/errors-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-xcode.test.ts
@@ -5,6 +5,9 @@ import {
   extractXcodeDiagnostics,
 } from '../engine/errors-xcode.ts';
 import type { Diagnostic } from '../engine/errors-xcode.ts';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const REAL_COMPILE_FAILURE = [
   "CompileC /tmp/stim-xc/dd/Build/Intermediates.noindex/Scratch.build/Debug-iphonesimulator/Scratch.build/Objects-normal/arm64/main.o /tmp/stim-xc/Scratch/main.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'Scratch' from project 'Scratch')",
@@ -203,6 +206,20 @@ describe('real transcripts', () => {
     expect(found[0]?.message).toMatch(/The sandbox is not in sync with the Podfile\.lock/);
     expect(found[0]?.remedy).toMatch(/pod install/);
     expect(found[0]?.file).toBe(undefined);
+  });
+
+  test('the sandbox remedy uses bundler when the project pins its pods, and plain pod when it does not (#137)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-xc-pin-'));
+    try {
+      writeFileSync(join(root, 'Gemfile'), "gem 'cocoapods'\n");
+      writeFileSync(join(root, 'Gemfile.lock'), 'GEM\n  specs:\n    cocoapods (1.15.2)\n');
+      expect(extractXcodeDiagnostics(REAL_PODS_FAILURE, root)[0]?.remedy).toMatch(/Run `bundle exec pod install`/);
+
+      writeFileSync(join(root, 'Gemfile.lock'), 'GEM\n  specs:\n    fastlane (2.219.0)\n');
+      expect(extractXcodeDiagnostics(REAL_PODS_FAILURE, root)[0]?.remedy).toMatch(/Run `pod install`/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('the run-script warning in that same transcript is not promoted to an error', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -290,6 +290,31 @@ test('the errors topic documents every code the engine can emit under a command'
   }
 });
 
+test('the STIM_DEPS_FAILED ladder names the commands and the gate the engine actually uses (#137)', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  const flat = body.slice(body.indexOf('STIM_DEPS_FAILED'), body.indexOf('STIM_BUILD_FAILED')).replace(/\s+/g, ' ');
+  const deps = readFileSync(new URL('../engine/deps.ts', import.meta.url), 'utf-8');
+  const bundler = readFileSync(new URL('../engine/bundler.ts', import.meta.url), 'utf-8');
+
+  for (const [spawned, documented] of [
+    ["args: ['check', '--dry-run']", 'bundle check --dry-run'],
+    ["args: ['install']", 'bundle install'],
+    ["['bundle', 'exec', 'pod', 'install']", 'bundle exec pod install'],
+    ["['pod', 'install']", 'pod install'],
+  ] as Array<[string, string]>) {
+    expect(deps.includes(spawned)).toBeTruthy();
+    expect(flat).toContain(documented);
+  }
+  expect(deps).toContain("BUNDLE_FROZEN: 'true'");
+  expect(flat).toContain('BUNDLE_FROZEN');
+  expect(deps).toContain("label: 'gems'");
+  expect(flat).toContain('`gems` label');
+  expect(bundler).toContain('COCOAPODS_SPEC');
+  expect(flat).toContain('Gemfile.lock that resolves cocoapods');
+  expect(flat).toContain('BUNDLE_PATH');
+});
+
 test('the remote start remedy covers existing bare and Expo servers', () => {
   const body = renderTopic('errors');
   assert(body);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1286,7 +1286,26 @@ describe('pods', () => {
     );
     expect(calls.order.includes('runPodInstall')).toBeTruthy();
     expect(calls.order.indexOf('runPodInstall') < calls.order.indexOf('buildIos')).toBeTruthy();
-    expect(errs.join('\n')).toMatch(/^  pods {8}.*differ -> installed \(18s\)/m);
+    expect(errs.join('\n')).toMatch(/^  pods {8}.*differ -> installed with `pod install` \(18s\)/m);
+  });
+
+  test('the pods phase names the bundler command and prints the engine notes', async () => {
+    reserve();
+    const { errs } = await run(
+      {},
+      {
+        readPodState: () => ({ hasPodfile: true, lockText: 'PODS: A', manifestText: 'PODS: B' }),
+        runPodInstall: async () => ({
+          ok: true,
+          durationMs: 18000,
+          command: 'bundle exec pod install',
+          notes: ['`bundle` is not on PATH'],
+        }),
+      },
+    );
+    const stderr = errs.join('\n');
+    expect(stderr).toMatch(/^  pods {8}.*-> installed with `bundle exec pod install` \(18s\)/m);
+    expect(stderr).toMatch(/^  pods {8}`bundle` is not on PATH/m);
   });
 
   test('a Podfile whose pods have never been installed is installed too', async () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -481,14 +481,19 @@ STIM_DEPS_FAILED
   then \`bundle install\` only when that reports missing gems, then \`bundle exec
   pod install\` -- so the CocoaPods the lockfile pins is the one that writes
   Podfile.lock. Everything else gets plain \`pod install\`: no Gemfile, a Gemfile
-  with no Gemfile.lock (\`bundle install\` would CREATE the lockfile in your
-  checkout, and Stim does not write into the project), and a Gemfile.lock that
+  with no Gemfile.lock (\`bundle install\` would CREATE that tracked file in
+  your checkout, which Stim will not do), and a Gemfile.lock that
   pins something other than pods, such as a fastlane-only bundle. When
   \`bundle\` is not on PATH the run prints one dim \`pods\` note and uses plain
-  \`pod install\`. The \`pods\` phase line always names the command that ran.
-  Bundler runs with BUNDLE_FROZEN for the same reason, so a Gemfile that no
-  longer matches its Gemfile.lock fails here instead of having the lockfile
-  rewritten under you: run \`bundle install\` yourself and keep the result.
+  \`pod install\`. The \`pods\` phase line always names the command that ran, and
+  the gem steps heartbeat under the \`gems\` label.
+  Bundler runs with BUNDLE_FROZEN, so a Gemfile that no longer matches its
+  Gemfile.lock FAILS the build rather than quietly falling back to unpinned
+  pods -- silently using a different CocoaPods than the lockfile pins is the
+  bug this path exists to kill. Run \`bundle install\` yourself and keep the
+  result. Gems themselves are installed wherever the project's own
+  \`.bundle/config\` points BUNDLE_PATH (vendor/bundle in the React Native
+  template); Stim reports that in a dim note and never edits Gemfile.lock.
 
 STIM_BUILD_FAILED
   xcodebuild or gradle failed. The EXTRACTED diagnostics are printed (capped),

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -476,6 +476,18 @@ STIM_DEPS_FAILED
   \`pod install\` (iOS) or the gradle dependency sync (Android) failed. On iOS
   this runs only when Podfile.lock and Pods/Manifest.lock disagree, or Pods is
   absent -- which is exactly what a carried worktree produces.
+  WHICH POD COMMAND: when the project root has BOTH a Gemfile and a
+  Gemfile.lock, pods go through bundler -- \`bundle check --dry-run\`, then
+  \`bundle install\` only when that reports missing gems, then \`bundle exec pod
+  install\` -- so the CocoaPods the lockfile pins is the one that writes
+  Podfile.lock. Everything else (no Gemfile, or a Gemfile with no Gemfile.lock)
+  gets plain \`pod install\`: without a lockfile \`bundle install\` would CREATE
+  Gemfile.lock in your checkout, and Stim does not write into the project. When
+  \`bundle\` is not on PATH the run prints one dim \`pods\` note and uses plain
+  \`pod install\`. The \`pods\` phase line always names the command that ran.
+  Bundler runs with BUNDLE_FROZEN for the same reason, so a Gemfile that no
+  longer matches its Gemfile.lock fails here instead of having the lockfile
+  rewritten under you: run \`bundle install\` yourself and keep the result.
 
 STIM_BUILD_FAILED
   xcodebuild or gradle failed. The EXTRACTED diagnostics are printed (capped),

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -476,13 +476,14 @@ STIM_DEPS_FAILED
   \`pod install\` (iOS) or the gradle dependency sync (Android) failed. On iOS
   this runs only when Podfile.lock and Pods/Manifest.lock disagree, or Pods is
   absent -- which is exactly what a carried worktree produces.
-  WHICH POD COMMAND: when the project root has BOTH a Gemfile and a
-  Gemfile.lock, pods go through bundler -- \`bundle check --dry-run\`, then
-  \`bundle install\` only when that reports missing gems, then \`bundle exec pod
-  install\` -- so the CocoaPods the lockfile pins is the one that writes
-  Podfile.lock. Everything else (no Gemfile, or a Gemfile with no Gemfile.lock)
-  gets plain \`pod install\`: without a lockfile \`bundle install\` would CREATE
-  Gemfile.lock in your checkout, and Stim does not write into the project. When
+  WHICH POD COMMAND: when the project root has a Gemfile and a Gemfile.lock
+  that resolves cocoapods, pods go through bundler -- \`bundle check --dry-run\`,
+  then \`bundle install\` only when that reports missing gems, then \`bundle exec
+  pod install\` -- so the CocoaPods the lockfile pins is the one that writes
+  Podfile.lock. Everything else gets plain \`pod install\`: no Gemfile, a Gemfile
+  with no Gemfile.lock (\`bundle install\` would CREATE the lockfile in your
+  checkout, and Stim does not write into the project), and a Gemfile.lock that
+  pins something other than pods, such as a fastlane-only bundle. When
   \`bundle\` is not on PATH the run prints one dim \`pods\` note and uses plain
   \`pod install\`. The \`pods\` phase line always names the command that ran.
   Bundler runs with BUNDLE_FROZEN for the same reason, so a Gemfile that no

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -491,9 +491,10 @@ STIM_DEPS_FAILED
   Gemfile.lock FAILS the build rather than quietly falling back to unpinned
   pods -- silently using a different CocoaPods than the lockfile pins is the
   bug this path exists to kill. Run \`bundle install\` yourself and keep the
-  result. Gems themselves are installed wherever the project's own
-  \`.bundle/config\` points BUNDLE_PATH (vendor/bundle in the React Native
-  template); Stim reports that in a dim note and never edits Gemfile.lock.
+  result. Gems themselves are installed wherever BUNDLE_PATH points -- the
+  project's own \`.bundle/config\` (vendor/bundle in the React Native template),
+  or the environment. When that lands inside the project, Stim says so in a dim
+  note naming which of the two set it; Gemfile.lock is never edited either way.
 
 STIM_BUILD_FAILED
   xcodebuild or gradle failed. The EXTRACTED diagnostics are printed (capped),

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1856,6 +1856,8 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         const action = podAction(podState, verdict);
         if (action.install) {
           const result = await d.runPodInstall(root, logWriter());
+          const podCommand = result?.command || 'pod install';
+          for (const line of result?.notes || []) note(chalk.dim(phaseLine('pods', line)));
           if (result?.failed) {
             phase('pods', 'FAILED');
             fail({
@@ -1867,8 +1869,11 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             });
             return false;
           }
-          phase('pods', `${action.reason} -> installed (${formatDuration(result?.durationMs ?? 0)})`);
-          mutatingSteps.push('pod install');
+          phase(
+            'pods',
+            `${action.reason} -> installed with \`${podCommand}\` (${formatDuration(result?.durationMs ?? 0)})`,
+          );
+          mutatingSteps.push(podCommand);
         }
 
         if (mutatingSteps.length) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { resolveSettings, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
+import { podInstallCommand } from '../engine/bundler.ts';
 import { reclaimProject } from '../reclaim.ts';
 import { withManagedRemoteWorktreeRemovalLock, withManagedTunnelRemovalLock } from '../engine/tunnel.ts';
 import { readMetroTunnel, readRemoteSession } from '../supervisor/state.ts';
@@ -286,11 +287,12 @@ export function registerCreate(worktree: Command): void {
         }
         for (const p of podsOutOfSync(target, res.copied)) {
           const where = p.dir === '.' ? 'Podfile.lock' : `${p.dir}/Podfile.lock`;
+          const pod = podInstallCommand(p.dir === '.' ? target : resolve(target, p.dir, '..'));
           console.error(
             chalk.yellow(
               p.reason === 'missing'
-                ? `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`pod install\` before building.`
-                : `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match ${where}. Pods are gitignored and cloned; Podfile.lock is tracked and comes from the branch, so the two can disagree. Run \`pod install\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
+                ? `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
+                : `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match ${where}. Pods are gitignored and cloned; Podfile.lock is tracked and comes from the branch, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
             ),
           );
         }

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -8,7 +8,7 @@ import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
 import { dirtyFingerprintFiles, gitCommonDir, listWorktrees, repoRoot } from './worktree.ts';
 import { workspaceDerivedData } from './paths.ts';
 import { type Config, type ConcurrencyLimits, getConcurrencyLimits, loadConfig } from './config.ts';
-import { bundlerPin } from './engine/deps.ts';
+import { podInstallCommand } from './engine/bundler.ts';
 import { liveOwnedDeviceCount } from './engine/device.ts';
 import { simslimIsOnPath } from './engine/simslim.ts';
 import { listBuildSlots } from './engine/build-slots.ts';
@@ -200,9 +200,7 @@ export function checkMainCheckout(
     }
     if (podsState) {
       const iosRoot = join(mainRoot, 'ios');
-      const podCommand = bundlerPin(mainRoot)
-        ? `cd ${quotedPath(iosRoot)} && bundle exec pod install`
-        : `cd ${quotedPath(iosRoot)} && pod install`;
+      const podCommand = `cd ${quotedPath(iosRoot)} && ${podInstallCommand(mainRoot)}`;
       findings.push(
         finding(
           'cost',
@@ -216,9 +214,7 @@ export function checkMainCheckout(
     const broken = brokenPods === undefined && existsSync(podsRoot) ? brokenPodLinks(podsRoot) : brokenPods || [];
     if (broken.length) {
       const iosRoot = join(mainRoot, 'ios');
-      const podCommand = bundlerPin(mainRoot)
-        ? `cd ${quotedPath(iosRoot)} && bundle exec pod install --clean-install`
-        : `cd ${quotedPath(iosRoot)} && pod install --clean-install`;
+      const podCommand = `cd ${quotedPath(iosRoot)} && ${podInstallCommand(mainRoot, '--clean-install')}`;
       findings.push(
         finding(
           'cost',

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -8,6 +8,7 @@ import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
 import { dirtyFingerprintFiles, gitCommonDir, listWorktrees, repoRoot } from './worktree.ts';
 import { workspaceDerivedData } from './paths.ts';
 import { type Config, type ConcurrencyLimits, getConcurrencyLimits, loadConfig } from './config.ts';
+import { bundlerPin } from './engine/deps.ts';
 import { liveOwnedDeviceCount } from './engine/device.ts';
 import { simslimIsOnPath } from './engine/simslim.ts';
 import { listBuildSlots } from './engine/build-slots.ts';
@@ -199,7 +200,7 @@ export function checkMainCheckout(
     }
     if (podsState) {
       const iosRoot = join(mainRoot, 'ios');
-      const podCommand = existsSync(join(mainRoot, 'Gemfile'))
+      const podCommand = bundlerPin(mainRoot)
         ? `cd ${quotedPath(iosRoot)} && bundle exec pod install`
         : `cd ${quotedPath(iosRoot)} && pod install`;
       findings.push(
@@ -215,7 +216,7 @@ export function checkMainCheckout(
     const broken = brokenPods === undefined && existsSync(podsRoot) ? brokenPodLinks(podsRoot) : brokenPods || [];
     if (broken.length) {
       const iosRoot = join(mainRoot, 'ios');
-      const podCommand = existsSync(join(mainRoot, 'Gemfile'))
+      const podCommand = bundlerPin(mainRoot)
         ? `cd ${quotedPath(iosRoot)} && bundle exec pod install --clean-install`
         : `cd ${quotedPath(iosRoot)} && pod install --clean-install`;
       findings.push(

--- a/packages/stim-cli/src/engine/bundler.ts
+++ b/packages/stim-cli/src/engine/bundler.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Bundler's lockfile indents a resolved spec name with exactly four spaces; six marks
+// that spec's own dependencies and two marks the DEPENDENCIES section. Matching the
+// four-space form finds cocoapods whether the Gemfile names it directly or pulls it in
+// through another gem, which is exactly when `bundle exec pod` can work; DEPENDENCIES
+// would miss the transitive case.
+const COCOAPODS_SPEC = /^ {4}cocoapods \(/m;
+
+export function bundlerPin(root: string): { gemfile: string; lockfile: string } | null {
+  const gemfile = join(root, 'Gemfile');
+  const lockfile = join(root, 'Gemfile.lock');
+  if (!existsSync(gemfile)) return null;
+  let lock: string;
+  try {
+    lock = readFileSync(lockfile, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (!COCOAPODS_SPEC.test(lock)) return null;
+  return { gemfile, lockfile };
+}
+
+export function podInstallCommand(root: string, ...args: string[]): string {
+  const pod = ['pod', 'install', ...args].join(' ');
+  return bundlerPin(root) ? `bundle exec ${pod}` : pod;
+}

--- a/packages/stim-cli/src/engine/deps.ts
+++ b/packages/stim-cli/src/engine/deps.ts
@@ -220,13 +220,20 @@ function bundlerEnv(root: string, gemfile: string): NodeJS.ProcessEnv {
 
 const BUNDLE_PATH_SETTING = /^BUNDLE_PATH:[ \t]*["']?([^"'\r\n]+?)["']?[ \t]*$/m;
 
-function bundlePathInsideProject(root: string, env: NodeJS.ProcessEnv): string | null {
-  const configured =
-    env.BUNDLE_PATH || BUNDLE_PATH_SETTING.exec(readOrNull(join(root, '.bundle', 'config')) ?? '')?.[1];
-  if (!configured) return null;
+function bundlePathInsideProject(root: string, env: NodeJS.ProcessEnv): { path: string; where: string } | null {
+  const fromEnv = env.BUNDLE_PATH;
+  const configured = fromEnv || BUNDLE_PATH_SETTING.exec(readOrNull(join(root, '.bundle', 'config')) ?? '')?.[1];
+  // Bundler expands a leading ~ to $HOME, which resolve() would instead read as a
+  // directory named "~" under the project.
+  if (!configured || configured.startsWith('~')) return null;
   const resolved = resolve(root, configured);
   if (resolved !== root && !resolved.startsWith(root + sep)) return null;
-  return relative(root, resolved) || '.';
+  return {
+    path: relative(root, resolved) || '.',
+    where: fromEnv
+      ? 'where the BUNDLE_PATH environment variable points'
+      : 'where its own .bundle/config points BUNDLE_PATH',
+  };
 }
 
 type RunContext = {
@@ -342,7 +349,7 @@ async function ensureBundledGems(
   if (install.error) return bundlerSpawnFailure('bundle install', install, pin);
   const inProject = bundlePathInsideProject(cwd, env);
   const note = inProject
-    ? `\`bundle install\` put this project's gems in ${inProject}/, where its own .bundle/config points BUNDLE_PATH; ` +
+    ? `\`bundle install\` put this project's gems in ${inProject.path}/, ${inProject.where}; ` +
       'Gemfile.lock itself is never written.'
     : undefined;
   if (install.code === 0) return { bundler: true, note };

--- a/packages/stim-cli/src/engine/deps.ts
+++ b/packages/stim-cli/src/engine/deps.ts
@@ -207,10 +207,19 @@ export type PodInstallResult = {
   durationMs?: number;
 };
 
-function bundlerPin(root: string): { gemfile: string; lockfile: string } | null {
+// Bundler's lockfile indents a resolved spec name with exactly four spaces; six marks
+// that spec's own dependencies and two marks the DEPENDENCIES section. Matching the
+// four-space form finds cocoapods whether the Gemfile names it directly or pulls it in
+// through another gem, which is exactly when `bundle exec pod` can work; DEPENDENCIES
+// would miss the transitive case.
+const COCOAPODS_SPEC = /^ {4}cocoapods \(/m;
+
+export function bundlerPin(root: string): { gemfile: string; lockfile: string } | null {
   const gemfile = join(root, 'Gemfile');
   const lockfile = join(root, 'Gemfile.lock');
-  if (!existsSync(gemfile) || !existsSync(lockfile)) return null;
+  if (!existsSync(gemfile)) return null;
+  const lock = readOrNull(lockfile);
+  if (lock === null || !COCOAPODS_SPEC.test(lock)) return null;
   return { gemfile, lockfile };
 }
 

--- a/packages/stim-cli/src/engine/deps.ts
+++ b/packages/stim-cli/src/engine/deps.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { getExecutor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
@@ -22,6 +22,9 @@ const RUBY_HEAD = /^\S.*\.rb:\d+:in\s+(?:`[^']*'|'[^']*'):\s*\S/;
 const RUBY_FRAME = /^\s*from\s+\S/;
 
 const RUBY_CONTEXT_BEFORE = 4;
+
+const BUNDLER_FROZEN = /frozen mode|deployment mode|lockfile can't be updated/i;
+const BUNDLER_NO_COCOAPODS = /cocoapods is not currently included in the bundle|command not found: pod\b/i;
 
 export interface PodDiagnostics {
   source: 'cocoapods' | 'ruby';
@@ -196,11 +199,207 @@ export type PodInstallResult = {
   code?: string;
   reason?: string;
   remedy?: string;
+  command?: string;
+  notes?: string[];
   diagnosticSource?: string;
   diagnosticLines?: string[];
   lastLines?: string[];
   durationMs?: number;
 };
+
+function bundlerPin(root: string): { gemfile: string; lockfile: string } | null {
+  const gemfile = join(root, 'Gemfile');
+  const lockfile = join(root, 'Gemfile.lock');
+  if (!existsSync(gemfile) || !existsSync(lockfile)) return null;
+  return { gemfile, lockfile };
+}
+
+// Bundler writes Gemfile.lock whenever it resolves: `bundle check`, `bundle install`,
+// and even `bundle exec` rewrite the lockfile when it does not match the Gemfile.
+// `--dry-run` and BUNDLE_FROZEN make bundler report instead of write, which is what
+// keeps these spawns out of the project tree (#137).
+function bundlerEnv(root: string, gemfile: string): NodeJS.ProcessEnv {
+  return { ...podEnv(root), BUNDLE_GEMFILE: gemfile, BUNDLE_FROZEN: 'true' };
+}
+
+type RunContext = {
+  logWriter: NdjsonWriter | null | undefined;
+  spawn: SpawnFn;
+  now: () => number;
+  heartbeatMs: number;
+  onHeartbeat: (line: string) => void;
+};
+
+type CapturedRun = {
+  transcript: string[];
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  error: unknown;
+  durationMs: number;
+};
+
+async function runCaptured(
+  ctx: RunContext & {
+    cmd: string;
+    args: string[];
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    event: string;
+    label?: string | null;
+  },
+): Promise<CapturedRun> {
+  const startedAt = ctx.now();
+  const transcript: string[] = [];
+  const push = (line: unknown) => {
+    const msg = stripAnsi(String(line)).trimEnd();
+    if (!msg.trim()) return;
+    transcript.push(msg);
+    ctx.logWriter?.write?.({ src: 'build', level: 'debug', msg, raw: true, event: ctx.event });
+  };
+
+  let child: ChildProcess;
+  try {
+    child = ctx.spawn(ctx.cmd, ctx.args, {
+      cwd: ctx.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: ctx.env,
+    });
+  } catch (error) {
+    return { transcript, code: null, signal: null, error, durationMs: ctx.now() - startedAt };
+  }
+
+  const reader = { out: createLineReader(push), err: createLineReader(push) };
+  child.stdout?.setEncoding?.('utf-8');
+  child.stderr?.setEncoding?.('utf-8');
+  child.stdout?.on('data', (chunk) => reader.out.push(chunk));
+  child.stderr?.on('data', (chunk) => reader.err.push(chunk));
+
+  const stopHeartbeat = ctx.label
+    ? startBuildHeartbeat({
+        intervalMs: ctx.heartbeatMs,
+        elapsed: () => ctx.now() - startedAt,
+        lastLine: () => transcript.at(-1) ?? '',
+        emit: ctx.onHeartbeat,
+        label: ctx.label,
+      })
+    : () => {};
+
+  let result: Awaited<ReturnType<typeof waitForChild>>;
+  try {
+    result = await waitForChild(child);
+  } finally {
+    stopHeartbeat();
+  }
+  reader.out.flush();
+  reader.err.flush();
+  return {
+    transcript,
+    code: result.code ?? null,
+    signal: result.signal ?? null,
+    error: result.error ?? null,
+    durationMs: ctx.now() - startedAt,
+  };
+}
+
+type GemsResult = { bundler: boolean; note?: string; failure?: PodInstallResult };
+
+async function ensureBundledGems(
+  root: string,
+  pin: { gemfile: string; lockfile: string },
+  ctx: RunContext,
+): Promise<GemsResult> {
+  const env = bundlerEnv(root, pin.gemfile);
+  const cwd = dirname(pin.gemfile);
+
+  const check = await runCaptured({
+    ...ctx,
+    cmd: 'bundle',
+    args: ['check', '--dry-run'],
+    cwd,
+    env,
+    event: 'bundle_check',
+  });
+  if (check.error) return bundlerSpawnFailure('bundle check', check, pin);
+  if (check.code === 0) return { bundler: true };
+
+  const install = await runCaptured({
+    ...ctx,
+    cmd: 'bundle',
+    args: ['install'],
+    cwd,
+    env,
+    event: 'bundle_install',
+    label: 'gems',
+  });
+  if (install.error) return bundlerSpawnFailure('bundle install', install, pin);
+  if (install.code === 0) return { bundler: true };
+
+  const how = install.signal ? `signal ${install.signal}` : `exit code ${install.code}`;
+  const transcript = install.transcript.join('\n');
+  const extracted = extractPodDiagnostics(transcript);
+  return {
+    bundler: false,
+    failure: {
+      failed: true,
+      code: DEPS_ERROR,
+      reason: `\`bundle install\` failed (${how}).`,
+      remedy: frozenRemedy(root, pin, transcript) || gemInstallRemedy(root, pin),
+      diagnosticSource: extracted ? extracted.source : 'tail',
+      diagnosticLines: extracted ? extracted.lines : [],
+      lastLines: install.transcript.slice(-LAST_LINES),
+      durationMs: install.durationMs,
+    },
+  };
+}
+
+function bundlerSpawnFailure(
+  command: string,
+  run: CapturedRun,
+  pin: { gemfile: string; lockfile: string },
+): GemsResult {
+  if (isMissingBinary(run.error)) return { bundler: false, note: missingBundlerNote(pin) };
+  return {
+    bundler: false,
+    failure: {
+      failed: true,
+      code: DEPS_ERROR,
+      reason: `Could not run \`${command}\`: ${(run.error as Error)?.message || run.error}`,
+      remedy: `Bundler is how this project pins its CocoaPods (${pin.lockfile}). Check that \`bundle\` runs in ${dirname(pin.gemfile)}, then run again.`,
+      lastLines: run.transcript.slice(-LAST_LINES),
+      durationMs: run.durationMs,
+    },
+  };
+}
+
+function missingBundlerNote(pin: { gemfile: string; lockfile: string }): string {
+  return (
+    `${pin.lockfile} pins this project's CocoaPods, but \`bundle\` is not on PATH, ` +
+    'so pods run as plain `pod install` with whatever CocoaPods PATH resolves to (`gem install bundler` to use the pin).'
+  );
+}
+
+function frozenRemedy(
+  root: string,
+  pin: { gemfile: string; lockfile: string },
+  transcript: string,
+): string | undefined {
+  if (!BUNDLER_FROZEN.test(transcript)) return undefined;
+  return (
+    `Stim runs bundler with BUNDLE_FROZEN so it can never write into your checkout, and ${pin.gemfile} no longer ` +
+    `matches ${pin.lockfile}. Run \`cd ${root} && bundle install\` yourself, keep the updated Gemfile.lock, then run again.`
+  );
+}
+
+function gemInstallRemedy(root: string, pin: { gemfile: string; lockfile: string }): string {
+  const version = readRubyVersion(root);
+  const ruby = version
+    ? `This repo pins ruby ${version} (.ruby-version), so put that ruby on PATH (rbenv/rvm/asdf/mise) first. `
+    : '';
+  return (
+    `${ruby}Bundler could not install the gems ${pin.lockfile} pins, so \`bundle exec pod install\` cannot run. ` +
+    `Run \`cd ${root} && bundle install\` and fix what it reports, then run again.`
+  );
+}
 
 export async function runPodInstall(
   root: string,
@@ -228,97 +427,103 @@ export async function runPodInstall(
     };
   }
 
-  const spawn: SpawnFn = spawnFn || ((cmd, args, opts) => getExecutor().spawn(cmd, args, opts));
-  const startedAt = now();
-  const transcript: string[] = [];
-  const push = (line: unknown) => {
-    const msg = stripAnsi(String(line)).trimEnd();
-    if (!msg.trim()) return;
-    transcript.push(msg);
-    logWriter?.write?.({ src: 'build', level: 'debug', msg, raw: true, event: 'pod_install' });
+  const ctx: RunContext = {
+    logWriter,
+    spawn: spawnFn || ((cmd, args, opts) => getExecutor().spawn(cmd, args, opts)),
+    now,
+    heartbeatMs,
+    onHeartbeat,
   };
 
-  let child: ChildProcess;
-  try {
-    child = spawn('pod', ['install'], {
-      cwd: iosDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: podEnv(root),
-    });
-  } catch (err) {
-    return (
-      missingPod(err) || {
-        failed: true,
-        code: DEPS_ERROR,
-        reason: `Could not run \`pod install\`: ${(err as Error)?.message || err}`,
-        lastLines: [] as string[],
-      }
-    );
+  const notes: string[] = [];
+  const pin = bundlerPin(root);
+  let bundler = false;
+  if (pin) {
+    const gems = await ensureBundledGems(root, pin, ctx);
+    if (gems.failure) return { ...gems.failure, notes };
+    if (gems.note) notes.push(gems.note);
+    bundler = gems.bundler;
   }
 
-  const reader = { out: createLineReader(push), err: createLineReader(push) };
-  child.stdout?.setEncoding?.('utf-8');
-  child.stderr?.setEncoding?.('utf-8');
-  child.stdout?.on('data', (chunk) => reader.out.push(chunk));
-  child.stderr?.on('data', (chunk) => reader.err.push(chunk));
-
-  const stopHeartbeat = startBuildHeartbeat({
-    intervalMs: heartbeatMs,
-    elapsed: () => now() - startedAt,
-    lastLine: () => transcript.at(-1) ?? '',
-    emit: onHeartbeat,
+  const args = bundler ? ['bundle', 'exec', 'pod', 'install'] : ['pod', 'install'];
+  const command = args.join(' ');
+  const run = await runCaptured({
+    ...ctx,
+    cmd: args[0] as string,
+    args: args.slice(1),
+    cwd: iosDir,
+    env: bundler && pin ? bundlerEnv(root, pin.gemfile) : podEnv(root),
+    event: 'pod_install',
     label: 'pods',
   });
 
-  let result: Awaited<ReturnType<typeof waitForChild>>;
-  try {
-    result = await waitForChild(child);
-  } finally {
-    stopHeartbeat();
-  }
-  reader.out.flush();
-  reader.err.flush();
-  const durationMs = now() - startedAt;
-
-  if (result.error) {
-    return (
-      missingPod(result.error) || {
+  if (run.error) {
+    const missing = missingPod(run.error);
+    return {
+      ...(missing || {
         failed: true,
         code: DEPS_ERROR,
-        reason: `Could not run \`pod install\`: ${result.error?.message || result.error}`,
-        lastLines: transcript.slice(-LAST_LINES),
-        durationMs,
-      }
-    );
+        reason: `Could not run \`${command}\`: ${(run.error as Error)?.message || run.error}`,
+        lastLines: run.transcript.slice(-LAST_LINES),
+        durationMs: run.durationMs,
+      }),
+      command,
+      notes,
+    };
   }
-  if (result.code !== 0) {
-    const how = result.signal ? `signal ${result.signal}` : `exit code ${result.code}`;
-    const extracted = extractPodDiagnostics(transcript.join('\n'));
-    const pinned = /Could not find proper version of cocoapods/.test(transcript.join('\n'))
-      ? readRubyVersion(root)
-      : null;
+  if (run.code !== 0) {
+    const how = run.signal ? `signal ${run.signal}` : `exit code ${run.code}`;
+    const transcript = run.transcript.join('\n');
+    const extracted = extractPodDiagnostics(transcript);
     return {
       failed: true,
       code: DEPS_ERROR,
-      reason: `\`pod install\` failed (${how}).`,
-      remedy: pinned
-        ? `This repo pins ruby ${pinned} (.ruby-version) and its Gemfile's cocoapods was installed under it; ` +
-          `the shell's ruby is likely a different version, so bundler looks in the wrong gem home. ` +
-          `Put ruby ${pinned} on PATH (rbenv/rvm/asdf/mise) -- \`bundle install\` will NOT fix this.`
-        : undefined,
+      reason: `\`${command}\` failed (${how}).`,
+      remedy: podFailureRemedy(root, pin, transcript),
+      command,
+      notes,
       diagnosticSource: extracted ? extracted.source : ('tail' as const),
       diagnosticLines: extracted ? extracted.lines : ([] as string[]),
-      lastLines: transcript.slice(-LAST_LINES),
-      durationMs,
+      lastLines: run.transcript.slice(-LAST_LINES),
+      durationMs: run.durationMs,
     };
   }
-  return { ok: true, durationMs };
+  return { ok: true, command, notes, durationMs: run.durationMs };
+}
+
+function podFailureRemedy(
+  root: string,
+  pin: { gemfile: string; lockfile: string } | null,
+  transcript: string,
+): string | undefined {
+  if (pin) {
+    const frozen = frozenRemedy(root, pin, transcript);
+    if (frozen) return frozen;
+    if (BUNDLER_NO_COCOAPODS.test(transcript)) {
+      return (
+        `${pin.lockfile} does not include cocoapods, so bundler has no \`pod\` to exec. Stim runs pods through ` +
+        `bundler whenever the project root has both a Gemfile and a Gemfile.lock: add \`gem 'cocoapods'\` to ` +
+        `${pin.gemfile} and run \`bundle install\`, or remove ${pin.lockfile} from the project root.`
+      );
+    }
+  }
+  const pinned = /Could not find proper version of cocoapods/.test(transcript) ? readRubyVersion(root) : null;
+  if (!pinned) return undefined;
+  return (
+    `This repo pins ruby ${pinned} (.ruby-version) and its Gemfile's cocoapods was installed under it; ` +
+    `the shell's ruby is likely a different version, so bundler looks in the wrong gem home. ` +
+    `Put ruby ${pinned} on PATH (rbenv/rvm/asdf/mise) -- \`bundle install\` will NOT fix this.`
+  );
+}
+
+function isMissingBinary(err: unknown): boolean {
+  const nodeErr = err as NodeJS.ErrnoException;
+  const message = String(nodeErr?.message || err || '');
+  return nodeErr?.code === 'ENOENT' || /ENOENT|not found/i.test(message);
 }
 
 function missingPod(err: unknown) {
-  const nodeErr = err as NodeJS.ErrnoException;
-  const message = String(nodeErr?.message || err || '');
-  if (nodeErr?.code !== 'ENOENT' && !/ENOENT|not found/i.test(message)) return null;
+  if (!isMissingBinary(err)) return null;
   return {
     failed: true,
     code: DEPS_ERROR,

--- a/packages/stim-cli/src/engine/deps.ts
+++ b/packages/stim-cli/src/engine/deps.ts
@@ -1,10 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { getExecutor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
+import { bundlerPin } from './bundler.ts';
 import { HEARTBEAT_INTERVAL_MS, startBuildHeartbeat } from './xcode.ts';
 
 type SpawnFn = (cmd: string, args: string[], opts: Record<string, unknown>) => ChildProcess;
@@ -23,7 +24,7 @@ const RUBY_FRAME = /^\s*from\s+\S/;
 
 const RUBY_CONTEXT_BEFORE = 4;
 
-const BUNDLER_FROZEN = /frozen mode|deployment mode|lockfile can't be updated/i;
+const BUNDLER_FROZEN = /frozen mode|lockfile can't be updated|in deployment mode after changing/i;
 const BUNDLER_NO_COCOAPODS = /cocoapods is not currently included in the bundle|command not found: pod\b/i;
 
 export interface PodDiagnostics {
@@ -207,28 +208,25 @@ export type PodInstallResult = {
   durationMs?: number;
 };
 
-// Bundler's lockfile indents a resolved spec name with exactly four spaces; six marks
-// that spec's own dependencies and two marks the DEPENDENCIES section. Matching the
-// four-space form finds cocoapods whether the Gemfile names it directly or pulls it in
-// through another gem, which is exactly when `bundle exec pod` can work; DEPENDENCIES
-// would miss the transitive case.
-const COCOAPODS_SPEC = /^ {4}cocoapods \(/m;
-
-export function bundlerPin(root: string): { gemfile: string; lockfile: string } | null {
-  const gemfile = join(root, 'Gemfile');
-  const lockfile = join(root, 'Gemfile.lock');
-  if (!existsSync(gemfile)) return null;
-  const lock = readOrNull(lockfile);
-  if (lock === null || !COCOAPODS_SPEC.test(lock)) return null;
-  return { gemfile, lockfile };
-}
-
 // Bundler writes Gemfile.lock whenever it resolves: `bundle check`, `bundle install`,
 // and even `bundle exec` rewrite the lockfile when it does not match the Gemfile.
-// `--dry-run` and BUNDLE_FROZEN make bundler report instead of write, which is what
-// keeps these spawns out of the project tree (#137).
+// `--dry-run` and BUNDLE_FROZEN make bundler report instead of write, so the tracked
+// lockfile is never edited. Gems still land wherever the project's own bundler config
+// points BUNDLE_PATH (the React Native template ships `.bundle/config` with
+// vendor/bundle), which is the project's dependency state, not Stim's (#137).
 function bundlerEnv(root: string, gemfile: string): NodeJS.ProcessEnv {
   return { ...podEnv(root), BUNDLE_GEMFILE: gemfile, BUNDLE_FROZEN: 'true' };
+}
+
+const BUNDLE_PATH_SETTING = /^BUNDLE_PATH:[ \t]*["']?([^"'\r\n]+?)["']?[ \t]*$/m;
+
+function bundlePathInsideProject(root: string, env: NodeJS.ProcessEnv): string | null {
+  const configured =
+    env.BUNDLE_PATH || BUNDLE_PATH_SETTING.exec(readOrNull(join(root, '.bundle', 'config')) ?? '')?.[1];
+  if (!configured) return null;
+  const resolved = resolve(root, configured);
+  if (resolved !== root && !resolved.startsWith(root + sep)) return null;
+  return relative(root, resolved) || '.';
 }
 
 type RunContext = {
@@ -327,6 +325,7 @@ async function ensureBundledGems(
     cwd,
     env,
     event: 'bundle_check',
+    label: 'gems',
   });
   if (check.error) return bundlerSpawnFailure('bundle check', check, pin);
   if (check.code === 0) return { bundler: true };
@@ -341,7 +340,12 @@ async function ensureBundledGems(
     label: 'gems',
   });
   if (install.error) return bundlerSpawnFailure('bundle install', install, pin);
-  if (install.code === 0) return { bundler: true };
+  const inProject = bundlePathInsideProject(cwd, env);
+  const note = inProject
+    ? `\`bundle install\` put this project's gems in ${inProject}/, where its own .bundle/config points BUNDLE_PATH; ` +
+      'Gemfile.lock itself is never written.'
+    : undefined;
+  if (install.code === 0) return { bundler: true, note };
 
   const how = install.signal ? `signal ${install.signal}` : `exit code ${install.code}`;
   const transcript = install.transcript.join('\n');
@@ -467,7 +471,7 @@ export async function runPodInstall(
   });
 
   if (run.error) {
-    const missing = missingPod(run.error);
+    const missing = bundler ? missingBundle(run.error, pin) : missingPod(run.error);
     return {
       ...(missing || {
         failed: true,
@@ -510,9 +514,9 @@ function podFailureRemedy(
     if (frozen) return frozen;
     if (BUNDLER_NO_COCOAPODS.test(transcript)) {
       return (
-        `${pin.lockfile} does not include cocoapods, so bundler has no \`pod\` to exec. Stim runs pods through ` +
-        `bundler whenever the project root has both a Gemfile and a Gemfile.lock: add \`gem 'cocoapods'\` to ` +
-        `${pin.gemfile} and run \`bundle install\`, or remove ${pin.lockfile} from the project root.`
+        `${pin.lockfile} resolves cocoapods, but bundler found no \`pod\` executable in the bundle it loaded: ` +
+        `the installed gems belong to a different Gemfile than ${pin.gemfile}, or that Gemfile's bundle was never ` +
+        `installed. Run \`cd ${root} && bundle install && bundle exec pod --version\` and make that work, then run again.`
       );
     }
   }
@@ -529,6 +533,19 @@ function isMissingBinary(err: unknown): boolean {
   const nodeErr = err as NodeJS.ErrnoException;
   const message = String(nodeErr?.message || err || '');
   return nodeErr?.code === 'ENOENT' || /ENOENT|not found/i.test(message);
+}
+
+function missingBundle(err: unknown, pin: { gemfile: string; lockfile: string } | null) {
+  if (!isMissingBinary(err)) return null;
+  return {
+    failed: true,
+    code: DEPS_ERROR,
+    reason: 'Bundler is not installed: no `bundle` executable on PATH.',
+    remedy:
+      `${pin?.lockfile ?? 'Gemfile.lock'} pins this project's CocoaPods, so pods run through bundler. ` +
+      'Install bundler (`gem install bundler`) and run again.',
+    lastLines: [] as string[],
+  };
 }
 
 function missingPod(err: unknown) {

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -1,3 +1,5 @@
+import { podInstallCommand } from './bundler.ts';
+
 export interface Diagnostic {
   file?: string | null;
   line?: number | null;
@@ -41,12 +43,13 @@ const NO_SUCH_SCHEME = /does not contain a scheme named/;
 // wrong node kind. See appandflow/stim#138.
 const CAS_CORRUPT = /not a IncludeTreeRoot node kind/;
 
-function remedyFor(message: string): string | null {
+function remedyFor(message: string, root: string | null): string | null {
   if (CAS_CORRUPT.test(message)) {
     return 'The compilation cache holds a damaged object. Run `stim gc --delete --cache "compilation cache"` to empty that cache, then build again. The next build is a cold one.';
   }
   if (PODS_OUT_OF_SYNC.test(message)) {
-    return 'Run `pod install` in ios/ (stim ios does this when Podfile.lock and Pods/Manifest.lock disagree), then build again.';
+    const pod = root ? podInstallCommand(root) : 'pod install';
+    return `Run \`${pod}\` in ios/ (stim ios does this when Podfile.lock and Pods/Manifest.lock disagree), then build again.`;
   }
   if (NO_SUCH_SCHEME.test(message)) {
     return 'Run `xcodebuild -list` in ios/ to see the schemes this project defines, and share the app scheme so it is visible to the build.';
@@ -70,24 +73,27 @@ function fileFromPrefix(prefix: string): string | null {
   return head;
 }
 
-function makeDiagnostic({
-  file = null,
-  line = null,
-  column = null,
-  message,
-}: {
-  file?: string | null;
-  line?: number | null;
-  column?: number | null;
-  message: string;
-}): Diagnostic {
+function makeDiagnostic(
+  {
+    file = null,
+    line = null,
+    column = null,
+    message,
+  }: {
+    file?: string | null;
+    line?: number | null;
+    column?: number | null;
+    message: string;
+  },
+  root: string | null,
+): Diagnostic {
   const text = String(message).trim();
   const out: Diagnostic = { message: text };
   if (file) out.file = file;
   if (line !== null && line !== undefined) out.line = line;
   if (column !== null && column !== undefined) out.column = column;
   out.message = text;
-  const remedy = remedyFor(text);
+  const remedy = remedyFor(text, root);
   if (remedy) out.remedy = remedy;
   return out;
 }
@@ -96,7 +102,7 @@ function dedupeKey(d: Diagnostic): string {
   return `${d.file || ''}|${d.line || ''}|${d.column || ''}|${d.message}`;
 }
 
-export function extractXcodeDiagnostics(transcript: string): Diagnostic[] {
+export function extractXcodeDiagnostics(transcript: string, root: string | null = null): Diagnostic[] {
   if (typeof transcript !== 'string' || transcript === '') return [];
 
   const lines = transcript.split('\n');
@@ -123,7 +129,7 @@ export function extractXcodeDiagnostics(transcript: string): Diagnostic[] {
         const sym = UNDEFINED_SYMBOL.exec(symLine.replace(/\r$/, ''));
         if (sym) {
           const symbol = sym[1];
-          if (symbol !== undefined) push(makeDiagnostic({ message: undefinedSymbolMessage(symbol) }));
+          if (symbol !== undefined) push(makeDiagnostic({ message: undefinedSymbolMessage(symbol) }, root));
           continue;
         }
         if (/^\s+\S/.test(symLine) && !/^\S/.test(symLine)) continue;
@@ -135,7 +141,7 @@ export function extractXcodeDiagnostics(transcript: string): Diagnostic[] {
 
     const ld = LD_ERROR.exec(raw);
     if (ld) {
-      push(makeDiagnostic({ message: `ld: ${ld[1]}` }));
+      push(makeDiagnostic({ message: `ld: ${ld[1]}` }, root));
       continue;
     }
 
@@ -144,12 +150,15 @@ export function extractXcodeDiagnostics(transcript: string): Diagnostic[] {
       const posMsg = positioned[4];
       if (posMsg === undefined) continue;
       push(
-        makeDiagnostic({
-          file: positioned[1],
-          line: Number(positioned[2]),
-          column: positioned[3] === undefined ? null : Number(positioned[3]),
-          message: posMsg,
-        }),
+        makeDiagnostic(
+          {
+            file: positioned[1],
+            line: Number(positioned[2]),
+            column: positioned[3] === undefined ? null : Number(positioned[3]),
+            message: posMsg,
+          },
+          root,
+        ),
       );
       continue;
     }
@@ -158,7 +167,7 @@ export function extractXcodeDiagnostics(transcript: string): Diagnostic[] {
     if (plain) {
       const plainMsg = plain[2];
       if (plainMsg === undefined) continue;
-      push(makeDiagnostic({ file: fileFromPrefix(plain[1] || ''), message: plainMsg }));
+      push(makeDiagnostic({ file: fileFromPrefix(plain[1] || ''), message: plainMsg }, root));
     }
   }
 

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -686,7 +686,7 @@ export async function buildIos({
   }
 
   if (outcome.code !== 0) {
-    const diagnostics = extractXcodeDiagnostics(text);
+    const diagnostics = extractXcodeDiagnostics(text, root);
     const capped = capDiagnostics(diagnostics);
     for (const d of capped.diagnostics) reportError(describeDiagnostic(d), d.remedy);
     if (capped.diagnostics.length === 0) {


### PR DESCRIPTION
## Description

`doctor` prints `bundle exec pod install` when the project has a Gemfile, while the engine always spawned plain `pod install` (#137). For a project whose `Gemfile.lock` pins cocoapods, the CocoaPods that rewrites `ios/Podfile.lock` during a Stim build can then be a different one than the repo pins -- the lockfile churn and rvm activation trouble #133/#135 hit in the e2e fixture.

Stim must not edit tracked project files, and bundler rewrites `Gemfile.lock` whenever it resolves, so every bundler spawn here runs with `BUNDLE_FROZEN=true` and the check runs `--dry-run`. To be precise about the scope of that claim: `BUNDLE_FROZEN` protects `Gemfile.lock` specifically. `bundle install` still installs *gems*, and when the project's own committed `.bundle/config` points `BUNDLE_PATH` inside the tree -- the React Native template ships `vendor/bundle` -- that is where they land. That is the project's dependency state written by the project's own toolchain config, the same class as `Pods/` and `node_modules/`, and the template gitignores it (`--carry-ignored` carries it into worktrees). I deliberately did not redirect `BUNDLE_PATH` to a Stim directory: the user's own `bundle exec` has to find the same gems. The run now prints a dim `pods` note when the resolved bundle path is inside the project.

<details><summary>What bundler 4.0.8 does to a Gemfile.lock that no longer matches its Gemfile (measured, not assumed)</summary>

| command | Gemfile.lock |
| --- | --- |
| `bundle check` | rewritten |
| `bundle check --dry-run` | untouched |
| `bundle exec <cmd>` | rewritten |
| `BUNDLE_FROZEN=true bundle exec <cmd>` | untouched, exits 1 |

</details>

## Solution

The pod step takes the first rung that applies:

1. **`Gemfile` + a `Gemfile.lock` that resolves cocoapods** -- `bundle check --dry-run` at the Gemfile, then `bundle install` only if that reports missing gems, then `bundle exec pod install` in `ios/`.
2. **`Gemfile` with no `Gemfile.lock`** -- plain `pod install`, exactly as before. `bundle install` there would CREATE a lockfile in the checkout, which is the write Stim will not do; there is no pin to honor anyway.
3. **A `Gemfile.lock` that pins something else** (fastlane-only bundles are common in RN repos) -- plain `pod install`. Nothing was pinned for pods, so nothing is gained by running `bundle exec pod install` and failing where plain `pod` worked. No note: there is no pin to report.
4. **No `bundle` on PATH** -- plain `pod install` plus one dim `pods` note naming the pin it could not use. A note, not a failure.

A drifted Gemfile (one that no longer matches its lockfile) fails the build rather than falling back to unpinned pods -- silently building with a different CocoaPods than the lockfile pins is the bug class this feature exists to kill -- and the failure carries the `bundle install` remedy.

Rung 1's test is a four-space-indented `cocoapods (` spec line in `Gemfile.lock` -- that is bundler's format for a resolved spec (six spaces marks a spec's dependencies, two marks `DEPENDENCIES`), so it catches cocoapods pulled in transitively, which `DEPENDENCIES` would miss. An unreadable or malformed lockfile is treated as "not pinned" rather than an error. The rule lives in `engine/bundler.ts` and every surface that prints a pod command reads it: `doctor`'s two CocoaPods remedies, `worktree create`'s carried-Pods warning, and the xcodebuild "sandbox is not in sync" remedy. A fastlane-only repo is told `pod install` everywhere; a pinned repo is told `bundle exec pod install` everywhere.

All three bundler spawns keep `podEnv()` (the `.ruby-version` PATH/GEM_HOME handling) and add `BUNDLE_GEMFILE`. A Gemfile that has drifted from its lockfile now fails the run with a remedy pointing at `bundle install` instead of having a tracked file updated underneath you; gems bundler cannot install keep the existing `.ruby-version` hint. The `pods` phase line names the command that ran, and `stim guide errors` describes the ladder under STIM_DEPS_FAILED. STIM_DEPS_FAILED itself and the extracted `[!]`/ruby diagnostics are unchanged.

## Test plan

Real tools, `stim ios` on a bare RN 0.87 worktree with `ios/Pods` and `vendor/` removed, which drives rung 1 end to end -- `bundle check --dry-run` (missing gems) -> `bundle install` -> `bundle exec pod install` -> build -> launch:

```
gems        still running (30s): Installing activesupport 7.2.3.2
pods        still running (30s): [Hermes] Cache hit: copying hermes-ios-...
  pods        ios/Pods/Manifest.lock is missing (pods have never been installed here) -> installed with `bundle exec pod install` (43.3s)
  build       ok (28.5s)
  verify      ready: bundle loaded, stable for 3s, process alive (3.9s total)
```

`git status --porcelain` in that worktree was empty before and after, and `git diff -- Gemfile.lock` was empty: 45 gems and 86 pods installed without touching a tracked file. The gems did land in the worktree, in `vendor/bundle` per the fixture's own `.bundle/config` -- gitignored, hence the clean status, and exactly what the new dim note now reports.

- `node test/e2e/native/run-native-e2e.mjs --framework bare --platform ios` -- PASS. Worth knowing: that e2e never reaches this code, because `worktree create --carry-ignored` carries a matching `ios/Pods` and the pod step is skipped. Hence the manual run above.
- Unit tests cover each rung with a mocked spawn: a cocoapods-pinned project uses check -> exec, a failing check inserts `bundle install`, a fastlane-only lock and a Gemfile without a lockfile stay on plain `pod install` (asserting the fallback env carries no `BUNDLE_FROZEN`/`BUNDLE_GEMFILE`), a missing `bundle` falls back with the note, and each new failure returns STIM_DEPS_FAILED with its remedy. `engine-bundler.test.ts` pins the lockfile parse itself: CRLF, a GIT-sourced spec, a transitive `cocoapods` dependency line with no spec of its own (negative), a `CHECKSUMS` entry alone (negative), and a lockfile that is a directory. A guide contract test ties the STIM_DEPS_FAILED text to the argv the engine actually spawns, so the two cannot drift again. The four-space spec match was also checked against a real `bundle lock` output pinning cocoapods 1.17.0.

Fixes #137
