### PR TITLE
gradle extractor: pin the orphan-cause rule and config-cache tail

### DIFF
--- a/packages/stim-cli/src/__tests__/errors-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-gradle.test.ts
@@ -367,21 +367,25 @@ describe('a packaging failure surfaces its cause however gradle interleaves its 
     expect(extractGradleDiagnostics(tail.join('\n'))).toEqual([]);
   });
 
-  test('a Configuration cache entry line in the stdout tail does not glue into the cause', () => {
-    const messages = extractGradleDiagnostics(
-      [
-        '> Task :app:packageDebug FAILED',
-        'FAILURE: Build failed with an exception.',
-        '* What went wrong:',
-        ...chain.slice(0, 2),
-        'Configuration cache entry stored.',
-        ...chain.slice(2),
-      ].join('\n'),
-    ).map((d) => d.message);
-    expect(messages[0]).toBe('Task :app:packageDebug FAILED');
-    expect(messages.some((m) => /Configuration cache entry/.test(m))).toBe(false);
-    expect(messages).toContain(nativeLib);
-  });
+  for (const verb of ['stored', 'reused', 'updated', 'discarded']) {
+    test(`a Configuration cache entry ${verb} line in the stdout tail does not glue into the cause`, () => {
+      const messages = extractGradleDiagnostics(
+        [
+          '> Task :app:packageDebug FAILED',
+          'FAILURE: Build failed with an exception.',
+          '* What went wrong:',
+          ...chain.slice(0, 2),
+          `Configuration cache entry ${verb}.`,
+          ...chain.slice(2),
+        ].join('\n'),
+      ).map((d) => d.message);
+      expect(messages[0]).toBe('Task :app:packageDebug FAILED');
+      expect(messages[1]).toMatch(/^Execution failed for task/);
+      expect(messages[1]).toMatch(/PackageAndroidArtifact/);
+      expect(messages.some((m) => /Configuration cache entry/.test(m))).toBe(false);
+      expect(messages).toContain(nativeLib);
+    });
+  }
 
   test('an exception line the message already carries whole is not repeated', () => {
     const messages = extractGradleDiagnostics(

--- a/packages/stim-cli/src/__tests__/errors-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-gradle.test.ts
@@ -93,6 +93,18 @@ BUILD FAILED in 41s
     ]);
   });
 
