### PR TITLE
Prove a collector pid belongs to this workspace before signalling it

### DIFF
--- a/packages/stim-cli/src/__tests__/_factories.ts
+++ b/packages/stim-cli/src/__tests__/_factories.ts
@@ -12,6 +12,9 @@ import type { MetroResolution } from '../metro.ts';
 import type { BuildLockInfo } from '../engine/build-lock.ts';
 import type { BuildSlotInfo } from '../engine/build-slots.ts';
 
+// Above every kernel's pid_max (macOS 99999, Linux 2^22): a stray signal fails ESRCH instead of reaching a process.
+export const IMPOSSIBLE_PID = 999999901;
+
 export function makeConfig(overrides: Partial<StimConfig> = {}): StimConfig {
   return { version: 2, projects: {}, repos: {}, ...overrides };
 }
@@ -51,7 +54,7 @@ export function makeBuildLock(overrides: Partial<BuildLockInfo> = {}): BuildLock
     name: 'ios-abc.lock',
     platform: 'ios',
     key: 'abc-debug-sim',
-    pid: 4242,
+    pid: IMPOSSIBLE_PID,
     projectRoot: '/w/project',
     startedAt: '2026-01-01T00:00:00.000Z',
     logFile: '/w/.stim/logs/build.log',
@@ -65,7 +68,7 @@ export function makeBuildSlot(overrides: Partial<BuildSlotInfo> = {}): BuildSlot
     path: '/h/build-slots/slot-0',
     name: 'slot-0',
     index: 0,
-    pid: 4242,
+    pid: IMPOSSIBLE_PID,
     projectRoot: '/w/project',
     startedAt: '2026-01-01T00:00:00.000Z',
     logFile: '/w/.stim/logs/build.log',
