### PR TITLE
Substitute inter-package versions at pack time instead of by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,10 @@
 # credential minted for exactly this repo + workflow + environment, and the
 # `release` environment requires a manual approval, which replaces the OTP.
 #
-# The tarballs are built by `pnpm pack`, not by `npm publish`, because the
-# packages declare their edges to each other with pnpm's `workspace:` protocol.
-# pnpm substitutes the real version when it packs; npm does not understand the
-# protocol and would upload a literal `workspace:^` range. npm still performs
-# every publish, from the packed tarball, so the OIDC and provenance path is
-# unchanged.
+# The tarballs come from `pnpm pack`: the packages declare their edges to each
+# other with pnpm's `workspace:` protocol, which only pnpm substitutes with the
+# real version. npm would upload the range verbatim, so npm only publishes the
+# already-packed tarball.
 #
 # Third-party actions are pinned by commit SHA and the job is deliberately
 # minimal -- nothing here may run code that could tamper with the tarballs.
@@ -28,6 +26,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      PACKAGE_DIRS: core cache metro expo-build-cache stim-cli
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -51,7 +51,7 @@ jobs:
       - name: Tag matches the package versions
         run: |
           tag="${GITHUB_REF_NAME#v}"
-          for p in core cache stim-cli expo-build-cache metro; do
+          for p in $PACKAGE_DIRS; do
             v=$(node -p "require('./packages/$p/package.json').version")
             if [ "$v" != "$tag" ]; then
               echo "packages/$p is $v but the tag is $tag"; exit 1
@@ -59,27 +59,36 @@ jobs:
           done
       - name: Pack the tarballs with pnpm
         run: |
-          mkdir -p "$RUNNER_TEMP/tarballs"
-          for p in core cache metro expo-build-cache stim-cli; do
+          for p in $PACKAGE_DIRS; do
             tarball=$(cd "packages/$p" && pnpm pack --pack-destination "$RUNNER_TEMP/tarballs" | tail -1)
             mv "$tarball" "$RUNNER_TEMP/tarballs/$p.tgz"
             tar -xzOf "$RUNNER_TEMP/tarballs/$p.tgz" package/package.json > "$RUNNER_TEMP/tarballs/$p.package.json"
           done
-      - name: Packed manifests name real versions
+      - name: Packed manifests name the tag, not a workspace range
         run: |
           tag="${GITHUB_REF_NAME#v}"
-          for p in core cache metro expo-build-cache stim-cli; do
+          for p in $PACKAGE_DIRS; do
             manifest="$RUNNER_TEMP/tarballs/$p.package.json"
-            if grep -q '"workspace:' "$manifest"; then
-              echo "packages/$p packed an unsubstituted workspace: range"
-              grep '"workspace:' "$manifest"
-              exit 1
+            if grep -nE '"[^"]*": *"workspace:' "$manifest"; then
+              echo "packages/$p packed an unsubstituted workspace: range"; exit 1
             fi
-            v=$(node -p "require('$manifest').version")
-            if [ "$v" != "$tag" ]; then
-              echo "packages/$p packed $v but the tag is $tag"; exit 1
-            fi
-            node -e "const m=require('$manifest');const d={...m.dependencies,...m.devDependencies};for(const [n,r] of Object.entries(d)) if(n==='stim-cli'||n.startsWith('@stim-cli/')) console.log(m.name,'->',n,r);"
+            node -e '
+              const manifest = require(process.argv[1]);
+              const tag = process.argv[2];
+              const accepted = new Set([tag, `^${tag}`, `~${tag}`]);
+              const groups = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+              let bad = manifest.version === tag ? 0 : 1;
+              if (bad) console.log(`${manifest.name} is ${manifest.version} but the tag is ${tag}`);
+              for (const group of groups) {
+                for (const [name, range] of Object.entries(manifest[group] ?? {})) {
+                  if (name !== "stim-cli" && !name.startsWith("@stim-cli/")) continue;
+                  const ok = accepted.has(range);
+                  console.log(`${manifest.name} ${group}.${name} ${range} ${ok ? "ok" : "MISMATCH"}`);
+                  if (!ok) bad += 1;
+                }
+              }
+              process.exit(bad === 0 ? 0 : 1);
+            ' "$manifest" "$tag"
           done
       - name: Publish @stim-cli/core
         run: |
@@ -128,7 +137,8 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           max_attempts=12
           retry_delay=10
-          for p in @stim-cli/core @stim-cli/cache stim-cli @stim-cli/expo-build-cache @stim-cli/metro; do
+          for d in $PACKAGE_DIRS; do
+            p=$(node -p "require('$RUNNER_TEMP/tarballs/$d.package.json').name")
             for attempt in $(seq 1 "$max_attempts"); do
               if v=$(npm view "$p@$version" version 2>/dev/null) && [ "$v" = "$version" ]; then
                 echo "$p -> $v"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@
 # credential minted for exactly this repo + workflow + environment, and the
 # `release` environment requires a manual approval, which replaces the OTP.
 #
+# The tarballs are built by `pnpm pack`, not by `npm publish`, because the
+# packages declare their edges to each other with pnpm's `workspace:` protocol.
+# pnpm substitutes the real version when it packs; npm does not understand the
+# protocol and would upload a literal `workspace:^` range. npm still performs
+# every publish, from the packed tarball, so the OIDC and provenance path is
+# unchanged.
+#
 # Third-party actions are pinned by commit SHA and the job is deliberately
 # minimal -- nothing here may run code that could tamper with the tarballs.
 name: Release
@@ -50,52 +57,71 @@ jobs:
               echo "packages/$p is $v but the tag is $tag"; exit 1
             fi
           done
-      - name: Publish @stim-cli/core
-        working-directory: packages/core
+      - name: Pack the tarballs with pnpm
         run: |
