### PR TITLE
RELEASE.md matches the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
           if npm view "@stim-cli/core@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/core@$version is already published"
           else
+            # latest-on-purpose while no stable exists (RELEASE.md section 1); issue #165
+            # gates the prerelease-aware selection required after 1.0.0 stable.
             npm publish --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/cache

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,10 @@ dist-tag: that is what the workflow does and what installs resolve, so
 `npm view stim-cli version` is always the current release. Once a stable
 1.0.0 ships, the workflow must gain prerelease-aware dist-tag selection
 (prereleases to `next`) BEFORE the next candidate is tagged, so a later
-`1.1.0-rc` cannot replace stable on `latest`.
+`1.1.0-rc` cannot replace stable on `latest` -- tracked as issue #165. The
+historical `next` tags on all five packages are stale (rc-era, mutually
+inconsistent) and should be removed as part of that change:
+`npm dist-tag rm <pkg> next` for each package.
 
 When a published version exists, check `git describe --tags --abbrev=0`. If
 that tag is _higher_ than `v$last`, a previous release got tagged but never

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,9 +52,13 @@ all five names are available, use the intended first version, and review the
 full release diff. Complete the first-publication bootstrap in section 4,
 step 7 before pushing the first tag.
 
-Use `X.Y.Z-rc.N` for a release candidate. Publish prereleases under the npm
-`next` dist-tag and query the current candidate with
-`npm view stim-cli@next version`. Stable releases use the `latest` dist-tag.
+Use `X.Y.Z-rc.N` for a release candidate. While no stable release exists,
+every publish -- release candidates included -- lands on the npm `latest`
+dist-tag: that is what the workflow does and what installs resolve, so
+`npm view stim-cli version` is always the current release. Once a stable
+1.0.0 ships, the workflow must gain prerelease-aware dist-tag selection
+(prereleases to `next`) BEFORE the next candidate is tagged, so a later
+`1.1.0-rc` cannot replace stable on `latest`.
 
 When a published version exists, check `git describe --tags --abbrev=0`. If
 that tag is _higher_ than `v$last`, a previous release got tagged but never
@@ -232,7 +236,7 @@ Before continuing:
    Do not add claims here. Once the tag is remote, a correction requires a new
    version; never move or force-push the published tag.
 7. **Publish to npm.** Pushing the tag in step 5 triggers the
-   `Release` workflow, which publishes all FOUR packages via OIDC trusted
+   `Release` workflow, which publishes all FIVE packages via OIDC trusted
    publishing (no token, `--provenance`) once you APPROVE the run in the
    `release` environment on GitHub (Actions -> the waiting run -> Review
    deployments -> check `release` -> Approve and deploy) -- that approval
@@ -253,10 +257,10 @@ Before continuing:
    packages manually in dependency order, then configure each package's trusted
    publisher for `appandflow/stim`, workflow `release.yml`, environment
    `release`. Do this before pushing the first tag. The tagged workflow skips an
-   exact package version that already exists, uses the npm `next` dist-tag for
-   prereleases, then verifies all five registry versions. The same commands are
-   the manual fallback for later releases. Add `--tag next` to every command
-   when publishing a prerelease:
+   exact package version that already exists, publishes to the `latest`
+   dist-tag (see section 1 for the pre-stable rationale), then verifies all
+   five registry versions. The same commands are the manual fallback for
+   later releases:
 
    ```bash
    npm whoami                                          # confirm login; if 401, `npm login` first


### PR DESCRIPTION
## Description
RELEASE.md told releasers to publish prereleases under the `next` dist-tag and said the workflow publishes "all FOUR packages". The workflow publishes all five with `--tag latest` unconditionally, and rc.4-rc.7 all landed there — correct while no stable exists, since installs resolve `latest`. Following the stale instructions is what left the `next` tag pointing at rc.0 until it was hand-repaired with OTPs.

## Solution
Describe the latest-while-prestable behavior as section 1's rule, correct the package count, drop the `--tag next` manual-fallback instruction, and record the one future obligation this creates: prerelease-aware dist-tag selection must land in the workflow before the first candidate after 1.0.0 stable, so a `1.1.0-rc` cannot replace stable on `latest`.

## Test plan
Doc-only. `grep` confirms no `--tag next`/`@next` instruction remains; the surviving `next` occurrences are the deliberate future-tag obligation (now citing #165) and one prose use.

Fixes #163
