### PR TITLE
Surface what actually failed when gradle's failure report is interleaved

### DIFF
--- a/packages/stim-cli/src/__tests__/errors-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-gradle.test.ts
@@ -302,45 +302,77 @@ describe('CMake FATAL_ERROR lines survive the What-went-wrong clip', () => {
 describe('a packaging failure surfaces its cause however gradle interleaves its two streams', () => {
   const nativeLib =
     "java.io.IOException: Failed to copy full contents from '/w/android/app/build/intermediates/stripped_native_libs/debug/out/lib/arm64-v8a/libreactnative.so' to '/w/android/app/build/intermediates/apk/debug/packageDebug/lib/arm64-v8a/libreactnative.so'";
-  const deprecation =
-    "Deprecated Gradle features were used in this build, making it incompatible with Gradle 10. You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.";
-  const report = [
-    'FAILURE: Build failed with an exception.',
-    '* What went wrong:',
+  const chain = [
     "Execution failed for task ':app:packageDebug'.",
     '> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable',
     `   > ${nativeLib}`,
+  ];
+  const report = [
+    'FAILURE: Build failed with an exception.',
+    '* What went wrong:',
+    ...chain,
     '* Try:',
     '> Run with --stacktrace option to get the stack trace.',
-    '* Get more help at https://help.gradle.org.',
   ];
-  const tail = [deprecation, 'BUILD FAILED in 1m22s', '104 actionable tasks: 104 executed'];
+  const tail = [
+    "Deprecated Gradle features were used in this build, making it incompatible with Gradle 10. You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.",
+    'BUILD FAILED in 1m22s',
+    '104 actionable tasks: 104 executed',
+  ];
 
   test('the cause chain is reported when the report arrives whole', () => {
-    const diagnostics = extractGradleDiagnostics(
+    const messages = extractGradleDiagnostics(
       ['> Task :app:stripDebugDebugSymbols', '> Task :app:packageDebug FAILED', ...report, ...tail].join('\n'),
-    );
-    const messages = diagnostics.map((d) => d.message);
+    ).map((d) => d.message);
     expect(messages[0]).toBe('Task :app:packageDebug FAILED');
-    expect(messages[1]).toMatch(/Execution failed for task ':app:packageDebug'\./);
+    expect(messages[1]).toMatch(/^Execution failed for task ':app:packageDebug'\./);
     expect(messages[1]).toMatch(/PackageAndroidArtifact/);
     expect(messages).toContain(nativeLib);
     expect(messages.some((m) => /Deprecated Gradle features/.test(m))).toBe(false);
   });
 
-  test('the cause chain is reported when the stdout tail lands inside the stderr report', () => {
-    const diagnostics = extractGradleDiagnostics(
-      ['> Task :app:packageDebug FAILED', ...report.slice(0, 2), ...tail, ...report.slice(2)].join('\n'),
-    );
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages[0]).toBe('Task :app:packageDebug FAILED');
-    expect(messages.some((m) => /Execution failed for task ':app:packageDebug'/.test(m))).toBe(true);
-    expect(messages).toContain(nativeLib);
-    expect(messages.some((m) => /Deprecated Gradle features/.test(m))).toBe(false);
-  });
+  for (const at of [0, 1, 2]) {
+    test(`the cause chain is reported when the stdout tail lands after ${at} of its lines`, () => {
+      const messages = extractGradleDiagnostics(
+        [
+          '> Task :app:packageDebug FAILED',
+          'FAILURE: Build failed with an exception.',
+          '* What went wrong:',
+          ...chain.slice(0, at),
+          ...tail,
+          ...chain.slice(at),
+        ].join('\n'),
+      ).map((d) => d.message);
+      expect(messages[0]).toBe('Task :app:packageDebug FAILED');
+      expect(messages[1]).toMatch(/^Execution failed for task ':app:packageDebug'\./);
+      expect(messages[1]).toMatch(/PackageAndroidArtifact/);
+      expect(messages).toContain(nativeLib);
+      expect(messages.some((m) => /Deprecated Gradle features/.test(m))).toBe(false);
+    });
+  }
 
   test('a build result tail on its own is not a diagnostic', () => {
     expect(extractGradleDiagnostics(tail.join('\n'))).toEqual([]);
+  });
+
+  test('an exception line the message already carries whole is not repeated', () => {
+    const messages = extractGradleDiagnostics(
+      ["Execution failed for task ':app:x'.", '> java.lang.IllegalStateException: boom'].join('\n'),
+    ).map((d) => d.message);
+    expect(messages).toEqual(["Execution failed for task ':app:x'. java.lang.IllegalStateException: boom"]);
+  });
+
+  test("a cause that quotes an inner tool's BUILD FAILED keeps the lines under it", () => {
+    const diagnostics = extractGradleDiagnostics(
+      [
+        '* What went wrong:',
+        "Execution failed for task ':app:someWrapper'.",
+        '> Process exited with code 1',
+        '  BUILD FAILED because the inner tool said so',
+        '  real cause: the keystore is missing',
+      ].join('\n'),
+    );
+    expect(diagnostics[0]?.message).toMatch(/the keystore is missing$/);
   });
 
   test('the cause chain stops at the next task line rather than swallowing the build', () => {
@@ -359,13 +391,18 @@ describe('a packaging failure surfaces its cause however gradle interleaves its 
     ]);
   });
 
-  test('a cause chain longer than the cap is cut, not printed whole', () => {
+  test('a cause chain longer than the cap is cut, and what follows is still scanned', () => {
     const deep = Array.from({ length: 12 }, (_, i) => `${' '.repeat(i)}> cause level ${i}`);
-    const diagnostics = extractGradleDiagnostics(
-      ["Execution failed for task ':app:packageDebug'.", ...deep, '* Try:'].join('\n'),
-    );
-    expect(diagnostics.length).toBe(1);
-    expect(diagnostics[0]?.message).toMatch(/cause level 4$/);
-    expect(diagnostics[0]?.message).not.toMatch(/cause level 5/);
+    const messages = extractGradleDiagnostics(
+      [
+        "Execution failed for task ':app:packageDebug'.",
+        ...deep,
+        '> FATAL_ERROR the ndk toolchain is gone',
+        '* Try:',
+      ].join('\n'),
+    ).map((d) => d.message);
+    expect(messages[0]).toMatch(/cause level 4$/);
+    expect(messages[0]).not.toMatch(/cause level 5/);
+    expect(messages).toContain('> FATAL_ERROR the ndk toolchain is gone');
   });
 });

--- a/packages/stim-cli/src/__tests__/errors-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-gradle.test.ts
@@ -298,3 +298,74 @@ describe('CMake FATAL_ERROR lines survive the What-went-wrong clip', () => {
     ]);
   });
 });