-          version=$(node -p "require('./package.json').version")
+          mkdir -p "$RUNNER_TEMP/tarballs"
+          for p in core cache metro expo-build-cache stim-cli; do
+            tarball=$(cd "packages/$p" && pnpm pack --pack-destination "$RUNNER_TEMP/tarballs" | tail -1)
+            mv "$tarball" "$RUNNER_TEMP/tarballs/$p.tgz"
+            tar -xzOf "$RUNNER_TEMP/tarballs/$p.tgz" package/package.json > "$RUNNER_TEMP/tarballs/$p.package.json"
+          done
+      - name: Packed manifests name real versions
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for p in core cache metro expo-build-cache stim-cli; do
+            manifest="$RUNNER_TEMP/tarballs/$p.package.json"
+            if grep -q '"workspace:' "$manifest"; then
+              echo "packages/$p packed an unsubstituted workspace: range"
+              grep '"workspace:' "$manifest"
+              exit 1
+            fi
+            v=$(node -p "require('$manifest').version")
+            if [ "$v" != "$tag" ]; then
+              echo "packages/$p packed $v but the tag is $tag"; exit 1
+            fi
+            node -e "const m=require('$manifest');const d={...m.dependencies,...m.devDependencies};for(const [n,r] of Object.entries(d)) if(n==='stim-cli'||n.startsWith('@stim-cli/')) console.log(m.name,'->',n,r);"
+          done
+      - name: Publish @stim-cli/core
+        run: |
+          version=$(node -p "require('$RUNNER_TEMP/tarballs/core.package.json').version")
           if npm view "@stim-cli/core@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/core@$version is already published"
           else
             # latest-on-purpose while no stable exists (RELEASE.md section 1); issue #165
             # gates the prerelease-aware selection required after 1.0.0 stable.
-            npm publish --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/core.tgz" --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/cache
-        working-directory: packages/cache
         run: |
-          version=$(node -p "require('./package.json').version")
+          version=$(node -p "require('$RUNNER_TEMP/tarballs/cache.package.json').version")
           if npm view "@stim-cli/cache@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/cache@$version is already published"
           else
-            npm publish --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/cache.tgz" --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/metro
-        working-directory: packages/metro
         run: |
-          version=$(node -p "require('./package.json').version")
+          version=$(node -p "require('$RUNNER_TEMP/tarballs/metro.package.json').version")
           if npm view "@stim-cli/metro@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/metro@$version is already published"
           else
-            npm publish --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/metro.tgz" --provenance --access public --tag latest
           fi
       - name: Publish @stim-cli/expo-build-cache
-        working-directory: packages/expo-build-cache
         run: |
-          version=$(node -p "require('./package.json').version")
+          version=$(node -p "require('$RUNNER_TEMP/tarballs/expo-build-cache.package.json').version")
           if npm view "@stim-cli/expo-build-cache@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/expo-build-cache@$version is already published"
           else
-            npm publish --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/expo-build-cache.tgz" --provenance --access public --tag latest
           fi
       - name: Publish stim-cli
-        working-directory: packages/stim-cli
         run: |
-          version=$(node -p "require('./package.json').version")
+          version=$(node -p "require('$RUNNER_TEMP/tarballs/stim-cli.package.json').version")
           if npm view "stim-cli@$version" version >/dev/null 2>&1; then
             echo "stim-cli@$version is already published"
           else
-            npm publish --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/stim-cli.tgz" --provenance --access public --tag latest
           fi
       - name: Smoke-test the registry
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -112,18 +112,28 @@ preparation, `git status --short` may show only the draft
    test "$(node packages/stim-cli/dist/cli.mjs --version)" = "X.Y.Z"
    ```
 
-3. **Verify each npm tarball** ships only what should ship, and that each one
-   carries its own README:
+3. **Verify each npm tarball** ships only what should ship, that each one
+   carries its own README, and that every `@stim-cli/*` line names a real
+   version. Pack with `pnpm`, never `npm`: the release workflow publishes
+   pnpm-packed tarballs, and `npm pack` prints the unsubstituted `workspace:`
+   ranges rather than what actually publishes.
 
    ```bash
-   for p in core stim-cli expo-build-cache metro; do
-     echo "== $p"; (cd "packages/$p" && npm pack --dry-run 2>&1 | grep -E 'README|Tarball|total files')
+   out=$(mktemp -d)
+   for p in core cache metro expo-build-cache stim-cli; do
+     tgz=$(cd "packages/$p" && pnpm pack --pack-destination "$out" | tail -1)
+     echo "== $p ($(tar -tzf "$tgz" | wc -l | tr -d ' ') files)"
+     tar -tzf "$tgz" | grep -E 'README|LICENSE'
+     tar -xzOf "$tgz" package/package.json | grep -E '"version"|"@stim-cli/'
    done
+   rm -rf "$out"
    ```
 
    Keep the `files` whitelists tight (`dist`, `shim`, `skill`, `LICENSE`,
    `README.md` for the CLI; `dist`, `README.md`, `LICENSE` for the other
-   packages). Every published JavaScript entry lives under `dist/`.
+   packages). Every published JavaScript entry lives under `dist/`. A
+   `workspace:` range in that output means the tarball was not packed by pnpm;
+   stop and fix the packing before publishing.
 
 4. **Inspect the candidate diff.** `git status --short` should contain only the
    five package manifests, `pnpm-lock.yaml`, and the draft
@@ -236,8 +246,9 @@ Before continuing:
    ```
 
    Send the `url` (the run page has Review deployments -> `release` ->
-   Approve and deploy). The workflow skips an exact package version that
-   already exists, publishes to the `latest` dist-tag (section 1), then
+   Approve and deploy). The workflow packs the five tarballs with pnpm, checks
+   that no `workspace:` range survived the pack, skips an exact package version
+   that already exists, publishes to the `latest` dist-tag (section 1), then
    verifies all five registry versions. A NEW package, a failed publish, or
    a provenance rejection: see
    [docs/release-recovery.md](./docs/release-recovery.md).
@@ -264,6 +275,7 @@ Before continuing:
 ## Don't
 
 - Force-push tags. Cut a new version.
-- Skip the `npm pack --dry-run` step. Untracked files have shipped before.
+- Skip the tarball check in section 2, step 3. Untracked files have shipped
+  before, and it is the only place a `workspace:` range would be caught by hand.
 - Publish one package at a new version and leave the others behind. The shared
   version is the compatibility statement; a partial release makes it a lie.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,15 +83,20 @@ preparation, `git status --short` may show only the draft
    pnpm run release:prep X.Y.Z
    ```
 
-   The script refuses a malformed version, a tree whose five versions already
-   disagree, and the version they already carry. It rewrites the five `version`
-   fields, runs `pnpm install --lockfile-only`, then re-reads the manifests and
-   the lockfile to prove the bump landed, and leaves the candidate uncommitted
-   and untagged.
+   The script refuses a malformed version, one that does not come after the
+   version the five packages already carry, and a tree whose versions already
+   disagree. It rewrites the five `version` fields together, refreshes the
+   lockfile, then re-reads the manifests to confirm all five landed on the new
+   version and that the lockfile still matches them, and leaves the candidate
+   uncommitted and untagged. If any of that fails it puts the five manifests
+   back at the version they had, so a failed run is never half-bumped.
 
    Nothing else moves. The packages depend on each other through pnpm's
    `workspace:` protocol, so there is no dependency range to bump: pnpm
    substitutes the real version when it packs (verified in step 3).
+   `pnpm run release:prep --check` audits that shape -- five versions in
+   lockstep, every internal range a bare `workspace:` range -- without changing
+   anything.
 
    Confirm all five moved:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -80,20 +80,23 @@ preparation, `git status --short` may show only the draft
    same number, and `dist/cli.mjs` reads it from its own `package.json`:
 
    ```bash
-   pnpm -r --filter './packages/*' exec npm version X.Y.Z --no-git-tag-version
-   pnpm install --lockfile-only
+   pnpm run release:prep X.Y.Z
    ```
 
-   The filtered `exec` bumps all five; `--no-git-tag-version` leaves the
-   candidate uncommitted and untagged. The lockfile duplicates every
-   workspace's version and must move with the manifests.
+   The script refuses a malformed version, a tree whose five versions already
+   disagree, and the version they already carry. It rewrites the five `version`
+   fields, runs `pnpm install --lockfile-only`, then re-reads the manifests and
+   the lockfile to prove the bump landed, and leaves the candidate uncommitted
+   and untagged.
 
-   Confirm all five moved, and that dependency ranges between the packages
-   still name versions that will exist when publishing finishes:
+   Nothing else moves. The packages depend on each other through pnpm's
+   `workspace:` protocol, so there is no dependency range to bump: pnpm
+   substitutes the real version when it packs (verified in step 3).
+
+   Confirm all five moved:
 
    ```bash
    grep -H '"version"' packages/*/package.json
