### PR TITLE
Refuse a flavored Android project before gradle runs

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1101,6 +1101,55 @@ describe('product flavors (--variant / android.variant)', () => {
     expect(result.facts.variant).toBe(null);
   });
 
+  const FLAVORED_BUILD_GRADLE = `android {
+    productFlavors {
+        production { applicationId "io.tlon.groups" }
+        preview { applicationId "io.tlon.groups.preview" }
+    }
+}
+`;
+
+  const declareFlavors = (text = FLAVORED_BUILD_GRADLE) =>
+    writeFileSync(join(root, 'android', 'app', 'build.gradle'), text);
+
+  test('declared flavors with no variant selected are refused before any device or build work', async () => {
+    declareFlavors();
+    const h = harness({ ensureDevice: never('the device'), build: never('the build') });
+    const result = await h.run();
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_BAD_ARG');
+    expect(result.error?.message).toMatch(/2 product flavors/);
+    expect(result.error?.remedy).toMatch(/productionDebug, previewDebug/);
+    expect(h.calls.ensureDevice).toEqual([]);
+    expect(h.calls.fingerprint).toEqual([]);
+    expect(h.calls.build).toEqual([]);
+  });
+
+  test('a selected variant says which flavor to build, so the flavored project builds', async () => {
+    declareFlavors();
+    const h = harness({ variant: 'productionDebug' });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.calls.build[0]?.variant).toBe('productionDebug');
+  });
+
+  test('a flavor declaration Stim cannot read builds, and the post-build refusal still applies', async () => {
+    declareFlavors(`android {
+    namespace "com.example.app"
+    productFlavors {
+        flavorNames.each { name ->
+            create(name) { }
+        }
+    }
+}
+`);
+    const h = harness();
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.calls.build.length).toBe(1);
+  });
+
   test("a variant reaches the provider's runOptions, so a flavored resolve is never answered with plain debug", async () => {
     setProjectSetting(root, 'android.variant', 'productionDebug');
     const h = harness({

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -18,7 +18,10 @@ import {
   locateApk,
   parseApkFromTranscript,
   parseOutputMetadata,
+  parseProductFlavors,
   pickDebugApk,
+  productFlavorRefusal,
+  readProductFlavors,
   variantNameOf,
 } from '../engine/gradle.ts';
 import { makeWriter } from './_factories.ts';
@@ -700,5 +703,217 @@ describe('buildAndroid', () => {
       },
     );
     expect((result as BuildAndroidResultLike).ok).toBe(true);
+  });
+});
+
+const FLAVORED_GRADLE = `apply plugin: "com.android.application"
+
+android {
+    namespace "com.example.app"
+    defaultConfig {
+        applicationId "io.tlon.groups"
+    }
+    productFlavors {
+        production {
+            applicationId "io.tlon.groups"
+        }
+        preview {
+            applicationId "io.tlon.groups.preview"
+        }
+    }
+}
+`;
+
+const PLAIN_GRADLE = `apply plugin: "com.android.application"
+
+android {
+    namespace "com.example.app"
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            minifyEnabled true
+        }
+    }
+}
+`;
+
+const NESTED_GRADLE = `android {
+    productFlavors {
+        production {
+            manifestPlaceholders = [appName: "Groups"]
+            ndk {
+                abiFilters "arm64-v8a", "x86_64"
+            }
+        }
+        preview {
+            buildConfigField "boolean", "PREVIEW", "true"
+        }
+    }
+}
+`;
+
+const COMMENTED_GRADLE = `android {
+    // productFlavors {
+    //     staging { }
+    // }
+    /* the flavors this project used to ship:
+    productFlavors {
+        legacy { }
+    }
+    */
+    productFlavors {
+        production { } // the store build
+        preview { }
+    }
+}
+`;
+
+const LOOPED_GRADLE = `def flavorNames = ["production", "preview"]
+
+android {
+    productFlavors {
+        flavorNames.each { name ->
+            create(name) {
+                applicationId "io.tlon.groups.\${name}"
+            }
+        }
+    }
+}
+`;
+
+const DIMENSIONED_GRADLE = `android {
+    flavorDimensions "tier", "store"
+    productFlavors {
+        free { dimension "tier" }
+        paid { dimension "tier" }
+        play { dimension "store" }
+        amazon { dimension "store" }
+    }
+}
+`;
+
+describe('parseProductFlavors', () => {
+  test('reads the flavor names of a two-flavor block in declaration order', () => {
+    expect(parseProductFlavors(FLAVORED_GRADLE)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('a project without flavors parses as known and empty', () => {
+    expect(parseProductFlavors(PLAIN_GRADLE)).toEqual({ known: true, dimensions: [] });
+  });
+
+  test('braces nested inside a flavor body do not end the flavor', () => {
+    expect(parseProductFlavors(NESTED_GRADLE)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('commented-out blocks are ignored and the real block is read', () => {
+    expect(parseProductFlavors(COMMENTED_GRADLE)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('flavors built from a variable in a loop are unknown, not a guess', () => {
+    expect(parseProductFlavors(LOOPED_GRADLE)).toEqual({ known: false, dimensions: [] });
+  });
+
+  test('multiple dimensions come back grouped in flavorDimensions order', () => {
+    expect(parseProductFlavors(DIMENSIONED_GRADLE)).toEqual({
+      known: true,
+      dimensions: [
+        ['free', 'paid'],
+        ['play', 'amazon'],
+      ],
+    });
+  });
+
+  test('a variantFilter can drop variants, so the file is unknown', () => {
+    expect(
+      parseProductFlavors(`${FLAVORED_GRADLE}\nandroid.variantFilter { variant -> variant.setIgnore(true) }\n`),
+    ).toEqual({ known: false, dimensions: [] });
+  });
+
+  test('a text that is not a string is unknown', () => {
+    expect(parseProductFlavors(null)).toEqual({ known: false, dimensions: [] });
+  });
+});
+
+describe('productFlavorRefusal', () => {
+  test('names the debug variants when flavors are declared and no variant was selected', () => {
+    const refusal = productFlavorRefusal({ flavors: parseProductFlavors(FLAVORED_GRADLE), variant: null });
+    assert(refusal);
+    expect(refusal.code).toBe('STIM_BAD_ARG');
+    expect(refusal.reason).toMatch(/2 product flavors/);
+    expect(refusal.reason).toMatch(/android\/app\/build\.gradle/);
+    expect(refusal.remedy).toMatch(/productionDebug, previewDebug/);
+  });
+
+  test('every dimension combination is named', () => {
+    const refusal = productFlavorRefusal({ flavors: parseProductFlavors(DIMENSIONED_GRADLE), variant: null });
+    assert(refusal);
+    expect(refusal.remedy).toMatch(/freePlayDebug, freeAmazonDebug, paidPlayDebug, paidAmazonDebug/);
+  });
+
+  test('a selected variant says which flavor to build, so there is nothing to refuse', () => {
+    expect(productFlavorRefusal({ flavors: parseProductFlavors(FLAVORED_GRADLE), variant: 'productionDebug' })).toBe(
+      null,
+    );
+  });
+
+  test('an unreadable declaration falls through to the build', () => {
+    expect(productFlavorRefusal({ flavors: parseProductFlavors(LOOPED_GRADLE), variant: null })).toBe(null);
+  });
+
+  test('a single flavor builds one APK, so there is nothing to refuse', () => {
+    const single = parseProductFlavors('android {\n  productFlavors {\n    production { }\n  }\n}\n');
+    expect(productFlavorRefusal({ flavors: single, variant: null })).toBe(null);
+  });
+
+  test('no flavors at all is nothing to refuse', () => {
+    expect(productFlavorRefusal({ flavors: parseProductFlavors(PLAIN_GRADLE), variant: null })).toBe(null);
+  });
+});
+
+describe('readProductFlavors', () => {
+  test('reads android/app/build.gradle', () => {
+    mkdirSync(join(root, 'android', 'app'), { recursive: true });
+    writeFileSync(join(root, 'android', 'app', 'build.gradle'), FLAVORED_GRADLE);
+    expect(readProductFlavors(root)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('a project whose android/ is not generated yet is unknown', () => {
+    expect(readProductFlavors(root)).toEqual({ known: false, dimensions: [] });
+  });
+});
+
+describe('a real flavored build.gradle', () => {
+  const TLON_GRADLE = `android {
+    flavorDimensions "profile"
+    productFlavors {
+        production {
+            dimension "profile"
+            applicationId "io.tlon.groups"
+        }
+        preview {
+            dimension "profile"
+            applicationId "io.tlon.groups.preview"
+        }
+    }
+}
+`;
+
+  test('one declared dimension groups every flavor into it', () => {
+    expect(parseProductFlavors(TLON_GRADLE)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('flavors that name one dimension with no flavorDimensions statement still group', () => {
+    const text = TLON_GRADLE.replace('    flavorDimensions "profile"\n', '');
+    expect(parseProductFlavors(text)).toEqual({ known: true, dimensions: [['production', 'preview']] });
+  });
+
+  test('flavors that name different dimensions with no declared order are unknown', () => {
+    const text = TLON_GRADLE.replace('    flavorDimensions "profile"\n', '').replace(
+      'dimension "profile"\n            applicationId "io.tlon.groups.preview"',
+      'dimension "store"\n            applicationId "io.tlon.groups.preview"',
+    );
+    expect(parseProductFlavors(text)).toEqual({ known: false, dimensions: [] });
   });
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -558,3 +558,15 @@ test('the guide documents the project cache provider as the tier between local a
   expect(settings).toMatch(/sharedCacheStores\(\)[\s\S]*stays local-only/);
   expect(lifecycle).toMatch(/--no-build-cache looks nothing up -- not the local cache, not either/);
 });
+
+test('the guide documents the flavor refusal that lands before the build', () => {
+  const lifecycle = renderTopic('lifecycle');
+  const errors = renderTopic('errors');
+  assert(lifecycle);
+  assert(errors);
+
+  expect(lifecycle).toMatch(/refuses BEFORE gradle runs and names the debug\s+variants/);
+  expect(lifecycle).toMatch(/best-effort[\s\S]*variable, a loop, or an applied script/);
+  expect(errors).toMatch(/STIM_BAD_ARG[\s\S]*declares product flavors with\s+no variant selected/);
+  expect(errors).toMatch(/caught before\s+the build instead \(STIM_BAD_ARG\)/);
+});

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -111,7 +111,7 @@ import { detectProviders } from '../engine/metro-reach.ts';
 import { ownedSessionName } from '../engine/eas-simulator.ts';
 import type { OwnedDeviceRecord } from '../engine/device.ts';
 import { needsPrebuild, runPrebuild } from '../engine/prebuild.ts';
-import { buildAndroid } from '../engine/gradle.ts';
+import { buildAndroid, productFlavorRefusal, readProductFlavors } from '../engine/gradle.ts';
 import { resolveKeystore, swapApkBundle } from '../engine/apk-swap.ts';
 import { captureAssetManifest } from '../engine/asset-manifest.ts';
 import {
@@ -1585,6 +1585,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     );
   }
   const variant = resolveVariant(variantFlag, settings);
+  const flavorRefusal = productFlavorRefusal({ flavors: readProductFlavors(root), variant });
+  if (flavorRefusal) return fail(flavorRefusal.code, flavorRefusal.reason, flavorRefusal.remedy);
   const release = isReleaseVariant(variant);
   const isExpo = detectIsExpo(root);
   const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -508,6 +508,9 @@ STIM_BUILD_FAILED
     already built). Stim will not guess which flavor to install: the
     refusal lists the candidates -- pass \`--variant <name>\` or set the
     android.variant setting (e.g. "productionDebug") to the one you want.
+    Flavors declared plainly in android/app/build.gradle are caught before
+    the build instead (STIM_BAD_ARG); this one remains for the declarations
+    that parse cannot read.
   - NO APK for the configured variant: the android.variant / --variant value
     does not name a real variant (\`./gradlew :app:tasks\` in android/ lists
     the assemble tasks).
@@ -730,8 +733,9 @@ STIM_SUPERVISOR_EXITED
 STIM_BAD_ARG / STIM_NO_PROJECT
   The command refused before doing anything: an unusable --wait value, an invalid
   Metro tunnel setting, an invalid android.dataPartitionSizeGb value, an unsafe
-  android.avdConfig key or fragment, or a working directory with no package.json
-  above it.
+  android.avdConfig key or fragment, a working directory with no package.json
+  above it, or an android/app/build.gradle that declares product flavors with
+  no variant selected (the refusal names the debug variants).
   These errors are caught before the port is reserved and before anything is
   spawned, so nothing was started.
 
@@ -1158,6 +1162,12 @@ THE OPTION SURFACE, IN FULL
   setting (see \`guide settings\`), which is the repo-level default; unset,
   the plain \`assembleDebug\` flow is unchanged. The --json payload's
   \`variant\` field reports what was built (null for the default).
+  When neither is set and android/app/build.gradle declares more than one
+  product flavor, \`android\` refuses BEFORE gradle runs and names the debug
+  variants to choose from, because \`assembleDebug\` would build every flavor
+  and leave nothing to pick from. That parse is best-effort: flavors built
+  from a variable, a loop, or an applied script are not detected, and such a
+  project builds as before.
 
   \`android --device [serial]\` installs and launches on a physical device
   connected to this machine instead of this workspace's owned emulator. With

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -234,6 +234,178 @@ export function locateApk(root: string, transcript = '', variant: string | null 
   return { apkPath: null };
 }
 
+export interface ProductFlavors {
+  known: boolean;
+  dimensions: string[][];
+}
+
+const UNKNOWN_FLAVORS: ProductFlavors = { known: false, dimensions: [] };
+
+function stripGroovyComments(text: string): string {
+  let out = '';
+  let quote = '';
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i]!;
+    const next = text[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === '\\') {
+        out += next ?? '';
+        i += 2;
+        continue;
+      }
+      if (ch === quote) quote = '';
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      while (i < text.length && text[i] !== '\n') i += 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i += 1;
+      i += 2;
+      out += ' ';
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+function closingBrace(text: string, open: number): number {
+  let depth = 1;
+  let quote = '';
+  for (let i = open; i < text.length; i += 1) {
+    const ch = text[i]!;
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === '"' || ch === "'") quote = ch;
+    else if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function productFlavorsBody(text: string): string | null {
+  const match = /(?:^|[^\w.])productFlavors\s*\{/.exec(text);
+  if (!match) return null;
+  const open = match.index + match[0].length;
+  const close = closingBrace(text, open);
+  return close < 0 ? null : text.slice(open, close);
+}
+
+function parseFlavorBlocks(body: string): { name: string; body: string }[] | null {
+  const entry = /([A-Za-z_][A-Za-z0-9_]*)\s*\{/y;
+  const blocks: { name: string; body: string }[] = [];
+  let i = 0;
+  while (i < body.length) {
+    if (/\s/.test(body[i]!)) {
+      i += 1;
+      continue;
+    }
+    entry.lastIndex = i;
+    const match = entry.exec(body);
+    if (!match) return null;
+    const open = i + match[0].length;
+    const close = closingBrace(body, open);
+    if (close < 0) return null;
+    blocks.push({ name: match[1]!, body: body.slice(open, close) });
+    i = close + 1;
+  }
+  return blocks;
+}
+
+function parseDimensionNames(text: string): string[] | null | undefined {
+  const statements = [...text.matchAll(/\bflavorDimensions\b([^\n]*)/g)];
+  if (statements.length === 0) return undefined;
+  const names: string[] = [];
+  for (const statement of statements) {
+    const line = statement[1] ?? '';
+    for (const quoted of line.matchAll(/(["'])([^"']*)\1/g)) names.push(quoted[2]!);
+    const rest = line.replace(/(["'])[^"']*\1/g, '').replace(/[[\]()=+,;]/g, '');
+    if (rest.trim() !== '') return null;
+  }
+  return names.length ? names : null;
+}
+
+function declaredDimensionOf(flavorBody: string): string | null {
+  const match = /\bdimension\b\s*=?\s*(["'])([^"']*)\1/.exec(flavorBody);
+  return match ? match[2]! : null;
+}
+
+export function parseProductFlavors(source: unknown): ProductFlavors {
+  if (typeof source !== 'string') return UNKNOWN_FLAVORS;
+  const text = stripGroovyComments(source);
+  if (/\bvariantFilter\b/.test(text)) return UNKNOWN_FLAVORS;
+  if (!/\bproductFlavors\b/.test(text)) return { known: true, dimensions: [] };
+  const body = productFlavorsBody(text);
+  if (body === null) return UNKNOWN_FLAVORS;
+  const flavors = parseFlavorBlocks(body);
+  if (!flavors) return UNKNOWN_FLAVORS;
+  if (flavors.length === 0) return { known: true, dimensions: [] };
+
+  const declared = parseDimensionNames(text);
+  if (declared === null) return UNKNOWN_FLAVORS;
+  const named = flavors.map((flavor) => declaredDimensionOf(flavor.body));
+  const used = [...new Set(named.filter((name) => name !== null))];
+  if (!declared || declared.length === 1) {
+    const only = declared ? declared[0] : used[0];
+    if (used.some((name) => name !== only)) return UNKNOWN_FLAVORS;
+    return { known: true, dimensions: [flavors.map((flavor) => flavor.name)] };
+  }
+  if (named.some((name) => name === null || !declared.includes(name))) return UNKNOWN_FLAVORS;
+  const dimensions: string[][] = [];
+  for (const dimension of declared) {
+    const group = flavors.filter((_, i) => named[i] === dimension).map((flavor) => flavor.name);
+    if (group.length === 0) return UNKNOWN_FLAVORS;
+    dimensions.push(group);
+  }
+  return { known: true, dimensions };
+}
+
+export function readProductFlavors(root: string): ProductFlavors {
+  return parseProductFlavors(readOrNull(join(androidDir(root), 'app', 'build.gradle')));
+}
+
+export function productFlavorRefusal({
+  flavors,
+  variant,
+}: {
+  flavors: ProductFlavors;
+  variant?: string | null;
+}): { code: string; reason: string; remedy: string } | null {
+  if (variant) return null;
+  if (!flavors.known || flavors.dimensions.length === 0) return null;
+  let combinations: string[][] = [[]];
+  for (const group of flavors.dimensions) {
+    combinations = combinations.flatMap((combination) => group.map((flavor) => combination.concat(flavor)));
+  }
+  if (combinations.length < 2) return null;
+  const count = flavors.dimensions.reduce((total, group) => total + group.length, 0);
+  const variants = combinations.map((combination) => variantNameOf(combination.concat('debug')));
+  return {
+    code: 'STIM_BAD_ARG',
+    reason: `android/app/build.gradle declares ${count} product flavors, so \`./gradlew ${ASSEMBLE_TASK}\` builds an APK for each of them and nothing says which flavor to install.`,
+    remedy: `Pass \`--variant ${variants[0]}\` or set the android.variant setting -- e.g. {"android": {"variant": "${variants[0]}"}} in .stim.json. The debug variants are: ${variants.join(', ')}.`,
+  };
+}
+
 export type BuildAndroidResult = {
   ok?: boolean;
   apkPath?: string;


### PR DESCRIPTION
Closes #153

## Description

On a project with product flavors, `stim android` with no variant ran `assembleDebug`, which builds every flavor, and only then refused because two APKs existed and nothing said which to install. On tlon that was a full Gradle build before the refusal -- up to six minutes cold.

## Solution

Read the flavors from `android/app/build.gradle` before any device, metro, fingerprint or build work, and refuse immediately with the variants that would actually build.

```
error   STIM_BAD_ARG: android/app/build.gradle declares 2 product flavors, so
        `./gradlew assembleDebug` builds an APK for each of them and nothing says
        which flavor to install.
remedy  Pass `--variant productionDebug` or set the android.variant setting ...
        The debug variants are: productionDebug, previewDebug.
```

Parsing is best-effort and fails open. `parseProductFlavors` strips comments quote-aware, brace-matches the `productFlavors` block, and groups entries by `flavorDimensions` order; anything it cannot read returns unknown and the run proceeds exactly as before, leaving the post-build refusal as the backstop. The refusal only fires when the parse is confident, no variant was selected, and the flavors produce more than one variant.

No Gradle invocation is added -- that would cost seconds and defeat the point.

## Scope, per the issue discussion

The Expo config is not consulted: product flavors are not an Expo concept and cannot be read from `app.json` / `app.config`. A prebuild project only gets flavors if a config plugin injects them into the generated `build.gradle`, where the same parse applies.

A project with no `android/` yet does nothing and falls through, because `needsPrebuild` runs inside the build block and there is no `build.gradle` to read at the point a fast refusal would help.

## Deliberately unhandled, all falling through to existing behaviour

- Dot-qualified `android.productFlavors { }`, `create("name")` entries, and `build.gradle.kts`.
- Any file mentioning `variantFilter`, since a filter can drop a variant and make a two-flavor project produce one APK.
- Variant existence is never verified; a `--variant` typo still fails the old way.

Other exotic ways to drop a variant are not detected. Those would name a variant that does not build, which the user resolves by picking the other one.

## Test plan

On the real tlon project, the unspecified-variant case now refuses in **0.25s** instead of building, and `--variant previewDebug` still installs and launches normally on a physical device.

Unit tests cover a two-flavor block, no flavors, nested braces, commented-out blocks, variable and loop declarations (unknown, not a wrong answer), multiple dimensions with a cross product, `variantFilter`, non-string input, a single flavor, a selected variant, a missing `build.gradle`, and tlon's real shape. Command tests assert the refusal happens before any device, fingerprint or build call, that `--variant` builds normally, and that an unreadable declaration still reaches the post-build refusal.

The parser was also run over 23 real `android/app/build.gradle` files on this machine: the three flavored projects refuse with correct variant names, one that declares flavors through an applied script comes back unknown and falls through, and no plain project is refused.

2612 tests pass, plus format, lint, typecheck and knip.
