### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -1,0 +1,29 @@
+---
+name: Report
+about: A bug, friction, or improvement found while working in or on Stim
+---
+
+## Problem
+
+<!-- Observed behavior, when it fires, and the exact output or refusal.
+State what was expected when it differs. -->
+
+## Evidence
+
+<!-- Commands, log paths, versions, run links. Enough that someone who was
+not there can verify the problem is real and re-find it. -->
+
+## Cause
+
+<!-- If diagnosed, the mechanism with file:line. If unknown, say unknown --
+a confident wrong cause is worse than an honest gap. -->
+
+## Fix idea
+
+<!-- Optional direction, not a mandate. Name what it would preserve and
+what it trades away. -->
+
+## Acceptance criteria
+
+<!-- What must be true to close this issue. Closing needs verification
+evidence, not just a merged commit. -->

--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -21,9 +21,5 @@ a confident wrong cause is worse than an honest gap. -->
 ## Fix idea
 
 <!-- Optional direction, not a mandate. Name what it would preserve and
-what it trades away. -->
-
-## Acceptance criteria
-
-<!-- What must be true to close this issue. Closing needs verification
-evidence, not just a merged commit. -->
+what it trades away. Closing the issue needs verification evidence, not
+just a merged commit. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@ deliberate trade-offs and any deviation from a spec or plan doc. -->
 
 <!-- What a reviewer would exercise to validate the change, with evidence:
 commands run, suite results, real-tool verification for changed tool calls
-(invariant 9). Routine checks (build, lint, unit battery) are table stakes;
-name them only when the PR changes that machinery. -->
+(invariant 9, "verify real tool calls"). Name the checks that are the
+evidence for this change. -->
 
 <!-- Link the issue: "Fixes #N". Every claim above needs a matching check or
 observation -- ground what you assert, hedge what you infer. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Context and the problem, stated as facts. Lead with what the reviewer
+cannot see in the diff: intent, root cause, constraints, blast radius. -->
+
+## Solution
+
+<!-- Intent and reasoning, not a file-by-file diff walkthrough. Name
+deliberate trade-offs and any deviation from a spec or plan doc. -->
+
+## Test plan
+
+<!-- What a reviewer would exercise to validate the change, with evidence:
+commands run, suite results, real-tool verification for changed tool calls
+(invariant 9). Routine checks (build, lint, unit battery) are table stakes;
+name them only when the PR changes that machinery. -->
+
+<!-- Link the issue: "Fixes #N". Every claim above needs a matching check or
+observation -- ground what you assert, hedge what you infer. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,7 @@ commit. Run `pnpm run test:e2e` when a change affects an end-to-end workflow.
 
 When you find a bug or improvement, search the open GitHub issues first. If no
 issue already describes it, create one before implementation, following the
-shape in `.github/ISSUE_TEMPLATE/report.md`; pull request descriptions follow
-`.github/PULL_REQUEST_TEMPLATE.md`. Refresh the
+shape in `.github/ISSUE_TEMPLATE/report.md`. Refresh the
 remote refs, then confirm that an existing issue still applies to current
 `origin/main`; close stale issues with the fixing commit and verification
 evidence instead of creating duplicate work.
@@ -56,7 +55,8 @@ evidence instead of creating duplicate work.
 Implement each valid issue in its own git worktree and branch created from the
 refreshed `origin/main`. Independent issues may run in parallel worktrees. Keep
 the branch limited to that issue, run the required checks, and open a pull
-request that links the issue.
+request that links the issue, with a description following
+`.github/PULL_REQUEST_TEMPLATE.md`.
 
 As soon as the pull request is open, assign a fresh agent that did not implement
 the change to review the issue, diff, tests, and user-facing guidance. Address

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,9 @@ commit. Run `pnpm run test:e2e` when a change affects an end-to-end workflow.
 ## Issue and pull request workflow
 
 When you find a bug or improvement, search the open GitHub issues first. If no
-issue already describes it, create one before implementation. Refresh the
+issue already describes it, create one before implementation, following the
+shape in `.github/ISSUE_TEMPLATE/report.md`; pull request descriptions follow
+`.github/PULL_REQUEST_TEMPLATE.md`. Refresh the
 remote refs, then confirm that an existing issue still applies to current
 `origin/main`; close stale issues with the fixing commit and verification
 evidence instead of creating duplicate work.


### PR DESCRIPTION
## Description
Issues and PR descriptions in this repo follow a consistent shape -- problem-first, evidence-heavy, verification named -- but nothing encoded it, so each agent session re-derives it from AGENTS.md prose and recent examples.

## Solution
`.github/PULL_REQUEST_TEMPLATE.md` carries the Description / Solution / Test plan structure with guidance comments (lead with what the diff cannot show; ground claims; invariant-9 real-tool evidence). `.github/ISSUE_TEMPLATE/report.md` carries Problem / Evidence / Cause / Fix idea / Acceptance criteria, a deliberate formalization of the prose shape workflow issues gesture at (only #128 used headings; the sections chosen are the ones every issue expresses as prose: problem, evidence, cause when known, fix idea). AGENTS.md's workflow section now points at both. Guidance lives in HTML comments so an empty section costs nothing and filled sections replace them.

## Test plan
- Doc-only; format check clean.
- Template placement follows GitHub's discovery rules (`.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/report.md` with name/about front matter); verify after merge that the web UI offers both.

Fixes #166

