### PR TITLE
Give the failing real-xcodebuild test its sibling's timeout

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -1436,5 +1436,5 @@ describe('buildIos against a real xcodebuild', { skip: LIVE as unknown as boolea
     expect(errors.length).toBe(1);
     expect(errors[0]?.msg).toMatch(/main\.m:5:18: use of undeclared identifier/);
     expect(records.some((r) => r.level === 'debug' && r.msg?.includes('** BUILD FAILED **'))).toBeTruthy();
-  });
+  }, 120_000);
 });


### PR DESCRIPTION
Closes #150

## Description

`fails for real: a broken source file becomes one diagnostic` in `engine-xcode.test.ts` shells out to a real xcodebuild but carried no explicit timeout, so it ran under vitest's 5s default. Its sibling, `builds for real`, invokes the same toolchain and is allowed `120_000`.

#150 recorded it at 4.24s in isolation and timing out at 5s on a loaded machine during a review battery.

## Solution

Give it the sibling's timeout.

## Test plan

Measured per-test on an idle machine:

```
discovers the workspace ... through a real -list -json    457ms
builds for real: the .app lands where productsDir says   1586ms   (already 120_000)
fails for real: a broken source file becomes one ...     1515ms   (this one)
```

1.5s idle against a 5s ceiling is roughly 3x headroom, which is exactly what #150 exhausted under load.

2626 tests pass, plus format, lint, typecheck and knip.

## Not changed

`discovers the workspace and resolves its scheme through a real -list -json` also shells out to xcodebuild and also runs on the 5s default. At 457ms it has about 11x headroom rather than 3x, so it is materially less exposed and I left it alone to keep this to what the issue reported. It is the same class of risk if a machine is loaded enough, and worth a second look if it ever flakes.
