### PR TITLE
release workflow: compute the publish dist-tag instead of hardcoding latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,32 +91,28 @@ jobs:
             ' "$manifest" "$tag"
           done
       - name: Compute publish dist-tag
-        # A candidate (X.Y.Z-rc.N) publishes to `next` only when the registry's
-        # current stim-cli `latest` is already a stable version; every other
-        # case -- a stable version, or a candidate published while no stable
-        # release exists yet, including a first-ever publish (E404) -- publishes
-        # to `latest` (RELEASE.md section 1). Refuse to guess if the registry
-        # probe fails for any other reason.
+        # Dist-tag selection: see RELEASE.md section 1.
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
-          err_log="$(mktemp)"
-          if current=$(npm view stim-cli version 2>"$err_log"); then
-            :
-          elif grep -q 'E404' "$err_log"; then
-            current=""
-          else
-            echo "::error::npm view stim-cli version failed and did not report E404; refusing to guess a dist-tag: $(cat "$err_log")"
-            rm -f "$err_log"
-            exit 1
-          fi
-          rm -f "$err_log"
-
           dist_tag=latest
-          if [[ "$tag_version" == *-* && -n "$current" && "$current" != *-* ]]; then
-            dist_tag=next
+
+          if [[ "$tag_version" == *-* ]]; then
+            err_log="$(mktemp)"
+            if current=$(npm view @stim-cli/core version 2>"$err_log"); then
+              if [[ -n "$current" && "$current" != *-* ]]; then
+                dist_tag=next
+              fi
+            elif grep -q 'code E404' "$err_log"; then
+              :
+            else
+              echo "::error::npm view @stim-cli/core version failed and did not report E404; refusing to guess a dist-tag: $(cat "$err_log")"
+              rm -f "$err_log"
+              exit 1
+            fi
+            rm -f "$err_log"
           fi
 
-          echo "tag_version=$tag_version current_latest=${current:-<none>} dist_tag=$dist_tag"
+          echo "tag_version=$tag_version dist_tag=$dist_tag"
           echo "DIST_TAG=$dist_tag" >> "$GITHUB_ENV"
       - name: Publish @stim-cli/core
         run: |
@@ -180,10 +176,18 @@ jobs:
               sleep "$retry_delay"
             done
 
-            tagged=$(npm view "$p" "dist-tags.$DIST_TAG" 2>/dev/null)
-            if [ "$tagged" != "$version" ]; then
-              echo "$p dist-tag $DIST_TAG points at ${tagged:-<unset>}, expected $version"
-              exit 1
-            fi
-            echo "$p dist-tag $DIST_TAG -> $tagged"
+            for attempt in $(seq 1 "$max_attempts"); do
+              if tagged=$(npm view "$p" "dist-tags.$DIST_TAG" 2>/dev/null) && [ "$tagged" = "$version" ]; then
+                echo "$p dist-tag $DIST_TAG -> $tagged"
+                break
+              fi
+
+              if [ "$attempt" -eq "$max_attempts" ]; then
+                echo "$p dist-tag $DIST_TAG points at ${tagged:-<unset>}, expected $version"
+                exit 1
+              fi
+
+              echo "$p dist-tag $DIST_TAG is ${tagged:-<unset>}, not $version yet (attempt $attempt/$max_attempts); retrying in ${retry_delay}s"
+              sleep "$retry_delay"
+            done
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,15 +90,41 @@ jobs:
               process.exit(bad === 0 ? 0 : 1);
             ' "$manifest" "$tag"
           done