@@ -132,7 +135,7 @@ export function makeExecutor(overrides: Partial<Executor> = {}): Executor {
 export function makeChildProcess(overrides: Partial<ChildProcess> = {}): ChildProcess {
   const emitter = new EventEmitter();
   const stub = Object.assign(emitter, {
-    pid: 4242,
+    pid: IMPOSSIBLE_PID,
     stdin: null,
     stdout: new EventEmitter(),
     stderr: new EventEmitter(),

--- a/packages/stim-cli/src/__tests__/collector-ownership.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-ownership.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectorProcessTitle, matchesCollectorProcess, verifyCollectorOwnership } from '../collector/ownership.ts';
+
+const ROOT = '/w/project';
+const alive = () => true;
+const dead = () => false;
+
+function titleArgs(platform: string, root: string): string[] {
+  return collectorProcessTitle(platform, root).split(' ');
+}
+
+describe('matchesCollectorProcess', () => {
+  test('the running collector title carries the platform and the root it was started for', () => {
+    expect(collectorProcessTitle('ios', ROOT)).toBe('stim-collector-ios --root /w/project');
+    expect(matchesCollectorProcess(titleArgs('ios', ROOT), { platform: 'ios', root: ROOT })).toBe(true);
+    expect(matchesCollectorProcess(titleArgs('android', ROOT), { platform: 'android', root: ROOT })).toBe(true);
+  });
+
+  test('the spawned argv matches before the collector renames itself', () => {
+    const argv = [
+      '/usr/local/bin/node',
+      '/opt/stim/dist/collector-run.mjs',
+      '--platform',
+      'ios',
+      '--root',
+      ROOT,
+      '--udid',
+      'U1',
+      '--bundle',
+      'com.example.app',
+    ];
+    expect(matchesCollectorProcess(argv, { platform: 'ios', root: ROOT })).toBe(true);
+    expect(matchesCollectorProcess(argv, { platform: 'android', root: ROOT })).toBe(false);
+  });
+
+  test('a collector for another root is not this workspace collector', () => {
+    expect(matchesCollectorProcess(titleArgs('ios', '/w/other'), { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess(titleArgs('ios', '/w/project-2'), { platform: 'ios', root: ROOT })).toBe(false);
+  });
+
+  test('a collector for another platform is not this record', () => {
+    expect(matchesCollectorProcess(titleArgs('android', ROOT), { platform: 'ios', root: ROOT })).toBe(false);
+  });
+
+  test('anything that is not a Stim collector is refused, including a lookalike', () => {
+    expect(matchesCollectorProcess(['node', '/w/project/index.js'], { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess(['vitest', '--root', ROOT], { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess(['stim-supervisor', '--root', ROOT], { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess(['stim-collector-ios'], { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess([], { platform: 'ios', root: ROOT })).toBe(false);
+    expect(matchesCollectorProcess(null, { platform: 'ios', root: ROOT })).toBe(false);
+  });
+
+  test('an unquoted root with a space still matches its own record', () => {
+    const spaced = '/w/My Project';
+    expect(matchesCollectorProcess(titleArgs('ios', spaced), { platform: 'ios', root: spaced })).toBe(true);
+    expect(matchesCollectorProcess(titleArgs('ios', spaced), { platform: 'ios', root: '/w/My' })).toBe(false);
+  });
+
+  test('Linux procfs hands back the renamed title as one padded argument', () => {
+    expect(matchesCollectorProcess([collectorProcessTitle('android', ROOT)], { platform: 'android', root: ROOT })).toBe(
+      true,
+    );
+    expect(
+      matchesCollectorProcess([collectorProcessTitle('android', '/w/other')], { platform: 'android', root: ROOT }),
+    ).toBe(false);
+  });
+
+  test('a symlinked root resolves to the same collector', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'stim-ownership-'));
+    const target = join(dir, 'target');
+    const link = join(dir, 'link');
+    try {
+      mkdirSync(target);
+      symlinkSync(target, link);
+      expect(matchesCollectorProcess(titleArgs('ios', target), { platform: 'ios', root: link })).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('verifyCollectorOwnership', () => {
+  test('a proven collector is ours', () => {
+    expect(
+      verifyCollectorOwnership({
+        pid: 111,
+        platform: 'ios',
+        root: ROOT,
+        isAlive: alive,
+        readArgs: () => titleArgs('ios', ROOT),
+      }),
+    ).toEqual({ status: 'ours' });
+  });
+
+  test('a live pid running something else is unverified, not ours', () => {
+    const result = verifyCollectorOwnership({
+      pid: 111,
+      platform: 'ios',
+      root: ROOT,
+      isAlive: alive,
+      readArgs: () => ['/usr/bin/node', 'server.js'],
+    });
+    expect(result.status).toBe('unverified');
+    expect(result).toMatchObject({
+      reason: expect.stringContaining("does not run this workspace's ios log collector"),
+    });
+  });
+
+  test('a collector for a different root is unverified', () => {
+    expect(
+      verifyCollectorOwnership({
+        pid: 111,
+        platform: 'ios',
+        root: ROOT,
+        isAlive: alive,
+        readArgs: () => titleArgs('ios', '/w/other'),
+      }).status,
+    ).toBe('unverified');
+  });
+
+  test('an unreadable command on a live pid is unverified, never proven', () => {
+    expect(
+      verifyCollectorOwnership({ pid: 111, platform: 'ios', root: ROOT, isAlive: alive, readArgs: () => null }).status,
+    ).toBe('unverified');
+    expect(
+      verifyCollectorOwnership({
+        pid: 111,
+        platform: 'ios',
+        root: ROOT,
+        isAlive: alive,
+        readArgs: () => {
+          throw new Error('ps failed');
+        },
+      }).status,
+    ).toBe('unverified');
+  });
+
+  test('a pid that died between the checks is gone, not a refusal to report', () => {
+    expect(
+      verifyCollectorOwnership({ pid: 111, platform: 'ios', root: ROOT, isAlive: dead, readArgs: () => null }),
+    ).toEqual({ status: 'gone' });
+    expect(
+      verifyCollectorOwnership({
+        pid: 111,
+        platform: 'ios',
+        root: ROOT,
+        isAlive: dead,
+        readArgs: () => ['/usr/bin/node', 'server.js'],
+      }),
+    ).toEqual({ status: 'gone' });
+  });
+});

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -215,6 +215,19 @@ test('the cleanup guide documents fail-closed EAS orphan recovery', () => {
   expect(cleanup).not.toMatch(/EAS session and local claim stay/i);
 });
 
+test('the cleanup guide documents the collector ownership proof and its upgrade window', () => {
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+
+  expect(cleanup).toMatch(/before signalling a recorded collector pid/i);
+  expect(cleanup).toMatch(/stop[\s\S]*gc --delete[\s\S]*worktree remove[\s\S]*live command/i);
+  expect(cleanup).toMatch(/cannot be proven[^.]*reported and left alone/i);
+  expect(cleanup).toMatch(/kernel reuses pids/i);
+  expect(cleanup).toMatch(/older Stim[^.]*no root[^.]*reports as\s+unverified/i);
+  expect(cleanup).toMatch(/clears itself[\s\S]*log\s+stream ends/i);
+  expect(cleanup).toMatch(/next `ios` \/ `android` run replaces it/i);
+});
+
 test('the cleanup guide documents that the shared Gradle build cache is report-only', () => {
   const cleanup = renderTopic('cleanup');
   assert(cleanup);

--- a/packages/stim-cli/src/__tests__/process-args.test.ts
+++ b/packages/stim-cli/src/__tests__/process-args.test.ts
@@ -1,0 +1,100 @@
+import { resetExecutor, setExecutor } from '../exec.ts';
+import { readProcessArgs } from '../process-args.ts';
+
+describe('readProcessArgs', () => {
+  test('reads a bounded NUL-delimited command from Linux procfs', () => {
+    const reads: Array<{ path: string; maxBytes: number }> = [];
+    const result = readProcessArgs(4242, {
+      platform: 'linux',
+      readProcCommand: (path, maxBytes) => {
+        reads.push({ path, maxBytes });
+        return Buffer.from(['/usr/bin/ngrok', 'http', '8081', ''].join('\0'));
+      },
+    });
+    expect(result).toEqual(['/usr/bin/ngrok', 'http', '8081']);
+    expect(reads).toEqual([{ path: '/proc/4242/cmdline', maxBytes: expect.any(Number) }]);
+    expect(reads[0]?.maxBytes).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  test('a process that renamed itself leaves NUL padding in procfs', () => {
+    const title = 'stim-collector-ios --root /w/project';
+    const padded = Buffer.concat([Buffer.from(title), Buffer.alloc(64)]);
+    expect(readProcessArgs(111, { platform: 'linux', readProcCommand: () => padded })).toEqual([title]);
+  });
+
+  test('an argument list with an empty member is malformed, not padding', () => {
+    const data = Buffer.from(['/usr/bin/ngrok', '', 'http', ''].join('\0'));
+    expect(readProcessArgs(111, { platform: 'linux', readProcCommand: () => data })).toBeNull();
+  });
+
+  test('an unreadable Linux procfs command fails closed', () => {
+    expect(
+      readProcessArgs(4242, {
+        platform: 'linux',
+        readProcCommand: () => {
+          throw new Error('EACCES');
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test('runs ps with a timeout on macOS and parses quoted arguments', () => {
+    const calls: Array<{ pid: number; timeoutMs: number }> = [];
+    const result = readProcessArgs(4242, {
+      platform: 'darwin',
+      runPsCommand: (pid, timeoutMs) => {
+        calls.push({ pid, timeoutMs });
+        return "'/opt/local/bin/ngrok' http 8081 --url 'https://stable.ngrok.app'";
+      },
+    });
+    expect(result).toEqual(['/opt/local/bin/ngrok', 'http', '8081', '--url', 'https://stable.ngrok.app']);
+    expect(calls).toEqual([{ pid: 4242, timeoutMs: expect.any(Number) }]);
+    expect(calls[0]?.timeoutMs).toBeLessThanOrEqual(5_000);
+  });
+
+  test('uses full-width BSD ps argv and preserves a long stable ngrok URL', () => {
+    const stableUrl = `https://${'a'.repeat(4_000)}.ngrok.app`;
+    const calls: Array<{ file: string; args: string[]; timeoutMs: number | undefined }> = [];
+    setExecutor({
+      runFile(file, args, options) {
+        calls.push({ file, args, timeoutMs: options?.timeoutMs });
+        return `ngrok http 8081 --log=stdout --log-format=json --url ${stableUrl}`;
+      },
+    });
+    try {
+      expect(readProcessArgs(4242, { platform: 'darwin' })).toEqual([
+        'ngrok',
+        'http',
+        '8081',
+        '--log=stdout',
+        '--log-format=json',
+        '--url',
+        stableUrl,
+      ]);
+    } finally {
+      resetExecutor();
+    }
+    expect(calls).toEqual([
+      { file: 'ps', args: ['-ww', '-o', 'command=', '-p', '4242'], timeoutMs: expect.any(Number) },
+    ]);
+  });
+
+  test.each([
+    [
+      'ps failure',
+      () => {
+        throw new Error('ps failed');
+      },
+    ],
+    [
+      'ps timeout',
+      () => {
+        throw Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
+      },
+    ],
+    ['empty output', () => ''],
+    ['malformed output', () => "'/usr/bin/ngrok http 8081"],
+  ])('%s fails closed', (_name, runPsCommand) => {
+    expect(readProcessArgs(4242, { platform: 'darwin', runPsCommand })).toBeNull();
+  });
+});

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -1,3 +1,4 @@
+import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -435,3 +436,114 @@ test('an operator-supplied tunnel (metro.publicUrl) is never recorded, so reclai
   expect(r.stoppedTunnel).toBeNull();
   rmSync(root, { recursive: true, force: true });
 });
+
+function workspaceWithCollector(pid: number, platform = 'ios'): string {
+  const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+  ensureWorkspaceStorage(root);
+  writeFileSync(
+    workspaceStateFile(root),
+    JSON.stringify({ collectors: { [platform]: { pid, startedAt: '2026-01-01T00:00:00.000Z' } } }),
+  );
+  upsertProject(root, { label: 'agent-1' });
+  return root;
+}
+
+function processCommand(pid: number): string {
+  try {
+    return execFileSync('ps', ['-ww', '-o', 'command=', '-p', String(pid)], { encoding: 'utf-8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+async function spawnFakeProcess(title: string | null): Promise<ChildProcess> {
+  const rename = title ? `process.title = ${JSON.stringify(title)};` : '';
+  const child = spawn(process.execPath, ['-e', `${rename} setInterval(() => {}, 1000);`], { stdio: 'ignore' });
+  const expected = title ?? process.execPath;
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline && !processCommand(child.pid as number).startsWith(expected)) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return child;
+}
+
+function stillRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function exits(child: ChildProcess, timeoutMs = 5_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+test('reclaim SIGTERMs a live pid whose command proves it is this workspace collector', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+  const child = await spawnFakeProcess(`stim-collector-ios --root ${root}`);
+  ensureWorkspaceStorage(root);
+  writeFileSync(
+    workspaceStateFile(root),
+    JSON.stringify({ collectors: { ios: { pid: child.pid, startedAt: '2026-01-01T00:00:00.000Z' } } }),
+  );
+  upsertProject(root, { label: 'agent-1' });
+
+  const died = exits(child);
+  const r = await reclaimProject(root);
+  expect(await died).toBe(true);
+  expect(r.skippedDevices).toEqual([]);
+  rmSync(root, { recursive: true, force: true });
+}, 20_000);
+
+test('reclaim leaves a live pid it cannot prove, and says so', async () => {
+  const child = await spawnFakeProcess(null);
+  const root = workspaceWithCollector(child.pid as number);
+
+  const r = await reclaimProject(root);
+  expect(stillRunning(child.pid as number)).toBe(true);
+  expect(r.skippedDevices).toEqual([
+    {
+      platform: 'ios',
+      name: `ios log collector (pid ${child.pid})`,
+      reason: expect.stringContaining("does not run this workspace's ios log collector"),
+    },
+  ]);
+  expect(r.skippedDevices[0]?.reason).toMatch(/not signalled/);
+  child.kill('SIGKILL');
+  await exits(child);
+  rmSync(root, { recursive: true, force: true });
+}, 20_000);
+
+test('reclaim leaves a collector recorded for another root alone', async () => {
+  const other = mkdtempSync(join(tmpdir(), 'stim-other-'));
+  const child = await spawnFakeProcess(`stim-collector-ios --root ${other}`);
+  const root = workspaceWithCollector(child.pid as number);
+
+  const r = await reclaimProject(root);
+  expect(stillRunning(child.pid as number)).toBe(true);
+  expect(r.skippedDevices.map((d) => d.name)).toEqual([`ios log collector (pid ${child.pid})`]);
+  child.kill('SIGKILL');
+  await exits(child);
+  rmSync(other, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
+}, 20_000);
+
+test('reclaim says nothing about a collector pid that is already gone', async () => {
+  const child = await spawnFakeProcess(null);
+  const pid = child.pid as number;
+  child.kill('SIGKILL');
+  await exits(child);
+  const root = workspaceWithCollector(pid);
+
+  const r = await reclaimProject(root);
+  expect(r.skippedDevices).toEqual([]);
+  rmSync(root, { recursive: true, force: true });
+}, 20_000);

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -29,7 +29,7 @@ import {
   tailLines,
   wantsExpoOwnTunnel,
 } from '../commands/start.ts';
-import { asProcessExit, makeChildProcess } from './_factories.ts';
+import { IMPOSSIBLE_PID, asProcessExit, makeChildProcess } from './_factories.ts';
 
 let tmpHome: string;
 let root: string;
@@ -1432,7 +1432,7 @@ describe('action: spawning the supervisor', () => {
     );
 
     expect(result.exitCode).toBe(1);
-    expect(JSON.parse(result.logs[0] ?? '').remedy).toMatch(/unmanaged.*pid 4242/i);
+    expect(JSON.parse(result.logs[0] ?? '').remedy).toMatch(new RegExp(`unmanaged.*pid ${IMPOSSIBLE_PID}`, 'i'));
     expect(exec.calls.spawn).toEqual([]);
   });
 

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -617,6 +617,20 @@ test('stop refuses to signal a collector pid it cannot prove, and keeps the reco
   ]);
   expect(r.summary).toMatch(/1 collector left unsignalled/);
   expect(reported.join('\n')).toMatch(/refusing to signal ios pid 111/);
+
+  const payload = JSON.parse(JSON.stringify({ root: '/proj/a', ok: r.ok, ...r.outcomes }));
+  expect(payload.collectors).toEqual({
+    status: 'stopped',
+    entries: [
+      {
+        platform: 'ios',
+        pid: 111,
+        status: 'unverified',
+        reason: "pid 111 does not run this workspace's ios log collector",
+      },
+      { platform: 'android', pid: 222, status: 'stopped' },
+    ],
+  });
 });
 
 test('a collector pid that died before the proof is already-stopped, not a refusal', async () => {

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { saveConfig, getProject } from '../config.ts';
+import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { ensureWorkspaceStorage, supervisorPidFile, workspaceStateFile } from '../paths.ts';
 import {
   clearCollectorState,
@@ -124,6 +125,7 @@ function seams(over = {}) {
     signalCollector: (pid: number) => {
       calls.collectorSignals.push(pid);
     },
+    verifyCollector: () => ({ status: 'ours' as const }),
     clearCollectors: () => {
       calls.collectorsCleared += 1;
     },
@@ -487,8 +489,17 @@ test('stopping clears the global supervisor registration', async () => {
 
 test('resolveCollectorTargets signals only live pids recorded for this workspace', () => {
   const targets = resolveCollectorTargets({
+    root: '/w/project',
     collectors: { ios: { pid: 111 }, android: { pid: 222 } },
     isAlive: (pid) => pid === 111,
+    verify: ({ pid, platform, root }) =>
+      verifyCollectorOwnership({
+        pid,
+        platform,
+        root,
+        isAlive: () => true,
+        readArgs: () => [`stim-collector-${platform}`, '--root', root],
+      }),
   });
   expect(targets).toEqual([
     { platform: 'ios', pid: 111, status: 'running' },
@@ -498,10 +509,32 @@ test('resolveCollectorTargets signals only live pids recorded for this workspace
 
 test('resolveCollectorTargets refuses a record with no usable pid, and refuses our own', () => {
   const targets = resolveCollectorTargets({
+    root: '/w/project',
     collectors: { ios: { pid: 'nope' }, android: { pid: process.pid } },
     isAlive: () => true,
   });
   expect(targets.map((t) => t.status)).toEqual(['invalid', 'invalid']);
+});
+
+test('resolveCollectorTargets refuses a live pid that is not this workspace collector', () => {
+  const targets = resolveCollectorTargets({
+    root: '/w/project',
+    collectors: { ios: { pid: 111 }, android: { pid: 222 } },
+    isAlive: () => true,
+    verify: ({ pid, platform, root }) =>
+      verifyCollectorOwnership({
+        pid,
+        platform,
+        root,
+        isAlive: () => true,
+        readArgs: () => (pid === 111 ? ['stim-collector-ios', '--root', '/w/other'] : ['/usr/bin/vitest', 'run']),
+      }),
+  });
+  expect(targets.map((t) => [t.platform, t.status])).toEqual([
+    ['ios', 'unverified'],
+    ['android', 'unverified'],
+  ]);
+  expect(targets[0]?.reason).toMatch(/does not run this workspace's ios log collector/);
 });
 
 test('stop SIGTERMs every recorded collector and clears the key', async () => {
@@ -558,6 +591,44 @@ test('collectors are still reaped when the supervisor could not be verified', as
   expect(calls.collectorSignals).toEqual([111]);
   expect(calls.collectorsCleared).toBe(1);
   expect(calls.teardowns).toEqual([]);
+});
+
+test('stop refuses to signal a collector pid it cannot prove, and keeps the record', async () => {
+  const { calls, opts } = seams({
+    collectors: { ios: { pid: 111 }, android: { pid: 222 } },
+    isAlive: () => true,
+    verifyCollector: ({ pid, platform }: { pid: number; platform: string }) =>
+      platform === 'ios'
+        ? ({ status: 'unverified', reason: `pid ${pid} does not run this workspace's ios log collector` } as const)
+        : ({ status: 'ours' } as const),
+  });
+  const reported: string[] = [];
+  const r = await runStop({ ...opts, report: (line: string) => reported.push(line) });
+  expect(calls.collectorSignals).toEqual([222]);
+  expect(calls.collectorsCleared).toBe(0);
+  expect(r.outcomes.collectors.entries).toEqual([
+    {
+      platform: 'ios',
+      pid: 111,
+      status: 'unverified',
+      reason: "pid 111 does not run this workspace's ios log collector",
+    },
+    { platform: 'android', pid: 222, status: 'stopped' },
+  ]);
+  expect(r.summary).toMatch(/1 collector left unsignalled/);
+  expect(reported.join('\n')).toMatch(/refusing to signal ios pid 111/);
+});
+
+test('a collector pid that died before the proof is already-stopped, not a refusal', async () => {
+  const { calls, opts } = seams({
+    collectors: { ios: { pid: 111 } },
+    isAlive: () => true,
+    verifyCollector: () => ({ status: 'gone' }) as const,
+  });
+  const r = await runStop(opts);
+  expect(calls.collectorSignals).toEqual([]);
+  expect(calls.collectorsCleared).toBe(1);
+  expect(r.outcomes.collectors.entries).toEqual([{ platform: 'ios', pid: 111, status: 'already-stopped' }]);
 });
 
 test('nothing recorded means no clear and no signal', async () => {

--- a/packages/stim-cli/src/__tests__/supervisor-expo.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-expo.test.ts
@@ -21,7 +21,7 @@ import {
   metroStoreConfirmedRoot,
   metroStoreRoot,
 } from '../supervisor/metro-store.ts';
-import { makeChildProcess } from './_factories.ts';
+import { IMPOSSIBLE_PID, makeChildProcess } from './_factories.ts';
 
 const ESC = '\u001B';
 
@@ -54,8 +54,22 @@ function fakeBin(dir = root, sdk = 54) {
   return bin;
 }
 
-function fakeChild(pid = 999999) {
+function fakeChild(pid = IMPOSSIBLE_PID) {
   return makeChildProcess({ pid });
+}
+
+async function withoutProcessKill(fn: (byPid: Array<[number, string | number]>) => Promise<void>): Promise<void> {
+  const byPid: Array<[number, string | number]> = [];
+  const realKill = process.kill;
+  process.kill = ((pid: number, sig: string | number) => {
+    byPid.push([pid, sig]);
+    return true;
+  }) as typeof process.kill;
+  try {
+    await fn(byPid);
+  } finally {
+    process.kill = realKill;
+  }
 }
 
 describe('line parsing', () => {
@@ -280,9 +294,15 @@ describe('startExpoServer', () => {
     expect(exits.length).toBe(1);
   });
 
-  test('close signals the child PID, not the process group it shares with us', async () => {
+  test('close signals through the child handle, never by pid', async () => {
     fakeBin();
-    const child = fakeChild(4242);
+    const child = fakeChild();
+    const signals: Array<string | number> = [];
+    child.kill = ((sig: string | number) => {
+      signals.push(sig);
+      if (sig === 'SIGTERM') child.emit('exit', 0, 'SIGTERM');
+      return true;
+    }) as typeof child.kill;
     const handle = await startExpoServer({
       root,
       port: 8116,
@@ -290,24 +310,22 @@ describe('startExpoServer', () => {
       spawnFn: () => child,
       killTimeoutMs: 50,
     });
-    const signals: Array<[number, string | number]> = [];
-    const realKill = process.kill;
-    process.kill = ((pid: number, sig: string | number) => {
-      signals.push([pid, sig]);
-      if (sig === 'SIGTERM') child.emit('exit', 0, 'SIGTERM');
-      return true;
-    }) as typeof process.kill;
-    try {
+    await withoutProcessKill(async (byPid) => {
       await handle.close();
-    } finally {
-      process.kill = realKill;
-    }
-    expect(signals).toEqual([[4242, 'SIGTERM']]);
+      expect(byPid).toEqual([]);
+    });
+    expect(signals).toEqual(['SIGTERM']);
   });
 
   test('a child that ignores SIGTERM is escalated to SIGKILL rather than left holding the port', async () => {
     fakeBin();
-    const child = fakeChild(4243);
+    const child = fakeChild();
+    const signals: Array<string | number> = [];
+    child.kill = ((sig: string | number) => {
+      signals.push(sig);
+      if (sig === 'SIGKILL') child.emit('exit', null, 'SIGKILL');
+      return true;
+    }) as typeof child.kill;
     const handle = await startExpoServer({
       root,
       port: 8117,
@@ -315,41 +333,28 @@ describe('startExpoServer', () => {
       spawnFn: () => child,
       killTimeoutMs: 20,
     });
-    const signals: Array<[number, string | number]> = [];
-    const realKill = process.kill;
-    process.kill = ((pid: number, sig: string | number) => {
-      signals.push([pid, sig]);
-      if (sig === 'SIGKILL') child.emit('exit', null, 'SIGKILL');
-      return true;
-    }) as typeof process.kill;
-    try {
+    await withoutProcessKill(async (byPid) => {
       await handle.close();
-    } finally {
-      process.kill = realKill;
-    }
-    expect(signals).toEqual([
-      [4243, 'SIGTERM'],
-      [4243, 'SIGKILL'],
-    ]);
+      expect(byPid).toEqual([]);
+    });
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
   });
 
   test('closing an already dead child signals nothing', async () => {
     fakeBin();
-    const child = fakeChild(4244);
+    const child = fakeChild();
+    const signals: Array<string | number> = [];
+    child.kill = ((sig: string | number) => {
+      signals.push(sig);
+      return true;
+    }) as typeof child.kill;
     const handle = await startExpoServer({ root, port: 8118, logsDir: join(root, 'logs'), spawnFn: () => child });
     child.emit('exit', 0, null);
-    const realKill = process.kill;
-    let called = 0;
-    process.kill = (() => {
-      called += 1;
-      return true;
-    }) as typeof process.kill;
-    try {
+    await withoutProcessKill(async (byPid) => {
       await handle.close();
-    } finally {
-      process.kill = realKill;
-    }
-    expect(called).toBe(0);
+      expect(byPid).toEqual([]);
+    });
+    expect(signals).toEqual([]);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/tunnel.test.ts
+++ b/packages/stim-cli/src/__tests__/tunnel.test.ts
@@ -1,5 +1,4 @@
 import {
-  readTunnelProcessArgs,
   readTunnelProcessToken,
   startTunnel,
   startTunnelSequence,
@@ -13,7 +12,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resetExecutor, setExecutor } from '../exec.ts';
-import { makeChildProcess } from './_factories.ts';
+import { IMPOSSIBLE_PID, makeChildProcess } from './_factories.ts';
 
 function clock(start = 1_000) {
   let t = start;
@@ -122,7 +121,7 @@ describe('startTunnel: the happy path', () => {
     child.stderr?.emit('data', 'banner |  https://random-words.trycloudflare.com  |\n');
     await expect(promise).resolves.toMatchObject({
       url: 'https://random-words.trycloudflare.com',
-      pid: 4242,
+      pid: IMPOSSIBLE_PID,
       processToken: 'linux:100',
       cleanup: expect.any(Function),
     });
@@ -139,7 +138,7 @@ describe('startTunnel: the happy path', () => {
     child.stdout?.emit('data', `${JSON.stringify({ msg: 'started tunnel', url: 'https://abcd.ngrok-free.app' })}\n`);
     await expect(promise).resolves.toMatchObject({
       url: 'https://abcd.ngrok-free.app',
-      pid: 4242,
+      pid: IMPOSSIBLE_PID,
       cleanup: expect.any(Function),
     });
   });
@@ -435,7 +434,11 @@ describe('startTunnel: nothing here throws -- every failure is a returned value'
     });
     child.stderr?.emit('data', 'https://x.trycloudflare.com\n');
     const result = await promise;
-    expect(result).toMatchObject({ url: 'https://x.trycloudflare.com', pid: 4242, cleanup: expect.any(Function) });
+    expect(result).toMatchObject({
+      url: 'https://x.trycloudflare.com',
+      pid: IMPOSSIBLE_PID,
+      cleanup: expect.any(Function),
+    });
     expect(calls).toBe(3);
   });
 
@@ -835,93 +838,6 @@ describe('stopTunnel: idempotent, never throws', () => {
     });
     expect(result.status).toBe('failed');
     expect(result.reason).toContain('did not exit');
-  });
-});
-
-describe('readTunnelProcessArgs', () => {
-  test('reads a bounded NUL-delimited command from Linux procfs', () => {
-    const reads: Array<{ path: string; maxBytes: number }> = [];
-    const result = readTunnelProcessArgs(4242, {
-      platform: 'linux',
-      readProcCommand: (path, maxBytes) => {
-        reads.push({ path, maxBytes });
-        return Buffer.from(['/usr/bin/ngrok', 'http', '8081', ''].join('\0'));
-      },
-    });
-    expect(result).toEqual(['/usr/bin/ngrok', 'http', '8081']);
-    expect(reads).toEqual([{ path: '/proc/4242/cmdline', maxBytes: expect.any(Number) }]);
-    expect(reads[0]?.maxBytes).toBeLessThanOrEqual(64 * 1024);
-  });
-
-  test('an unreadable Linux procfs command fails closed', () => {
-    expect(
-      readTunnelProcessArgs(4242, {
-        platform: 'linux',
-        readProcCommand: () => {
-          throw new Error('EACCES');
-        },
-      }),
-    ).toBeNull();
-  });
-
-  test('runs ps with a timeout on macOS and parses quoted arguments', () => {
-    const calls: Array<{ pid: number; timeoutMs: number }> = [];
-    const result = readTunnelProcessArgs(4242, {
-      platform: 'darwin',
-      runPsCommand: (pid, timeoutMs) => {
-        calls.push({ pid, timeoutMs });
-        return "'/opt/local/bin/ngrok' http 8081 --url 'https://stable.ngrok.app'";
-      },
-    });
-    expect(result).toEqual(['/opt/local/bin/ngrok', 'http', '8081', '--url', 'https://stable.ngrok.app']);
-    expect(calls).toEqual([{ pid: 4242, timeoutMs: expect.any(Number) }]);
-    expect(calls[0]?.timeoutMs).toBeLessThanOrEqual(5_000);
-  });
-
-  test('uses full-width BSD ps argv and preserves a long stable ngrok URL', () => {
-    const stableUrl = `https://${'a'.repeat(4_000)}.ngrok.app`;
-    const calls: Array<{ file: string; args: string[]; timeoutMs: number | undefined }> = [];
-    setExecutor({
-      runFile(file, args, options) {
-        calls.push({ file, args, timeoutMs: options?.timeoutMs });
-        return `ngrok http 8081 --log=stdout --log-format=json --url ${stableUrl}`;
-      },
-    });
-    try {
-      expect(readTunnelProcessArgs(4242, { platform: 'darwin' })).toEqual([
-        'ngrok',
-        'http',
-        '8081',
-        '--log=stdout',
-        '--log-format=json',
-        '--url',
-        stableUrl,
-      ]);
-    } finally {
-      resetExecutor();
-    }
-    expect(calls).toEqual([
-      { file: 'ps', args: ['-ww', '-o', 'command=', '-p', '4242'], timeoutMs: expect.any(Number) },
-    ]);
-  });
-
-  test.each([
-    [
-      'ps failure',
-      () => {
-        throw new Error('ps failed');
-      },
-    ],
-    [
-      'ps timeout',
-      () => {
-        throw Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
-      },
-    ],
-    ['empty output', () => ''],
-    ['malformed output', () => "'/usr/bin/ngrok http 8081"],
-  ])('%s fails closed', (_name, runPsCommand) => {
-    expect(readTunnelProcessArgs(4242, { platform: 'darwin', runPsCommand })).toBeNull();
   });
 });
 

--- a/packages/stim-cli/src/collector/ownership.ts
+++ b/packages/stim-cli/src/collector/ownership.ts
@@ -1,0 +1,92 @@
+import { realpathSync } from 'node:fs';
+import { isPidAlive } from '../metro.ts';
+import { readProcessArgs } from '../process-args.ts';
+
+const TITLE_PREFIX = 'stim-collector-';
+const COLLECTOR_ENTRY = /(^|\/)(collector-run\.mjs|collector\/run\.ts)$/;
+
+// libuv writes process.title over the argv region, so `ps -o command=` reports
+// the title instead of the spawn arguments. The title carries --root because it
+// is the only place a live collector can state which workspace owns it.
+export function collectorProcessTitle(platform: string, root: string): string {
+  return `${TITLE_PREFIX}${platform} --root ${root}`;
+}
+
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function sameRoot(recorded: string, actual: string): boolean {
+  return recorded === actual || canonical(recorded) === canonical(actual);
+}
+
+function identifiesCollector(args: readonly string[], platform: string): boolean {
+  if (args[0] === `${TITLE_PREFIX}${platform}`) return true;
+  const flag = args.indexOf('--platform');
+  if (flag === -1 || args[flag + 1] !== platform) return false;
+  return args.some((arg) => COLLECTOR_ENTRY.test(arg));
+}
+
+function tokenize(args: readonly string[]): string[] {
+  const only = args.length === 1 ? args[0] : null;
+  return only && /\s/.test(only) ? only.trim().split(/\s+/) : [...args];
+}
+
+function statesRoot(args: readonly string[], root: string): boolean {
+  const flag = args.indexOf('--root');
+  if (flag === -1) return false;
+  const tail = args.slice(flag + 1);
+  for (let end = 1; end <= tail.length; end++) {
+    const next = tail[end];
+    if (next !== undefined && !next.startsWith('--')) continue;
+    if (sameRoot(tail.slice(0, end).join(' '), root)) return true;
+  }
+  return false;
+}
+
+export function matchesCollectorProcess(
+  args: readonly string[] | null | undefined,
+  { platform, root }: { platform: string; root: string },
+): boolean {
+  if (!args?.length || !platform || !root) return false;
+  const tokens = tokenize(args);
+  return identifiesCollector(tokens, platform) && statesRoot(tokens, root);
+}
+
+export type CollectorOwnership = { status: 'ours' } | { status: 'gone' } | { status: 'unverified'; reason: string };
+
+export function verifyCollectorOwnership({
+  pid,
+  platform,
+  root,
+  readArgs = readProcessArgs,
+  isAlive = isPidAlive,
+}: {
+  pid: number;
+  platform: string;
+  root: string;
+  readArgs?: (pid: number) => readonly string[] | null;
+  isAlive?: (pid: number) => boolean;
+}): CollectorOwnership {
+  let args: readonly string[] | null = null;
+  try {
+    args = readArgs(pid);
+  } catch {
+    args = null;
+  }
+  if (!args) {
+    return isAlive(pid)
+      ? { status: 'unverified', reason: `the command of pid ${pid} could not be read` }
+      : { status: 'gone' };
+  }
+  if (!matchesCollectorProcess(args, { platform, root })) {
+    return isAlive(pid)
+      ? { status: 'unverified', reason: `pid ${pid} does not run this workspace's ${platform} log collector` }
+      : { status: 'gone' };
+  }
+  return { status: 'ours' };
+}

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -7,6 +7,7 @@ import { type NdjsonWriter, createNdjsonWriter } from '../ndjson.ts';
 import { workspaceLogsDir } from '../paths.ts';
 import { createLineReader } from '../process-output.ts';
 import { appNameFromBundleId, parseLogStreamLine, startIosLogStream } from './ios.ts';
+import { collectorProcessTitle } from './ownership.ts';
 import {
   type PidResolution,
   type PidWatcher,
@@ -328,7 +329,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     process.exit(2);
     return;
   }
-  process.title = `stim-collector-${parsed.platform}`;
+  process.title = collectorProcessTitle(parsed.platform as string, root);
   await runCollector(parsed as RunCollectorOptions);
 }
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1327,6 +1327,12 @@ WHAT ELSE STOP REAPS
   the device it was reading. A fresh \`ios\` / \`android\` run also kills the
   previous collector for that platform before starting its own.
 
+  Before signalling a recorded collector pid, \`stop\`, \`gc --delete\` and
+  \`worktree remove\` read that pid's live command and require it to be this
+  workspace's collector for that platform. A pid that cannot be proven is
+  reported and left alone: the kernel reuses pids, and an unreaped record is a
+  smaller problem than a signal delivered to someone else's process.
+
 BUILD LOCKS
   \`gc\` also reports the single-flight build locks (above): the ones whose
   builder is no longer running are debris a reboot or a kill left behind, and

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1331,7 +1331,10 @@ WHAT ELSE STOP REAPS
   \`worktree remove\` read that pid's live command and require it to be this
   workspace's collector for that platform. A pid that cannot be proven is
   reported and left alone: the kernel reuses pids, and an unreaped record is a
-  smaller problem than a signal delivered to someone else's process.
+  smaller problem than a signal delivered to someone else's process. A collector
+  started by an older Stim states no root in its command, so it reports as
+  unverified until it clears itself -- which it does when its device's log
+  stream ends, or when the next \`ios\` / \`android\` run replaces it.
 
 BUILD LOCKS
   \`gc\` also reports the single-flight build locks (above): the ones whose

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -15,6 +15,7 @@ import {
   readRemoteSession,
   readWorkspaceState,
 } from '../supervisor/state.ts';
+import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 import { endRecordedSession } from '../engine/device-remote.ts';
 import { resolveEasCliBin } from '../engine/remote-cache.ts';
@@ -150,17 +151,22 @@ interface CollectorTarget {
   platform: string;
   pid: number | null;
   status: string;
+  reason?: string;
 }
 
 export function resolveCollectorTargets({
+  root,
   collectors,
   isAlive = isPidAlive,
   selfPid = process.pid,
+  verify = verifyCollectorOwnership,
 }: {
+  root: string;
   collectors?: CollectorStateMap | null;
   isAlive?: (pid: number) => boolean;
   selfPid?: number;
-} = {}): CollectorTarget[] {
+  verify?: typeof verifyCollectorOwnership;
+}): CollectorTarget[] {
   const targets: CollectorTarget[] = [];
   for (const [platform, record] of Object.entries(collectors || {})) {
     const pid = numberOrNull(Number(record?.pid));
@@ -168,7 +174,20 @@ export function resolveCollectorTargets({
       targets.push({ platform, pid: pid ?? null, status: 'invalid' });
       continue;
     }
-    targets.push({ platform, pid, status: isAlive(pid) ? 'running' : 'stale' });
+    if (!isAlive(pid)) {
+      targets.push({ platform, pid, status: 'stale' });
+      continue;
+    }
+    const ownership = verify({ pid, platform, root, isAlive });
+    if (ownership.status === 'gone') {
+      targets.push({ platform, pid, status: 'stale' });
+      continue;
+    }
+    if (ownership.status === 'unverified') {
+      targets.push({ platform, pid, status: 'unverified', reason: ownership.reason });
+      continue;
+    }
+    targets.push({ platform, pid, status: 'running' });
   }
   return targets;
 }
@@ -207,6 +226,7 @@ interface CollectorEntry {
   platform: string;
   pid: number | null;
   status: string;
+  reason?: string;
 }
 
 interface CollectorsOutcome {
@@ -269,6 +289,7 @@ export async function runStop({
   state = undefined,
   collectors = undefined,
   signalCollector = (pid: number) => process.kill(pid, 'SIGTERM'),
+  verifyCollector = verifyCollectorOwnership,
   clearCollectors = clearCollectorState,
   isAlive = isPidAlive,
   killGroup = killMetroTree,
@@ -294,6 +315,7 @@ export async function runStop({
   state?: SupervisorStateRecord | null;
   collectors?: CollectorStateMap | null;
   signalCollector?: (pid: number) => void;
+  verifyCollector?: typeof verifyCollectorOwnership;
   clearCollectors?: (root: string) => void;
   isAlive?: (pid: number) => boolean;
   killGroup?: (leader: number | null | undefined) => boolean;
@@ -353,8 +375,20 @@ export async function runStop({
     }
   }
 
-  outcomes.collectors = reapCollectors(collectorRecords, { isAlive, signal: signalCollector, report });
-  if (outcomes.collectors.entries.length) clearCollectors(root);
+  outcomes.collectors = reapCollectors(root, collectorRecords, {
+    isAlive,
+    signal: signalCollector,
+    report,
+    verify: verifyCollector,
+  });
+  const unverifiedCollectors = outcomes.collectors.entries.filter((e) => e.status === 'unverified');
+  if (unverifiedCollectors.length) {
+    report(
+      chalk.dim(
+        `collectors: keeping the records; ${unverifiedCollectors.length} pid(s) could not be verified, and a later \`ios\` / \`android\` run replaces them`,
+      ),
+    );
+  } else if (outcomes.collectors.entries.length) clearCollectors(root);
 
   const supervisorHandled =
     outcomes.supervisor.status === 'stopped' ||
@@ -454,18 +488,21 @@ export async function runStop({
 }
 
 function reapCollectors(
+  root: string,
   collectors: CollectorStateMap | null | undefined,
   {
     isAlive,
     signal,
     report,
+    verify = verifyCollectorOwnership,
   }: {
     isAlive: (pid: number) => boolean;
     signal: (pid: number) => void;
     report: (line: string) => void;
+    verify?: typeof verifyCollectorOwnership;
   },
 ): CollectorsOutcome {
-  const targets = resolveCollectorTargets({ collectors, isAlive });
+  const targets = resolveCollectorTargets({ root, collectors, isAlive, verify });
   const entries: CollectorEntry[] = [];
   for (const target of targets) {
     if (target.status === 'invalid') {
@@ -476,6 +513,11 @@ function reapCollectors(
     if (target.status === 'stale') {
       entries.push({ platform: target.platform, pid: target.pid, status: 'already-stopped' });
       report(chalk.dim(`collectors: ${target.platform} pid ${target.pid} is already gone`));
+      continue;
+    }
+    if (target.status === 'unverified') {
+      entries.push({ platform: target.platform, pid: target.pid, status: 'unverified', reason: target.reason });
+      report(chalk.yellow(`collectors: refusing to signal ${target.platform} pid ${target.pid}: ${target.reason}`));
       continue;
     }
     try {
@@ -666,6 +708,8 @@ function summarize(root: string, outcomes: StopOutcomes, ok: boolean): string {
     parts.push(`supervisor pid ${outcomes.supervisor.pid} could not be signalled`);
   const reaped = outcomes.collectors.entries.filter((e) => e.status === 'stopped').length;
   if (reaped) parts.push(`${reaped} collector${reaped === 1 ? '' : 's'} stopped`);
+  const unverified = outcomes.collectors.entries.filter((e) => e.status === 'unverified').length;
+  if (unverified) parts.push(`${unverified} collector${unverified === 1 ? '' : 's'} left unsignalled`);
   if (outcomes.metro.status === 'stopped') parts.push(`metro on port ${outcomes.metro.port} stopped`);
   if (outcomes.metro.status === 'forced') parts.push(`port ${outcomes.metro.port} killed (forced)`);
   if (outcomes.metro.status === 'refused') parts.push(`port ${outcomes.metro.port} refused`);

--- a/packages/stim-cli/src/engine/tunnel.ts
+++ b/packages/stim-cli/src/engine/tunnel.ts
@@ -1,10 +1,18 @@
 import type { ChildProcess } from 'node:child_process';
-import { closeSync, mkdirSync, openSync, readFileSync, readSync, unlinkSync } from 'node:fs';
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { basename, join, resolve as resolvePath, sep } from 'node:path';
 import { getConfigDir } from '../config.ts';
 import { getExecutor } from '../exec.ts';
 import { isPidAlive } from '../metro.ts';
+import {
+  PROCESS_COMMAND_MAX_BYTES,
+  PROCESS_COMMAND_TIMEOUT_MS,
+  type ReadProcCommand,
+  type RunPsCommand,
+  readProcFile,
+  readProcessArgs as readProcessArgsDefault,
+} from '../process-args.ts';
 import { createLineReader } from '../process-output.ts';
 import type { ManagedProvider } from './metro-reach.ts';
 import { withWorkspaceProcessLock, type WorkspaceProcessLockOptions } from './workspace-process-lock.ts';
@@ -565,9 +573,6 @@ export interface StopTunnelResult {
 
 const STOP_TIMEOUT_MS = 5_000;
 const STOP_POLL_MS = 100;
-const PROCESS_COMMAND_TIMEOUT_MS = 1_000;
-const PROCESS_COMMAND_MAX_BYTES = 32 * 1024;
-
 function defaultKill(pid: number): void {
   process.kill(pid, 'SIGTERM');
 }
@@ -576,115 +581,8 @@ function isEsrch(err: unknown): boolean {
   return (err as NodeJS.ErrnoException)?.code === 'ESRCH';
 }
 
-type ReadProcCommand = (path: string, maxBytes: number) => Buffer;
-type RunPsCommand = (pid: number, timeoutMs: number) => string;
-
-function defaultReadProcCommand(path: string, maxBytes: number): Buffer {
-  const fd = openSync(path, 'r');
-  const buffer = Buffer.alloc(maxBytes + 1);
-  let bytesRead = 0;
-  try {
-    while (bytesRead < buffer.length) {
-      const count = readSync(fd, buffer, bytesRead, buffer.length - bytesRead, null);
-      if (count === 0) break;
-      bytesRead += count;
-    }
-  } finally {
-    closeSync(fd);
-  }
-  if (bytesRead > maxBytes) throw new Error(`process command exceeds ${maxBytes} bytes`);
-  return buffer.subarray(0, bytesRead);
-}
-
-function defaultRunPsCommand(pid: number, timeoutMs: number): string {
-  return getExecutor().runFile('ps', ['-ww', '-o', 'command=', '-p', String(pid)], { timeoutMs });
-}
-
 function defaultRunPsStartCommand(pid: number, timeoutMs: number): string {
   return getExecutor().runFile('ps', ['-ww', '-o', 'lstart=', '-p', String(pid)], { timeoutMs });
-}
-
-function parseProcCommand(data: Buffer, maxBytes: number): string[] | null {
-  if (data.length === 0 || data.length > maxBytes || data[data.length - 1] !== 0) return null;
-  const args = data.subarray(0, -1).toString('utf-8').split('\0');
-  return args.length > 0 && args.every((arg) => arg.length > 0) ? args : null;
-}
-
-function parsePsCommand(command: string): string[] | null {
-  const input = command.trim();
-  if (!input || input.includes('\0') || input.includes('\n') || input.includes('\r')) return null;
-
-  const args: string[] = [];
-  let current = '';
-  let quote: "'" | '"' | null = null;
-  let escaped = false;
-  let started = false;
-  const finishArg = () => {
-    if (!started) return;
-    args.push(current);
-    current = '';
-    started = false;
-  };
-
-  for (const char of input) {
-    if (escaped) {
-      current += char;
-      started = true;
-      escaped = false;
-      continue;
-    }
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      started = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = null;
-      else current += char;
-      started = true;
-      continue;
-    }
-    if (char === "'" || char === '"') {
-      quote = char;
-      started = true;
-      continue;
-    }
-    if (/\s/.test(char)) {
-      finishArg();
-      continue;
-    }
-    current += char;
-    started = true;
-  }
-  if (quote || escaped) return null;
-  finishArg();
-  return args.length > 0 && args.every((arg) => arg.length > 0) ? args : null;
-}
-
-export function readTunnelProcessArgs(
-  pid: number,
-  {
-    platform = process.platform,
-    readProcCommand = defaultReadProcCommand,
-    runPsCommand = defaultRunPsCommand,
-  }: {
-    platform?: NodeJS.Platform;
-    readProcCommand?: ReadProcCommand;
-    runPsCommand?: RunPsCommand;
-  } = {},
-): string[] | null {
-  try {
-    if (platform === 'linux') {
-      return parseProcCommand(
-        readProcCommand(`/proc/${pid}/cmdline`, PROCESS_COMMAND_MAX_BYTES),
-        PROCESS_COMMAND_MAX_BYTES,
-      );
-    }
-    if (platform === 'win32') return null;
-    return parsePsCommand(runPsCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
-  } catch {
-    return null;
-  }
 }
 
 function parseLinuxStartToken(data: Buffer, maxBytes: number): string | null {
@@ -708,7 +606,7 @@ export function readTunnelProcessToken(
   pid: number,
   {
     platform = process.platform,
-    readProcStat = defaultReadProcCommand,
+    readProcStat = readProcFile,
     runPsStartCommand = defaultRunPsStartCommand,
   }: {
     platform?: NodeJS.Platform;
@@ -763,7 +661,7 @@ export async function stopTunnel(
   record: TunnelRecord | null | undefined,
   {
     isAlive = isPidAlive,
-    readProcessArgs = readTunnelProcessArgs,
+    readProcessArgs = readProcessArgsDefault,
     readProcessToken = readTunnelProcessToken,
     kill = defaultKill,
     now = Date.now,

--- a/packages/stim-cli/src/process-args.ts
+++ b/packages/stim-cli/src/process-args.ts
@@ -1,0 +1,114 @@
+import { closeSync, openSync, readSync } from 'node:fs';
+import { getExecutor } from './exec.ts';
+
+export const PROCESS_COMMAND_TIMEOUT_MS: number = 1_000;
+export const PROCESS_COMMAND_MAX_BYTES: number = 32 * 1024;
+
+export type ReadProcCommand = (path: string, maxBytes: number) => Buffer;
+export type RunPsCommand = (pid: number, timeoutMs: number) => string;
+
+export function readProcFile(path: string, maxBytes: number): Buffer {
+  const fd = openSync(path, 'r');
+  const buffer = Buffer.alloc(maxBytes + 1);
+  let bytesRead = 0;
+  try {
+    while (bytesRead < buffer.length) {
+      const count = readSync(fd, buffer, bytesRead, buffer.length - bytesRead, null);
+      if (count === 0) break;
+      bytesRead += count;
+    }
+  } finally {
+    closeSync(fd);
+  }
+  if (bytesRead > maxBytes) throw new Error(`process command exceeds ${maxBytes} bytes`);
+  return buffer.subarray(0, bytesRead);
+}
+
+function defaultRunPsCommand(pid: number, timeoutMs: number): string {
+  return getExecutor().runFile('ps', ['-ww', '-o', 'command=', '-p', String(pid)], { timeoutMs });
+}
+
+function parseProcCommand(data: Buffer, maxBytes: number): string[] | null {
+  if (data.length === 0 || data.length > maxBytes || data[data.length - 1] !== 0) return null;
+  let end = data.length;
+  while (end > 0 && data[end - 1] === 0) end -= 1;
+  const args = data.subarray(0, end).toString('utf-8').split('\0');
+  return args.length > 0 && args.every((arg) => arg.length > 0) ? args : null;
+}
+
+function parsePsCommand(command: string): string[] | null {
+  const input = command.trim();
+  if (!input || input.includes('\0') || input.includes('\n') || input.includes('\r')) return null;
+
+  const args: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  let started = false;
+  const finishArg = () => {
+    if (!started) return;
+    args.push(current);
+    current = '';
+    started = false;
+  };
+
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      started = true;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      started = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      started = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      finishArg();
+      continue;
+    }
+    current += char;
+    started = true;
+  }
+  if (quote || escaped) return null;
+  finishArg();
+  return args.length > 0 && args.every((arg) => arg.length > 0) ? args : null;
+}
+
+export function readProcessArgs(
+  pid: number,
+  {
+    platform = process.platform,
+    readProcCommand = readProcFile,
+    runPsCommand = defaultRunPsCommand,
+  }: {
+    platform?: NodeJS.Platform;
+    readProcCommand?: ReadProcCommand;
+    runPsCommand?: RunPsCommand;
+  } = {},
+): string[] | null {
+  try {
+    if (platform === 'linux') {
+      return parseProcCommand(
+        readProcCommand(`/proc/${pid}/cmdline`, PROCESS_COMMAND_MAX_BYTES),
+        PROCESS_COMMAND_MAX_BYTES,
+      );
+    }
+    if (platform === 'win32') return null;
+    return parsePsCommand(runPsCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
+  } catch {
+    return null;
+  }
+}

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -3,6 +3,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { resolveProjectMetro, killMetroTree, isPidAlive } from './metro.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from './teardown.ts';
 import { readCollectors } from './collector/state.ts';
+import { verifyCollectorOwnership } from './collector/ownership.ts';
 import {
   clearManagedMetroTunnel,
   clearRemoteSession,
@@ -15,14 +16,26 @@ import { resolveEasCliBin } from './engine/remote-cache.ts';
 import { stopTunnel, type StopTunnelResult } from './engine/tunnel.ts';
 import { workspaceDir } from './paths.ts';
 
-function reapCollectors(root: string): void {
-  for (const record of Object.values(readCollectors(root))) {
+function reapCollectors(root: string): SkippedDevice[] {
+  const skipped: SkippedDevice[] = [];
+  for (const [platform, record] of Object.entries(readCollectors(root))) {
     const pid = (record as { pid?: unknown } | null)?.pid;
     if (typeof pid !== 'number' || pid <= 0 || pid === process.pid || !isPidAlive(pid)) continue;
+    const ownership = verifyCollectorOwnership({ pid, platform, root });
+    if (ownership.status === 'gone') continue;
+    if (ownership.status === 'unverified') {
+      skipped.push({
+        platform: platform === 'android' ? 'android' : 'ios',
+        name: `${platform} log collector (pid ${pid})`,
+        reason: `${ownership.reason}, so it was not signalled -- inspect it with \`ps -p ${pid}\``,
+      });
+      continue;
+    }
     try {
       process.kill(pid, 'SIGTERM');
     } catch {}
   }
+  return skipped;
 }
 
 // eas simulator:stop needs a project cwd, so end the session before removing the worktree.
@@ -207,7 +220,7 @@ export async function reclaimProject(
   const project = getProject(path);
   const dereferenced = describeDereferenced(project);
 
-  reapCollectors(path);
+  const skippedCollectors = reapCollectors(path);
 
   const {
     deletedDevices,
@@ -218,6 +231,7 @@ export async function reclaimProject(
     skippedDevices: SkippedDevice[];
     failedDevices: SkippedDevice[];
   } = deleteOwnedDevices ? reclaimOwnedDevices(project) : { deletedDevices: [], skippedDevices: [], failedDevices: [] };
+  skippedDevices.push(...skippedCollectors);
 
   const remote = reclaimRemoteSession(path, { stopSession });
   if (remote.failed) {

--- a/packages/stim-cli/src/supervisor/server-expo.ts
+++ b/packages/stim-cli/src/supervisor/server-expo.ts
@@ -358,14 +358,14 @@ export async function startExpoServer({
         child.once('exit', () => resolve());
       });
       try {
-        process.kill(child.pid, 'SIGTERM');
+        if (!child.kill('SIGTERM')) return;
       } catch {
         return;
       }
       await Promise.race([dead, delay(killTimeoutMs)]);
       if (!exited) {
         try {
-          process.kill(child.pid, 'SIGKILL');
+          child.kill('SIGKILL');
         } catch {}
         await Promise.race([dead, delay(killTimeoutMs)]);
       }

--- a/packages/stim-cli/src/supervisor/server-expo.ts
+++ b/packages/stim-cli/src/supervisor/server-expo.ts
@@ -357,16 +357,10 @@ export async function startExpoServer({
       const dead = new Promise<void>((resolve) => {
         child.once('exit', () => resolve());
       });
-      try {
-        if (!child.kill('SIGTERM')) return;
-      } catch {
-        return;
-      }
+      if (!child.kill('SIGTERM')) return;
       await Promise.race([dead, delay(killTimeoutMs)]);
       if (!exited) {
-        try {
-          child.kill('SIGKILL');
-        } catch {}
+        child.kill('SIGKILL');
         await Promise.race([dead, delay(killTimeoutMs)]);
       }
     },


### PR DESCRIPTION
## Description

`stim stop`, `gc --delete` and `worktree remove` each signalled any live, non-self pid a collector
record named. Nothing checked that the pid still belonged to a collector Stim started, so a record
whose collector died and whose pid the kernel reused sent SIGTERM to whatever now holds that number
-- on a user's machine, not only in CI. #151 fixed this shape inside the collector itself; the three
weaknesses in #161 are what remained.

The one visible behavior change: a collector record Stim cannot prove is now left running and
reported, instead of signalled.

## Solution

**The proof** (`collector/ownership.ts`, shared by both call paths). Read the recorded pid's live
command and require it to name this workspace's collector for that platform. The verdict has three
states because callers need to tell them apart: `ours` signals, `gone` (the pid died between the
liveness check and the read) is silent, and `unverified` is reported and never signalled. Anything
short of proof means "do not signal", including an unreadable `ps`.

libuv writes `process.title` over the argv region, so a running collector reports its title and not
its spawn arguments -- which is why the title now carries `--root <root>`, the only place a live
collector can state which workspace owns it:

```
$ ps -ww -o command= -p 27057
stim-collector-android --root /tmp/stim-real-root
```

A collector titled for a different root is not ours. The spawn argv
(`collector-run.mjs --platform <p> --root <root>`) is accepted too, for the window before the rename
and for a raw `/proc` cmdline.

**Where a refusal surfaces.** `worktree remove` and `gc` report it through the same `skippedDevices`
channel a refused device teardown uses (`kept ios log collector (pid N): ...`). `stop` records an
`unverified` collector entry, keeps the collector records instead of clearing the key, and counts
them in its summary. Unlike an unverified *supervisor*, an unverified collector does not fail the
command -- the pid is not holding the port, and the next `ios` / `android` run replaces the record.

**Upgrade window.** A collector already running from an older Stim carries the old title, which
states no root, so the proof cannot place it in a workspace and it reports as `refusing to signal` /
`kept ios log collector (pid N)` on every `stop`, `gc --delete` and `worktree remove` until it is
gone. It clears itself the moment its device's log stream ends (the collector unregisters on exit),
and the next `ios` / `android` run replaces it outright. Noise, not breakage, and it does not
survive a device teardown -- but a user upgrading mid-session will see it.

**The other two weaknesses.** `server-expo.ts` closed its Expo child with
`process.kill(child.pid, ...)` behind an `exited` flag that is a race rather than a proof; it now
signals through the child handle, which reaches the same process because the child is spawned
`detached: false`. And `makeChildProcess` handed every test a plausible live pid (`4242`) -- exactly
what turned #151's defect into a killed vitest worker -- so the default becomes `999999901`, above
every kernel's pid_max and the constant `start.test` and `status.test` already use.

**Why `tunnel.ts` is in this diff.** The tunnel stop path already proves a pid this way, so its argv
reader moved to `process-args.ts` and is now shared rather than copied. One behavior change there:
trailing NUL padding in a `/proc` cmdline is no longer read as a malformed argument list, which is
what a process that renamed itself leaves behind.

**Still unproven, out of scope for this issue:** `replaceCollector` (ios) and `killPreviousCollector`
(android) signal the previously recorded collector pid before spawning a new one, with the same
missing check. Same defect class, different command; it wants its own issue rather than a wider diff
here.

## Test plan

- `reclaim.test.ts` is the end-to-end one, and it uses real processes and the real `ps`: a spawned
  process whose title proves it is SIGTERMed by `reclaimProject`; an unrelated live process and a
  collector titled for *another* root are both still running afterwards and come back in
  `skippedDevices`; a pid that already exited is silent.
- `collector-ownership.test.ts` pins the matcher -- title shape, spawn-argv shape, wrong root, wrong
  platform, lookalikes (`stim-supervisor --root <root>`, `vitest --root <root>`), a root containing a
  space, a symlinked root, and the single padded argument a `/proc` read returns.
- `stop.test.ts` covers the second call path: an unverified collector is not signalled, is reported,
  keeps the state key, and lands in the summary.
- `supervisor-expo.test.ts` pins the close path structurally -- `child.kill` receives SIGTERM then
  SIGKILL, and `process.kill` is never called.
- Real tool (invariant 9): ran the real `dist/collector-run.mjs` and read it back with
  `ps -ww -o command= -p <pid>` (output above; `ps -p <pid> -o command=` agrees, and a second `-o`
  column truncates `command` to 16 chars, which is why it is read alone).
- Battery: build, typecheck, lint, format:check, knip, `pnpm test` (2686 passed), `pnpm run test:e2e`
  (19 passed, including `worktree remove ... leaving nothing behind`).

## Release note

Collector pids are now proven before they are signalled: `stop`, `gc --delete` and `worktree remove`
read the pid's live command and refuse to signal anything they cannot place in this workspace, so a
stale record whose pid the kernel reused can no longer take down an unrelated process. A collector
still running from an earlier version reports as unverified until its log stream ends or the next
`ios` / `android` run replaces it.

Fixes #161
