### PR TITLE
Drop the stale-APK mtime refusal

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -19,7 +19,6 @@ import {
   parseApkFromTranscript,
   parseOutputMetadata,
   pickDebugApk,
-  staleApkRefusal,
   variantNameOf,
 } from '../engine/gradle.ts';
 import { makeWriter } from './_factories.ts';
@@ -278,34 +277,6 @@ describe('locateApk', () => {
     const result = locateApk(root, '');
     expect(result.apkPath).toBe(apk);
     expect(result.note).toBeUndefined();
-  });
-});
-
-describe('staleApkRefusal', () => {
-  const task = 'assembleDebug';
-  const apkPath = '/w/android/app/build/outputs/apk/debug/app-debug.apk';
-
-  test('an APK older than the build that just ran is refused, naming the file', () => {
-    const refusal = staleApkRefusal({ task, apkPath, mtimeMs: 1_000_000, buildStartMs: 2_000_000 });
-    assert(refusal);
-    expect(refusal.code).toBe(BUILD_ERROR);
-    expect(refusal.reason).toMatch(/predates the build/);
-    expect(refusal.reason).toContain(apkPath);
-    expect(refusal.remedy).toMatch(/android\.variant/);
-  });
-
-  test('an APK written during or after the build is fresh', () => {
-    expect(staleApkRefusal({ task, apkPath, mtimeMs: 2_000_500, buildStartMs: 2_000_000 })).toBe(null);
-    expect(staleApkRefusal({ task, apkPath, mtimeMs: 5_000_000, buildStartMs: 2_000_000 })).toBe(null);
-  });
-
-  test('the slop absorbs filesystem timestamp granularity', () => {
-    expect(staleApkRefusal({ task, apkPath, mtimeMs: 1_999_000, buildStartMs: 2_000_000 })).toBe(null);
-    expect(staleApkRefusal({ task, apkPath, mtimeMs: 1_997_000, buildStartMs: 2_000_000 })).not.toBe(null);
-  });
-
-  test('an unreadable mtime never refuses', () => {
-    expect(staleApkRefusal({ task, apkPath, mtimeMs: Number.NaN, buildStartMs: 2_000_000 })).toBe(null);
   });
 });
 
@@ -605,18 +576,22 @@ describe('buildAndroid', () => {
     expect(result.lastLines.some((l) => l.includes('app-production-debug.apk'))).toBeTruthy();
   });
 
-  test('an APK whose mtime predates the build is refused as a stale carried artifact', async () => {
+  test('an UP-TO-DATE variant build installs the APK gradle left in place, whatever its mtime (#154)', async () => {
     makeAndroidProject();
-    const apk = writeApk('app-debug.apk');
+    const apk = writeFlavoredApk('preview', 'debug', 'app-preview-debug.apk');
     const old = (Date.now() - 3_600_000) / 1000;
     utimesSync(apk, old, old);
     const result = await buildAndroid(
-      { root, logWriter: recordingWriter() },
-      { spawnFn: () => fakeChild({ lines: ['BUILD SUCCESSFUL in 1s'] }) },
+      { root, logWriter: recordingWriter(), variant: 'previewDebug' },
+      {
+        spawnFn: () =>
+          fakeChild({
+            lines: ['BUILD SUCCESSFUL in 13s', '1055 actionable tasks: 78 executed, 977 up-to-date'],
+          }),
+      },
     );
-    expect(result.failed).toBe(true);
-    expect(result.code).toBe(BUILD_ERROR);
-    expect(result.reason).toMatch(/predates the build/);
+    expect((result as BuildAndroidResultLike).ok).toBe(true);
+    expect((result as BuildAndroidResultLike).apkPath).toBe(apk);
   });
 
   test('a wrapper that will not execute names the permission bit', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -303,6 +303,21 @@ test('the errors topic documents every code the engine can emit under a command'
   }
 });
 
+test('STIM_BUILD_FAILED lists only the Android refusals gradle.ts still raises (#154)', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  const section = body.slice(body.indexOf('STIM_BUILD_FAILED'), body.indexOf('FALLBACK NOTES THAT ARE NOT CODES'));
+  const gradle = readFileSync(new URL('../engine/gradle.ts', import.meta.url), 'utf-8');
+
+  expect(gradle).not.toMatch(/mtime|predates the build/);
+  expect(section).toContain('Two Android refusals');
+  expect(section).toMatch(/MORE THAN ONE debug APK/);
+  expect(section).toMatch(/NO APK for the configured variant/);
+  expect(section).not.toMatch(/STALE APK/);
+  expect(section).toMatch(/AN APK OLDER THAN THE BUILD IS NOT A REFUSAL/);
+  expect(section.replace(/\s+/g, ' ')).toContain('reports UP-TO-DATE');
+});
+
 test('the STIM_DEPS_FAILED ladder names the commands and the gate the engine actually uses (#137)', () => {
   const body = renderTopic('errors');
   assert(body);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -502,7 +502,7 @@ STIM_DEPS_FAILED
 STIM_BUILD_FAILED
   xcodebuild or gradle failed. The EXTRACTED diagnostics are printed (capped),
   not the transcript. Read the log path on the next line for the rest.
-  Three Android refusals share this code without gradle itself failing:
+  Two Android refusals share this code without gradle itself failing:
   - MORE THAN ONE debug APK under android/app/build/outputs/apk and nothing
     configured to pick one (a project with product flavors, several flavors
     already built). Stim will not guess which flavor to install: the
@@ -511,10 +511,11 @@ STIM_BUILD_FAILED
   - NO APK for the configured variant: the android.variant / --variant value
     does not name a real variant (\`./gradlew :app:tasks\` in android/ lists
     the assemble tasks).
-  - A STALE APK: the build succeeded but the APK's mtime predates the build
-    that just ran, so it is an artifact this run did not produce (a copied
-    build/ directory, a carried worktree). Delete
-    android/app/build/outputs/apk and run again.
+  AN APK OLDER THAN THE BUILD IS NOT A REFUSAL. \`assembleDebug\` packages every
+  flavor, so a later \`--variant previewDebug\` finds a current APK that gradle
+  reports UP-TO-DATE and repackages nothing. Stim installs it. Gradle owns task
+  freshness and the fingerprint owns cache freshness; Stim does not second-guess
+  either from the file's mtime.
 
 FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
   On a release cache hit Stim regenerates this workspace's JS bundle into a

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -234,29 +234,6 @@ export function locateApk(root: string, transcript = '', variant: string | null 
   return { apkPath: null };
 }
 
-export function staleApkRefusal({
-  task,
-  apkPath,
-  mtimeMs,
-  buildStartMs,
-  slopMs = 2000,
-}: {
-  task: string;
-  apkPath: string;
-  mtimeMs: number;
-  buildStartMs: number;
-  slopMs?: number;
-}): { code: string; reason: string; remedy: string } | null {
-  if (!Number.isFinite(mtimeMs) || !Number.isFinite(buildStartMs)) return null;
-  if (mtimeMs >= buildStartMs - slopMs) return null;
-  return {
-    code: BUILD_ERROR,
-    reason: `\`./gradlew ${task}\` succeeded, but the APK at ${apkPath} predates the build that just ran, so it is a stale artifact this run did not produce.`,
-    remedy:
-      'Delete android/app/build/outputs/apk and run again so gradle repackages the APK. If the build was UP-TO-DATE because a flavor redirects its output elsewhere, set the android.variant setting.',
-  };
-}
-
 export type BuildAndroidResult = {
   ok?: boolean;
   apkPath?: string;
@@ -420,15 +397,6 @@ export async function buildAndroid(
     };
   }
   const apkPath = located.apkPath;
-
-  let mtimeMs = Number.NaN;
-  try {
-    mtimeMs = statSync(apkPath).mtimeMs;
-  } catch {}
-  const stale = staleApkRefusal({ task, apkPath, mtimeMs, buildStartMs: startedAt });
-  if (stale) {
-    return { failed: true, ...stale, diagnostics: [], truncated: 0, lastLines: tail.slice(), durationMs };
-  }
 
   return { ok: true, apkPath, apkNote: located.note ?? null, durationMs, lastLines: tail.slice() };
 }