+      - name: Compute publish dist-tag
+        # A candidate (X.Y.Z-rc.N) publishes to `next` only when the registry's
+        # current stim-cli `latest` is already a stable version; every other
+        # case -- a stable version, or a candidate published while no stable
+        # release exists yet, including a first-ever publish (E404) -- publishes
+        # to `latest` (RELEASE.md section 1). Refuse to guess if the registry
+        # probe fails for any other reason.
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          err_log="$(mktemp)"
+          if current=$(npm view stim-cli version 2>"$err_log"); then
+            :
+          elif grep -q 'E404' "$err_log"; then
+            current=""
+          else
+            echo "::error::npm view stim-cli version failed and did not report E404; refusing to guess a dist-tag: $(cat "$err_log")"
+            rm -f "$err_log"
+            exit 1
+          fi
+          rm -f "$err_log"
+
+          dist_tag=latest
+          if [[ "$tag_version" == *-* && -n "$current" && "$current" != *-* ]]; then
+            dist_tag=next
+          fi
+
+          echo "tag_version=$tag_version current_latest=${current:-<none>} dist_tag=$dist_tag"
+          echo "DIST_TAG=$dist_tag" >> "$GITHUB_ENV"
       - name: Publish @stim-cli/core
         run: |
           version=$(node -p "require('$RUNNER_TEMP/tarballs/core.package.json').version")
           if npm view "@stim-cli/core@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/core@$version is already published"
           else
-            # latest-on-purpose while no stable exists (RELEASE.md section 1); issue #165
-            # gates the prerelease-aware selection required after 1.0.0 stable.
-            npm publish "$RUNNER_TEMP/tarballs/core.tgz" --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/core.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
       - name: Publish @stim-cli/cache
         run: |
@@ -106,7 +132,7 @@ jobs:
           if npm view "@stim-cli/cache@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/cache@$version is already published"
           else
-            npm publish "$RUNNER_TEMP/tarballs/cache.tgz" --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/cache.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
       - name: Publish @stim-cli/metro
         run: |
@@ -114,7 +140,7 @@ jobs:
           if npm view "@stim-cli/metro@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/metro@$version is already published"
           else
-            npm publish "$RUNNER_TEMP/tarballs/metro.tgz" --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/metro.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
       - name: Publish @stim-cli/expo-build-cache
         run: |
@@ -122,7 +148,7 @@ jobs:
           if npm view "@stim-cli/expo-build-cache@$version" version >/dev/null 2>&1; then
             echo "@stim-cli/expo-build-cache@$version is already published"
           else
-            npm publish "$RUNNER_TEMP/tarballs/expo-build-cache.tgz" --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/expo-build-cache.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
       - name: Publish stim-cli
         run: |
@@ -130,7 +156,7 @@ jobs:
           if npm view "stim-cli@$version" version >/dev/null 2>&1; then
             echo "stim-cli@$version is already published"
           else
-            npm publish "$RUNNER_TEMP/tarballs/stim-cli.tgz" --provenance --access public --tag latest
+            npm publish "$RUNNER_TEMP/tarballs/stim-cli.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
       - name: Smoke-test the registry
         run: |
@@ -153,4 +179,11 @@ jobs:
               echo "$p@$version is not visible yet (attempt $attempt/$max_attempts); retrying in ${retry_delay}s"
               sleep "$retry_delay"
             done
+
+            tagged=$(npm view "$p" "dist-tags.$DIST_TAG" 2>/dev/null)
+            if [ "$tagged" != "$version" ]; then
+              echo "$p dist-tag $DIST_TAG points at ${tagged:-<unset>}, expected $version"
+              exit 1
+            fi
+            echo "$p dist-tag $DIST_TAG -> $tagged"
           done

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,12 +26,37 @@ page and is not copied anywhere.
 
 The source of truth for "what was last released" is the npm registry, not
 local git tags — a publish can fail after the tag is pushed, leaving the tag
