### PR TITLE
Signal the collector's log stream through its handle, not its pid

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -583,3 +583,54 @@ describe('runCollector reattach seams', () => {
     expect(stopped).toBe(true);
   });
 });
+
+describe('the collector never signals a pid it does not own', () => {
+  test('reattaching kills the stream through its own handle, not process.kill on its pid', async () => {
+    const signalled: [number, string | number][] = [];
+    const killedHandles: (string | number | undefined)[] = [];
+    const origKill = process.kill;
+    process.kill = ((pid: number, sig: string | number) => {
+      signalled.push([pid, sig]);
+      return true;
+    }) as typeof process.kill;
+    try {
+      const started: ChildProcess[] = [];
+      let pid = 3132;
+      const result = await runCollector({
+        platform: 'android',
+        root,
+        serial: 'emulator-5554',
+        packageName: 'com.example.app',
+        resolvePid: async () => ({ ok: true, pid: 3132 }),
+        pidOf: () => pid,
+        pidWatchMs: 60000,
+        startStream: ({ pid: streamPid }) => {
+          const c = makeChildProcess({
+            pid: streamPid ?? undefined,
+            kill: ((sig?: string | number) => {
+              killedHandles.push(sig);
+              return true;
+            }) as ChildProcess['kill'],
+          });
+          started.push(c);
+          return c;
+        },
+        attachSignals: false,
+        onExit: () => {},
+      });
+
+      pid = 4200;
+      const firstStarted = started[0];
+      assert(firstStarted);
+      firstStarted.emit('exit', 0, null);
+
+      expect(killedHandles).toEqual(['SIGTERM']);
+      expect(signalled.filter(([, sig]) => sig !== 0)).toEqual([]);
+
+      assert(result);
+      result.finish(0, 'info', 'done', 'collector_stopped');
+    } finally {
+      process.kill = origKill;
+    }
+  });
+});

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -301,10 +301,12 @@ export async function runCollector({
   return { child, writer, finish, startedAt, pid };
 }
 
+// ChildProcess.kill signals through the handle, so it can only reach a process
+// this collector spawned. process.kill(child.pid) would signal whatever holds
+// that number, including a pid the OS recycled after the child exited.
 function killChild(child: ChildProcess | null): void {
   try {
-    if (child?.pid) process.kill(child.pid, 'SIGTERM');
-    else child?.kill?.('SIGTERM');
+    child?.kill?.('SIGTERM');
   } catch {}
 }
 


### PR DESCRIPTION
Closes #146

## Description

`killChild` in the collector preferred `process.kill(child.pid, 'SIGTERM')` over `child.kill('SIGTERM')`:

```ts
if (child?.pid) process.kill(child.pid, 'SIGTERM');
else child?.kill?.('SIGTERM');
```

Signalling by number reaches whatever currently holds that pid. `ChildProcess.kill` signals through the handle, so it can only reach a process this collector actually spawned. The `else` branch was already correct; the `if` bypassed it whenever a pid was present, which is always.

That is the CI flake. A mock child object carries a plausible `pid` and no process behind it, so in `runCollector`'s reattach path the number went straight to the kernel from inside a vitest worker, and the surrounding `catch {}` swallowed the `ESRCH` when nothing was there. Every test passed, so nothing pointed at it. On a contended runner spawning 71 worker processes, a live worker holding that recycled pid received the SIGTERM instead -- which is how a run reported

```
Worker exited unexpectedly with signal SIGTERM during started state
while running test file packages/stim-cli/src/__tests__/start.test.ts

 Test Files  69 passed (70)
      Tests  2547 passed | 3 skipped (2562)
```

The `started` state is what ruled out the earlier theory in #146 that this was an EPIPE race during pool shutdown. The worker was running, and something signalled it.

## Test plan

The new test drives the reattach path with a stream handle whose `kill` is recorded, and asserts the handle was used and no real signal was sent.

Evidence beyond the unit test, since the flake never reproduced locally: wrapping `process.kill` and running the whole suite gives every signal it sends.

Before, one signal targeted a pid the suite does not own -- fixture pid `3132`, from `killChild`. After, every signal targets a large run-varying pid the suite spawned itself:

```
2 target=26407 sig=SIGKILL
1 target=26247 sig=SIGTERM
1 target=25605 sig=SIGTERM
1 target=-26988 sig=SIGTERM     <- killMetroTree on its own detached child
...
grep for fixture pids (3132, 4242, 4200, 999, 111): NONE
```

Full suite: 2589 passed, plus format, lint, typecheck and knip.

## Risk

`ChildProcess.kill` targets the same process for these children -- the expo child is spawned `detached: false` and the collector's log stream takes the default -- so no process-group semantics are lost. It additionally no-ops on a child that already exited, which the pid path could not do.

## What this does not cover

`supervisor/server-expo.ts:361,368` has the same shape. It is guarded by an `exited` check and its tests stub `process.kill`, so it is not this bug, but signalling by pid there is the same latent defect and deserves its own change.

`reclaim.ts:21` reaps collector pids read from disk without verifying the pid belongs to Stim. It fired no real signal in any traced run, so it is not this flake either -- but `stim stop` and `stim worktree remove` reach it, so a stale record whose pid was recycled could signal an unrelated process on a user's machine. Also its own change.

Test fixtures still default to `pid: 4242` (`_factories.ts`), which is a plausible live pid. A default outside the kernel's pid range would make any future slip of this kind fail with ESRCH instead of hitting a real process.