+
+describe('a packaging failure surfaces its cause however gradle interleaves its two streams', () => {
+  const nativeLib =
+    "java.io.IOException: Failed to copy full contents from '/w/android/app/build/intermediates/stripped_native_libs/debug/out/lib/arm64-v8a/libreactnative.so' to '/w/android/app/build/intermediates/apk/debug/packageDebug/lib/arm64-v8a/libreactnative.so'";
+  const deprecation =
+    "Deprecated Gradle features were used in this build, making it incompatible with Gradle 10. You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.";
+  const report = [
+    'FAILURE: Build failed with an exception.',
+    '* What went wrong:',
+    "Execution failed for task ':app:packageDebug'.",
+    '> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable',
+    `   > ${nativeLib}`,
+    '* Try:',
+    '> Run with --stacktrace option to get the stack trace.',
+    '* Get more help at https://help.gradle.org.',
+  ];
+  const tail = [deprecation, 'BUILD FAILED in 1m22s', '104 actionable tasks: 104 executed'];
+
+  test('the cause chain is reported when the report arrives whole', () => {
+    const diagnostics = extractGradleDiagnostics(
+      ['> Task :app:stripDebugDebugSymbols', '> Task :app:packageDebug FAILED', ...report, ...tail].join('\n'),
+    );
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages[0]).toBe('Task :app:packageDebug FAILED');
+    expect(messages[1]).toMatch(/Execution failed for task ':app:packageDebug'\./);
+    expect(messages[1]).toMatch(/PackageAndroidArtifact/);
+    expect(messages).toContain(nativeLib);
+    expect(messages.some((m) => /Deprecated Gradle features/.test(m))).toBe(false);
+  });
+
+  test('the cause chain is reported when the stdout tail lands inside the stderr report', () => {
+    const diagnostics = extractGradleDiagnostics(
+      ['> Task :app:packageDebug FAILED', ...report.slice(0, 2), ...tail, ...report.slice(2)].join('\n'),
+    );
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages[0]).toBe('Task :app:packageDebug FAILED');
+    expect(messages.some((m) => /Execution failed for task ':app:packageDebug'/.test(m))).toBe(true);
+    expect(messages).toContain(nativeLib);
+    expect(messages.some((m) => /Deprecated Gradle features/.test(m))).toBe(false);
+  });
+
+  test('a build result tail on its own is not a diagnostic', () => {
+    expect(extractGradleDiagnostics(tail.join('\n'))).toEqual([]);
+  });
+
+  test('the cause chain stops at the next task line rather than swallowing the build', () => {
+    const diagnostics = extractGradleDiagnostics(
+      [
+        "Execution failed for task ':app:packageDebug'.",
+        '> A failure occurred while executing PackageAndroidArtifact',
+        '> Task :app:packageRelease FAILED',
+        'e: file:///w/Main.kt:10:5 Unresolved reference: foo',
+      ].join('\n'),
+    );
+    expect(diagnostics.map((d) => d.message)).toEqual([
+      "Execution failed for task ':app:packageDebug'. A failure occurred while executing PackageAndroidArtifact",
+      'Task :app:packageRelease FAILED',
+      'Unresolved reference: foo',
+    ]);
+  });
+
+  test('a cause chain longer than the cap is cut, not printed whole', () => {
+    const deep = Array.from({ length: 12 }, (_, i) => `${' '.repeat(i)}> cause level ${i}`);
+    const diagnostics = extractGradleDiagnostics(
+      ["Execution failed for task ':app:packageDebug'.", ...deep, '* Try:'].join('\n'),
+    );
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toMatch(/cause level 4$/);
+    expect(diagnostics[0]?.message).not.toMatch(/cause level 5/);
+  });
+});