### PR DESCRIPTION
Closes #154

## Description

`staleApkRefusal` failed a run when the APK's mtime predated the build's start. On a flavored project that refuses valid builds: `assembleDebug` builds every flavor, so a later `--variant previewDebug` finds a correct, current APK that Gradle rightly reports UP-TO-DATE, and the mtime check calls it stale. The only remedy offered was deleting `outputs/apk` and paying a full rebuild.

The protection it advertised does not apply where it fires. The check lives in `buildAndroid`, so it only runs on a cache miss and never sees a cache hit. It has no release gate, so it fires on debug builds, where the app loads its JS from Metro and the bundle inside the APK is unused. Native staleness is already covered twice: the fingerprint gates the cache on native inputs, and Gradle gates its own task inputs.

## Solution

Remove the check rather than replace it.

Correlating against AGP's `output-metadata.json` -- the option the issue floated -- is **already implemented**. `apkInDir` reads that file and prefers the `outputFile` it names, and `findVariantApkDir` matches the requested variant against AGP's own output layout. A second comparison would restate a match that locating the APK already makes, while adding a fresh way to refuse a valid build. An APK that is genuinely absent still fails, unchanged, through a different path.

## The APP_VARIANT question from the issue, measured

The issue asked whether an env var changing generated config without Gradle seeing it opens a hole. Ran `@expo/fingerprint` twice against the real `apps/tlon-mobile`:

| | hash | expoConfig source hash |
| --- | --- | --- |
| unset | `84baf31e...` | `77c26253...` |
| `APP_VARIANT=preview` | `226d7232...` | `74eb7499...` |

Detection is covered. `@expo/fingerprint` spawns `ExpoConfigLoader` without an `env` override, so the child inherits the environment, the evaluated config is hashed, and the cache key moves.

Regeneration is not covered -- but the mtime check never covered it either. `needsPrebuild` only runs `expo prebuild` when `android/` is absent, so a project with a committed `android/` builds from whatever the last prebuild wrote. The old check did fire there, but its remedy reproduced the identical APK from identical sources, so it was a dead end rather than a protection. The real remedy is `expo prebuild -p android`.

For tlon specifically it was a pure false failure: `build.gradle` declares the flavors, so the variant is a Gradle input and never needed to reach the APK through generated config.

## Test plan

Unit: a `previewDebug` build with an APK backdated an hour and a transcript of `BUILD SUCCESSFUL` + `977 up-to-date` now installs instead of refusing. Confirmed it failed first against the old code for the right reason.

On a physical Samsung SM-G996W, the sequence that used to refuse twice in a row:

```
assembleDebug (both flavors built)         -> refuses, name a flavor      (unchanged, correct)
--variant previewDebug --no-build-cache    -> build app-preview-debug.apk (13s)
                                              install app-preview-debug.apk (42.7s)
                                              OK: launched
```

`--no-build-cache` forces `buildAndroid`, which is the only path the removed check sat on. Before, that second run failed with `predates the build that just ran`.

`guide` gains a paragraph saying an APK older than the build is not a refusal and naming who owns freshness. A new contract test asserts the errors topic lists exactly the two refusals `gradle.ts` still raises and that `gradle.ts` contains no `mtime` / `predates the build` text, so the doc and the code cannot drift apart again.

2586 tests pass, plus format, lint, typecheck and knip.
