### PR TITLE
Install the APK's applicationId, not the gradle namespace

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1132,9 +1132,44 @@ describe('the applicationId comes from the built APK', () => {
     const h = harness();
     const result = await h.run();
     expect(h.calls.readApkPackage.length).toBe(1);
+    expect(h.calls.install[0]?.packageName).toBe('com.example.app');
     expect(h.calls.launch[0]?.packageName).toBe('com.example.app');
     assert(result.facts);
     expect(result.facts.bundleId).toBe('com.example.app');
+  });
+
+  test('the install gets the APK applicationId, not the project namespace', async () => {
+    const h = harness({ readApkPackage: () => 'io.tlon.groups' });
+    const result = await h.run();
+
+    expect(result.ok).toBe(true);
+    expect(h.calls.install[0]?.packageName).toBe('io.tlon.groups');
+  });
+
+  test('a release run hands the uninstall-and-retry the APK applicationId', async () => {
+    const h = harness({ variant: 'productionRelease', readApkPackage: () => 'io.tlon.groups' });
+    await h.run();
+
+    expect(h.calls.install[0]).toMatchObject({ packageName: 'io.tlon.groups', allowUninstall: true });
+  });
+
+  test('a downgrade conflict names the APK applicationId in the uninstall it suggests', async () => {
+    const h = harness({
+      readApkPackage: () => 'io.tlon.groups',
+      install: (args: InstallArgs = {}) => {
+        h.calls.install.push(args);
+        return {
+          failed: true,
+          code: 'STIM_INSTALL_FAILED',
+          reason: 'adb install failed for app.apk: INSTALL_FAILED_VERSION_DOWNGRADE',
+        };
+      },
+    });
+    const result = await h.run();
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.remedy).toContain('adb -s emulator-5584 uninstall io.tlon.groups');
+    expect(result.error?.remedy).not.toContain('com.example.app');
   });
 });
 

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1087,6 +1087,12 @@ async function finishAndroidRun({
       : `${device.avdName || serial} (${serial}) booted ${bootDuration()}`,
   );
 
+  const packageFromApk = readApkPackage(apkPath);
+  if (packageFromApk && androidPackage && packageFromApk !== androidPackage) {
+    phase('install', chalk.dim(`applicationId ${packageFromApk} (from the APK; project files say ${androidPackage})`));
+  }
+  androidPackage = packageFromApk || androidPackage || detectAndroidPackage(root);
+
   const installTimer = stepTimer(now);
   const installed: InstallResultLike = install({
     serial,
@@ -1096,10 +1102,14 @@ async function finishAndroidRun({
   });
   if (installed.failed) {
     const conflict = installConflictKind(installed.reason);
+    const rerun = useBuildCache
+      ? ' Then run this command again; it installs the APK from cache without building it again.'
+      : ' Then run this command again.';
     const installRemedy = conflict
       ? `${androidPackage} is already installed on ${serial} ` +
         (conflict === 'signature' ? 'with a different signer' : 'at a higher versionCode') +
-        `. Uninstall it first (\`adb -s ${serial} uninstall ${androidPackage}\`); its data goes with it.`
+        `. Uninstall it first (\`adb -s ${serial} uninstall ${androidPackage}\`); its data goes with it.` +
+        rerun
       : `Check that ${serial} is still connected (\`adb devices\`) and has room for the APK.`;
     return fail(installed.code || INSTALL_FAILED, installed.reason, installRemedy, { lastBuildStatus: true });
   }
@@ -1114,11 +1124,6 @@ async function finishAndroidRun({
     } catch {}
   }
 
-  const packageFromApk = readApkPackage(apkPath);
-  if (packageFromApk && androidPackage && packageFromApk !== androidPackage) {
-    phase('launch', chalk.dim(`applicationId ${packageFromApk} (from the APK; project files say ${androidPackage})`));
-  }
-  androidPackage = packageFromApk || androidPackage || detectAndroidPackage(root);
   if (androidPackage) upsertProject(root, { androidPackage });
   record.bundleId = androidPackage;
   if (!androidPackage) {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -553,9 +553,11 @@ FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
                 so it was uninstalled (its data went with it) before this APK
                 could be installed
 
-  Debug runs never do this: every debug artifact is debug-keystore-signed, the
-  conflict cannot arise, and losing a dev app's data to a silent uninstall
-  would be a worse bug than the one it fixes.
+  Debug runs never do this. A debug run meets the conflict on a physical
+  device that already carries a store build, and there the colliding package is
+  the user's real app: losing its data to a silent uninstall would be a worse
+  bug than the one it fixes. A debug run fails with STIM_INSTALL_FAILED and
+  hands you the uninstall to run yourself.
 
 STIM_BUILD_WAIT_TIMEOUT
   This run was waiting for ANOTHER workspace's build of the same fingerprint
@@ -569,6 +571,11 @@ STIM_BUILD_WAIT_TIMEOUT
 STIM_INSTALL_FAILED
   The artifact built or came from cache, but \`simctl install\` / \`adb install\`
   refused it. A signature or architecture mismatch, or a full device.
+  On Android a signature or downgrade conflict names the package that is really
+  installed -- the built APK's applicationId, which on a flavored project is
+  the flavor's id and not the gradle namespace -- and gives you the
+  \`adb -s <serial> uninstall <applicationId>\` that clears it. Re-running after
+  that is a cache hit: one install, no build.
 
 STIM_LAUNCH_FAILED
   Installed, but the app would not start. On Android this usually means no


### PR DESCRIPTION
Closes #155

## Description

`finishAndroidRun` installed with `androidPackage` still holding `detectAndroidPackage(root)` -- the `namespace` from `android/app/build.gradle`. The APK's real `applicationId` was only read afterwards. On a project with product flavors those differ: tlon declares `namespace "io.tlon.landscape"` and flavor ids `io.tlon.groups` / `io.tlon.groups.preview`.

Two things went wrong with that. The install-failure remedy named a package that is not installed, so the `adb uninstall` it printed could only fail. And `installAndroidApp` received the same wrong name, so its uninstall-and-retry on a signature or downgrade conflict -- the release path -- ran `adb uninstall` against a package that was not there and could never recover. The second half predates the remedy text and is the more serious of the two.

## Solution

Read the APK's applicationId before installing, so the install, the remedy, and the retry all use the same real value. The note reporting a differing applicationId moves with it and now prints under `install` rather than `launch`, because it precedes the install it describes.

The fallback is unchanged: when the manifest cannot be read the value stays the project-files one, so a machine without aapt is no worse off than today. The cost is that the aapt dump is now paid on every run rather than only on runs whose install succeeded.

The remedy already printed a concrete `adb uninstall`; only the name was wrong, so no new remedy shape was needed. It gains one sentence saying a re-run installs from cache without rebuilding, gated on `useBuildCache` so it is not claimed under `--no-build-cache`. Debug runs still never auto-uninstall -- the colliding package can be the user's real app.

While updating `guide`, one claim there turned out to be false and is corrected: it said a debug run's install conflict "cannot arise" because every debug artifact is debug-keystore-signed. A debug run hits exactly this against a physical device carrying a store build, which is how the bug was found.

## Test plan

Reproduced on a physical Samsung SM-G996W against the Play Store build of `io.tlon.groups` (versionCode 428 vs the local 108).

Before, the remedy named the gradle namespace and its command was inert:

```
remedy  io.tlon.landscape is already installed ... (`adb -s RFCR7081Q9L uninstall io.tlon.landscape`)
```

After:

```
install applicationId io.tlon.groups (from the APK; project files say io.tlon.landscape)
error   STIM_INSTALL_FAILED: ... INSTALL_FAILED_VERSION_DOWNGRADE: Update version code 108 is older than current 428
remedy  io.tlon.groups is already installed on RFCR7081Q9L at a higher versionCode. Uninstall it
        first (`adb -s RFCR7081Q9L uninstall io.tlon.groups`); its data goes with it. Then run this
        command again; it installs the APK from cache without building it again.
```

Unit tests cover the install call, the release retry (asserting `packageName` alongside `allowUninstall: true`), the remedy text, and the unreadable-APK fallback. 2592 tests pass, plus format, lint, typecheck and knip.