-ahead of what's actually on npm. Pull the published version and list commits
-since the matching tag:
+ahead of what's actually on npm. Post-stable, the highest published version
+can sit on either the `latest` or the `next` dist-tag, so check both and take
+the semver-higher one. Pull it and list commits since the matching tag:
 
 ```bash
 git fetch --tags
-if last=$(npm view stim-cli version 2>/dev/null); then
+if last=$(npm view stim-cli dist-tags --json 2>/dev/null | node -e '
+  const { latest, next } = JSON.parse(require("fs").readFileSync(0, "utf8"));
+  const parse = (v) => {
+    const [core, pre] = v.split("-");
+    return { core: core.split(".").map(Number), pre: pre ? pre.split(".") : null };
+  };
+  const compare = (l, r) => {
+    const a = parse(l), b = parse(r);
+    for (let i = 0; i < 3; i += 1) if (a.core[i] !== b.core[i]) return a.core[i] - b.core[i];
+    if (!a.pre && !b.pre) return 0;
+    if (!a.pre) return 1;
+    if (!b.pre) return -1;
+    for (let i = 0; i < Math.max(a.pre.length, b.pre.length); i += 1) {
+      const x = a.pre[i], y = b.pre[i];
+      if (x === undefined) return -1;
+      if (y === undefined) return 1;
+      if (x === y) continue;
+      return /^\d+$/.test(x) && /^\d+$/.test(y) ? Number(x) - Number(y) : x < y ? -1 : 1;
+    }
+    return 0;
+  };
+  const versions = [latest, next].filter(Boolean);
+  if (!versions.length) process.exit(1);
+  process.stdout.write(versions.reduce((hi, v) => (compare(v, hi) > 0 ? v : hi)));
+'); then
   echo "Last published: v$last"
   git log "v$last..HEAD" --oneline
 else
@@ -45,13 +70,21 @@ first-publication bootstrap in
 [docs/release-recovery.md](./docs/release-recovery.md) before pushing the tag.
 
 Use `X.Y.Z-rc.N` for a release candidate. The workflow computes the publish
-dist-tag itself from the tag and the registry: `npm view stim-cli version`
-is the registry's current release, and a candidate publishes to `next`
-instead of `latest` only when that current release is already stable, so a
-plain `npm install` never regresses to a candidate. Every other publish --
-a stable version, or a candidate published while no stable release exists
-yet, including a first-ever publish (`E404`) -- lands on `latest`, which is
-what installs resolve. A tag higher than the published version
+dist-tag itself from the tag and the registry: it reads `npm view
+@stim-cli/core version` -- the first package every run publishes, not
+`stim-cli`, the last -- as its stable-or-not signal, and a candidate
+publishes to `next` instead of `latest` only when that signal is already a
+stable version, so a plain `npm install` never regresses to a candidate.
+Every other publish -- a stable version, or a candidate published while no
+stable release exists yet, including a first-ever publish (`E404`) -- lands
+on `latest`, which is what installs resolve. Probing the first-published
+package instead of the last fails safe if a release dies mid-run: the worst
+case is a candidate landing on `next` a little early, never a candidate
+stomping `latest` on packages that already went stable. The gate assumes a
+partial release is always completed or recovered (see
+[docs/release-recovery.md](./docs/release-recovery.md)) before the next tag
+lands; the workflow does not check that on its own. A tag higher than the
+published version
 means a release never landed: see
 [docs/release-recovery.md](./docs/release-recovery.md) before bumping.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,12 +44,14 @@ An npm `E404` means a first release for that package name: complete the
 first-publication bootstrap in
 [docs/release-recovery.md](./docs/release-recovery.md) before pushing the tag.
 
-Use `X.Y.Z-rc.N` for a release candidate. While no stable release exists,
-every publish lands on the npm `latest` dist-tag -- that is what installs
-resolve, so an rc on `latest` is correct, and
-`npm view stim-cli version` is always the current release. Before the first
-candidate AFTER 1.0.0 stable, the workflow must gain prerelease-aware
-dist-tag selection (issue #165). A tag higher than the published version
+Use `X.Y.Z-rc.N` for a release candidate. The workflow computes the publish
+dist-tag itself from the tag and the registry: `npm view stim-cli version`
+is the registry's current release, and a candidate publishes to `next`
+instead of `latest` only when that current release is already stable, so a
+plain `npm install` never regresses to a candidate. Every other publish --
+a stable version, or a candidate published while no stable release exists
+yet, including a first-ever publish (`E404`) -- lands on `latest`, which is
+what installs resolve. A tag higher than the published version
 means a release never landed: see
 [docs/release-recovery.md](./docs/release-recovery.md) before bumping.
 
@@ -258,8 +260,9 @@ Before continuing:
    Send the `url` (the run page has Review deployments -> `release` ->
    Approve and deploy). The workflow packs the five tarballs with pnpm, checks
    that no `workspace:` range survived the pack, skips an exact package version
-   that already exists, publishes to the `latest` dist-tag (section 1), then
-   verifies all five registry versions. A NEW package, a failed publish, or
+   that already exists, computes the dist-tag (section 1) and publishes every
+   package to it, then verifies all five registry versions and that dist-tag.
+   A NEW package, a failed publish, or
    a provenance rejection: see
    [docs/release-recovery.md](./docs/release-recovery.md).
 

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -23,16 +23,18 @@ so re-running the whole workflow is also safe.
 For when the workflow cannot run: the same five publishes, by hand and in
 dependency order. `pnpm publish` packs with pnpm, so it substitutes the
 `workspace:` ranges the packages declare -- a bare `npm publish` from a package
-directory would upload them verbatim. `--tag latest` matches what the workflow
-does (RELEASE.md section 1). 2FA is on, so each publish prompts for an OTP:
+directory would upload them verbatim. Compute the dist-tag exactly as the
+workflow does (RELEASE.md section 1): `latest`, unless this version is a
+release candidate AND `npm view stim-cli version` is already a stable
+release, in which case `next`. 2FA is on, so each publish prompts for an OTP:
 
 ```bash
 npm whoami                                          # confirm login; if 401, `npm login` first