--- a/packages/stim-cli/src/engine/errors-gradle.ts
+++ b/packages/stim-cli/src/engine/errors-gradle.ts
@@ -134,7 +134,7 @@ export function extractGradleDiagnostics(text: string): Diagnostic[] {
       continue;
     }
 
-    const orphanCause = line.replace(/^>\s*/, '');
+    const orphanCause = CAUSE_LINE.test(line) ? line.replace(/^>\s*/, '') : '';
     if (JAVA_EXCEPTION.test(orphanCause)) {
       add({ message: orphanCause });
       continue;

--- a/packages/stim-cli/src/engine/errors-gradle.ts
+++ b/packages/stim-cli/src/engine/errors-gradle.ts
@@ -27,7 +27,7 @@ const CAUSE_LINE = /^>\s+\S/;
 const JAVA_EXCEPTION = /^(?:[a-z][A-Za-z0-9_]*\.){2,}[A-Za-z0-9_$]*(?:Exception|Error)\b/;
 const TASK_LINE = /^>\s*Task\s+:/;
 const BUILD_TAIL =
-  /^(?:BUILD (?:FAILED|SUCCESSFUL)\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task)/;
+  /^(?:BUILD (?:FAILED|SUCCESSFUL) in\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task)/;
 
 const MAX_CAUSE_LINES = 6;
 
@@ -131,6 +131,12 @@ export function extractGradleDiagnostics(text: string): Diagnostic[] {
 
     if (FATAL_ERROR.test(line)) {
       add({ message: line });
+      continue;
+    }
+
+    const orphanCause = line.replace(/^>\s*/, '');
+    if (JAVA_EXCEPTION.test(orphanCause)) {
+      add({ message: orphanCause });
       continue;
     }
 
@@ -251,7 +257,8 @@ function readWhatWentWrong(lines: string[], start: number): CauseBlock | null {
   for (; j < lines.length; j++) {
     const line = stripCarriage(lines[j]).trim();
     if (SECTION.test(line)) break;
-    if (BUILD_TAIL.test(line) || TASK_LINE.test(line)) break;
+    if (TASK_LINE.test(line)) break;
+    if (BUILD_TAIL.test(line)) continue;
     if (line === '') {
       if (parts.length) break;
       continue;
@@ -275,7 +282,8 @@ function readCauseChain(lines: string[], start: number): CauseBlock {
 }
 
 function highlightsOf(parts: string[]): string[] {
-  return parts.filter((part) => FATAL_ERROR.test(part) || JAVA_EXCEPTION.test(part));
+  const joined = clip(parts.join(' '));
+  return parts.filter((part) => (FATAL_ERROR.test(part) || JAVA_EXCEPTION.test(part)) && !joined.includes(clip(part)));
 }
 
 function stripAaptPrefix(message: string): string {

--- a/packages/stim-cli/src/engine/errors-gradle.ts
+++ b/packages/stim-cli/src/engine/errors-gradle.ts
@@ -22,6 +22,14 @@ const FAILURE_HEADER = /^FAILURE:\s*Build (?:failed|completed with)/;
 const WHAT_WENT_WRONG = /^\*\s*What went wrong:/;
 const SECTION = /^\*\s*[A-Za-z]/;
 const COULD_NOT_RESOLVE = /^>?\s*(Could not (?:resolve|find|download|GET) .+)$/;
+const EXECUTION_FAILED = /^Execution failed for task\s+'(?::[^']+)'/;
+const CAUSE_LINE = /^>\s+\S/;
+const JAVA_EXCEPTION = /^(?:[a-z][A-Za-z0-9_]*\.){2,}[A-Za-z0-9_$]*(?:Exception|Error)\b/;
+const TASK_LINE = /^>\s*Task\s+:/;
+const BUILD_TAIL =
+  /^(?:BUILD (?:FAILED|SUCCESSFUL)\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task)/;
+
+const MAX_CAUSE_LINES = 6;
 
 const REMEDIES: Array<[RegExp, string]> = [
   [
@@ -62,6 +70,12 @@ export function remedyFor(message: string): string | null {
   return null;
 }
 
+interface CauseBlock {
+  message: string;
+  highlights: string[];
+  endIndex: number;
+}
+
 export function extractGradleDiagnostics(text: string): Diagnostic[] {
   if (typeof text !== 'string' || text.trim() === '') return [];
   const lines = text.split('\n');
@@ -92,7 +106,7 @@ export function extractGradleDiagnostics(text: string): Diagnostic[] {
       const block = readWhatWentWrong(lines, i);
       if (block) {
         add({ message: block.message });
-        for (const fatal of block.fatal) add({ message: fatal });
+        for (const highlight of block.highlights) add({ message: highlight });
         i = block.endIndex;
       }
       continue;
@@ -101,9 +115,17 @@ export function extractGradleDiagnostics(text: string): Diagnostic[] {
       const block = readWhatWentWrong(lines, i - 1);
       if (block) {
         add({ message: block.message });
-        for (const fatal of block.fatal) add({ message: fatal });
+        for (const highlight of block.highlights) add({ message: highlight });
         i = block.endIndex;
       }
+      continue;
+    }
+
+    if (EXECUTION_FAILED.test(line)) {
+      const chain = readCauseChain(lines, i);
+      add({ message: chain.message });
+      for (const highlight of chain.highlights) add({ message: highlight });
+      i = chain.endIndex;
       continue;
     }
 
@@ -215,10 +237,7 @@ export function formatDiagnostic(diag?: Diagnostic | null): string {
   return `${where}${diag.message}`;
 }
 
-function readWhatWentWrong(
-  lines: string[],
-  start: number,
-): { message: string; fatal: string[]; endIndex: number } | null {
+function readWhatWentWrong(lines: string[], start: number): CauseBlock | null {
   let i = start + 1;
   while (i < lines.length && !WHAT_WENT_WRONG.test(stripCarriage(lines[i]).trim())) {
     const probe = stripCarriage(lines[i]).trim();
@@ -232,6 +251,7 @@ function readWhatWentWrong(
   for (; j < lines.length; j++) {
     const line = stripCarriage(lines[j]).trim();
     if (SECTION.test(line)) break;
+    if (BUILD_TAIL.test(line) || TASK_LINE.test(line)) break;
     if (line === '') {
       if (parts.length) break;
       continue;
@@ -239,7 +259,23 @@ function readWhatWentWrong(
     parts.push(line.replace(/^>\s*/, ''));
   }
   if (parts.length === 0) return null;
-  return { message: parts.join(' '), fatal: parts.filter((part) => FATAL_ERROR.test(part)), endIndex: j - 1 };
+  return { message: parts.join(' '), highlights: highlightsOf(parts), endIndex: j - 1 };
+}
+
+function readCauseChain(lines: string[], start: number): CauseBlock {
+  const parts = [stripCarriage(lines[start]).trim()];
+  let end = start;
+  for (let j = start + 1; j < lines.length && parts.length < MAX_CAUSE_LINES; j++) {
+    const line = stripCarriage(lines[j]).trim();
+    if (!CAUSE_LINE.test(line) || TASK_LINE.test(line)) break;
+    parts.push(line.replace(/^>\s*/, ''));
+    end = j;
+  }
+  return { message: parts.join(' '), highlights: highlightsOf(parts), endIndex: end };
+}
+
+function highlightsOf(parts: string[]): string[] {
+  return parts.filter((part) => FATAL_ERROR.test(part) || JAVA_EXCEPTION.test(part));
 }
 
 function stripAaptPrefix(message: string): string {


### PR DESCRIPTION
Improves diagnostics for #162. The flake itself is not fixed here; this makes the next occurrence readable.

## Description

When `./gradlew assembleDebug` fails at `:app:packageDebug`, `stim android` reports the task name and a clipped Gradle deprecation warning, and nothing else. That is the whole of what the rc.7 gate captured, twice:

```
error  Task :app:packageDebug FAILED
error  Deprecated Gradle features were used in this build, making it incompatible with Gradle 10. You can use '--warning-mode all' to show ...
```

Gradle's stderr failure report and its stdout build tail (the deprecation summary, `BUILD FAILED in ...`) go through independent line readers, so a stdout line can land between `* What went wrong:` and the cause beneath it. `readWhatWentWrong` then reports that tail as the block body *and advances the scan index past the real cause*; nothing else in the extractor matches `Execution failed for task ...` or its `>` cause chain, so the cause is dropped. Feeding that ordering to the extractor on `main` reproduces the two lines above exactly.

## Solution

- The What-went-wrong body skips Gradle's build-result tail rather than ending on it, so the cause reassembles wherever the tail lands -- before the `Execution failed` line, after it, or mid-chain. A body that ends up empty reports nothing and consumes nothing, leaving the displaced cause to the rest of the scan.
- `Execution failed for task ':x'.` and up to five following `>` cause lines are recognized on their own, wherever they land. They join into the same shape the block reader produces, so a contiguous report still yields a single diagnostic and the two paths dedupe against each other.
- A cause line naming a Java exception is reported whole when the joined message clipped it off -- with two absolute intermediates paths in it, the 300-char clip lops off exactly the innermost cause. That is the same reason the existing `FATAL_ERROR` handling exists. An exception line that survives into the message is not repeated.

Extraction is read-only over a transcript that is already captured, so the worst case is a noisier or thinner error list, never a changed build outcome.

A `packageDebug` failure now reads:

```
error  Task :app:packageDebug FAILED
error  Execution failed for task ':app:packageDebug'. A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable java.io.IOException: Failed to copy full conte...
error  java.io.IOException: Failed to copy full contents from '/w/android/app/build/intermediates/stripped_native_libs/debug/out/lib/arm64-v8a/libreactnative.so' to '/w/android/app/build/intermediates/apk/debug/packageDebug/lib/arm64-v8a/libreactnative.so'
```

## Test plan

- Canned transcripts covering the contiguous report, the interleaved one, a build-result tail with no failure at all, the chain stopping at the next task line, and the cap: `pnpm exec vitest run packages/stim-cli/src/__tests__/errors-gradle.test.ts` (31 pass, including the 26 that were already there).
