### PR TITLE
Skip the install when the device already holds the artifact

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -979,6 +979,7 @@ describe('a cache hit', () => {
       waitedForBuild: null,
       appPath: '/cache/app-debug.apk',
       bundleId: 'com.example.app',
+      installSkipped: false,
       launched: true,
       debugHttpHost: '10.0.2.2:8082',
       debugHttpHostNote: null,
@@ -2123,6 +2124,7 @@ describe('the pure parts', () => {
       waitedForBuild: null,
       appPath: null,
       bundleId: null,
+      installSkipped: false,
       launched: false,
       debugHttpHost: null,
       debugHttpHostNote: null,
@@ -3626,4 +3628,29 @@ test('the wired line reports the reverses that were actually registered', async 
   const wired = labelled(h.stderr, 'wired').join(' ');
   expect(wired).toContain('tcp:8082->tcp:8082');
   expect(wired).not.toContain('tcp:8081');
+});
+
+describe('an APK the device already holds', () => {
+  test('the skip is named on the install line and carried in the facts', async () => {
+    const h = harness({
+      resolveCached: () => '/cache/app-debug.apk',
+      build: never('the build'),
+      install: (args: InstallArgs = {}) => ({ ok: true, apkPath: args.apkPath ?? '', skipped: true }),
+    });
+    const result = await h.run();
+
+    expect(result.ok).toBe(true);
+    expect(labelled(h.stderr, 'install')[0]).toMatch(/skipped; emulator-5584 already holds this APK/);
+    assert(result.facts);
+    expect(result.facts.installSkipped).toBe(true);
+  });
+
+  test('an install that really ran reports installSkipped false', async () => {
+    const h = harness({ resolveCached: () => '/cache/app-debug.apk', build: never('the build') });
+    const result = await h.run();
+
+    assert(result.facts);
+    expect(result.facts.installSkipped).toBe(false);
+    expect(labelled(h.stderr, 'install')[0]).not.toMatch(/skipped/);
+  });
 });

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Executor } from '../exec.ts';
@@ -41,6 +41,7 @@ import {
   reverseMetroPorts,
   writeDebugHttpHost,
 } from '../engine/app-install.ts';
+import { hashFile } from '../engine/installed-artifact.ts';
 
 type LaunchResult = {
   ok?: boolean;
@@ -144,6 +145,7 @@ describe('ios', () => {
       ),
     ).toEqual({ ok: true, appPath });
     expect(exec.calls).toEqual([
+      ['xcrun', 'simctl', 'get_app_container', 'U1', 'com.example.app'],
       ['xcrun', 'simctl', 'install', 'U1', appPath],
       [
         'xcrun',
@@ -1007,6 +1009,7 @@ describe('installAndroidApp: the uninstall-and-retry, exactly once', () => {
     expect(result.note).toMatch(/different signer/);
     expect(result.note).toMatch(/data went with it/);
     expect(calls).toEqual([
+      ['adb', '-s', 'emulator-5584', 'shell', 'pm', 'path', 'com.example.app'],
       ['adb', '-s', 'emulator-5584', 'install', '-r', apkPath],
       ['adb', '-s', 'emulator-5584', 'uninstall', 'com.example.app'],
       ['adb', '-s', 'emulator-5584', 'install', '-r', apkPath],
@@ -1735,5 +1738,95 @@ describe('the 8081 adb reverse is a fallback, not a default', () => {
     const { calls, exec } = execRecording(true);
     launchAndroidApp({ serial: 'emulator-5554', packageName: 'com.example.app', metroPort: 8081 }, { exec });
     expect(reverses(calls)).toEqual(['tcp:8081 tcp:8081']);
+  });
+});
+
+describe('skipping an install the device already holds', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'stim-identical-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function localApk(body = 'apk bytes') {
+    const path = join(dir, 'app-debug.apk');
+    writeFileSync(path, body);
+    return path;
+  }
+
+  function localApp(name: string, body: string) {
+    const path = join(dir, name);
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, 'Fixture'), body);
+    return path;
+  }
+
+  test('an identical APK is not installed again, and says so', () => {
+    const apkPath = localApk();
+    const exec = recordingExec({
+      outputs: {
+        'pm path': 'package:/data/app/a/base.apk\n',
+        sha256sum: `${hashFile(apkPath)}  /data/app/a/base.apk\n`,
+      },
+    });
+    const result = installAndroidApp({ serial: 'emulator-5584', apkPath, packageName: 'com.example.app' }, { exec });
+    expect(result).toEqual({ ok: true, apkPath, skipped: true });
+    expect(exec.calls.some((c) => c.includes('install'))).toBe(false);
+  });
+
+  test('a RELEASE run installs the swapped APK: fresh JS makes it a different artifact', () => {
+    const cachedApk = localApk('apk with the builders js');
+    const swappedApk = join(dir, 'apk-swap', 'app-production-release.apk');
+    mkdirSync(join(dir, 'apk-swap'), { recursive: true });
+    writeFileSync(swappedApk, 'apk with this workspaces js');
+    const exec = recordingExec({
+      outputs: {
+        'pm path': 'package:/data/app/a/base.apk\n',
+        sha256sum: `${hashFile(cachedApk)}  /data/app/a/base.apk\n`,
+      },
+    });
+    const result = installAndroidApp(
+      { serial: 'emulator-5584', apkPath: swappedApk, packageName: 'com.example.app', allowUninstall: true },
+      { exec },
+    );
+    expect(result).toEqual({ ok: true, apkPath: swappedApk });
+    expect(exec.calls).toContainEqual(['adb', '-s', 'emulator-5584', 'install', '-r', swappedApk]);
+  });
+
+  test('a device without sha256sum installs exactly as before', () => {
+    const apkPath = localApk();
+    const exec = recordingExec({
+      outputs: { 'pm path': 'package:/data/app/a/base.apk\n', sha256sum: 'sha256sum: not found' },
+    });
+    const result = installAndroidApp({ serial: 'emulator-5584', apkPath, packageName: 'com.example.app' }, { exec });
+    expect(result).toEqual({ ok: true, apkPath });
+    expect(exec.calls).toContainEqual(['adb', '-s', 'emulator-5584', 'install', '-r', apkPath]);
+  });
+
+  test('an identical .app is not installed again, but the dev client is still prepared', () => {
+    const installed = localApp('installed.app', 'macho');
+    const appPath = localApp('built.app', 'macho');
+    const exec = recordingExec({ outputs: { get_app_container: `${installed}\n` } });
+    const result = installIosApp(
+      { udid: 'U1', appPath, bundleId: 'com.example.app', devClientScheme: 'myapp' },
+      { exec },
+    );
+    expect(result).toEqual({ ok: true, appPath, skipped: true });
+    expect(exec.calls.some((c) => c.includes('install'))).toBe(false);
+    expect(exec.calls.some((c) => c.includes('EXDevMenuIsOnboardingFinished'))).toBe(true);
+    expect(exec.calls.some((c) => c.includes('com.apple.CoreSimulator.CoreSimulatorBridge-->myapp'))).toBe(true);
+  });
+
+  test('a .app whose JS was swapped is installed: the container holds the other one', () => {
+    const installed = localApp('installed.app', 'macho');
+    const appPath = localApp('js-swap.app', 'macho with this workspaces js');
+    const exec = recordingExec({ outputs: { get_app_container: `${installed}\n` } });
+    const result = installIosApp({ udid: 'U1', appPath, bundleId: 'com.example.app' }, { exec });
+    expect(result).toEqual({ ok: true, appPath });
+    expect(exec.calls).toContainEqual(['xcrun', 'simctl', 'install', 'U1', appPath]);
   });
 });

--- a/packages/stim-cli/src/__tests__/engine-installed-artifact.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-installed-artifact.test.ts
@@ -1,0 +1,280 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Executor } from '../exec.ts';
+import {
+  artifactsMatch,
+  deviceHoldsApk,
+  deviceHoldsBundle,
+  hashBundle,
+  hashFile,
+  parseAppContainerPath,
+  parseDeviceSha256,
+  parseInstalledApkPath,
+} from '../engine/installed-artifact.ts';
+
+const SHA = 'a'.repeat(64);
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stim-artifact-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+interface RecordingExec extends Executor {
+  calls: string[][];
+}
+
+function recordingExec({
+  outputs = {},
+  fail = null,
+}: { outputs?: Record<string, string>; fail?: string | null } = {}): RecordingExec {
+  const calls: string[][] = [];
+  return {
+    calls,
+    runFile(file: string, args: string[] = []) {
+      calls.push([file, ...args]);
+      const key = [file, ...args].join(' ');
+      if (fail && key.includes(fail)) throw new Error(`Command failed: ${key}`);
+      for (const [match, value] of Object.entries(outputs)) if (key.includes(match)) return value;
+      return '';
+    },
+    run: () => {
+      throw new Error('the identity check must use runFile, not the shell');
+    },
+    runQuiet: () => {
+      throw new Error('the identity check must use runFile, not the shell');
+    },
+    spawn: () => {
+      throw new Error('the identity check does not spawn');
+    },
+  };
+}
+
+describe('parseInstalledApkPath', () => {
+  test('reads the one package path pm reports', () => {
+    expect(parseInstalledApkPath('package:/data/app/~~aB0==/com.example.app-x9/base.apk\n')).toBe(
+      '/data/app/~~aB0==/com.example.app-x9/base.apk',
+    );
+  });
+
+  test('a package that is not installed reports nothing', () => {
+    expect(parseInstalledApkPath('')).toBe(null);
+    expect(parseInstalledApkPath('\n')).toBe(null);
+    expect(parseInstalledApkPath(null)).toBe(null);
+  });
+
+  test('a split install has no single artifact to compare, so it reads as unknown', () => {
+    const text = ['package:/data/app/a/base.apk', 'package:/data/app/a/split_config.arm64_v8a.apk', ''].join('\n');
+    expect(parseInstalledApkPath(text)).toBe(null);
+  });
+
+  test('an error line is not a path', () => {
+    expect(parseInstalledApkPath('Error: android.content.pm.PackageManager$NameNotFoundException')).toBe(null);
+    expect(parseInstalledApkPath('package:')).toBe(null);
+  });
+});
+
+describe('parseDeviceSha256', () => {
+  test('reads the digest sha256sum prints beside the path', () => {
+    expect(parseDeviceSha256(`${SHA}  /data/app/a/base.apk\n`)).toBe(SHA);
+  });
+
+  test('a device without sha256sum reads as unknown, never as a match', () => {
+    expect(parseDeviceSha256('/system/bin/sh: sha256sum: not found')).toBe(null);
+    expect(parseDeviceSha256('sha256sum: /data/app/a/base.apk: No such file or directory')).toBe(null);
+    expect(parseDeviceSha256('')).toBe(null);
+    expect(parseDeviceSha256(null)).toBe(null);
+  });
+
+  test('a digest of the wrong width is not a sha256', () => {
+    expect(parseDeviceSha256(`${'b'.repeat(32)}  /data/app/a/base.apk`)).toBe(null);
+    expect(parseDeviceSha256(`${'c'.repeat(40)}  /data/app/a/base.apk`)).toBe(null);
+    expect(parseDeviceSha256(`${'d'.repeat(65)}  /data/app/a/base.apk`)).toBe(null);
+  });
+});
+
+describe('parseAppContainerPath', () => {
+  test('reads the container simctl prints', () => {
+    const path = '/Users/x/Library/Developer/CoreSimulator/Devices/BF2A/data/Containers/Bundle/App/1/Fixture.app';
+    expect(parseAppContainerPath(`${path}\n`)).toBe(path);
+  });
+
+  test('an app that is not installed reads as unknown', () => {
+    expect(parseAppContainerPath('No such file or directory')).toBe(null);
+    expect(parseAppContainerPath('')).toBe(null);
+    expect(parseAppContainerPath(null)).toBe(null);
+  });
+});
+
+describe('artifactsMatch', () => {
+  test('two known, equal digests match', () => {
+    expect(artifactsMatch(SHA, SHA)).toBe(true);
+  });
+
+  test('an unknown digest on either side NEVER matches', () => {
+    expect(artifactsMatch(null, SHA)).toBe(false);
+    expect(artifactsMatch(SHA, null)).toBe(false);
+    expect(artifactsMatch(null, null)).toBe(false);
+  });
+
+  test('different digests do not match', () => {
+    expect(artifactsMatch(SHA, 'b'.repeat(64))).toBe(false);
+  });
+});
+
+describe('hashFile', () => {
+  test('equal bytes hash equal, one changed byte does not', () => {
+    writeFileSync(join(dir, 'a'), 'payload');
+    writeFileSync(join(dir, 'b'), 'payload');
+    writeFileSync(join(dir, 'c'), 'payloae');
+    expect(hashFile(join(dir, 'a'))).toBe(hashFile(join(dir, 'b')));
+    expect(hashFile(join(dir, 'a'))).not.toBe(hashFile(join(dir, 'c')));
+  });
+
+  test('an unreadable file is unknown, not a digest', () => {
+    expect(hashFile(join(dir, 'missing'))).toBe(null);
+  });
+});
+
+describe('hashBundle', () => {
+  function bundle(name: string, files: Record<string, string>) {
+    const root = join(dir, name);
+    for (const [path, body] of Object.entries(files)) {
+      const abs = join(root, path);
+      mkdirSync(join(abs, '..'), { recursive: true });
+      writeFileSync(abs, body);
+    }
+    return root;
+  }
+
+  test('the same file set hashes equal whatever order it was written in', () => {
+    const left = bundle('left', { Info: 'plist', 'Frameworks/A/A': 'binary', Fixture: 'macho' });
+    const right = bundle('right', { Fixture: 'macho', 'Frameworks/A/A': 'binary', Info: 'plist' });
+    expect(hashBundle(left)).toBe(hashBundle(right));
+  });
+
+  test('a changed byte, a renamed file, and a moved file each change the hash', () => {
+    const base = hashBundle(bundle('base', { Info: 'plist', 'Frameworks/A/A': 'binary' }));
+    expect(hashBundle(bundle('edited', { Info: 'plist!', 'Frameworks/A/A': 'binary' }))).not.toBe(base);
+    expect(hashBundle(bundle('renamed', { Info2: 'plist', 'Frameworks/A/A': 'binary' }))).not.toBe(base);
+    expect(hashBundle(bundle('moved', { Info: 'plist', 'Frameworks/B/A': 'binary' }))).not.toBe(base);
+  });
+
+  test('a missing directory is unknown', () => {
+    expect(hashBundle(join(dir, 'missing.app'))).toBe(null);
+  });
+
+  test('an entry that is not a plain file or directory is unknown, not a match', () => {
+    const root = bundle('linked', { Info: 'plist' });
+    symlinkSync(join(root, 'Info'), join(root, 'Alias'));
+    expect(hashBundle(root)).toBe(null);
+  });
+});
+
+describe('deviceHoldsApk', () => {
+  function localApk(body = 'apk bytes') {
+    const path = join(dir, 'app-debug.apk');
+    writeFileSync(path, body);
+    return path;
+  }
+
+  test('an identical APK on the device is a match, asked for by pm path then sha256sum', () => {
+    const apkPath = localApk();
+    const exec = recordingExec({
+      outputs: {
+        'pm path': 'package:/data/app/a/base.apk\n',
+        sha256sum: `${hashFile(apkPath)}  /data/app/a/base.apk\n`,
+      },
+    });
+    expect(deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec })).toBe(true);
+    expect(exec.calls).toEqual([
+      ['adb', '-s', 'emulator-5584', 'shell', 'pm', 'path', 'com.example.app'],
+      ['adb', '-s', 'emulator-5584', 'shell', 'sha256sum', '/data/app/a/base.apk'],
+    ]);
+  });
+
+  test('a different APK on the device is not a match', () => {
+    const exec = recordingExec({
+      outputs: { 'pm path': 'package:/data/app/a/base.apk\n', sha256sum: `${SHA}  /data/app/a/base.apk\n` },
+    });
+    const apkPath = localApk();
+    expect(deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec })).toBe(false);
+  });
+
+  test('a device with no sha256sum is unknown, so it never matches', () => {
+    const exec = recordingExec({
+      outputs: { 'pm path': 'package:/data/app/a/base.apk\n', sha256sum: 'sha256sum: not found' },
+    });
+    const apkPath = localApk();
+    expect(deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec })).toBe(false);
+  });
+
+  test('a package that is not installed is asked once and never hashed', () => {
+    const exec = recordingExec();
+    const apkPath = localApk();
+    expect(deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec })).toBe(false);
+    expect(exec.calls).toEqual([['adb', '-s', 'emulator-5584', 'shell', 'pm', 'path', 'com.example.app']]);
+  });
+
+  test('an adb that fails is unknown, so it never matches', () => {
+    const apkPath = localApk();
+    const failPath = recordingExec({ fail: 'pm path' });
+    expect(
+      deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec: failPath }),
+    ).toBe(false);
+    const failHash = recordingExec({ outputs: { 'pm path': 'package:/data/app/a/base.apk\n' }, fail: 'sha256sum' });
+    expect(
+      deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec: failHash }),
+    ).toBe(false);
+  });
+
+  test('a local APK that cannot be read is unknown, so it never matches', () => {
+    const exec = recordingExec({
+      outputs: { 'pm path': 'package:/data/app/a/base.apk\n', sha256sum: `${SHA}  /data/app/a/base.apk\n` },
+    });
+    const apkPath = join(dir, 'gone.apk');
+    expect(deviceHoldsApk({ serial: 'emulator-5584', packageName: 'com.example.app', apkPath }, { exec })).toBe(false);
+  });
+});
+
+describe('deviceHoldsBundle', () => {
+  function bundleAt(name: string, body: string) {
+    const root = join(dir, name);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'Fixture'), body);
+    return root;
+  }
+
+  test('an identical .app in the simulator container is a match', () => {
+    const installed = bundleAt('installed.app', 'macho');
+    const appPath = bundleAt('built.app', 'macho');
+    const exec = recordingExec({ outputs: { get_app_container: `${installed}\n` } });
+    expect(deviceHoldsBundle({ udid: 'BF2A', bundleId: 'com.example.app', appPath }, { exec })).toBe(true);
+    expect(exec.calls).toEqual([['xcrun', 'simctl', 'get_app_container', 'BF2A', 'com.example.app']]);
+  });
+
+  test('a different .app in the container is not a match', () => {
+    const installed = bundleAt('installed.app', 'macho');
+    const appPath = bundleAt('built.app', 'macho with fresh js');
+    const exec = recordingExec({ outputs: { get_app_container: `${installed}\n` } });
+    expect(deviceHoldsBundle({ udid: 'BF2A', bundleId: 'com.example.app', appPath }, { exec })).toBe(false);
+  });
+
+  test('an app that is not installed, or a simctl that fails, is unknown', () => {
+    const appPath = bundleAt('built.app', 'macho');
+    expect(deviceHoldsBundle({ udid: 'BF2A', bundleId: 'com.example.app', appPath }, { exec: recordingExec() })).toBe(
+      false,
+    );
+    expect(
+      deviceHoldsBundle(
+        { udid: 'BF2A', bundleId: 'com.example.app', appPath },
+        { exec: recordingExec({ fail: 'get_app_container' }) },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -43,6 +43,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'waitedForBuild',
       'appPath',
       'bundleId',
+      'installSkipped',
       'launched',
       'metroPort',
     ],
@@ -57,6 +58,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'waitedForBuild',
       'appPath',
       'bundleId',
+      'installSkipped',
       'launched',
     ],
   };
@@ -111,6 +113,17 @@ test('the Metro guide documents explicit remote intent and the local default', (
   expect(body).toMatch(/stim start --remote/);
   expect(body).toMatch(/plain `stim start`[^.]*local/i);
   expect(body).toMatch(/metro\.tunnel[^.]*provider/i);
+});
+
+test('the guide documents the identical-artifact skip and its fail-closed rule', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(lifecycle).toMatch(/pm path/);
+  expect(lifecycle).toMatch(/sha256sum/);
+  expect(lifecycle).toMatch(/simctl get_app_container/);
+  expect(lifecycle).toMatch(/cannot determine[^.]*installs exactly as it always did/i);
+  expect(lifecycle).toMatch(/release[\s\S]*COPY of the artifact[\s\S]*always installed/i);
+  expect(lifecycle).toMatch(/installSkipped/);
 });
 
 test('the guide documents scoped iOS dev-client preapproval', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1890,6 +1890,7 @@ describe('iosFacts', () => {
       waitedForBuild: null,
       appPath: '/a/b.app',
       bundleId: 'com.x',
+      installSkipped: false,
       launched: true,
       metroPort: 8082,
       logs: { dir: '/w/.stim/logs' },
@@ -3072,4 +3073,25 @@ test('a local hit leaves no provider download directory behind', async () => {
 
   expect(exitCode).toBe(null);
   expect(existsSync(join(workspaceDir(root), 'cache-provider'))).toBe(false);
+});
+
+describe('an app the simulator already holds', () => {
+  test('the skip is named on the install line and carried in the facts', async () => {
+    reserve();
+    const { logs, stderr } = await run(
+      { json: true },
+      { installIosApp: (args) => ({ ok: true, appPath: args.appPath, skipped: true }) },
+    );
+
+    expect(stderr).toMatch(/skipped; .*already holds this app/);
+    expect(parseFirst(logs).installSkipped).toBe(true);
+  });
+
+  test('an install that really ran reports installSkipped false', async () => {
+    reserve();
+    const { logs, stderr } = await run({ json: true });
+
+    expect(stderr).not.toMatch(/skipped/);
+    expect(parseFirst(logs).installSkipped).toBe(false);
+  });
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -192,6 +192,7 @@ interface InstallResultLike {
   code?: string;
   reason?: string;
   note?: string;
+  skipped?: boolean;
 }
 
 interface LaunchResultLike {
@@ -451,6 +452,7 @@ export function androidFacts({
   waitedForBuild = null,
   appPath,
   bundleId,
+  installSkipped = false,
   launched,
   logs,
   debugHttpHost = null,
@@ -469,6 +471,7 @@ export function androidFacts({
   waitedForBuild?: WaitedForBuild | null;
   appPath?: string | null;
   bundleId?: string | null;
+  installSkipped?: boolean;
   launched?: boolean | string;
   logs?: string | null;
   debugHttpHost?: string | null;
@@ -489,6 +492,7 @@ export function androidFacts({
     waitedForBuild: waitedForBuild ? { pid: waitedForBuild.pid ?? null, ms: waitedForBuild.ms ?? 0 } : null,
     appPath: appPath ?? null,
     bundleId: bundleId ?? null,
+    installSkipped: Boolean(installSkipped),
     launched: launched === LAUNCH_UNVERIFIED || launched === LAUNCH_BUNDLING ? launched : Boolean(launched),
     debugHttpHost: debugHttpHost ?? null,
     debugHttpHostNote: debugHttpHostNote ?? null,
@@ -873,6 +877,7 @@ interface ReportAndroidResultArgs {
   serial: string;
   apkPath: string | null;
   androidPackage: string;
+  installSkipped: boolean;
   record: AndroidRecord;
   storeHash: string;
   storeKey: string;
@@ -896,6 +901,7 @@ function reportAndroidResult({
   serial,
   apkPath,
   androidPackage,
+  installSkipped,
   record,
   storeHash,
   storeKey,
@@ -923,6 +929,7 @@ function reportAndroidResult({
     waitedForBuild,
     appPath: apkPath,
     bundleId: androidPackage,
+    installSkipped,
     launched: launchState,
     logs: logsDir,
   });
@@ -1113,7 +1120,13 @@ async function finishAndroidRun({
       : `Check that ${serial} is still connected (\`adb devices\`) and has room for the APK.`;
     return fail(installed.code || INSTALL_FAILED, installed.reason, installRemedy, { lastBuildStatus: true });
   }
-  phase('install', `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} ${installTimer()}`);
+  const installSkipped = Boolean(installed.skipped);
+  phase(
+    'install',
+    installSkipped
+      ? `skipped; ${serial} already holds this APK ${installTimer()}`
+      : `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} ${installTimer()}`,
+  );
   if (installed.note) {
     phase('install', chalk.yellow(installed.note));
     writer.write({ src: 'build', level: 'warn', event: 'install_uninstalled_first', msg: installed.note });
@@ -1241,6 +1254,7 @@ async function finishAndroidRun({
     serial,
     apkPath,
     androidPackage,
+    installSkipped,
     record,
     storeHash,
     storeKey,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -78,6 +78,9 @@ other line goes to stderr, so it is always safe to pipe.
                   cheaper than a second build). Both commands carry it
   appPath         the .app that was installed
   bundleId        the iOS bundle id that was launched
+  installSkipped  true when the artifact was ALREADY on the device byte for
+                  byte, so nothing was installed and the run went straight to
+                  launch (see \`guide lifecycle\`). false means an install ran
   launched        true, "bundling", or "unverified". THE THREE ARE DIFFERENT
                   FACTS and only the last one is a problem.
                     true         Metro finished the bundle, then the app stayed
@@ -128,7 +131,7 @@ other line goes to stderr, so it is always safe to pipe.
                   \`emulator -avd\`, avdmanager, or a device tool
   deviceName      the same name, matching the iOS payload's field
   fingerprint / cacheKey / cacheHit / cacheSkipped / waitedForBuild /
-  appPath / launched
+  appPath / installSkipped / launched
                   as above -- cacheKey keys on the VARIANT here
                   (<fingerprint>-productionrelease-sim) the way the iOS one
                   keys on the configuration
@@ -952,6 +955,25 @@ and produces an app that cannot load a bundle.
 
 Repeat step 3 whenever a NATIVE input changes. A JS-only edit needs nothing --
 that is what Fast Refresh over the running dev server is for.
+
+AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
+  Both platforms store the artifact verbatim, so its hash is its identity.
+  Before installing, Stim hashes the artifact it is about to install and the
+  one the device already has -- \`pm path\` then \`sha256sum\` on Android, the
+  \`simctl get_app_container\` bundle on iOS. Byte-identical means the install
+  is skipped and the run goes straight to launch, which is under a second
+  instead of the ~43s a 400MB APK costs over USB.
+
+    install     skipped; emulator-5584 already holds this APK (0.4s)
+
+  The skip needs PROOF. A package that is not installed, a split install, an
+  image without \`sha256sum\`, and any adb or simctl failure all read as
+  "cannot determine", and the run installs exactly as it always did. A release
+  run swaps this workspace's JS into a COPY of the artifact, which is a
+  different artifact and is therefore always installed.
+
+  \`--json\` carries installSkipped so a caller can tell a skipped run from an
+  installed one.
 
 OPTIONAL SIMSLIM PROFILE
   Install SimSlim once on each Mac:

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -507,6 +507,7 @@ export function iosFacts({
   waitedForBuild = null,
   appPath,
   bundleId,
+  installSkipped = false,
   metroPort,
   logsDir,
   durationMs,
@@ -524,6 +525,7 @@ export function iosFacts({
   waitedForBuild?: WaitedForBuild | null;
   appPath?: string | null;
   bundleId?: string | null;
+  installSkipped?: boolean;
   metroPort?: number | null;
   logsDir?: string;
   durationMs?: number;
@@ -543,6 +545,7 @@ export function iosFacts({
     waitedForBuild: waitedForBuild ? { pid: waitedForBuild.pid ?? null, ms: waitedForBuild.ms ?? 0 } : null,
     appPath,
     bundleId,
+    installSkipped: Boolean(installSkipped),
     launched: launched === LAUNCH_UNVERIFIED || launched === LAUNCH_BUNDLING ? launched : Boolean(launched),
     metroPort,
     logs: { dir: logsDir },
@@ -966,6 +969,7 @@ interface ReportIosResultArgs {
   udid: string;
   appPath: string | null;
   bundleId: string;
+  installSkipped: boolean;
   elapsed: () => number;
   startedAt: string;
   storeHash: string;
@@ -994,6 +998,7 @@ function reportIosResult({
   udid,
   appPath,
   bundleId,
+  installSkipped,
   elapsed,
   startedAt,
   storeHash,
@@ -1038,6 +1043,7 @@ function reportIosResult({
     waitedForBuild,
     appPath,
     bundleId,
+    installSkipped,
     metroPort,
     logsDir,
     durationMs,
@@ -1198,7 +1204,13 @@ async function finishIosRun({
       build: { ...buildFailure, appPath, bundleId },
     });
   }
-  phase('install', `-> ${deviceLabel(device, udid)} ${installTimer()}`);
+  const installSkipped = Boolean(installed?.skipped);
+  phase(
+    'install',
+    installSkipped
+      ? `skipped; ${deviceLabel(device, udid)} already holds this app ${installTimer()}`
+      : `-> ${deviceLabel(device, udid)} ${installTimer()}`,
+  );
 
   if (swapDir) {
     try {
@@ -1280,6 +1292,7 @@ async function finishIosRun({
     udid,
     appPath,
     bundleId: bundleId!,
+    installSkipped,
     elapsed,
     startedAt,
     storeHash,

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
+import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -20,6 +21,7 @@ interface ExecOpt {
 export type IosInstallResult = {
   ok?: boolean;
   appPath?: string;
+  skipped?: boolean;
   failed?: boolean;
   code?: string;
   reason?: string;
@@ -39,6 +41,7 @@ export type IosLaunchResult = {
 export type AndroidInstallResult = {
   ok?: boolean;
   apkPath?: string;
+  skipped?: boolean;
   uninstalled?: boolean;
   note?: string;
   failed?: boolean;
@@ -70,10 +73,13 @@ export function installIosApp(
   { exec = null }: ExecOpt = {},
 ): IosInstallResult {
   const e = exec || getExecutor();
-  try {
-    e.runFile('xcrun', ['simctl', 'install', udid, appPath]);
-  } catch (err) {
-    return { failed: true, code: INSTALL_ERROR, reason: `simctl install failed for ${appPath}: ${describe(err)}` };
+  const skipped = bundleId ? deviceHoldsBundle({ udid, bundleId, appPath }, { exec: e }) : false;
+  if (!skipped) {
+    try {
+      e.runFile('xcrun', ['simctl', 'install', udid, appPath]);
+    } catch (err) {
+      return { failed: true, code: INSTALL_ERROR, reason: `simctl install failed for ${appPath}: ${describe(err)}` };
+    }
   }
   if (bundleId && devClientScheme) {
     try {
@@ -120,7 +126,7 @@ export function installIosApp(
       };
     }
   }
-  return { ok: true, appPath };
+  return skipped ? { ok: true, appPath, skipped: true } : { ok: true, appPath };
 }
 
 export function jsLocationValue(metroPort: number | string): string {
@@ -238,6 +244,9 @@ export function installAndroidApp(
   { exec = null }: ExecOpt = {},
 ): AndroidInstallResult {
   const e = exec || getExecutor();
+  if (packageName && deviceHoldsApk({ serial, packageName, apkPath }, { exec: e })) {
+    return { ok: true, apkPath, skipped: true };
+  }
   const install = () => {
     e.runFile('adb', ['-s', serial, 'install', '-r', apkPath]);
   };

--- a/packages/stim-cli/src/engine/installed-artifact.ts
+++ b/packages/stim-cli/src/engine/installed-artifact.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+import { closeSync, openSync, readSync, lstatSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { getExecutor, type Executor } from '../exec.ts';
+
+const READ_CHUNK_BYTES = 1024 * 1024;
+
+const DEVICE_PATH_TIMEOUT_MS = 30000;
+
+const DEVICE_HASH_TIMEOUT_MS = 120000;
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+export function parseInstalledApkPath(text: unknown): string | null {
+  if (typeof text !== 'string') return null;
+  const paths: string[] = [];
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('package:')) continue;
+    const path = line.slice('package:'.length);
+    if (path.startsWith('/')) paths.push(path);
+  }
+  return paths.length === 1 ? paths[0]! : null;
+}
+
+export function parseDeviceSha256(text: unknown): string | null {
+  if (typeof text !== 'string') return null;
+  const first = text.trim().split(/\s+/)[0] ?? '';
+  return SHA256_HEX.test(first) ? first : null;
+}
+
+export function parseAppContainerPath(text: unknown): string | null {
+  if (typeof text !== 'string') return null;
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.length === 1 && lines[0]!.startsWith('/') ? lines[0]! : null;
+}
+
+export function artifactsMatch(local: string | null, installed: string | null): boolean {
+  return Boolean(local) && local === installed;
+}
+
+export function hashFile(file: string): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(file, 'r');
+    const digest = createHash('sha256');
+    const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, READ_CHUNK_BYTES, null);
+      if (read <= 0) break;
+      digest.update(buffer.subarray(0, read));
+    }
+    return digest.digest('hex');
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {}
+    }
+  }
+}
+
+export function hashBundle(dir: string): string | null {
+  const digest = createHash('sha256');
+  const walk = (abs: string, rel: string): boolean => {
+    let names: string[];
+    try {
+      names = readdirSync(abs);
+    } catch {
+      return false;
+    }
+    for (const name of names.toSorted()) {
+      const child = join(abs, name);
+      const path = rel === '' ? name : `${rel}/${name}`;
+      let stat;
+      try {
+        stat = lstatSync(child);
+      } catch {
+        return false;
+      }
+      if (stat.isDirectory()) {
+        if (!walk(child, path)) return false;
+        continue;
+      }
+      if (!stat.isFile()) return false;
+      const file = hashFile(child);
+      if (file === null) return false;
+      digest.update(`${path}\0${file}\n`);
+    }
+    return true;
+  };
+  return walk(dir, '') ? digest.digest('hex') : null;
+}
+
+export function deviceHoldsApk(
+  { serial, packageName, apkPath }: { serial: string; packageName: string; apkPath: string },
+  { exec = null }: { exec?: Executor | null } = {},
+): boolean {
+  const e = exec || getExecutor();
+  let path: string | null;
+  try {
+    path = parseInstalledApkPath(
+      e.runFile('adb', ['-s', serial, 'shell', 'pm', 'path', packageName], { timeoutMs: DEVICE_PATH_TIMEOUT_MS }),
+    );
+  } catch {
+    return false;
+  }
+  if (!path) return false;
+  let installed: string | null;
+  try {
+    installed = parseDeviceSha256(
+      e.runFile('adb', ['-s', serial, 'shell', 'sha256sum', path], { timeoutMs: DEVICE_HASH_TIMEOUT_MS }),
+    );
+  } catch {
+    return false;
+  }
+  if (!installed) return false;
+  return artifactsMatch(hashFile(apkPath), installed);
+}
+
+export function deviceHoldsBundle(
+  { udid, bundleId, appPath }: { udid: string; bundleId: string; appPath: string },
+  { exec = null }: { exec?: Executor | null } = {},
+): boolean {
+  const e = exec || getExecutor();
+  let container: string | null;
+  try {
+    container = parseAppContainerPath(
+      e.runFile('xcrun', ['simctl', 'get_app_container', udid, bundleId], { timeoutMs: DEVICE_PATH_TIMEOUT_MS }),
+    );
+  } catch {
+    return false;
+  }
+  if (!container) return false;
+  const installed = hashBundle(container);
+  if (!installed) return false;
+  return artifactsMatch(hashBundle(appPath), installed);
+}

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -114,6 +114,7 @@ export interface IosFacts {
   waitedForBuild: { pid: number | null; ms: number } | null;
   appPath?: string | null;
   bundleId?: string | null;
+  installSkipped: boolean;
   launched: LaunchStatus;
   metroPort?: number | null;
   logs: LogsInfo;
@@ -135,6 +136,7 @@ export interface AndroidFacts {
   waitedForBuild: { pid: number | null; ms: number } | null;
   appPath: string | null;
   bundleId: string | null;
+  installSkipped: boolean;
   launched: LaunchStatus;
   debugHttpHost: string | null;
   debugHttpHostNote: string | null;


### PR DESCRIPTION
Closes #152

Depends on #156, now merged. Without it the skip never fires on a flavored project -- see "Why this needed #156" below.

## Description

Every run installed, even when the device already held a byte-identical artifact. On a physical Android device that was 43 seconds of pure waste per iteration.

Both platforms store the artifact verbatim, so its hash is already a reliable identity and nothing needs to be embedded in the app. `pm install` does not rewrite the APK, and `simctl install` copies the `.app` unchanged.

## Solution

Before installing, resolve the installed artifact and hash it. Match means skip and go straight to launch; anything else installs exactly as today.

- Android: `pm path <pkg>`, then `sha256sum` on the returned path.
- iOS: `simctl get_app_container`, then a sorted recursive digest over relative path plus file digest.

Every failure path returns "not a match", so an unreadable path, a missing `sha256sum`, a timeout, or an absent app all install. There is no path where uncertainty is read as a match.

The skip is visible in the phase output and in the `--json` facts as `installSkipped`, so an agent reading the payload can tell a skipped run from an install.

## Why this needed #156

Verified end to end on a physical device, and this is not theoretical: on `main` the skip never fires on a flavored project. `installAndroidApp` receives `androidPackage`, which before #156 is the gradle namespace, so the probe runs `pm path io.tlon.landscape` -- not installed, exit 1 -- fails closed, and installs. The hashes matched perfectly the whole time.

```
$ adb shell pm path io.tlon.landscape        # what the probe asked for
                                              # (empty, exit 1)
$ adb shell pm path io.tlon.groups.preview   # what is actually installed
package:/data/app/~~mw7q6ix.../base.apk
```

The unit tests pass either way, because they inject the package name. Only running it against a device showed it.

## Test plan

On a physical Samsung SM-G996W, rebased onto #156:

```
install  applicationId io.tlon.groups.preview (from the APK; project files say io.tlon.landscape)
install  skipped; RFCR7081Q9L already holds this APK (662ms)
verify   ready: bundle loaded, stable for 3s, process alive
```

662ms against 44s, and 7.3s for the whole run against ~51s.

Negative case, same device: `adb uninstall io.tlon.groups.preview`, then re-run -> `install from local cache (26.2s)`. It installs when the app is absent rather than skipping.

The release-swap rule has an explicit test on each platform: the device reports the cached artifact's digest, the swapped copy hashes differently, and the swapped file is asserted to install.

2629 tests pass, plus format, lint, typecheck and knip.

## Known limits

- **Split installs read as "cannot determine".** `pm path` returns one line per APK and the parse requires exactly one, so a split install always proceeds. Stim installs a single APK, so its own installs are unaffected -- but a Play Store build of the same package returns four lines and is correctly never matched.
- **`--no-build-cache` does not force a reinstall.** If that run produces an identical artifact, the install is still skipped.
- **`hashBundle` refuses anything that is not a plain file or directory**, symlinks included, and returns null. The feature turns itself off for such a bundle rather than risking a wrong match.
- `--remote` is untouched; the remote deps replace the install function entirely, so no probe runs there.

## Review note

The new module was committed containing a literal NUL byte as the bundle-hash path separator, which made the file binary to git and broke the ASCII-only rule in AGENTS.md. Replaced with the `\0` escape -- semantically identical, and the suite is unchanged at 2629 passing.