-pnpm --filter @stim-cli/core publish --access public --tag latest --otp <code>
-pnpm --filter @stim-cli/cache publish --access public --tag latest --otp <code>
-pnpm --filter @stim-cli/metro publish --access public --tag latest --otp <code>
-pnpm --filter @stim-cli/expo-build-cache publish --access public --tag latest --otp <code>
-pnpm --filter stim-cli publish --access public --tag latest --otp <code>
+pnpm --filter @stim-cli/core publish --access public --tag <dist-tag> --otp <code>
+pnpm --filter @stim-cli/cache publish --access public --tag <dist-tag> --otp <code>
+pnpm --filter @stim-cli/metro publish --access public --tag <dist-tag> --otp <code>
+pnpm --filter @stim-cli/expo-build-cache publish --access public --tag <dist-tag> --otp <code>
+pnpm --filter stim-cli publish --access public --tag <dist-tag> --otp <code>
 ```
 
 ## First publication of a NEW package
@@ -64,7 +66,8 @@ fires, the package directory is missing its README.
 
 ## Stale or wrong dist-tags
 
-While no stable exists, everything publishes to `latest` (see RELEASE.md
-section 1). The historical `next` tags went stale twice under the old
-instructions and were removed on 2026-09-01. Post-stable dist-tag selection
-is tracked as issue #165. Repairs are `npm dist-tag add|rm` with an OTP.
+The workflow computes the publish dist-tag itself (RELEASE.md section 1): a
+release candidate lands on `next` only when the registry's current
+`stim-cli` release is already stable; every other publish -- including every
+publish before 1.0.0 stable ships -- lands on `latest`. If a dist-tag still
+ends up stale or wrong, repair it with `npm dist-tag add|rm` and an OTP.

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -5,18 +5,26 @@ so the normal path stays short. Come here from the step that failed.
 
 ## A tag exists but npm does not have it
 
-`npm view stim-cli version` is the source of truth for "what was last
-released" -- a publish can fail after the tag is pushed, leaving the tag
-ahead of the registry. If `git describe --tags --abbrev=0` is higher than
-the published version, a previous release got tagged but never landed.
-**Retry that publish at the existing version** (RELEASE.md section 4 step 7,
-or the manual fallback below) rather than incrementing past it.
+The npm registry is the source of truth for "what was last released" -- a
+publish can fail after the tag is pushed, leaving the tag ahead of the
+registry. Post-stable, the last-published version can sit on either the
+`latest` or the `next` dist-tag; RELEASE.md section 1 shows the
+`npm view stim-cli dist-tags --json` invocation that checks both and picks
+the semver-higher one. If `git describe --tags --abbrev=0` is higher than
+that, a previous release got tagged but never landed. **Retry that publish
+at the existing version** (RELEASE.md section 4 step 7, or the manual
+fallback below) rather than incrementing past it.
 
 ## One publish failed after another succeeded
 
 Do NOT bump the version to retry -- re-run only the failed publish at the
 same version. The tagged workflow already skips exact versions that exist,
-so re-running the whole workflow is also safe.
+so re-running the whole workflow is also safe. That safety flips once a
+newer release has since shipped: the smoke-test step's dist-tag check now
+fails the run red, because the freshly computed `DIST_TAG` no longer matches
+what actually got published, and a backfill publish for the old version can
+re-point `latest` or `next` backwards onto it -- confirm with
+`npm dist-tag ls <package>` afterward if you do this.
 
 ## Manual publish fallback
 
@@ -25,7 +33,7 @@ dependency order. `pnpm publish` packs with pnpm, so it substitutes the
 `workspace:` ranges the packages declare -- a bare `npm publish` from a package
 directory would upload them verbatim. Compute the dist-tag exactly as the
 workflow does (RELEASE.md section 1): `latest`, unless this version is a
-release candidate AND `npm view stim-cli version` is already a stable
+release candidate AND `npm view @stim-cli/core version` is already a stable
 release, in which case `next`. 2FA is on, so each publish prompts for an OTP:
 
 ```bash
