### PR TITLE
Close the replacement and reclaim gaps left open by #181's ownership proof

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2028,14 +2028,36 @@ describe('Contract 5: the device-log collector', () => {
     expect(unrefed).toBe(true);
   });
 
-  test('the previous android collector is killed first -- replaced, not duplicated', async () => {
+  test('the previous android collector, proven ours, is killed first -- replaced, not duplicated', async () => {
     writeWorkspaceState(root, {
       collectors: { android: { pid: 4242, startedAt: 'then' }, ios: { pid: 777, startedAt: 'then' } },
     });
-    const h = harness();
+    const h = harness({ verifyCollector: () => ({ status: 'ours' as const }) });
     await h.run();
     expect(h.calls.kill).toEqual([[4242, 'SIGTERM']]);
     expect(h.calls.spawn.length).toBe(1);
+  });
+
+  test('a previous android collector proven gone is left alone, never signalled', async () => {
+    writeWorkspaceState(root, { collectors: { android: { pid: 4242, startedAt: 'then' } } });
+    const h = harness({ verifyCollector: () => ({ status: 'gone' as const }) });
+    await h.run();
+    expect(h.calls.kill).toEqual([]);
+    expect(h.calls.spawn.length).toBe(1);
+  });
+
+  test('a previous android collector that cannot be proven ours is left running, noted, and replaced anyway', async () => {
+    writeWorkspaceState(root, { collectors: { android: { pid: 4242, startedAt: 'then' } } });
+    const h = harness({
+      verifyCollector: () => ({
+        status: 'unverified' as const,
+        reason: "pid 4242 does not run this workspace's android log collector",
+      }),
+    });
+    await h.run();
+    expect(h.calls.kill).toEqual([]);
+    expect(h.calls.spawn.length).toBe(1);
+    expect(h.stderr.some((l) => /pid 4242/.test(l) && /not signalled/.test(l))).toBeTruthy();
   });
 
   test('the ios collector is left alone', async () => {
@@ -2212,11 +2234,13 @@ describe('the pure parts', () => {
     expect(lastBuildRecord({ startedAt: 'now', status: 'failed', errorCode: BUILD_ERROR }).errorCode).toBe(BUILD_ERROR);
   });
 
-  test('killPreviousCollector signals a recorded pid and tolerates a dead one', () => {
+  test('killPreviousCollector signals a pid proven ours and tolerates a dead one', () => {
     const signalled: Array<[number, NodeJS.Signals]> = [];
+    const ours = () => ({ status: 'ours' as const });
     expect(
       killPreviousCollector(root, {
         collectors: { android: { pid: 4242 } },
+        verify: ours,
         kill: (pid, sig) => {
           signalled.push([pid, sig]);
           return true;
@@ -2227,6 +2251,7 @@ describe('the pure parts', () => {
     expect(
       killPreviousCollector(root, {
         collectors: { android: { pid: 4242 } },
+        verify: ours,
         kill: () => {
           throw new Error('ESRCH');
         },
@@ -2235,6 +2260,7 @@ describe('the pure parts', () => {
     expect(
       killPreviousCollector(root, {
         collectors: {},
+        verify: ours,
         kill: () => {
           throw new Error('must not be called');
         },
@@ -2243,11 +2269,40 @@ describe('the pure parts', () => {
     expect(
       killPreviousCollector(root, {
         collectors: { android: { pid: process.pid } },
+        verify: ours,
         kill: () => {
           throw new Error('must not be called');
         },
       }),
     ).toBe(null);
+  });
+
+  test('killPreviousCollector leaves a pid proven gone alone, and never signals it', () => {
+    expect(
+      killPreviousCollector(root, {
+        collectors: { android: { pid: 4242 } },
+        verify: () => ({ status: 'gone' as const }),
+        kill: () => {
+          throw new Error('must not be called');
+        },
+      }),
+    ).toBe(null);
+  });
+
+  test('killPreviousCollector leaves an unverified pid running, notes it, and does not signal it', () => {
+    const notes: string[] = [];
+    expect(
+      killPreviousCollector(root, {
+        collectors: { android: { pid: 4242 } },
+        verify: () => ({ status: 'unverified' as const, reason: "pid 4242 does not run this workspace's collector" }),
+        note: (line) => notes.push(line),
+        kill: () => {
+          throw new Error('must not be called');
+        },
+      }),
+    ).toBe(null);
+    expect(notes.length).toBe(1);
+    expect(notes[0]).toMatch(/not signalled/);
   });
 });
 
@@ -3240,6 +3295,7 @@ test('a new android collector waits for the previous one to exit before it is sp
       order.push('alive');
       return liveChecks < 3;
     },
+    verify: () => ({ status: 'ours' as const }),
     sleep: async () => {},
     out: () => {},
   });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert';
+import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
+import { collectorProcessTitle } from '../collector/ownership.ts';
 import { loadConfig, setProjectSetting, upsertProject } from '../config.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { emulatorLogFile, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
@@ -2001,6 +2003,39 @@ describe('Contract 4: state.json.lastBuild', () => {
   });
 });
 
+function collectorProcessCommand(pid: number): string {
+  try {
+    return execFileSync('ps', ['-ww', '-o', 'command=', '-p', String(pid)], { encoding: 'utf-8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+// Spawns a real detached process so the default `verifyCollectorOwnership` reads its actual
+// live command (via ps on darwin, via /proc/[pid]/cmdline on linux) instead of a mocked
+// executor, which only exercises the darwin ps path and fails closed for the wrong reason on
+// Linux CI.
+async function spawnFakeCollector(title: string | null): Promise<ChildProcess> {
+  const rename = title ? `process.title = ${JSON.stringify(title)};` : '';
+  const child = spawn(process.execPath, ['-e', `${rename} setInterval(() => {}, 1000);`], { stdio: 'ignore' });
+  const expected = title ?? process.execPath;
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline && !collectorProcessCommand(child.pid as number).startsWith(expected)) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return child;
+}
+
+function collectorExits(child: ChildProcess, timeoutMs = 5_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
 describe('Contract 5: the device-log collector', () => {
   test("is spawned detached and unreferenced with this platform's identity", async () => {
     const h = harness();
@@ -2059,6 +2094,46 @@ describe('Contract 5: the device-log collector', () => {
     expect(h.calls.spawn.length).toBe(1);
     expect(h.stderr.some((l) => /pid 4242/.test(l) && /not signalled/.test(l))).toBeTruthy();
   });
+
+  test('the default ownership check is wired through: a live process titled for this workspace is signalled', async () => {
+    const child = await spawnFakeCollector(collectorProcessTitle('android', root));
+    try {
+      const signalled: Array<[number, NodeJS.Signals]> = [];
+      const result = killPreviousCollector(root, {
+        collectors: { android: { pid: child.pid as number } },
+        kill: (pid, sig) => {
+          signalled.push([pid, sig]);
+          return true;
+        },
+      });
+      expect(result).toBe(child.pid);
+      expect(signalled).toEqual([[child.pid, 'SIGTERM']]);
+    } finally {
+      child.kill('SIGKILL');
+      await collectorExits(child);
+    }
+  }, 20_000);
+
+  test('the default ownership check is wired through: a live process that cannot be proven is left running and noted', async () => {
+    const child = await spawnFakeCollector(null);
+    try {
+      const notes: string[] = [];
+      const result = killPreviousCollector(root, {
+        collectors: { android: { pid: child.pid as number } },
+        isAlive: () => true,
+        note: (line) => notes.push(line),
+        kill: () => {
+          throw new Error('must not be called');
+        },
+      });
+      expect(result).toBe(null);
+      expect(notes.length).toBe(1);
+      expect(notes[0]).toMatch(/not signalled/);
+    } finally {
+      child.kill('SIGKILL');
+      await collectorExits(child);
+    }
+  }, 20_000);
 
   test('the ios collector is left alone', async () => {
     writeWorkspaceState(root, { collectors: { ios: { pid: 777, startedAt: 'then' } } });

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -170,22 +170,32 @@ describe('Contract 5: the registration', () => {
     registerCollector(root, 'ios', { pid: 1, startedAt: 'a' });
     registerCollector(root, 'android', { pid: 2, startedAt: 'b' });
     expect(Object.keys(readCollectors(root)).toSorted()).toEqual(['android', 'ios']);
-    unregisterCollector(root, 'ios');
+    unregisterCollector(root, 'ios', 1);
     expect(readCollectors(root)).toEqual({ android: { pid: 2, startedAt: 'b' } });
   });
 
   test('the last collector out removes the key entirely rather than leaving an empty object', () => {
     writeWorkspaceState(root, { supervisor: { pid: 123 } });
     registerCollector(root, 'ios', { pid: 1, startedAt: 'a' });
-    unregisterCollector(root, 'ios');
+    unregisterCollector(root, 'ios', 1);
     expect('collectors' in state()).toBe(false);
     expect(state().supervisor).toEqual({ pid: 123 });
   });
 
   test('unregistering a platform that was never registered is a no-op', () => {
     registerCollector(root, 'android', { pid: 2, startedAt: 'b' });
-    unregisterCollector(root, 'ios');
+    unregisterCollector(root, 'ios', 999);
     expect(readCollectors(root)).toEqual({ android: { pid: 2, startedAt: 'b' } });
+  });
+
+  test('a stale unregister from a replaced collector does not clobber the newer registration', () => {
+    // #182: a replaced collector (proven unverified) is left running instead of signalled, so
+    // it can still reach its own finish() -> unregisterCollector after a newer collector has
+    // registered over the same platform key. Its own pid must not match the current record.
+    registerCollector(root, 'ios', { pid: 1, startedAt: 'a' });
+    registerCollector(root, 'ios', { pid: 2, startedAt: 'b' });
+    unregisterCollector(root, 'ios', 1);
+    expect(readCollectors(root)).toEqual({ ios: { pid: 2, startedAt: 'b' } });
   });
 });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -226,6 +226,18 @@ test('the cleanup guide documents the collector ownership proof and its upgrade 
   expect(cleanup).toMatch(/older Stim[^.]*no root[^.]*reports as\s+unverified/i);
   expect(cleanup).toMatch(/clears itself[\s\S]*log\s+stream ends/i);
   expect(cleanup).toMatch(/next `ios` \/ `android` run replaces it/i);
+  expect(cleanup).toMatch(/a fresh `ios` \/ `android`\s+run[^.]*starts its replacement anyway/i);
+});
+
+test('the cleanup guide documents the keep-and-retry split for a live, unverified collector pid', () => {
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+
+  expect(cleanup).toMatch(/weigh an unproven live\s+pid against the record's own startedAt claim/i);
+  expect(cleanup).toMatch(/started AFTER that\s+claim[^.]*recycled the number[^.]*genuinely stale[^.]*dropped/i);
+  expect(cleanup).toMatch(
+    /started at or\s+before that claim[^.]*may still be the collector[^.]*kept and reported for a retry/i,
+  );
 });
 
 test('the cleanup guide documents that the shared Gradle build cache is report-only', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -224,8 +224,9 @@ test('the cleanup guide documents the collector ownership proof and its upgrade 
   expect(cleanup).toMatch(/cannot be proven[^.]*reported and left alone/i);
   expect(cleanup).toMatch(/kernel reuses pids/i);
   expect(cleanup).toMatch(/older Stim[^.]*no root[^.]*reports as\s+unverified/i);
-  expect(cleanup).toMatch(/clears itself[\s\S]*log\s+stream ends/i);
-  expect(cleanup).toMatch(/next `ios` \/ `android` run replaces it/i);
+  expect(cleanup).toMatch(/record clears[\s\S]*log\s+stream ends[^.]*unregisters itself/i);
+  expect(cleanup).toMatch(/next\s+`ios` \/ `android` run overwrites the record with its own/i);
+  expect(cleanup).toMatch(/the old process itself keeps running until it exits on its own/i);
   expect(cleanup).toMatch(/a fresh `ios` \/ `android`\s+run[^.]*starts its replacement anyway/i);
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
 import { upsertProject } from '../config.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { workspaceDir, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import type { WorkspaceState } from '../supervisor/run.ts';
@@ -1582,13 +1583,16 @@ describe('the collector', () => {
   function collectorHarness({
     state = null,
     killImpl = null,
+    verify = () => ({ status: 'ours' as const }),
   }: {
     state?: WorkspaceState | null;
     killImpl?: ((pid: number, signal: NodeJS.Signals) => void) | null;
+    verify?: NonNullable<ReplaceCollectorArgs['verify']>;
   } = {}) {
     if (state) writeWorkspaceState(root, state);
     const spawns: { cmd: string; args: readonly string[]; opts: Record<string, unknown> }[] = [];
     const kills: { pid: number; signal: NodeJS.Signals }[] = [];
+    const notes: string[] = [];
     const opts: ReplaceCollectorArgs = {
       root,
       udid: UDID,
@@ -1604,12 +1608,14 @@ describe('the collector', () => {
         return true;
       },
       alive: () => false,
+      verify,
       waitMs: 0,
+      note: (line) => notes.push(line),
     };
-    return { spawns, kills, opts };
+    return { spawns, kills, notes, opts };
   }
 
-  test('a previous collector is SIGTERMed and replaced, not duplicated', async () => {
+  test('a previous collector proven ours is SIGTERMed and replaced, not duplicated', async () => {
     const h = collectorHarness({ state: { collectors: { ios: { pid: 999, startedAt: 'T' } } } });
     const result = await replaceCollector(h.opts);
     expect(h.kills).toEqual([{ pid: 999, signal: 'SIGTERM' }]);
@@ -1628,6 +1634,71 @@ describe('the collector', () => {
     const result = await replaceCollector(h.opts);
     expect(result.killed).toBe(null);
     expect(h.spawns.length).toBe(1);
+  });
+
+  test('a previous collector proven gone is left alone, never signalled, and not noted', async () => {
+    const h = collectorHarness({
+      state: { collectors: { ios: { pid: 999 } } },
+      verify: () => ({ status: 'gone' }),
+    });
+    const result = await replaceCollector(h.opts);
+    expect(h.kills).toEqual([]);
+    expect(result.killed).toBe(null);
+    expect(h.notes).toEqual([]);
+    expect(h.spawns.length).toBe(1);
+    expect(result.pid).toBe(7001);
+  });
+
+  test('a previous collector that cannot be proven ours is left running, noted once, and replaced anyway', async () => {
+    const h = collectorHarness({
+      state: { collectors: { ios: { pid: 999 } } },
+      verify: () => ({ status: 'unverified', reason: "pid 999 does not run this workspace's ios log collector" }),
+    });
+    const result = await replaceCollector(h.opts);
+    expect(h.kills).toEqual([]);
+    expect(result.killed).toBe(null);
+    expect(h.notes.length).toBe(1);
+    expect(h.notes[0]).toMatch(/pid 999/);
+    expect(h.notes[0]).toMatch(/not signalled/);
+    expect(h.spawns.length).toBe(1);
+    expect(result.pid).toBe(7001);
+  });
+
+  test('the default ownership check is wired through: a ps-proven previous collector is signalled', async () => {
+    setExecutor(
+      makeExecutor({
+        runFile: (cmd, args) => {
+          expect(cmd).toBe('ps');
+          expect(args?.slice(0, 3)).toEqual(['-ww', '-o', 'command=']);
+          return `stim-collector-ios --root ${root}`;
+        },
+      }),
+    );
+    try {
+      const h = collectorHarness({ state: { collectors: { ios: { pid: 999, startedAt: 'T' } } } });
+      h.opts.verify = undefined;
+      const result = await replaceCollector(h.opts);
+      expect(h.kills).toEqual([{ pid: 999, signal: 'SIGTERM' }]);
+      expect(result.killed).toBe(999);
+    } finally {
+      resetExecutor();
+    }
+  });
+
+  test('the default ownership check is wired through: a ps mismatch is left running and noted', async () => {
+    setExecutor(makeExecutor({ runFile: () => 'node server.js' }));
+    try {
+      const h = collectorHarness({ state: { collectors: { ios: { pid: 999, startedAt: 'T' } } } });
+      h.opts.verify = undefined;
+      h.opts.alive = () => true;
+      const result = await replaceCollector(h.opts);
+      expect(h.kills).toEqual([]);
+      expect(result.killed).toBe(null);
+      expect(h.notes.length).toBe(1);
+      expect(h.notes[0]).toMatch(/not signalled/);
+    } finally {
+      resetExecutor();
+    }
   });
 
   test('the collector is spawned detached, unref-ed, with the REAL app name from the .app path', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert';
+import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
+import { collectorProcessTitle } from '../collector/ownership.ts';
 import { upsertProject } from '../config.ts';
-import { resetExecutor, setExecutor } from '../exec.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { workspaceDir, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import type { WorkspaceState } from '../supervisor/run.ts';
@@ -1579,6 +1580,39 @@ describe('Contract 6: the dev-client scheme', () => {
   });
 });
 
+function collectorProcessCommand(pid: number): string {
+  try {
+    return execFileSync('ps', ['-ww', '-o', 'command=', '-p', String(pid)], { encoding: 'utf-8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+// Spawns a real detached process so the default `verifyCollectorOwnership` reads its actual
+// live command (via ps on darwin, via /proc/[pid]/cmdline on linux) instead of a mocked
+// executor, which only exercises the darwin ps path and fails closed for the wrong reason on
+// Linux CI.
+async function spawnFakeCollector(title: string | null): Promise<ChildProcess> {
+  const rename = title ? `process.title = ${JSON.stringify(title)};` : '';
+  const child = spawn(process.execPath, ['-e', `${rename} setInterval(() => {}, 1000);`], { stdio: 'ignore' });
+  const expected = title ?? process.execPath;
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline && !collectorProcessCommand(child.pid as number).startsWith(expected)) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return child;
+}
+
+function collectorExits(child: ChildProcess, timeoutMs = 5_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
 describe('the collector', () => {
   function collectorHarness({
     state = null,
@@ -1664,31 +1698,24 @@ describe('the collector', () => {
     expect(result.pid).toBe(7001);
   });
 
-  test('the default ownership check is wired through: a ps-proven previous collector is signalled', async () => {
-    setExecutor(
-      makeExecutor({
-        runFile: (cmd, args) => {
-          expect(cmd).toBe('ps');
-          expect(args?.slice(0, 3)).toEqual(['-ww', '-o', 'command=']);
-          return `stim-collector-ios --root ${root}`;
-        },
-      }),
-    );
+  test('the default ownership check is wired through: a live process titled for this workspace is signalled', async () => {
+    const child = await spawnFakeCollector(collectorProcessTitle('ios', root));
     try {
-      const h = collectorHarness({ state: { collectors: { ios: { pid: 999, startedAt: 'T' } } } });
+      const h = collectorHarness({ state: { collectors: { ios: { pid: child.pid, startedAt: 'T' } } } });
       h.opts.verify = undefined;
       const result = await replaceCollector(h.opts);
-      expect(h.kills).toEqual([{ pid: 999, signal: 'SIGTERM' }]);
-      expect(result.killed).toBe(999);
+      expect(h.kills).toEqual([{ pid: child.pid, signal: 'SIGTERM' }]);
+      expect(result.killed).toBe(child.pid);
     } finally {
-      resetExecutor();
+      child.kill('SIGKILL');
+      await collectorExits(child);
     }
-  });
+  }, 20_000);
 
-  test('the default ownership check is wired through: a ps mismatch is left running and noted', async () => {
-    setExecutor(makeExecutor({ runFile: () => 'node server.js' }));
+  test('the default ownership check is wired through: a live process that cannot be proven is left running and noted', async () => {
+    const child = await spawnFakeCollector(null);
     try {
-      const h = collectorHarness({ state: { collectors: { ios: { pid: 999, startedAt: 'T' } } } });
+      const h = collectorHarness({ state: { collectors: { ios: { pid: child.pid, startedAt: 'T' } } } });
       h.opts.verify = undefined;
       h.opts.alive = () => true;
       const result = await replaceCollector(h.opts);
@@ -1697,9 +1724,10 @@ describe('the collector', () => {
       expect(h.notes.length).toBe(1);
       expect(h.notes[0]).toMatch(/not signalled/);
     } finally {
-      resetExecutor();
+      child.kill('SIGKILL');
+      await collectorExits(child);
     }
-  });
+  }, 20_000);
 
   test('the collector is spawned detached, unref-ed, with the REAL app name from the .app path', async () => {
     const h = collectorHarness();

--- a/packages/stim-cli/src/__tests__/process-args.test.ts
+++ b/packages/stim-cli/src/__tests__/process-args.test.ts
@@ -1,5 +1,5 @@
 import { resetExecutor, setExecutor } from '../exec.ts';
-import { readProcessArgs } from '../process-args.ts';
+import { parseLinuxStartTicks, parseLstartOutput, readProcessArgs, readProcessStartTime } from '../process-args.ts';
 
 describe('readProcessArgs', () => {
   test('reads a bounded NUL-delimited command from Linux procfs', () => {
@@ -96,5 +96,121 @@ describe('readProcessArgs', () => {
     ['malformed output', () => "'/usr/bin/ngrok http 8081"],
   ])('%s fails closed', (_name, runPsCommand) => {
     expect(readProcessArgs(4242, { platform: 'darwin', runPsCommand })).toBeNull();
+  });
+});
+
+// state (field 3) is fields[0] after "(comm) "; starttime (field 22) is fields[19], so 18 filler
+// fields sit between them (fields[1..18]).
+function linuxStatFields(startTicks: string): string {
+  return `S ${Array<string>(18).fill('0').join(' ')} ${startTicks}`;
+}
+
+function linuxStatWithStartTicks(ticks: string): Buffer {
+  return Buffer.from(`4242 (node worker) ${linuxStatFields(ticks)}`);
+}
+
+describe('parseLinuxStartTicks', () => {
+  test('reads the starttime field (22nd, 1-indexed) out of /proc/[pid]/stat', () => {
+    expect(parseLinuxStartTicks(linuxStatWithStartTicks('123456'), 32 * 1024)).toBe(123456);
+  });
+
+  test('a comm containing spaces or parens does not throw off the field count', () => {
+    const data = Buffer.from(`4242 (node (worker)) ${linuxStatFields('987')}`);
+    expect(parseLinuxStartTicks(data, 32 * 1024)).toBe(987);
+  });
+
+  test.each([
+    ['empty', Buffer.alloc(0)],
+    ['no comm parens', Buffer.from('4242 node S 0 0')],
+    ['starttime is not numeric', Buffer.from(`4242 (node) ${linuxStatFields('abc')}`)],
+    ['too short', Buffer.from('4242 (node) S 0 0')],
+  ])('%s fails closed', (_name, data) => {
+    expect(parseLinuxStartTicks(data as Buffer, 32 * 1024)).toBeNull();
+  });
+
+  test('a buffer past maxBytes fails closed', () => {
+    expect(parseLinuxStartTicks(linuxStatWithStartTicks('123456'), 4)).toBeNull();
+  });
+});
+
+describe('parseLstartOutput', () => {
+  test('trims and collapses internal whitespace', () => {
+    expect(parseLstartOutput('  Wed Aug  27 14:32:10 2025  ')).toBe('Wed Aug 27 14:32:10 2025');
+  });
+
+  test.each([
+    ['empty', ''],
+    ['embedded NUL', 'Wed Aug 27\0 14:32:10 2025'],
+    ['embedded newline', 'Wed Aug 27\n14:32:10 2025'],
+    ['embedded carriage return', 'Wed Aug 27\r14:32:10 2025'],
+  ])('%s fails closed', (_name, output) => {
+    expect(parseLstartOutput(output)).toBeNull();
+  });
+});
+
+describe('readProcessStartTime', () => {
+  test('darwin: parses ps -o lstart= into a real Date', () => {
+    const calls: Array<{ pid: number; timeoutMs: number }> = [];
+    const result = readProcessStartTime(4242, {
+      platform: 'darwin',
+      runPsCommand: (pid, timeoutMs) => {
+        calls.push({ pid, timeoutMs });
+        return 'Wed Aug 27 14:32:10 2025';
+      },
+    });
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.getFullYear()).toBe(2025);
+    expect(result?.getMonth()).toBe(7);
+    expect(result?.getDate()).toBe(27);
+    expect(calls).toEqual([{ pid: 4242, timeoutMs: expect.any(Number) }]);
+  });
+
+  test.each([
+    [
+      'ps failure',
+      () => {
+        throw new Error('ps failed');
+      },
+    ],
+    ['empty output', () => ''],
+    ['unparseable date text', () => 'not a date'],
+  ])('darwin: %s fails closed', (_name, runPsCommand) => {
+    expect(readProcessStartTime(4242, { platform: 'darwin', runPsCommand })).toBeNull();
+  });
+
+  test('linux: converts starttime ticks + /proc/uptime into a wall-clock Date', () => {
+    const now = () => 1_700_000_000_000;
+    const result = readProcessStartTime(4242, {
+      platform: 'linux',
+      readProcStat: () => linuxStatWithStartTicks('123456'),
+      readUptimeSeconds: () => 500,
+      now,
+    });
+    // boot = now - 500s; start = boot + (123456 ticks / 100 ticks-per-second)
+    expect(result?.getTime()).toBe(now() - 500 * 1000 + (123456 / 100) * 1000);
+  });
+
+  test('linux: an unparseable stat fails closed', () => {
+    expect(
+      readProcessStartTime(4242, {
+        platform: 'linux',
+        readProcStat: () => Buffer.alloc(0),
+        readUptimeSeconds: () => 500,
+      }),
+    ).toBeNull();
+  });
+
+  test('linux: an unreadable /proc/uptime fails closed even with a valid stat', () => {
+    expect(
+      readProcessStartTime(4242, {
+        platform: 'linux',
+        readProcStat: () => linuxStatWithStartTicks('123456'),
+        readUptimeSeconds: () => null,
+      }),
+    ).toBeNull();
+  });
+
+  test('win32: never supported, always null', () => {
+    expect(readProcessStartTime(4242, { platform: 'win32' })).toBeNull();
   });
 });

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -503,8 +503,10 @@ test('reclaim SIGTERMs a live pid whose command proves it is this workspace coll
   rmSync(root, { recursive: true, force: true });
 }, 20_000);
 
-test('reclaim leaves a live pid it cannot prove, and says so', async () => {
+test('reclaim leaves a live pid it cannot prove running, says so, and -- since it started after the recorded startedAt -- drops the now-stale record', async () => {
   const child = await spawnFakeProcess(null);
+  // workspaceWithCollector's startedAt (2026-01-01) predates this real process, which just
+  // started: the live pid is a newer, unrelated process that recycled the number.
   const root = workspaceWithCollector(child.pid as number);
 
   const r = await reclaimProject(root);
@@ -517,12 +519,15 @@ test('reclaim leaves a live pid it cannot prove, and says so', async () => {
     },
   ]);
   expect(r.skippedDevices[0]?.reason).toMatch(/not signalled/);
+  expect(r.failedDevices).toEqual([]);
+  expect(r.keptEntry).toBe(false);
+  expect(getProject(root)).toBe(null);
   child.kill('SIGKILL');
   await exits(child);
   rmSync(root, { recursive: true, force: true });
 }, 20_000);
 
-test('reclaim leaves a collector recorded for another root alone', async () => {
+test('reclaim leaves a collector recorded for another root alone and, since it started after the recorded startedAt, drops the record', async () => {
   const other = mkdtempSync(join(tmpdir(), 'stim-other-'));
   const child = await spawnFakeProcess(`stim-collector-ios --root ${other}`);
   const root = workspaceWithCollector(child.pid as number);
@@ -530,6 +535,8 @@ test('reclaim leaves a collector recorded for another root alone', async () => {
   const r = await reclaimProject(root);
   expect(stillRunning(child.pid as number)).toBe(true);
   expect(r.skippedDevices.map((d) => d.name)).toEqual([`ios log collector (pid ${child.pid})`]);
+  expect(r.keptEntry).toBe(false);
+  expect(getProject(root)).toBe(null);
   child.kill('SIGKILL');
   await exits(child);
   rmSync(other, { recursive: true, force: true });
@@ -545,5 +552,143 @@ test('reclaim says nothing about a collector pid that is already gone', async ()
 
   const r = await reclaimProject(root);
   expect(r.skippedDevices).toEqual([]);
+  expect(r.keptEntry).toBe(false);
+  expect(getProject(root)).toBe(null);
   rmSync(root, { recursive: true, force: true });
 }, 20_000);
+
+test("reclaim keeps the record and routes it to failedDevices when a live, unverified pid started at or before the record's startedAt -- it may still be ours", async () => {
+  const child = await spawnFakeProcess(null);
+  const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+  ensureWorkspaceStorage(root);
+  const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  writeFileSync(
+    workspaceStateFile(root),
+    JSON.stringify({ collectors: { ios: { pid: child.pid, startedAt: future } } }),
+  );
+  upsertProject(root, { label: 'agent-1' });
+
+  const r = await reclaimProject(root);
+  expect(stillRunning(child.pid as number)).toBe(true);
+  expect(r.failedDevices.map((d) => d.name)).toEqual([`ios log collector (pid ${child.pid})`]);
+  expect(r.failedDevices[0]?.reason).toMatch(/not signalled/);
+  expect(r.keptEntry).toBe(true);
+  expect(getProject(root)).toBeTruthy();
+  child.kill('SIGKILL');
+  await exits(child);
+  rmSync(root, { recursive: true, force: true });
+}, 20_000);
+
+describe('the unverified-collector start-time split (mocked verify and start time, real pid for liveness)', () => {
+  test('recycled: the live process started after the record -- drop the record, as today', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number); // startedAt: 2026-01-01T00:00:00.000Z
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date(),
+    });
+    expect(r.keptEntry).toBe(false);
+    expect(r.failedDevices).toEqual([]);
+    expect(r.skippedDevices.length).toBe(1);
+    expect(getProject(root)).toBe(null);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('possibly ours: the live process started before the record -- keep it for retry', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number); // startedAt: 2026-01-01T00:00:00.000Z
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date('2025-01-01T00:00:00.000Z'),
+    });
+    expect(r.keptEntry).toBe(true);
+    expect(r.failedDevices.length).toBe(1);
+    expect(r.failedDevices[0]?.reason).toMatch(/not signalled/);
+    expect(getProject(root)).toBeTruthy();
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test("possibly ours: the live process started at exactly the record's startedAt -- keep it (boundary is inclusive)", async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number);
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+    expect(r.keptEntry).toBe(true);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('a record with no startedAt at all fails closed to keep', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+    ensureWorkspaceStorage(root);
+    writeFileSync(workspaceStateFile(root), JSON.stringify({ collectors: { ios: { pid: child.pid } } }));
+    upsertProject(root, { label: 'agent-1' });
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date(),
+    });
+    expect(r.keptEntry).toBe(true);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('an unreadable live start time fails closed to keep, even against a stale-looking record', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number);
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => null,
+    });
+    expect(r.keptEntry).toBe(true);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('gone never consults the start time and never signals', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number);
+    let readStartTimeCalls = 0;
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'gone' }),
+      readCollectorStartTime: () => {
+        readStartTimeCalls += 1;
+        return new Date();
+      },
+    });
+    expect(r.skippedDevices).toEqual([]);
+    expect(r.failedDevices).toEqual([]);
+    expect(readStartTimeCalls).toBe(0);
+    expect(stillRunning(child.pid as number)).toBe(true);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('ours signals the pid without consulting the start time', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number);
+    let readStartTimeCalls = 0;
+    const died = exits(child);
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'ours' }),
+      readCollectorStartTime: () => {
+        readStartTimeCalls += 1;
+        return new Date();
+      },
+    });
+    expect(await died).toBe(true);
+    expect(readStartTimeCalls).toBe(0);
+    expect(r.skippedDevices).toEqual([]);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+});

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -625,6 +625,35 @@ describe('the unverified-collector start-time split (mocked verify and start tim
     rmSync(root, { recursive: true, force: true });
   }, 20_000);
 
+  test('possibly ours: a live process a few seconds after the record is within the clock-skew tolerance -- keep it', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number); // startedAt: 2026-01-01T00:00:00.000Z
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date('2026-01-01T00:00:02.000Z'), // 2s after, inside the tolerance
+    });
+    expect(r.keptEntry).toBe(true);
+    expect(r.failedDevices.length).toBe(1);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
+  test('recycled: a live process comfortably past the clock-skew tolerance is still dropped', async () => {
+    const child = await spawnFakeProcess(null);
+    const root = workspaceWithCollector(child.pid as number); // startedAt: 2026-01-01T00:00:00.000Z
+    const r = await reclaimProject(root, {
+      verifyCollector: () => ({ status: 'unverified', reason: 'stubbed' }),
+      readCollectorStartTime: () => new Date('2026-01-01T00:00:10.000Z'), // 10s after, past the tolerance
+    });
+    expect(r.keptEntry).toBe(false);
+    expect(r.failedDevices).toEqual([]);
+    expect(getProject(root)).toBe(null);
+    child.kill('SIGKILL');
+    await exits(child);
+    rmSync(root, { recursive: true, force: true });
+  }, 20_000);
+
   test('a record with no startedAt at all fails closed to keep', async () => {
     const child = await spawnFakeProcess(null);
     const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -159,7 +159,7 @@ export async function runCollector({
     watcher?.stop();
     writer.write({ src: 'device', platform, level, event, msg });
     try {
-      unregisterCollector(root, platform);
+      unregisterCollector(root, platform, process.pid);
     } catch {}
     const closed = writer.close();
     if (closed.dropped > 0) {

--- a/packages/stim-cli/src/collector/state.ts
+++ b/packages/stim-cli/src/collector/state.ts
@@ -12,11 +12,12 @@ export function registerCollector(
   });
 }
 
-export function unregisterCollector(root: string, platform: string): Record<string, unknown> {
+export function unregisterCollector(root: string, platform: string, pid: number): Record<string, unknown> {
   return withWorkspaceStateLock(root, () => {
     const state = readWorkspaceState(root);
     const collectors: Record<string, unknown> = { ...state?.collectors };
-    if (!(platform in collectors)) return collectors;
+    const record = collectors[platform] as { pid?: unknown } | undefined;
+    if (!(platform in collectors) || record?.pid !== pid) return collectors;
     delete collectors[platform];
     writeWorkspaceState(root, { collectors: Object.keys(collectors).length ? collectors : undefined });
     return collectors;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -14,6 +14,7 @@ import {
 } from '@stim-cli/cache';
 import type { AndroidFacts, RemoteDeviceBackend, SettingsObject, WaitedForBuild } from '../types.ts';
 import { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import { getExecutor } from '../exec.ts';
 import {
@@ -555,15 +556,31 @@ export function killPreviousCollector(
     platform = PLATFORM,
     kill = (pid: number, signal: NodeJS.Signals) => process.kill(pid, signal),
     collectors = null,
+    verify = verifyCollectorOwnership,
+    isAlive = isPidAlive,
+    note = (_line: string) => {},
   }: {
     platform?: string;
     kill?: (pid: number, signal: NodeJS.Signals) => boolean;
     collectors?: Record<string, { pid?: number }> | null;
+    verify?: typeof verifyCollectorOwnership;
+    isAlive?: (pid: number) => boolean;
+    note?: (line: string) => void;
   } = {},
 ): number | null {
   const record = (collectors ?? readCollectors(root))?.[platform] as { pid?: number } | undefined;
   const pid = Number(record?.pid);
   if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return null;
+  const ownership = verify({ pid, platform, root, isAlive });
+  if (ownership.status === 'gone') return null;
+  if (ownership.status === 'unverified') {
+    note(
+      chalk.dim(
+        `Previous ${platform} log collector (pid ${pid}): ${ownership.reason}, so it was not signalled -- starting a replacement anyway`,
+      ),
+    );
+    return null;
+  }
   try {
     kill(pid, 'SIGTERM');
     return pid;
@@ -658,6 +675,7 @@ interface RunAndroidOptions {
   resolveMetroRetrying?: typeof resolveMetroWithRetry;
   readState?: typeof readWorkspaceState;
   pidAlive?: typeof isPidAlive;
+  verifyCollector?: typeof verifyCollectorOwnership;
   verifyLaunched?: typeof verifyLaunch;
   ensureStorage?: typeof ensureWorkspaceStorageSafely;
   fingerprint?: typeof fingerprintProject;
@@ -1018,6 +1036,8 @@ interface FinishAndroidRunArgs {
   verifyReleaseLaunched: typeof verifyAndroidReleaseLaunch;
   spawn: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => ChildProcess;
   kill: (pid: number, signal: NodeJS.Signals) => boolean;
+  pidAlive: typeof isPidAlive;
+  verifyCollector: typeof verifyCollectorOwnership;
   writeState: typeof writeWorkspaceState;
   now: () => number;
   out: (line: string) => void;
@@ -1066,6 +1086,8 @@ async function finishAndroidRun({
   verifyReleaseLaunched,
   spawn,
   kill,
+  pidAlive,
+  verifyCollector,
   writeState,
   now,
   out,
@@ -1210,7 +1232,16 @@ async function finishAndroidRun({
 
   const remoteRelease = Boolean(remoteDevice && release);
   if (!remoteRelease) {
-    const collectorPid = await startCollector({ root, serial, packageName: androidPackage, spawn, kill, out });
+    const collectorPid = await startCollector({
+      root,
+      serial,
+      packageName: androidPackage,
+      spawn,
+      kill,
+      alive: pidAlive,
+      verify: verifyCollector,
+      out,
+    });
     phase('logs', `${displayPath(root, logsDir)}${collectorPid ? ` (collector pid ${collectorPid})` : ''}`);
   }
 
@@ -1300,6 +1331,7 @@ function resolveRunAndroidOptions(
     resolveMetroRetrying = resolveMetroWithRetry,
     readState = readWorkspaceState,
     pidAlive = isPidAlive,
+    verifyCollector = verifyCollectorOwnership,
     verifyLaunched = verifyLaunch,
     ensureStorage = ensureWorkspaceStorageSafely,
     fingerprint = fingerprintProject,
@@ -1364,6 +1396,7 @@ function resolveRunAndroidOptions(
     resolveMetroRetrying,
     readState,
     pidAlive,
+    verifyCollector,
     verifyLaunched,
     ensureStorage,
     fingerprint,
@@ -1430,6 +1463,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     resolveMetroRetrying,
     readState,
     pidAlive,
+    verifyCollector,
     verifyLaunched,
     ensureStorage,
     fingerprint,
@@ -2241,6 +2275,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     verifyReleaseLaunched,
     spawn,
     kill,
+    pidAlive,
+    verifyCollector,
     writeState,
     now,
     out,
@@ -2289,6 +2325,7 @@ export async function startCollector({
   spawn,
   kill,
   alive = isPidAlive,
+  verify = verifyCollectorOwnership,
   waitMs = COLLECTOR_EXIT_WAIT_MS,
   sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
   out,
@@ -2299,11 +2336,17 @@ export async function startCollector({
   spawn: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => ChildProcess;
   kill: (pid: number, signal: NodeJS.Signals) => boolean;
   alive?: (pid: number) => boolean;
+  verify?: typeof verifyCollectorOwnership;
   waitMs?: number;
   sleep?: (ms: number) => Promise<void>;
   out: (line: string) => void;
 }): Promise<number | null> {
-  const previousPid = killPreviousCollector(root, { kill });
+  const previousPid = killPreviousCollector(root, {
+    kill,
+    isAlive: alive,
+    verify,
+    note: (line) => out(phaseLine('logs', line)),
+  });
   if (previousPid) {
     const deadline = Date.now() + waitMs;
     while (Date.now() < deadline && alive(previousPid)) {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1335,8 +1335,10 @@ WHAT ELSE STOP REAPS
   signal delivered to someone else's process. A fresh \`ios\` / \`android\`
   run starts its replacement anyway, leaving the unproven pid to clear on its
   own. A collector started by an older Stim states no root in its command, so
-  it reports as unverified until it clears itself -- which it does when its
-  device's log stream ends, or when the next \`ios\` / \`android\` run replaces it.
+  it reports as unverified until its record clears -- which happens when its
+  own device's log stream ends and it unregisters itself, or when the next
+  \`ios\` / \`android\` run overwrites the record with its own, whichever
+  comes first; the old process itself keeps running until it exits on its own.
 
   \`stop\`, \`gc --delete\`, and \`worktree remove\` weigh an unproven live
   pid against the record's own startedAt claim: a pid that started AFTER that

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1327,14 +1327,24 @@ WHAT ELSE STOP REAPS
   the device it was reading. A fresh \`ios\` / \`android\` run also kills the
   previous collector for that platform before starting its own.
 
-  Before signalling a recorded collector pid, \`stop\`, \`gc --delete\` and
-  \`worktree remove\` read that pid's live command and require it to be this
-  workspace's collector for that platform. A pid that cannot be proven is
-  reported and left alone: the kernel reuses pids, and an unreaped record is a
-  smaller problem than a signal delivered to someone else's process. A collector
-  started by an older Stim states no root in its command, so it reports as
-  unverified until it clears itself -- which it does when its device's log
-  stream ends, or when the next \`ios\` / \`android\` run replaces it.
+  Before signalling a recorded collector pid, \`stop\`, \`gc --delete\`,
+  \`worktree remove\`, and a fresh \`ios\` / \`android\` run each read that
+  pid's live command and require it to be this workspace's collector for
+  that platform. A pid that cannot be proven is reported and left alone: the
+  kernel reuses pids, and an unreaped record is a smaller problem than a
+  signal delivered to someone else's process. A fresh \`ios\` / \`android\`
+  run starts its replacement anyway, leaving the unproven pid to clear on its
+  own. A collector started by an older Stim states no root in its command, so
+  it reports as unverified until it clears itself -- which it does when its
+  device's log stream ends, or when the next \`ios\` / \`android\` run replaces it.
+
+  \`stop\`, \`gc --delete\`, and \`worktree remove\` weigh an unproven live
+  pid against the record's own startedAt claim: a pid that started AFTER that
+  claim is a newer process that recycled the number, so the record is
+  genuinely stale and gets dropped, as before. A pid that started at or
+  before that claim may still be the collector Stim registered, so the
+  record is kept and reported for a retry, the same way a device teardown
+  that could not be confirmed keeps its record.
 
 BUILD LOCKS
   \`gc\` also reports the single-flight build locks (above): the ones whose

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -30,6 +30,7 @@ import {
 } from '../build-cache.ts';
 import type { FingerprintSource } from '@expo/fingerprint';
 import { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import {
   DEFAULT_METRO_PORT,
@@ -574,6 +575,7 @@ interface ReplaceCollectorArgs {
   kill?: (pid: number, signal: NodeJS.Signals) => boolean;
   alive?: (pid: number) => boolean;
   readState?: typeof readWorkspaceState;
+  verify?: typeof verifyCollectorOwnership;
   waitMs?: number;
   note?: (line: string) => void;
 }
@@ -587,6 +589,7 @@ export async function replaceCollector({
   kill = (pid, signal) => process.kill(pid, signal),
   alive = isPidAlive,
   readState = readWorkspaceState,
+  verify = verifyCollectorOwnership,
   waitMs = COLLECTOR_EXIT_WAIT_MS,
   note = (_line: string) => {},
 }: ReplaceCollectorArgs): Promise<{ killed: number | null; pid: number | null }> {
@@ -595,21 +598,30 @@ export async function replaceCollector({
   let killed: number | null = null;
 
   if (previousPid) {
-    try {
-      kill(previousPid, 'SIGTERM');
-      killed = previousPid;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== 'ESRCH') {
-        note(
-          chalk.yellow(
-            `Could not stop the previous ${PLATFORM} log collector (pid ${previousPid}): ${(err as Error)?.message || err}`,
-          ),
-        );
+    const ownership = verify({ pid: previousPid, platform: PLATFORM, root, isAlive: alive });
+    if (ownership.status === 'ours') {
+      try {
+        kill(previousPid, 'SIGTERM');
+        killed = previousPid;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code !== 'ESRCH') {
+          note(
+            chalk.yellow(
+              `Could not stop the previous ${PLATFORM} log collector (pid ${previousPid}): ${(err as Error)?.message || err}`,
+            ),
+          );
+        }
       }
-    }
-    const deadline = Date.now() + waitMs;
-    while (Date.now() < deadline && alive(previousPid)) {
-      await sleep(COLLECTOR_POLL_MS);
+      const deadline = Date.now() + waitMs;
+      while (Date.now() < deadline && alive(previousPid)) {
+        await sleep(COLLECTOR_POLL_MS);
+      }
+    } else if (ownership.status === 'unverified') {
+      note(
+        chalk.dim(
+          `Previous ${PLATFORM} log collector (pid ${previousPid}): ${ownership.reason}, so it was not signalled -- starting a replacement anyway`,
+        ),
+      );
     }
   }
 

--- a/packages/stim-cli/src/engine/tunnel.ts
+++ b/packages/stim-cli/src/engine/tunnel.ts
@@ -10,8 +10,11 @@ import {
   PROCESS_COMMAND_TIMEOUT_MS,
   type ReadProcCommand,
   type RunPsCommand,
+  parseLinuxStartTicks,
+  parseLstartOutput,
   readProcFile,
   readProcessArgs as readProcessArgsDefault,
+  runPsStartCommand,
 } from '../process-args.ts';
 import { createLineReader } from '../process-output.ts';
 import type { ManagedProvider } from './metro-reach.ts';
@@ -581,24 +584,13 @@ function isEsrch(err: unknown): boolean {
   return (err as NodeJS.ErrnoException)?.code === 'ESRCH';
 }
 
-function defaultRunPsStartCommand(pid: number, timeoutMs: number): string {
-  return getExecutor().runFile('ps', ['-ww', '-o', 'lstart=', '-p', String(pid)], { timeoutMs });
+function linuxStartToken(data: Buffer, maxBytes: number): string | null {
+  const ticks = parseLinuxStartTicks(data, maxBytes);
+  return ticks === null ? null : `linux:${ticks}`;
 }
 
-function parseLinuxStartToken(data: Buffer, maxBytes: number): string | null {
-  if (data.length === 0 || data.length > maxBytes || data.includes(0)) return null;
-  const stat = data.toString('utf-8').trim();
-  const commandEnd = stat.lastIndexOf(')');
-  if (commandEnd < 2 || stat[commandEnd + 1] !== ' ') return null;
-  const fields = stat.slice(commandEnd + 2).split(' ');
-  const startTime = fields[19];
-  return startTime && /^\d+$/.test(startTime) ? `linux:${startTime}` : null;
-}
-
-function parsePsStartToken(output: string): string | null {
-  const trimmed = output.trim();
-  if (!trimmed || trimmed.includes('\0') || trimmed.includes('\n') || trimmed.includes('\r')) return null;
-  const normalized = trimmed.replace(/\s+/g, ' ');
+function psStartToken(output: string): string | null {
+  const normalized = parseLstartOutput(output);
   return normalized ? `ps-lstart:${normalized}` : null;
 }
 
@@ -607,7 +599,7 @@ export function readTunnelProcessToken(
   {
     platform = process.platform,
     readProcStat = readProcFile,
-    runPsStartCommand = defaultRunPsStartCommand,
+    runPsStartCommand: runPsCommand = runPsStartCommand,
   }: {
     platform?: NodeJS.Platform;
     readProcStat?: ReadProcCommand;
@@ -616,13 +608,10 @@ export function readTunnelProcessToken(
 ): string | null {
   try {
     if (platform === 'linux') {
-      return parseLinuxStartToken(
-        readProcStat(`/proc/${pid}/stat`, PROCESS_COMMAND_MAX_BYTES),
-        PROCESS_COMMAND_MAX_BYTES,
-      );
+      return linuxStartToken(readProcStat(`/proc/${pid}/stat`, PROCESS_COMMAND_MAX_BYTES), PROCESS_COMMAND_MAX_BYTES);
     }
     if (platform === 'win32') return null;
-    return parsePsStartToken(runPsStartCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
+    return psStartToken(runPsCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
   } catch {
     return null;
   }

--- a/packages/stim-cli/src/process-args.ts
+++ b/packages/stim-cli/src/process-args.ts
@@ -1,4 +1,4 @@
-import { closeSync, openSync, readSync } from 'node:fs';
+import { closeSync, openSync, readFileSync, readSync } from 'node:fs';
 import { getExecutor } from './exec.ts';
 
 export const PROCESS_COMMAND_TIMEOUT_MS: number = 1_000;
@@ -6,6 +6,7 @@ export const PROCESS_COMMAND_MAX_BYTES: number = 32 * 1024;
 
 export type ReadProcCommand = (path: string, maxBytes: number) => Buffer;
 export type RunPsCommand = (pid: number, timeoutMs: number) => string;
+export type ReadUptimeSeconds = () => number | null;
 
 export function readProcFile(path: string, maxBytes: number): Buffer {
   const fd = openSync(path, 'r');
@@ -108,6 +109,82 @@ export function readProcessArgs(
     }
     if (platform === 'win32') return null;
     return parsePsCommand(runPsCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
+  } catch {
+    return null;
+  }
+}
+
+// The single place that shells out for a process's start time (`ps -ww -o lstart=`); every
+// caller that needs a process's start time, whether as an opaque token or a parsed Date, goes
+// through this so there is exactly one `ps -o lstart=` call site.
+export function runPsStartCommand(pid: number, timeoutMs: number): string {
+  return getExecutor().runFile('ps', ['-ww', '-o', 'lstart=', '-p', String(pid)], { timeoutMs });
+}
+
+export function parseLstartOutput(output: string): string | null {
+  const trimmed = output.trim();
+  if (!trimmed || trimmed.includes('\0') || trimmed.includes('\n') || trimmed.includes('\r')) return null;
+  const normalized = trimmed.replace(/\s+/g, ' ');
+  return normalized || null;
+}
+
+export function parseLinuxStartTicks(data: Buffer, maxBytes: number): number | null {
+  if (data.length === 0 || data.length > maxBytes || data.includes(0)) return null;
+  const stat = data.toString('utf-8').trim();
+  const commandEnd = stat.lastIndexOf(')');
+  if (commandEnd < 2 || stat[commandEnd + 1] !== ' ') return null;
+  const fields = stat.slice(commandEnd + 2).split(' ');
+  const startTicks = fields[19];
+  return startTicks && /^\d+$/.test(startTicks) ? Number(startTicks) : null;
+}
+
+// glibc's sysconf(_SC_CLK_TCK) is fixed at 100 on Linux regardless of the kernel's actual HZ,
+// so /proc/[pid]/stat's starttime field (in clock ticks since boot) converts with a flat /100.
+const LINUX_CLK_TCK = 100;
+
+function defaultReadUptimeSeconds(): number | null {
+  try {
+    const raw = readFileSync('/proc/uptime', 'utf-8');
+    const first = Number.parseFloat(raw.split(' ')[0] ?? '');
+    return Number.isFinite(first) ? first : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readProcessStartTime(
+  pid: number,
+  {
+    platform = process.platform,
+    readProcStat = readProcFile,
+    readUptimeSeconds = defaultReadUptimeSeconds,
+    runPsCommand = runPsStartCommand,
+    now = Date.now,
+  }: {
+    platform?: NodeJS.Platform;
+    readProcStat?: ReadProcCommand;
+    readUptimeSeconds?: ReadUptimeSeconds;
+    runPsCommand?: RunPsCommand;
+    now?: () => number;
+  } = {},
+): Date | null {
+  try {
+    if (platform === 'linux') {
+      const ticks = parseLinuxStartTicks(
+        readProcStat(`/proc/${pid}/stat`, PROCESS_COMMAND_MAX_BYTES),
+        PROCESS_COMMAND_MAX_BYTES,
+      );
+      if (ticks === null) return null;
+      const uptimeSeconds = readUptimeSeconds();
+      if (uptimeSeconds === null) return null;
+      const bootMs = now() - uptimeSeconds * 1000;
+      return new Date(bootMs + (ticks / LINUX_CLK_TCK) * 1000);
+    }
+    if (platform === 'win32') return null;
+    const raw = parseLstartOutput(runPsCommand(pid, PROCESS_COMMAND_TIMEOUT_MS));
+    if (!raw) return null;
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   } catch {
     return null;
   }

--- a/packages/stim-cli/src/process-args.ts
+++ b/packages/stim-cli/src/process-args.ts
@@ -114,9 +114,6 @@ export function readProcessArgs(
   }
 }
 
-// The single place that shells out for a process's start time (`ps -ww -o lstart=`); every
-// caller that needs a process's start time, whether as an opaque token or a parsed Date, goes
-// through this so there is exactly one `ps -o lstart=` call site.
 export function runPsStartCommand(pid: number, timeoutMs: number): string {
   return getExecutor().runFile('ps', ['-ww', '-o', 'lstart=', '-p', String(pid)], { timeoutMs });
 }

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -17,25 +17,47 @@ import { resolveEasCliBin } from './engine/remote-cache.ts';
 import { stopTunnel, type StopTunnelResult } from './engine/tunnel.ts';
 import { workspaceDir } from './paths.ts';
 
-// A record's startedAt is the collector's own claim about when it started. If the live pid we
-// cannot otherwise verify started AFTER that claim, it is a newer, unrelated process that
-// recycled the pid -- the record is genuinely stale and safe to drop. If it started at or
-// before that claim, the live process predates the record and may still be the collector we
-// registered (e.g. a rename or a delayed registration write); keep the record for a retry
-// rather than orphaning a pid Stim can no longer see. An unreadable start time on either side
-// fails closed to "keep".
-function isRecycledPid(recordedStartedAt: unknown, pid: number, readStartTime: (pid: number) => Date | null): boolean {
-  if (typeof recordedStartedAt !== 'string') return false;
+// #183: fail closed toward "keep" for an unverified live pid unless its own start time proves
+// it recycled the number. RECYCLED_PID_TOLERANCE_MS absorbs NTP steps and lstart's one-second
+// truncation so a genuinely-ours collector never flips to "recycled" on a near-equal timestamp.
+const RECYCLED_PID_TOLERANCE_MS = 5_000;
+
+type StartTimeVerdict =
+  | { recycled: true }
+  | { recycled: false; cause: 'no-recorded-start' }
+  | { recycled: false; cause: 'unreadable-live-start' }
+  | { recycled: false; cause: 'started-at-or-before' };
+
+function classifyPidAgainstRecord(
+  recordedStartedAt: unknown,
+  pid: number,
+  readStartTime: (pid: number) => Date | null,
+): StartTimeVerdict {
+  if (typeof recordedStartedAt !== 'string') return { recycled: false, cause: 'no-recorded-start' };
   const recordedMs = Date.parse(recordedStartedAt);
-  if (!Number.isFinite(recordedMs)) return false;
+  if (!Number.isFinite(recordedMs)) return { recycled: false, cause: 'no-recorded-start' };
   let liveStart: Date | null;
   try {
     liveStart = readStartTime(pid);
   } catch {
     liveStart = null;
   }
-  if (!liveStart) return false;
-  return liveStart.getTime() > recordedMs;
+  if (!liveStart) return { recycled: false, cause: 'unreadable-live-start' };
+  if (liveStart.getTime() > recordedMs + RECYCLED_PID_TOLERANCE_MS) return { recycled: true };
+  return { recycled: false, cause: 'started-at-or-before' };
+}
+
+function keptReason(
+  cause: 'no-recorded-start' | 'unreadable-live-start' | 'started-at-or-before',
+  pid: number,
+): string {
+  if (cause === 'started-at-or-before') {
+    return `it started at or before this record's startedAt, so it may still be ours; inspect it with \`ps -p ${pid}\` and retry`;
+  }
+  if (cause === 'unreadable-live-start') {
+    return `pid ${pid}'s start time could not be read, so it may still be ours; inspect it with \`ps -p ${pid}\` and retry`;
+  }
+  return `this record has no usable startedAt to compare against, so pid ${pid} may still be ours; inspect it with \`ps -p ${pid}\` and retry`;
 }
 
 function reapCollectors(
@@ -59,7 +81,8 @@ function reapCollectors(
     if (ownership.status === 'unverified') {
       const name = `${platform} log collector (pid ${pid})`;
       const platformLabel = platform === 'android' ? 'android' : 'ios';
-      if (isRecycledPid(rec?.startedAt, pid, readStartTime)) {
+      const verdict = classifyPidAgainstRecord(rec?.startedAt, pid, readStartTime);
+      if (verdict.recycled) {
         skippedDevices.push({
           platform: platformLabel,
           name,
@@ -69,7 +92,7 @@ function reapCollectors(
         const entry: SkippedDevice = {
           platform: platformLabel,
           name,
-          reason: `${ownership.reason}, so it was not signalled -- it started at or before this record's startedAt, so it may still be ours; inspect it with \`ps -p ${pid}\` and retry`,
+          reason: `${ownership.reason}, so it was not signalled -- ${keptReason(verdict.cause, pid)}`,
         };
         skippedDevices.push(entry);
         failedDevices.push(entry);

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -4,6 +4,7 @@ import { resolveProjectMetro, killMetroTree, isPidAlive } from './metro.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from './teardown.ts';
 import { readCollectors } from './collector/state.ts';
 import { verifyCollectorOwnership } from './collector/ownership.ts';
+import { readProcessStartTime } from './process-args.ts';
 import {
   clearManagedMetroTunnel,
   clearRemoteSession,
@@ -16,26 +17,70 @@ import { resolveEasCliBin } from './engine/remote-cache.ts';
 import { stopTunnel, type StopTunnelResult } from './engine/tunnel.ts';
 import { workspaceDir } from './paths.ts';
 
-function reapCollectors(root: string): SkippedDevice[] {
-  const skipped: SkippedDevice[] = [];
+// A record's startedAt is the collector's own claim about when it started. If the live pid we
+// cannot otherwise verify started AFTER that claim, it is a newer, unrelated process that
+// recycled the pid -- the record is genuinely stale and safe to drop. If it started at or
+// before that claim, the live process predates the record and may still be the collector we
+// registered (e.g. a rename or a delayed registration write); keep the record for a retry
+// rather than orphaning a pid Stim can no longer see. An unreadable start time on either side
+// fails closed to "keep".
+function isRecycledPid(recordedStartedAt: unknown, pid: number, readStartTime: (pid: number) => Date | null): boolean {
+  if (typeof recordedStartedAt !== 'string') return false;
+  const recordedMs = Date.parse(recordedStartedAt);
+  if (!Number.isFinite(recordedMs)) return false;
+  let liveStart: Date | null;
+  try {
+    liveStart = readStartTime(pid);
+  } catch {
+    liveStart = null;
+  }
+  if (!liveStart) return false;
+  return liveStart.getTime() > recordedMs;
+}
+
+function reapCollectors(
+  root: string,
+  {
+    verify = verifyCollectorOwnership,
+    readStartTime = readProcessStartTime,
+  }: {
+    verify?: typeof verifyCollectorOwnership;
+    readStartTime?: (pid: number) => Date | null;
+  } = {},
+): { skippedDevices: SkippedDevice[]; failedDevices: SkippedDevice[] } {
+  const skippedDevices: SkippedDevice[] = [];
+  const failedDevices: SkippedDevice[] = [];
   for (const [platform, record] of Object.entries(readCollectors(root))) {
-    const pid = (record as { pid?: unknown } | null)?.pid;
+    const rec = record as { pid?: unknown; startedAt?: unknown } | null;
+    const pid = rec?.pid;
     if (typeof pid !== 'number' || pid <= 0 || pid === process.pid || !isPidAlive(pid)) continue;
-    const ownership = verifyCollectorOwnership({ pid, platform, root });
+    const ownership = verify({ pid, platform, root });
     if (ownership.status === 'gone') continue;
     if (ownership.status === 'unverified') {
-      skipped.push({
-        platform: platform === 'android' ? 'android' : 'ios',
-        name: `${platform} log collector (pid ${pid})`,
-        reason: `${ownership.reason}, so it was not signalled -- inspect it with \`ps -p ${pid}\``,
-      });
+      const name = `${platform} log collector (pid ${pid})`;
+      const platformLabel = platform === 'android' ? 'android' : 'ios';
+      if (isRecycledPid(rec?.startedAt, pid, readStartTime)) {
+        skippedDevices.push({
+          platform: platformLabel,
+          name,
+          reason: `${ownership.reason}, so it was not signalled -- inspect it with \`ps -p ${pid}\``,
+        });
+      } else {
+        const entry: SkippedDevice = {
+          platform: platformLabel,
+          name,
+          reason: `${ownership.reason}, so it was not signalled -- it started at or before this record's startedAt, so it may still be ours; inspect it with \`ps -p ${pid}\` and retry`,
+        };
+        skippedDevices.push(entry);
+        failedDevices.push(entry);
+      }
       continue;
     }
     try {
       process.kill(pid, 'SIGTERM');
     } catch {}
   }
-  return skipped;
+  return { skippedDevices, failedDevices };
 }
 
 // eas simulator:stop needs a project cwd, so end the session before removing the worktree.
@@ -210,17 +255,24 @@ export async function reclaimProject(
     preserveProjectRecord = false,
     stopSession = defaultStopSession,
     stopMetroTunnel = defaultStopMetroTunnel,
+    verifyCollector = verifyCollectorOwnership,
+    readCollectorStartTime = readProcessStartTime,
   }: {
     deleteOwnedDevices?: boolean;
     preserveProjectRecord?: boolean;
     stopSession?: StopSession;
     stopMetroTunnel?: StopMetroTunnelFn;
+    verifyCollector?: typeof verifyCollectorOwnership;
+    readCollectorStartTime?: (pid: number) => Date | null;
   } = {},
 ): Promise<ReclaimResult> {
   const project = getProject(path);
   const dereferenced = describeDereferenced(project);
 
-  const skippedCollectors = reapCollectors(path);
+  const { skippedDevices: skippedCollectors, failedDevices: failedCollectors } = reapCollectors(path, {
+    verify: verifyCollector,
+    readStartTime: readCollectorStartTime,
+  });
 
   const {
     deletedDevices,
@@ -232,6 +284,7 @@ export async function reclaimProject(
     failedDevices: SkippedDevice[];
   } = deleteOwnedDevices ? reclaimOwnedDevices(project) : { deletedDevices: [], skippedDevices: [], failedDevices: [] };
   skippedDevices.push(...skippedCollectors);
+  failedDevices.push(...failedCollectors);
 
   const remote = reclaimRemoteSession(path, { stopSession });
   if (remote.failed) {


### PR DESCRIPTION
## Description

PR #181 added `verifyCollectorOwnership` for `stop`, `gc --delete`, and `worktree remove`, deliberately leaving two gaps:

- `replaceCollector` (ios.ts) and `killPreviousCollector` (android.ts) still signal the recorded previous-collector pid on every `ios`/`android` run without proof (#182) -- the same recycled-pid risk #181 closed for cleanup.
- reclaim's collector handling, once it refuses to signal an unverified pid, still deletes the workspace dir and drops the project's registry entry unconditionally, orphaning a possibly-still-live collector from Stim's view for good (#183) -- a corner case #181's review flagged but left out of scope.

## Solution

`replaceCollector`/`killPreviousCollector` now route through `verifyCollectorOwnership`: ours signals as before, gone proceeds silently, and unverified skips the signal, emits one dim note (matching each file's existing note style), and starts the replacement anyway -- a leaked old collector is the lesser harm next to killing a stranger's process. `verify` is threaded as an injectable param the way `stop.ts` threads `verifyCollector`.

Leaving that collector running uncovered a second bug: its own eventual exit called `unregisterCollector`, which cleared `collectors[platform]` unconditionally and could clobber whatever a newer collector had registered in the meantime. `unregisterCollector` now takes the caller's own pid and only clears the record when it still matches.

reclaim.ts now weighs an unverified record's `startedAt` against the live pid's actual start time (`readProcessStartTime`, reusing tunnel.ts's `ps -o lstart=`/Linux-ticks parsing so there's one call site) to tell these apart:

- Started well after that claim (past a few seconds of tolerance for NTP steps and `lstart`'s one-second truncation) -- a recycled pid, genuinely stale, dropped as before.
- Started at or before, or its start time is unreadable, or the record has no usable `startedAt` -- may still be the collector Stim registered, so it routes through `failedDevices`/`keptEntry` (the same path a failed device teardown uses) and the entry survives for a retry instead of being silently orphaned. The reported reason names which of these actually happened.

`guide cleanup` and its contract tests now cover the `ios`/`android` replace-anyway behavior, the keep-vs-drop split, and that an unverified older-Stim collector's *record* (not necessarily its process) is what gets replaced.

## Test plan

- Unit tests covering every ownership verdict for `replaceCollector` (ios-command.test.ts) and `killPreviousCollector`/`startCollector` (android-command.test.ts). The "default wiring" cases spawn a real detached process (titled as this workspace's collector, or not) so the real `verifyCollectorOwnership` reads its actual live command -- via `ps` on darwin, via `/proc/[pid]/cmdline` on Linux -- instead of a mocked executor that only exercised the darwin path.
- `process-args.test.ts`: new coverage for `parseLinuxStartTicks`, `parseLstartOutput`, and `readProcessStartTime` on both the Linux ticks-and-uptime path and the darwin `ps -o lstart=` path.
- `reclaim.test.ts`: mocked-verify unit tests for every branch of the start-time split (recycled / possibly-ours / exact boundary / within-tolerance / past-tolerance / no startedAt / unreadable live start / gone / ours), plus the existing real-process rig extended with a "possibly ours, keep for retry" case, and the pre-existing "recycled, drop" cases now also assert `keptEntry` / `getProject`.
- `collector-run.test.ts`: registers a second collector over an already-registered platform, then unregisters using the first collector's own (now stale) pid, and asserts the second's record survives.
- `pnpm run build`, `typecheck`, `lint`, `format:check`, `knip`, `test` (2729 tests / 74 files), and `test:e2e` (19 tests) all pass.

Fixes #182
Fixes #183