-   grep -H '"@stim-cli/' packages/stim-cli/package.json packages/expo-build-cache/package.json packages/metro/package.json packages/cache/package.json
    ```
 
 2. **Install and run the full pre-flight against those exact files:**
@@ -136,8 +139,10 @@ preparation, `git status --short` may show only the draft
    stop and fix the packing before publishing.
 
 4. **Inspect the candidate diff.** `git status --short` should contain only the
-   five package manifests, `pnpm-lock.yaml`, and the draft
-   release notes. Resolve anything else before QA.
+   five package manifests and the draft release notes. `pnpm-lock.yaml` no
+   longer moves with a version bump -- it records the internal edges as
+   `workspace:` specifiers and `link:` targets, neither of which carries a
+   version. Resolve anything else before QA.
 
 ## 3. Pre-tag QA gate
 

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -20,18 +20,19 @@ so re-running the whole workflow is also safe.
 
 ## Manual publish fallback
 
-The same commands the workflow runs, for when it cannot. 2FA is on, so each
-publish prompts for an OTP. These use `pnpm publish`, which packs with pnpm
-and therefore substitutes the `workspace:` ranges the packages declare; a bare
-`npm publish` from a package directory would upload them verbatim:
+For when the workflow cannot run: the same five publishes, by hand and in
+dependency order. `pnpm publish` packs with pnpm, so it substitutes the
+`workspace:` ranges the packages declare -- a bare `npm publish` from a package
+directory would upload them verbatim. `--tag latest` matches what the workflow
+does (RELEASE.md section 1). 2FA is on, so each publish prompts for an OTP:
 
 ```bash
 npm whoami                                          # confirm login; if 401, `npm login` first
-pnpm --filter @stim-cli/core publish --access public --otp <code>
-pnpm --filter @stim-cli/cache publish --access public --otp <code>
-pnpm --filter @stim-cli/metro publish --access public --otp <code>
-pnpm --filter @stim-cli/expo-build-cache publish --access public --otp <code>
-pnpm --filter stim-cli publish --access public --otp <code>
+pnpm --filter @stim-cli/core publish --access public --tag latest --otp <code>
+pnpm --filter @stim-cli/cache publish --access public --tag latest --otp <code>
+pnpm --filter @stim-cli/metro publish --access public --tag latest --otp <code>
+pnpm --filter @stim-cli/expo-build-cache publish --access public --tag latest --otp <code>
+pnpm --filter stim-cli publish --access public --tag latest --otp <code>
 ```
 
 ## First publication of a NEW package

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -21,7 +21,9 @@ so re-running the whole workflow is also safe.
 ## Manual publish fallback
 
 The same commands the workflow runs, for when it cannot. 2FA is on, so each
-publish prompts for an OTP:
+publish prompts for an OTP. These use `pnpm publish`, which packs with pnpm
+and therefore substitutes the `workspace:` ranges the packages declare; a bare
+`npm publish` from a package directory would upload them verbatim:
 
 ```bash
 npm whoami                                          # confirm login; if 401, `npm login` first

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "pnpm -r --filter \"./packages/*\" run build",
     "test:e2e": "node --test test/e2e/*.e2e.js",
     "knip": "knip",