@@ -67,7 +75,7 @@ fires, the package directory is missing its README.
 ## Stale or wrong dist-tags
 
 The workflow computes the publish dist-tag itself (RELEASE.md section 1): a
-release candidate lands on `next` only when the registry's current
-`stim-cli` release is already stable; every other publish -- including every
-publish before 1.0.0 stable ships -- lands on `latest`. If a dist-tag still
-ends up stale or wrong, repair it with `npm dist-tag add|rm` and an OTP.
+release candidate lands on `next` only when `@stim-cli/core`'s registry
+`latest` is already stable; every other publish -- including every publish
+before 1.0.0 stable ships -- lands on `latest`. If a dist-tag still ends up
+stale or wrong, repair it with `npm dist-tag add|rm` and an OTP.


### PR DESCRIPTION
## Description

Every publish step in `release.yml` hardcoded `--tag latest`. That's correct today because no stable release exists yet, but it breaks the moment a post-1.0.0 candidate ships: a `1.1.0-rc.0` publish would replace stable on `latest` for every plain `npm install`. RELEASE.md section 1 flagged this as a human obligation to remember before tagging the first post-stable candidate.

## Solution

Added a `Compute publish dist-tag` step that runs once, early, and exports `DIST_TAG` via `GITHUB_ENV` for all five publish steps and the smoke-test step to consume. `tag_version` is the pushed tag with its `v` prefix stripped; the probe and fail-closed check only run when `tag_version` is a prerelease (contains `-`), so a stable release never fails on a registry blip it doesn't need an answer from.

For the prerelease case, the step probes `npm view @stim-cli/core version` — `@stim-cli/core` is the first package every run publishes, not `stim-cli`, the last — and publishes to `next` only when that comes back stable (no `-`); every other case, including `E404` (nothing published yet), publishes to `latest`. Probing the first-published package instead of the last matters for a partial release: if a run dies after publishing core/cache/metro/expo-build-cache but before stim-cli, probing `stim-cli` would still see the old prerelease and let the next rc land on `latest`, stomping the four packages that already went stable. Probing `core` fails safe instead — worst case is a candidate landing on `next` a little early. This gate assumes a partial release is completed or recovered before the next tag lands (RELEASE.md section 1 says so explicitly now); the workflow doesn't verify that on its own.

