### PR TITLE
State AGENTS.md rules in the present tense

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Stim agent guide
 
-Use this guide when you change this repository. User documentation lives in
+Use this guide when you change this repository. State rules here in the
+present tense: a rule's history lives in issues and commits, not in this
+file. User documentation lives in
 [`packages/stim-cli/README.md`](./packages/stim-cli/README.md).
 
 ## Project
@@ -21,8 +23,8 @@ flags without an explicit product decision. Projects can wrap Stim when they
 need custom behavior.
 
 Runtime state belongs under `$STIM_HOME/workspaces/`, not in the project
-tree. Do not restore `init`, project setup mutations, or the deleted
-`stim-init` skill. `doctor` reports setup that requires project judgment.
+tree. Stim has no init step and never mutates project setup; `doctor`
+reports setup that requires project judgment.
 
 ## Development
 
@@ -119,8 +121,7 @@ that reference text in the skill.
 
 Update `guide` output and its contract tests when commands, flags, defaults, or
 remedies change. Update the skill only when the normal workflow, a permanent
-safety rule, or topic routing changes. Only one skill ships; do not restore
-`stim-init`.
+safety rule, or topic routing changes. Only one skill ships.
 
 Document command invocation once in each main entry point. Show the no-install
 form, `npx stim-cli <command>`, and the global install,
@@ -144,7 +145,7 @@ installs, launches, and reads logs, and nothing more. It records no device, so
 `stop`, `gc`, and `teardown.ts` never see it. Keep it that way: a physical
 serial must never enter the project registry.
 
-### 3. Reimplement; do not reconstruct
+### 3. Fixed invocations; never derive commands from project scripts
 
 Do not infer and rebuild commands from project scripts. Bare React Native hosts
 Metro from the project's dependencies. Expo runs its fixed start command. iOS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,7 @@
 # Stim agent guide
 
 Use this guide when you change this repository. State rules here in the
-present tense: a rule's history lives in issues and commits, not in this
-file. User documentation lives in
+present tense: a rule's history lives in issues and commits, not here. User documentation lives in
 [`packages/stim-cli/README.md`](./packages/stim-cli/README.md).
 
 ## Project
@@ -23,8 +22,8 @@ flags without an explicit product decision. Projects can wrap Stim when they
 need custom behavior.
 
 Runtime state belongs under `$STIM_HOME/workspaces/`, not in the project
-tree. Stim has no init step and never mutates project setup; `doctor`
-reports setup that requires project judgment.
+tree. Stim has no init step and never mutates project setup; do not add
+either. `doctor` reports setup that requires project judgment.
 
 ## Development
 
@@ -49,8 +48,8 @@ commit. Run `pnpm run test:e2e` when a change affects an end-to-end workflow.
 
 When you find a bug or improvement, search the open GitHub issues first. If no
 issue already describes it, create one before implementation, following the
-shape in `.github/ISSUE_TEMPLATE/report.md`. Refresh the
-remote refs, then confirm that an existing issue still applies to current
+shape in `.github/ISSUE_TEMPLATE/report.md`. Refresh the remote refs, then
+confirm that an existing issue still applies to current
 `origin/main`; close stale issues with the fixing commit and verification
 evidence instead of creating duplicate work.
 


### PR DESCRIPTION
## Description
Several rules were phrased as history: "do not restore the deleted `stim-init` skill" requires knowing what stim-init was, and "Reimplement; do not reconstruct" is opaque until its body is read. A fresh session cannot parse a prohibition against restoring something it never saw.

## Solution
Lore becomes rules: "Stim has no init step and never mutates project setup"; "Only one skill ships"; invariant 3 is retitled "Fixed invocations; never derive commands from project scripts" (its body already said exactly that). The intro gains the one-line writing rule so the pattern doesn't regrow. Every substantive rule is unchanged -- the diff is phrasing only.

## Test plan
- Doc-only; format check clean; CLAUDE.md is a symlink so one edit covers both.
- grep confirms zero remaining restore/stim-init/Reimplement references.

Fixes #173