+    "release:prep": "node scripts/release-prep.mjs",
     "preinstall": "npx only-allow pnpm"
   },
   "devDependencies": {

--- a/packages/expo-build-cache/package.json
+++ b/packages/expo-build-cache/package.json
@@ -28,7 +28,7 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@stim-cli/core": "^1.0.0-rc.7"
+    "@stim-cli/core": "workspace:^"
   },
   "engines": {
     "node": "^20.19.4 || >=22.12.0"

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -28,8 +28,8 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@stim-cli/cache": "^1.0.0-rc.7",
-    "@stim-cli/core": "^1.0.0-rc.7"
+    "@stim-cli/cache": "workspace:^",
+    "@stim-cli/core": "workspace:^"
   },
   "peerDependencies": {
     "metro-cache": "*"

--- a/packages/stim-cli/package.json
+++ b/packages/stim-cli/package.json
@@ -46,14 +46,14 @@
   },
   "dependencies": {
     "@expo/fingerprint": "^0.20.10",
-    "@stim-cli/cache": "^1.0.0-rc.7",
-    "@stim-cli/core": "^1.0.0-rc.7",
-    "@stim-cli/metro": "^1.0.0-rc.7",
+    "@stim-cli/cache": "workspace:^",
+    "@stim-cli/core": "workspace:^",
+    "@stim-cli/metro": "workspace:^",
     "chalk": "^5.4.1",
     "commander": "^13.1.0"
   },
   "devDependencies": {
-    "@stim-cli/expo-build-cache": "*"
+    "@stim-cli/expo-build-cache": "workspace:*"
   },
   "engines": {
     "node": "^20.19.4 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,16 +138,16 @@ importers:
   packages/expo-build-cache:
     dependencies:
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../core
 
   packages/metro:
     dependencies:
       '@stim-cli/cache':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../cache
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../core
       metro-cache:
         specifier: '*'
@@ -159,13 +159,13 @@ importers:
         specifier: ^0.20.10
         version: 0.20.10(supports-color@8.1.1)
       '@stim-cli/cache':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../cache
       '@stim-cli/core':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../core
       '@stim-cli/metro':
-        specifier: ^1.0.0-rc.7
+        specifier: workspace:^
         version: link:../metro
       chalk:
         specifier: ^5.4.1
@@ -175,7 +175,7 @@ importers:
         version: 13.1.0
     devDependencies:
       '@stim-cli/expo-build-cache':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../expo-build-cache
 
   website:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,9 @@ packages:
   - packages/*
   - website
 
-# The packages declare each other with `workspace:` ranges, which always link;
-# this keeps a plain semver internal dep linking to the workspace copy too.
+# Defence in depth: the packages declare each other with `workspace:` ranges,
+# which link regardless. This keeps a plain semver internal dep linking to the
+# workspace copy rather than silently resolving to a published version.
 linkWorkspacePackages: true
 
 # Security posture (pnpm 12 defaults + explicit choices):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,8 @@ packages:
   - packages/*
   - website
 
-# Internal deps declared by semver resolve to the workspace copies.
+# The packages declare each other with `workspace:` ranges, which always link;
+# this keeps a plain semver internal dep linking to the workspace copy too.
 linkWorkspacePackages: true
 
 # Security posture (pnpm 12 defaults + explicit choices):

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -6,9 +6,11 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const repositoryRoot = join(import.meta.dirname, '..');
+const repositoryRoot = process.env.RELEASE_PREP_ROOT ?? join(import.meta.dirname, '..');
 const packageDirs = ['core', 'cache', 'metro', 'expo-build-cache', 'stim-cli'];
-const versionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const versionPattern =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][\dA-Za-z-]*))*)?$/;
+const acceptedRanges = new Set(['workspace:^', 'workspace:~', 'workspace:*']);
 const usage = 'usage: node scripts/release-prep.mjs <X.Y.Z[-rc.N]>\n       node scripts/release-prep.mjs --check';
 
 const fail = (message) => {
@@ -17,8 +19,21 @@ const fail = (message) => {
 };
 
 const manifestPath = (dir) => join(repositoryRoot, 'packages', dir, 'package.json');
-const readManifestText = (dir) => readFileSync(manifestPath(dir), 'utf8');
-const readManifest = (dir) => JSON.parse(readManifestText(dir));
+const readManifestText = (dir) => {
+  try {
+    return readFileSync(manifestPath(dir), 'utf8');
+  } catch (error) {
+    return fail(`cannot read ${manifestPath(dir)}: ${error.message}`);
+  }
+};
+const readManifest = (dir) => {
+  const text = readManifestText(dir);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return fail(`${manifestPath(dir)} is not valid JSON: ${error.message}`);
+  }
+};
 
 const internalRanges = (manifest) => {
   const found = [];
@@ -39,8 +54,10 @@ const audit = () => {
     versions.set(dir, manifest.version);
     for (const { group, name, range } of internalRanges(manifest)) {
       ranges += 1;
-      if (!range.startsWith('workspace:')) {
-        problems.push(`packages/${dir} ${group}.${name} is "${range}", not a workspace: range`);
+      // A `workspace:` range carrying its own semver (`workspace:^1.2.3`) is
+      // still a hand-maintained number, which is the thing this replaces.
+      if (!acceptedRanges.has(range)) {
+        problems.push(`packages/${dir} ${group}.${name} is "${range}", not one of ${[...acceptedRanges].join(', ')}`);
       }
     }
   }
@@ -52,21 +69,46 @@ const audit = () => {
   return { problems, version: distinct.size === 1 ? [...distinct][0] : null, ranges };
 };
 
-const setVersion = (dir, current, next) => {
+const parseVersion = (version) => {
+  const [core, prerelease] = version.split('-');
+  return { core: core.split('.').map(Number), prerelease: prerelease ? prerelease.split('.') : null };
+};
+
+// Semver precedence, enough for X.Y.Z and X.Y.Z-rc.N: a prerelease sorts below
+// its release, and prerelease identifiers compare numerically when both are
+// numeric, otherwise as strings.
+const compareVersions = (left, right) => {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (a.core[index] !== b.core[index]) return a.core[index] - b.core[index];
+  }
+  if (!a.prerelease && !b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  for (let index = 0; index < Math.max(a.prerelease.length, b.prerelease.length); index += 1) {
+    const x = a.prerelease[index];
+    const y = b.prerelease[index];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    if (x === y) continue;
+    if (/^\d+$/.test(x) && /^\d+$/.test(y)) return Number(x) - Number(y);
+    return x < y ? -1 : 1;
+  }
+  return 0;
+};
+
+const bumped = (dir, current, next) => {
   const text = readManifestText(dir);
   const matches = text.match(/^ {2}"version": "[^"]*",$/gm) ?? [];
   if (matches.length !== 1 || matches[0] !== `  "version": "${current}",`) {
     fail(`packages/${dir}/package.json has no single top-level "version": "${current}" line to rewrite`);
   }
-  writeFileSync(manifestPath(dir), text.replace(matches[0], `  "version": "${next}",`));
+  return { dir, before: text, after: text.replace(matches[0], `  "version": "${next}",`) };
 };
 
 const pnpm = (args) => {
-  try {
-    execFileSync('pnpm', args, { cwd: repositoryRoot, stdio: ['ignore', 'inherit', 'inherit'] });
-  } catch {
-    fail(`pnpm ${args.join(' ')} failed`);
-  }
+  execFileSync('pnpm', args, { cwd: repositoryRoot, stdio: ['ignore', 'inherit', 'inherit'] });
 };
 
 const [target] = process.argv.slice(2);
@@ -92,19 +134,36 @@ if (before.problems.length > 0) {
   for (const problem of before.problems) process.stderr.write(`release-prep: ${problem}\n`);
   fail('refusing to bump an inconsistent tree');
 }
-if (before.version === target) fail(`the five packages are already at ${target}`);
+if (compareVersions(target, before.version) <= 0) {
+  fail(`${target} does not come after ${before.version}, which the five packages already carry`);
+}
 
-for (const dir of packageDirs) setVersion(dir, before.version, target);
-pnpm(['install', '--lockfile-only']);
-pnpm(['install', '--frozen-lockfile', '--lockfile-only']);
+// Every manifest is validated and its new text computed before anything is
+// written, and the originals go back if the install or the re-audit fails, so a
+// refusal never leaves the five versions half-bumped.
+const rewrites = packageDirs.map((dir) => bumped(dir, before.version, target));
+for (const { dir, after } of rewrites) writeFileSync(manifestPath(dir), after);
+
+const restore = (message) => {
+  for (const { dir, before: original } of rewrites) writeFileSync(manifestPath(dir), original);
+  fail(`${message}\nthe five manifests were restored to ${before.version}`);
+};
+
+try {
+  pnpm(['install', '--lockfile-only']);
+  pnpm(['install', '--frozen-lockfile', '--lockfile-only']);
+} catch {
+  restore('pnpm could not refresh the lockfile for the bumped manifests');
+}
 
 const after = audit();
-for (const problem of after.problems) process.stderr.write(`release-prep: ${problem}\n`);
-if (after.problems.length > 0) process.exit(1);
-if (after.version !== target) fail(`the manifests read ${after.version} after the bump, not ${target}`);
+if (after.problems.length > 0) restore(after.problems.join('\n'));
+if (after.version !== target) restore(`the manifests read ${after.version} after the bump, not ${target}`);
 
 process.stdout.write(`\nrelease-prep: ${before.version} -> ${target}\n`);
-for (const dir of packageDirs) process.stdout.write(`  packages/${dir} ${' '.repeat(18 - dir.length)}${target}\n`);
-process.stdout.write(`  inter-package ranges  ${after.ranges} workspace: ranges, substituted at pack time\n`);
-process.stdout.write('  pnpm-lock.yaml        in sync with the manifests\n');
+for (const dir of packageDirs) process.stdout.write(`  ${`packages/${dir}`.padEnd(28)}${target}\n`);
+process.stdout.write(
+  `  ${'inter-package ranges'.padEnd(28)}${after.ranges} workspace: ranges, substituted at pack time\n`,
+);
+process.stdout.write(`  ${'pnpm-lock.yaml'.padEnd(28)}still matches the manifests\n`);
 process.stdout.write('\nNext: RELEASE.md section 2, step 2.\n');

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -1,0 +1,110 @@
+// The five packages share one version (RELEASE.md section 0) and declare their
+// edges to each other with pnpm's `workspace:` protocol, which pnpm substitutes
+// with the real version at pack time. So a release bumps five `version` fields
+// and nothing else.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repositoryRoot = join(import.meta.dirname, '..');
+const packageDirs = ['core', 'cache', 'metro', 'expo-build-cache', 'stim-cli'];
+const versionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const usage = 'usage: node scripts/release-prep.mjs <X.Y.Z[-rc.N]>\n       node scripts/release-prep.mjs --check';
+
+const fail = (message) => {
+  process.stderr.write(`release-prep: ${message}\n`);
+  process.exit(1);
+};
+
+const manifestPath = (dir) => join(repositoryRoot, 'packages', dir, 'package.json');
+const readManifestText = (dir) => readFileSync(manifestPath(dir), 'utf8');
+const readManifest = (dir) => JSON.parse(readManifestText(dir));
+
+const internalRanges = (manifest) => {
+  const found = [];
+  for (const group of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    for (const [name, range] of Object.entries(manifest[group] ?? {})) {
+      if (name === 'stim-cli' || name.startsWith('@stim-cli/')) found.push({ group, name, range });
+    }
+  }
+  return found;
+};
+
+const audit = () => {
+  const problems = [];
+  const versions = new Map();
+  let ranges = 0;
+  for (const dir of packageDirs) {
+    const manifest = readManifest(dir);
+    versions.set(dir, manifest.version);
+    for (const { group, name, range } of internalRanges(manifest)) {
+      ranges += 1;
+      if (!range.startsWith('workspace:')) {
+        problems.push(`packages/${dir} ${group}.${name} is "${range}", not a workspace: range`);
+      }
+    }
+  }
+  const distinct = new Set(versions.values());
+  if (distinct.size !== 1) {
+    const listed = [...versions].map(([dir, version]) => `packages/${dir}=${version}`).join(' ');
+    problems.push(`the five versions are not in lockstep: ${listed}`);
+  }
+  return { problems, version: distinct.size === 1 ? [...distinct][0] : null, ranges };
+};
+
+const setVersion = (dir, current, next) => {
+  const text = readManifestText(dir);
+  const matches = text.match(/^ {2}"version": "[^"]*",$/gm) ?? [];
+  if (matches.length !== 1 || matches[0] !== `  "version": "${current}",`) {
+    fail(`packages/${dir}/package.json has no single top-level "version": "${current}" line to rewrite`);
+  }
+  writeFileSync(manifestPath(dir), text.replace(matches[0], `  "version": "${next}",`));
+};
+
+const pnpm = (args) => {
+  try {
+    execFileSync('pnpm', args, { cwd: repositoryRoot, stdio: ['ignore', 'inherit', 'inherit'] });
+  } catch {
+    fail(`pnpm ${args.join(' ')} failed`);
+  }
+};
+
+const [target] = process.argv.slice(2);
+if (!target || target === '--help' || target === '-h') {
+  process.stdout.write(`${usage}\n`);
+  process.exit(target ? 0 : 1);
+}
+
+const before = audit();
+
+if (target === '--check') {
+  for (const problem of before.problems) process.stderr.write(`release-prep: ${problem}\n`);
+  if (before.problems.length > 0) process.exit(1);
+  process.stdout.write(`release-prep: ${packageDirs.length} packages at ${before.version}\n`);
+  process.stdout.write(`release-prep: ${before.ranges} inter-package ranges, all workspace:\n`);
+  process.exit(0);
+}
+
+if (!versionPattern.test(target)) {
+  fail(`"${target}" is not a version. Use X.Y.Z or X.Y.Z-rc.N, with no leading "v".\n${usage}`);
+}
+if (before.problems.length > 0) {
+  for (const problem of before.problems) process.stderr.write(`release-prep: ${problem}\n`);
+  fail('refusing to bump an inconsistent tree');
+}
+if (before.version === target) fail(`the five packages are already at ${target}`);
+
+for (const dir of packageDirs) setVersion(dir, before.version, target);
+pnpm(['install', '--lockfile-only']);
+pnpm(['install', '--frozen-lockfile', '--lockfile-only']);
+
+const after = audit();
+for (const problem of after.problems) process.stderr.write(`release-prep: ${problem}\n`);
+if (after.problems.length > 0) process.exit(1);
+if (after.version !== target) fail(`the manifests read ${after.version} after the bump, not ${target}`);
+
+process.stdout.write(`\nrelease-prep: ${before.version} -> ${target}\n`);
+for (const dir of packageDirs) process.stdout.write(`  packages/${dir} ${' '.repeat(18 - dir.length)}${target}\n`);
+process.stdout.write(`  inter-package ranges  ${after.ranges} workspace: ranges, substituted at pack time\n`);
+process.stdout.write('  pnpm-lock.yaml        in sync with the manifests\n');
+process.stdout.write('\nNext: RELEASE.md section 2, step 2.\n');

--- a/test/e2e/release-prep.e2e.js
+++ b/test/e2e/release-prep.e2e.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,43 +10,120 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..', '..');
 const SCRIPT = join(REPO, 'scripts', 'release-prep.mjs');
 const PACKAGE_DIRS = ['core', 'cache', 'metro', 'expo-build-cache', 'stim-cli'];
+const ACCEPTED_RANGES = new Set(['workspace:^', 'workspace:~', 'workspace:*']);
 
-const runPrep = (...args) => spawnSync(process.execPath, [SCRIPT, ...args], { cwd: REPO, encoding: 'utf8' });
+const manifestIn = (root, dir) => join(root, 'packages', dir, 'package.json');
+const readManifest = (root, dir) => JSON.parse(readFileSync(manifestIn(root, dir), 'utf8'));
+const versionsIn = (root) => PACKAGE_DIRS.map((dir) => readManifest(root, dir).version);
 
-const manifest = (dir) => JSON.parse(readFileSync(join(REPO, 'packages', dir, 'package.json'), 'utf8'));
+const runPrep = (root, ...args) =>
+  spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: REPO,
+    encoding: 'utf8',
+    env: { ...process.env, RELEASE_PREP_ROOT: root },
+  });
+
+// A workspace pnpm can resolve without the network: every importer the lockfile
+// names, and no dependency versions to re-resolve because the internal edges are
+// `workspace:` ranges and `link:` targets.
+const makeWorkspace = () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-release-prep-'));
+  mkdirSync(join(root, 'website'), { recursive: true });
+  for (const file of ['pnpm-workspace.yaml', 'pnpm-lock.yaml']) cpSync(join(REPO, file), join(root, file));
+  cpSync(join(REPO, 'website', 'package.json'), join(root, 'website', 'package.json'));
+  for (const dir of PACKAGE_DIRS) {
+    mkdirSync(join(root, 'packages', dir), { recursive: true });
+    cpSync(join(REPO, 'packages', dir, 'package.json'), manifestIn(root, dir));
+  }
+  const rootManifest = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf8'));
+  delete rootManifest.scripts.preinstall;
+  writeFileSync(join(root, 'package.json'), `${JSON.stringify(rootManifest, null, 2)}\n`);
+  return root;
+};
+
+const withWorkspace = (body) => {
+  const root = makeWorkspace();
+  try {
+    body(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
 
 test('--check accepts the repository as it stands', () => {
-  const result = runPrep('--check');
+  const result = spawnSync(process.execPath, [SCRIPT, '--check'], { cwd: REPO, encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /5 packages at \d+\.\d+\.\d+/);
   assert.match(result.stdout, /inter-package ranges, all workspace:/);
 });
 
-test('the five packages share one version and only workspace: ranges', () => {
-  const versions = new Set(PACKAGE_DIRS.map((dir) => manifest(dir).version));
+test('the five packages share one version and only bare workspace: ranges', () => {
+  const versions = new Set(PACKAGE_DIRS.map((dir) => readManifest(REPO, dir).version));
   assert.equal(versions.size, 1, `versions are not in lockstep: ${[...versions].join(', ')}`);
 
   for (const dir of PACKAGE_DIRS) {
-    const pkg = manifest(dir);
+    const pkg = readManifest(REPO, dir);
     for (const group of ['dependencies', 'devDependencies', 'peerDependencies']) {
       for (const [name, range] of Object.entries(pkg[group] ?? {})) {
         if (name !== 'stim-cli' && !name.startsWith('@stim-cli/')) continue;
-        assert.match(range, /^workspace:/, `packages/${dir} ${group}.${name} is "${range}"`);
+        assert.equal(ACCEPTED_RANGES.has(range), true, `packages/${dir} ${group}.${name} is "${range}"`);
       }
     }
   }
 });
 
-test('a malformed version, a missing version, and the current version are all refused', () => {
-  for (const args of [[], ['v1.2.3'], ['1.2'], ['1.2.3.4'], [manifest('core').version]]) {
-    const result = runPrep(...args);
-    assert.equal(result.status, 1, `expected a refusal for ${JSON.stringify(args)}`);
-  }
-  assert.equal(runPrep('--check').status, 0, 'a refused run must not change the manifests');
+test('a bump rewrites all five versions and leaves the lockfile alone', () => {
+  withWorkspace((root) => {
+    const before = readManifest(root, 'core').version;
+    const lockBefore = readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8');
+
+    const result = runPrep(root, '99.0.0');
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      versionsIn(root),
+      Array.from({ length: 5 }, () => '99.0.0'),
+    );
+    assert.notEqual(before, '99.0.0');
+
+    const cli = readManifest(root, 'stim-cli');
+    assert.equal(cli.dependencies['@stim-cli/core'], 'workspace:^', 'the bump must not touch the ranges');
+    assert.equal(
+      readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8'),
+      lockBefore,
+      'a version bump must not move the lockfile',
+    );
+    assert.equal(runPrep(root, '--check').status, 0, result.stderr);
+  });
+});
+
+test('a malformed, non-increasing, or missing version is refused without touching a manifest', () => {
+  withWorkspace((root) => {
+    const before = versionsIn(root);
+    for (const args of [[], ['v1.2.3'], ['1.2'], ['1.2.3.4'], ['01.2.3'], ['0.0.1'], [before[0]]]) {
+      const result = runPrep(root, ...args);
+      assert.equal(result.status, 1, `expected a refusal for ${JSON.stringify(args)}`);
+      assert.deepEqual(versionsIn(root), before, `${JSON.stringify(args)} changed a manifest`);
+    }
+  });
+});
+
+test('a manifest the bump cannot rewrite leaves every version where it was', () => {
+  withWorkspace((root) => {
+    const before = versionsIn(root);
+    writeFileSync(manifestIn(root, 'stim-cli'), '{ "name": "stim-cli" }\n');
+
+    const result = runPrep(root, '99.0.0');
+    assert.equal(result.status, 1, result.stdout);
+    assert.deepEqual(
+      PACKAGE_DIRS.slice(0, 4).map((dir) => readManifest(root, dir).version),
+      before.slice(0, 4),
+      'the other four manifests must not be left bumped',
+    );
+  });
 });
 
 test('pnpm pack substitutes the workspace ranges the CLI ships with', () => {
-  const out = mkdtempSync(join(tmpdir(), 'stim-release-prep-'));
+  const out = mkdtempSync(join(tmpdir(), 'stim-release-pack-'));
   try {
     const packed = execFileSync('pnpm', ['pack', '--pack-destination', out], {
       cwd: join(REPO, 'packages', 'stim-cli'),
@@ -56,7 +133,7 @@ test('pnpm pack substitutes the workspace ranges the CLI ships with', () => {
       .split('\n')
       .at(-1);
     const shipped = JSON.parse(execFileSync('tar', ['-xzOf', packed, 'package/package.json'], { encoding: 'utf8' }));
-    const version = manifest('stim-cli').version;
+    const version = readManifest(REPO, 'stim-cli').version;
 
     assert.equal(shipped.version, version);
     for (const name of ['@stim-cli/cache', '@stim-cli/core', '@stim-cli/metro']) {

--- a/test/e2e/release-prep.e2e.js
+++ b/test/e2e/release-prep.e2e.js
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const SCRIPT = join(REPO, 'scripts', 'release-prep.mjs');
+const PACKAGE_DIRS = ['core', 'cache', 'metro', 'expo-build-cache', 'stim-cli'];
+
+const runPrep = (...args) => spawnSync(process.execPath, [SCRIPT, ...args], { cwd: REPO, encoding: 'utf8' });
+
+const manifest = (dir) => JSON.parse(readFileSync(join(REPO, 'packages', dir, 'package.json'), 'utf8'));
+
+test('--check accepts the repository as it stands', () => {
+  const result = runPrep('--check');
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /5 packages at \d+\.\d+\.\d+/);
+  assert.match(result.stdout, /inter-package ranges, all workspace:/);
+});
+
+test('the five packages share one version and only workspace: ranges', () => {
+  const versions = new Set(PACKAGE_DIRS.map((dir) => manifest(dir).version));
+  assert.equal(versions.size, 1, `versions are not in lockstep: ${[...versions].join(', ')}`);
+
+  for (const dir of PACKAGE_DIRS) {
+    const pkg = manifest(dir);
+    for (const group of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      for (const [name, range] of Object.entries(pkg[group] ?? {})) {
+        if (name !== 'stim-cli' && !name.startsWith('@stim-cli/')) continue;
+        assert.match(range, /^workspace:/, `packages/${dir} ${group}.${name} is "${range}"`);
+      }
+    }
+  }
+});
+
+test('a malformed version, a missing version, and the current version are all refused', () => {
+  for (const args of [[], ['v1.2.3'], ['1.2'], ['1.2.3.4'], [manifest('core').version]]) {
+    const result = runPrep(...args);
+    assert.equal(result.status, 1, `expected a refusal for ${JSON.stringify(args)}`);
+  }
+  assert.equal(runPrep('--check').status, 0, 'a refused run must not change the manifests');
+});
+
+test('pnpm pack substitutes the workspace ranges the CLI ships with', () => {
+  const out = mkdtempSync(join(tmpdir(), 'stim-release-prep-'));
+  try {
+    const packed = execFileSync('pnpm', ['pack', '--pack-destination', out], {
+      cwd: join(REPO, 'packages', 'stim-cli'),
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n')
+      .at(-1);
+    const shipped = JSON.parse(execFileSync('tar', ['-xzOf', packed, 'package/package.json'], { encoding: 'utf8' }));
+    const version = manifest('stim-cli').version;
+
+    assert.equal(shipped.version, version);
+    for (const name of ['@stim-cli/cache', '@stim-cli/core', '@stim-cli/metro']) {
+      assert.equal(shipped.dependencies[name], `^${version}`);
+    }
+    assert.equal(shipped.devDependencies['@stim-cli/expo-build-cache'], version);
+    assert.equal(JSON.stringify(shipped).includes('workspace:'), false, 'a workspace: range reached the tarball');
+  } finally {
+    rmSync(out, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Description

The `@stim-cli/*` ranges the five packages use to depend on each other were literal semver, so they did not move when a release bumped the five `version` fields. RELEASE.md guarded that with a `grep` the releaser had to read correctly; a skimmed grep ships a package whose declared dependency range points at the previous release, and nothing downstream catches it. The same literal ranges meant a locally packed tarball asked the registry for its siblings instead of using the tree it was built from.

Fixes #171.

## Solution

The packages now declare each other with pnpm's `workspace:` protocol, which pnpm substitutes with the real version when it packs. Nothing is left to bump but the five `version` fields, so:

- **Release day is now `pnpm run release:prep X.Y.Z`** (RELEASE.md section 2, step 1). `scripts/release-prep.mjs` validates the version, refuses one that does not come after the version the packages carry or a tree whose five versions already disagree, rewrites the five fields, refreshes the lockfile, and re-reads the manifests to confirm the result. Every replacement text is computed and validated before any file is written, and the originals go back if a later step fails, so a refusal cannot leave the tree half-bumped. Node-only, no deps.
- **RELEASE.md's tarball check (step 3) now packs with `pnpm`, not `npm`** -- and covers all five packages; the old `npm pack --dry-run` loop silently skipped `@stim-cli/cache`. Not cosmetic: `npm pack` on these manifests prints `workspace:` ranges and tells the releaser the opposite of the truth about what publishes.

**The trap this had to clear:** npm does not understand the protocol, so changing only the manifests would have published literal ranges on the next tag. Packing `packages/stim-cli` both ways:

```
npm pack   ->  "@stim-cli/cache": "workspace:^"   "@stim-cli/core": "workspace:^"
               "@stim-cli/metro": "workspace:^"   "@stim-cli/expo-build-cache": "workspace:*"
pnpm pack  ->  "@stim-cli/cache": "^1.0.0-rc.7"   "@stim-cli/core": "^1.0.0-rc.7"
               "@stim-cli/metro": "^1.0.0-rc.7"   "@stim-cli/expo-build-cache": "1.0.0-rc.7"
```

So `release.yml` packs the five tarballs with `pnpm pack` and hands each to `npm publish <tarball>`. `pnpm publish --provenance` would also work -- pnpm 12 ships its own OIDC and provenance implementation -- but it replaces the whole credential leg, the one part of this workflow that cannot be exercised outside CI, with a second implementation. Packing with pnpm and publishing with npm changes only the artifact source: OIDC trusted publishing, `--provenance`, `--access public`, `--tag latest`, the skip-if-already-published guard, the `release` environment approval, and the registry verify step are untouched.

A new step between the build and the publishes fails the release unless every packed manifest carries the tag's version and every `@stim-cli/*` range resolves to it. That is what makes the trap non-repeatable: a surviving `workspace:` string, a stale range, and a tarball that disagrees with the tag all stop the run before the first upload.

**Residual risk.** npm reads the manifest out of the tarball and then follows the same publish path it follows from a directory -- the trusted-publisher exchange is keyed on the package name and version, not on how the tarball was produced -- so `npm publish <tarball>` should not change the credential leg. Locally it reaches npm's provenance code and fails with `EUSAGE: Automatic provenance generation not supported for provider: null`, which is the correct outside-CI answer, and `--access public --tag latest` are confirmed by dry run. What remains is that this repo has not run an OIDC publish with a tarball argument, and that only the next tagged release proves. If it does fail it fails before upload (auth precedes the tarball PUT), the version is not consumed, and `docs/release-recovery.md`'s manual fallback uses `pnpm publish`, which substitutes on its own.

Two things a reviewer may not expect:

- **`stim-cli`'s dev-only `@stim-cli/expo-build-cache` became `workspace:*`, not `workspace:^`.** It has been `"*"` since the package was created ([612a447](https://github.com/appandflow/stim/commit/612a447ffbafbf54d14fefdd1708f26d2202b6f9), and under its pre-rename name before that) -- it exists so `cache-packages.test.ts` can import the provider, consumers never install it, so it never carried a real range. `workspace:*` keeps that "whatever is local" intent; it publishes as an exact version rather than a caret range, which nothing resolves either way in a devDependency.
- **`pnpm-lock.yaml` no longer moves with a version bump.** The importers record `specifier: workspace:^` and `version: link:../core`, neither of which carries a version. RELEASE.md step 4 said to expect the lockfile in the candidate diff; it now says why it will not be there. `release-prep` still runs `pnpm install --lockfile-only` and then a `--frozen-lockfile --lockfile-only` confirmation: both are sub-second, and the second is what turns "the lockfile probably still matches" into a checked invariant before the releaser spends an hour on the QA gate.

## Test plan

Full battery on the rebased branch, all green: `format:check`, `lint`, `build`, `typecheck`, `knip`, `test` (2649), `test:e2e` (19), `test:runtime`. `pnpm install --frozen-lockfile` verified from a deleted `node_modules` -- the lockfile importers change shape, so that is the check that matters here.

**Substitution, before and after.** The `pnpm pack` column above is the after; before the change the same tarball carried the identical `^1.0.0-rc.7` on the three runtime deps (and `*` on the dev one). Semantically identical, which is the point: what publishes today is unchanged, and the next bump is free. `pnpm run release:prep 1.0.0-rc.8` then repacking gives `^1.0.0-rc.8` on all three, with no manifest edit beyond the version fields; the bump leaves `pnpm-lock.yaml` byte-identical.

**The published artifact resolves.** `npm install` of the packed CLI tarball in a scratch directory pulled `@stim-cli/{core,cache,metro}` from the registry at `1.0.0-rc.7`, and `./node_modules/.bin/stim --version` printed `1.0.0-rc.7`.

**The workflow guard, run the way the workflow runs it** (steps extracted from `release.yml`, `bash -e`, with `RUNNER_TEMP` and `GITHUB_REF_NAME` set): pnpm-packed tarballs at the matching tag pass and log all seven inter-package edges as `ok`; an npm-packed `stim-cli` tarball fails and prints the four surviving `workspace:` lines; a tag that disagrees with the manifests fails; and one edge hand-edited to `^1.0.0-rc.6` fails with `MISMATCH`. Each of the three failures exits 1.

`test/e2e/release-prep.e2e.js` runs the real rewrite against a throwaway workspace built from the repo's own manifests (`RELEASE_PREP_ROOT`), so it covers the happy path, the rollback when one manifest cannot be rewritten, and every refusal without touching the repository. It also asserts the repo's own invariants -- five versions in lockstep, every internal range a bare `workspace:` range -- and packs the CLI for real to prove no `workspace:` range reaches a tarball. A manifest edited back to literal ranges, or a packing path that stops substituting, fails CI rather than a release.