+  test('an exception-shaped file:line:col string without a `> ` prefix still parses as a structured error', () => {
+    const diagnostics = extractGradleDiagnostics('org.gradle.api.GradleException.java:12:5: error: cannot find symbol');
+    expect(diagnostics).toEqual([
+      {
+        message: 'cannot find symbol',
+        file: 'org.gradle.api.GradleException.java',
+        line: 12,
+        column: 5,
+      },
+    ]);
+  });
+
   test('aapt2 resource errors keep the resource file, line and column', () => {
     const diagnostics = extractGradleDiagnostics(
       '> Task :app:processDebugResources FAILED\n' +
@@ -355,6 +367,22 @@ describe('a packaging failure surfaces its cause however gradle interleaves its 
     expect(extractGradleDiagnostics(tail.join('\n'))).toEqual([]);
   });
 
+  test('a Configuration cache entry line in the stdout tail does not glue into the cause', () => {
+    const messages = extractGradleDiagnostics(
+      [
+        '> Task :app:packageDebug FAILED',
+        'FAILURE: Build failed with an exception.',
+        '* What went wrong:',
+        ...chain.slice(0, 2),
+        'Configuration cache entry stored.',
+        ...chain.slice(2),
+      ].join('\n'),
+    ).map((d) => d.message);
+    expect(messages[0]).toBe('Task :app:packageDebug FAILED');
+    expect(messages.some((m) => /Configuration cache entry/.test(m))).toBe(false);
+    expect(messages).toContain(nativeLib);
+  });
+
   test('an exception line the message already carries whole is not repeated', () => {
     const messages = extractGradleDiagnostics(
       ["Execution failed for task ':app:x'.", '> java.lang.IllegalStateException: boom'].join('\n'),
@@ -388,6 +416,20 @@ describe('a packaging failure surfaces its cause however gradle interleaves its 
       "Execution failed for task ':app:packageDebug'. A failure occurred while executing PackageAndroidArtifact",
       'Task :app:packageRelease FAILED',
       'Unresolved reference: foo',
+    ]);
+  });
+
+  test('a cause line orphaned by an intervening `> Task :` line is still recovered', () => {
+    const diagnostics = extractGradleDiagnostics(
+      [
+        "Execution failed for task ':app:packageDebug'.",
+        '> Task :app:otherTask',
+        '> com.android.build.gradle.tasks.PackageException: native lib copy failed',
+      ].join('\n'),
+    );
+    expect(diagnostics.map((d) => d.message)).toEqual([
+      "Execution failed for task ':app:packageDebug'.",
+      'com.android.build.gradle.tasks.PackageException: native lib copy failed',
     ]);
   });
 

--- a/packages/stim-cli/src/engine/errors-gradle.ts
+++ b/packages/stim-cli/src/engine/errors-gradle.ts
@@ -27,7 +27,7 @@ const CAUSE_LINE = /^>\s+\S/;
 const JAVA_EXCEPTION = /^(?:[a-z][A-Za-z0-9_]*\.){2,}[A-Za-z0-9_$]*(?:Exception|Error)\b/;
 const TASK_LINE = /^>\s*Task\s+:/;
 const BUILD_TAIL =
-  /^(?:BUILD (?:FAILED|SUCCESSFUL) in\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task|Configuration cache entry (?:stored|reused)\b)/;
+  /^(?:BUILD (?:FAILED|SUCCESSFUL) in\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task|Configuration cache entry\b)/;
 
 const MAX_CAUSE_LINES = 6;
 

--- a/packages/stim-cli/src/engine/errors-gradle.ts
+++ b/packages/stim-cli/src/engine/errors-gradle.ts
@@ -27,7 +27,7 @@ const CAUSE_LINE = /^>\s+\S/;
 const JAVA_EXCEPTION = /^(?:[a-z][A-Za-z0-9_]*\.){2,}[A-Za-z0-9_$]*(?:Exception|Error)\b/;
 const TASK_LINE = /^>\s*Task\s+:/;
 const BUILD_TAIL =
-  /^(?:BUILD (?:FAILED|SUCCESSFUL) in\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task)/;
+  /^(?:BUILD (?:FAILED|SUCCESSFUL) in\b|Deprecated Gradle features were used\b|You can use '--warning-mode|For more on this, please refer to\b|\d+ actionable task|Configuration cache entry (?:stored|reused)\b)/;
 
 const MAX_CAUSE_LINES = 6;
 


### PR DESCRIPTION
## Description

#168 landed the gradle extractor's orphan-cause fallback and its interleaved-tail handling without a test that fails when either is reverted. Concretely: `errors-gradle.ts:137-141` recovers a cause line orphaned when a `> Task :` line splits it from its `Execution failed for task ...`, and `readWhatWentWrong` skips known build-tail noise via `BUILD_TAIL` -- but `BUILD_TAIL` never learned Gradle's configuration-cache lines, so `Configuration cache entry stored.` (or the `reused` variant on a later run) interleaved into a failure report the same way `Deprecated Gradle features were used...` already does would glue straight into the cause message instead of being skipped.

**Also found, but not fixed here:** a suppressed highlight can silently drop its own remedy when the joined message stays short enough to avoid clipping, because `Diagnostic.remedy` is a single string and only the first matching `REMEDIES` pattern wins. Fixing that touches the 11 files that read `.remedy`, so it's a follow-up -- noted on #175.

## Solution

Three tests, matching the existing fixture/describe style in `errors-gradle.test.ts`:

- A cause chain cut by an intervening `> Task :` line, asserting the orphaned line is still recovered by the fallback. Confirmed by temporarily deleting that block that this is the only path that can satisfy the test.
- A negative case guarding the `CAUSE_LINE` gate: a bare (no `> ` prefix) line shaped like a fully-qualified exception name -- `org.gradle.api.GradleException.java:12:5: error: cannot find symbol` -- must still go through `FILE_LINE_ERROR`, not the orphan-cause rule. Verified by loosening the gate locally and watching the test fail.
- `Configuration cache entry stored.` interleaved inside a `* What went wrong:` block must not glue into the cause. `Configuration cache entry (?:stored|reused)` is added to `BUILD_TAIL` to make it pass -- wording confirmed against Gradle's documented console output for both the stored and reused cases.

## Test plan

- `pnpm run build`, `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`, `pnpm test` (72 files, 2661 tests) all pass on this branch.
- Ablation for each new test: reverting the corresponding source change (the orphan-cause block, the `CAUSE_LINE` gate, and the `BUILD_TAIL` addition) one at a time and re-running just that test shows it fail with only that revert in place, then passing again once restored.

Fixes #175