Any non-`E404` probe error (network blip, etc.) fails the step with `::error::` rather than guessing.

The smoke-test step now also retries (same backoff as the existing version-visibility check) `npm view "$p" "dist-tags.$DIST_TAG"` until it equals the published version, so it verifies against the tag actually used instead of only checking the version is resolvable.

**Docs:** RELEASE.md section 1's "what was last released" script now checks both the `latest` and `next` dist-tags and picks the semver-higher one — post-stable, the highest published version can be sitting on `next`, not `latest`, and the old script (`npm view stim-cli version`, which only reads `latest`) would silently pick the wrong "last released" base to diff commits against. `docs/release-recovery.md`'s "A tag exists but npm does not have it" stranded-tag check is now dist-tag-aware the same way — the old version would false-alarm on every post-stable rc that correctly landed on `next`, since `git describe` would show it as "higher than the published version" (i.e. `latest`). Its "One publish failed after another succeeded" section also gained a caveat: re-running the whole workflow is no longer unconditionally safe once a newer release has since shipped — the new dist-tag smoke check fails that run red, and a backfill publish for the old version can re-point `latest`/`next` backwards onto it.

## Test plan

Extracted the step's script verbatim (pulled straight from the committed workflow, not retyped) and ran it under `bash -e -o pipefail` with a stubbed `npm` on `PATH`:

```bash
tag_version="${GITHUB_REF_NAME#v}"
dist_tag=latest

if [[ "$tag_version" == *-* ]]; then
  err_log="$(mktemp)"
  if current=$(npm view @stim-cli/core version 2>"$err_log"); then
    if [[ -n "$current" && "$current" != *-* ]]; then
      dist_tag=next
    fi
  elif grep -q 'code E404' "$err_log"; then
    :
  else
    echo "::error::npm view @stim-cli/core version failed and did not report E404; refusing to guess a dist-tag: $(cat "$err_log")"
    rm -f "$err_log"
    exit 1
  fi
  rm -f "$err_log"
fi

echo "tag_version=$tag_version dist_tag=$dist_tag"
echo "DIST_TAG=$dist_tag" >> "$GITHUB_ENV"
```

| `@stim-cli/core` probe | tag | outcome |
| --- | --- | --- |
| stable (`1.0.0`) | `v1.1.0-rc.0` | `dist_tag=next` |
| prerelease (`1.0.0-rc.7`) | `v1.0.0-rc.8` | `dist_tag=latest` (today's actual behavior, unchanged) |
| `E404` (nothing published) | `v0.1.0-rc.0` | `dist_tag=latest` |
| network failure (non-`E404`) | `v1.1.0-rc.0` | step exits 1 with `::error::…` |
| partial-stable: `core` already stable, other packages irrelevant now | `v1.1.0-rc.0` | `dist_tag=next` (the fix — probing `stim-cli` instead would have stayed `latest` here and stomped the four already-stable packages) |
| stable tag, probe would fail (network) | `v1.0.0` | probe never runs (gated on `tag_version == *-*`), step exits 0 with `dist_tag=latest` |

Also ran:
- `shellcheck -s bash` against the extracted "Compute publish dist-tag" and "Smoke-test the registry" steps (pulled directly from the file with `awk`/`sed`, not retyped): clean.
- `pnpm run format:check`: passes.
- `pnpm run lint`: passes.
- `node --test test/e2e/release-prep.e2e.js`: 6/6 pass. Confirmed first that this suite reads only `scripts/release-prep.mjs` and package manifests, not `release.yml`, so it's unaffected — ran it anyway since it's the e2e suite closest to the release process.

Fixes #165
