### PR TITLE
Build the iOS device slice, select a phone, and re-seal a bundle

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -1,5 +1,14 @@
-import { expect, test } from 'vitest';
-import { parseDevicectlDevices, resolveIosPhysicalDevice, type IosDeviceEntry } from '../engine/ios-device.ts';
+import { existsSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, test } from 'vitest';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
+import {
+  listIosDevices,
+  parseDevicectlDevices,
+  resolveIosPhysicalDevice,
+  type IosDeviceEntry,
+} from '../engine/ios-device.ts';
 import { hostLanCandidates, lanCandidates } from '../engine/lan-address.ts';
 
 const PHONE = '00008030-001A2B3C4D5E802E';
@@ -93,7 +102,7 @@ test('resolveIosPhysicalDevice names what is connected when the requested udid i
   expect(refusal.error).toContain(OTHER);
   expect(refusal.error).toContain(PHONE);
   const empty = resolveIosPhysicalDevice(OTHER, []);
-  expect(empty.error).toMatch(/no device at all/);
+  expect(empty.error).toMatch(/no cabled device at all/);
 });
 
 test('resolveIosPhysicalDevice refuses an unpaired phone and a phone without Developer Mode', () => {
@@ -176,4 +185,101 @@ test('hostLanCandidates is lanCandidates over the host os.networkInterfaces()', 
     expect(candidate.address).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
     expect(candidate.interfaceName.length).toBeGreaterThan(0);
   }
+});
+
+test('a phone reachable only over the network is refused: v1 installs over the cable', () => {
+  const wireless = entry({ transportType: 'localNetwork' });
+  const refused = resolveIosPhysicalDevice(null, [wireless]);
+  expect(refused.udid).toBeUndefined();
+  expect(refused.error).toContain('localNetwork');
+  expect(refused.remedy).toMatch(/cable/);
+
+  const named = resolveIosPhysicalDevice(PHONE, [wireless]);
+  expect(named.udid).toBeUndefined();
+  expect(named.error).toContain('not a cable');
+});
+
+test('a wireless phone is not a candidate, so a single cabled one is still unambiguous', () => {
+  expect(
+    resolveIosPhysicalDevice(null, [entry({ udid: OTHER, name: 'Wireless', transportType: 'localNetwork' }), entry()]),
+  ).toEqual({ udid: PHONE, name: 'Test Phone' });
+});
+
+test('an absent transportType is not treated as wireless', () => {
+  expect(resolveIosPhysicalDevice(null, [entry({ transportType: null })])).toEqual({ udid: PHONE, name: 'Test Phone' });
+  expect(resolveIosPhysicalDevice(null, [entry({ transportType: 'USB' })])).toEqual({
+    udid: PHONE,
+    name: 'Test Phone',
+  });
+});
+
+test('listIosDevices runs devicectl into a temp file, parses it, and removes the directory', () => {
+  const calls: Array<{ file: string; args: string[] }> = [];
+  let outPath = '';
+  setExecutor({
+    runFile(file: string, args: string[]) {
+      calls.push({ file, args });
+      outPath = args[args.length - 1] as string;
+      writeFileSync(outPath, payload([device(PHONE)]));
+      return '';
+    },
+  });
+  try {
+    expect(listIosDevices()).toEqual([
+      {
+        udid: PHONE,
+        name: 'Phone 802E',
+        bootState: 'booted',
+        developerModeStatus: 'enabled',
+        pairingState: 'paired',
+        transportType: 'wired',
+      },
+    ]);
+  } finally {
+    resetExecutor();
+  }
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.file).toBe('xcrun');
+  expect(calls[0]?.args.slice(0, 4)).toEqual(['devicectl', 'list', 'devices', '-j']);
+  expect(outPath.startsWith(tmpdir()) || outPath.startsWith('/private')).toBe(true);
+  expect(existsSync(outPath)).toBe(false);
+  expect(readdirSync(tmpdir()).some((e) => e.startsWith('stim-devicectl-') && existsSync(join(tmpdir(), e)))).toBe(
+    false,
+  );
+});
+
+test('listIosDevices reports no devices when devicectl fails, and still cleans up', () => {
+  let outPath = '';
+  setExecutor({
+    runFile(_file: string, args: string[]) {
+      outPath = args[args.length - 1] as string;
+      throw new Error('xcrun: devicectl is not available');
+    },
+  });
+  try {
+    expect(listIosDevices()).toEqual([]);
+  } finally {
+    resetExecutor();
+  }
+  expect(existsSync(outPath)).toBe(false);
+});
+
+function devicectlAvailable(): boolean {
+  if (process.platform !== 'darwin') return false;
+  return getExecutor().runQuiet('command -v xcrun') !== null;
+}
+
+const LIVE = devicectlAvailable() ? false : 'xcrun is not available on this machine';
+
+describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as boolean }, () => {
+  test('the argv is accepted and every entry it returns is well formed', () => {
+    resetExecutor();
+    const devices = listIosDevices();
+    expect(Array.isArray(devices)).toBe(true);
+    for (const found of devices) {
+      expect(found.udid.length).toBeGreaterThan(0);
+      expect(found.name.length).toBeGreaterThan(0);
+    }
+    expect(readdirSync(tmpdir()).filter((e) => e.startsWith('stim-devicectl-'))).toEqual([]);
+  }, 60_000);
 });

--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from 'vitest';
+import { parseDevicectlDevices, resolveIosPhysicalDevice, type IosDeviceEntry } from '../engine/ios-device.ts';
+import { hostLanCandidates, lanCandidates } from '../engine/lan-address.ts';
+
+const PHONE = '00008030-001A2B3C4D5E802E';
+const OTHER = '00008120-000A11223C44201E';
+
+function payload(devices: unknown[]): string {
+  return JSON.stringify({
+    info: { jsonVersion: 3, outcome: 'success' },
+    result: { devices },
+  });
+}
+
+function device(udid: string, overrides: Record<string, unknown> = {}): unknown {
+  return {
+    hardwareProperties: { udid, platform: 'iOS' },
+    deviceProperties: { name: `Phone ${udid.slice(-4)}`, bootState: 'booted', developerModeStatus: 'enabled' },
+    connectionProperties: { pairingState: 'paired', transportType: 'wired' },
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<IosDeviceEntry> = {}): IosDeviceEntry {
+  return {
+    udid: PHONE,
+    name: 'Test Phone',
+    bootState: 'booted',
+    developerModeStatus: 'enabled',
+    pairingState: 'paired',
+    transportType: 'wired',
+    ...overrides,
+  };
+}
+
+test('parseDevicectlDevices reads the fields devicectl -j actually nests', () => {
+  expect(parseDevicectlDevices(payload([device(PHONE)]))).toEqual([
+    {
+      udid: PHONE,
+      name: 'Phone 802E',
+      bootState: 'booted',
+      developerModeStatus: 'enabled',
+      pairingState: 'paired',
+      transportType: 'wired',
+    },
+  ]);
+});
+
+test('parseDevicectlDevices tolerates the empty list a Mac with no phone produces', () => {
+  expect(parseDevicectlDevices(payload([]))).toEqual([]);
+  expect(parseDevicectlDevices('{"info":{}}')).toEqual([]);
+  expect(parseDevicectlDevices('not json')).toEqual([]);
+  expect(parseDevicectlDevices(null)).toEqual([]);
+});
+
+test('parseDevicectlDevices drops entries with no udid and defaults a missing name', () => {
+  const parsed = parseDevicectlDevices(
+    payload([{ deviceProperties: { name: 'nameless' } }, { hardwareProperties: { udid: OTHER } }]),
+  );
+  expect(parsed).toHaveLength(1);
+  expect(parsed[0]).toMatchObject({ udid: OTHER, name: OTHER, developerModeStatus: null, pairingState: null });
+});
+
+test('parseDevicectlDevices accepts an already-parsed object', () => {
+  expect(parseDevicectlDevices(JSON.parse(payload([device(PHONE)])))).toHaveLength(1);
+});
+
+test('resolveIosPhysicalDevice uses the one connected device when none is named', () => {
+  expect(resolveIosPhysicalDevice(null, [entry()])).toEqual({ udid: PHONE, name: 'Test Phone' });
+});
+
+test('resolveIosPhysicalDevice refuses an ambiguous selection and lists the candidates', () => {
+  const refusal = resolveIosPhysicalDevice(null, [entry(), entry({ udid: OTHER, name: 'Second' })]);
+  expect(refusal.udid).toBeUndefined();
+  expect(refusal.error).toContain(PHONE);
+  expect(refusal.error).toContain(OTHER);
+  expect(refusal.remedy).toContain('stim ios --device <udid>');
+});
+
+test('resolveIosPhysicalDevice refuses when nothing is connected', () => {
+  const refusal = resolveIosPhysicalDevice(null, []);
+  expect(refusal.udid).toBeUndefined();
+  expect(refusal.error).toMatch(/No physical iOS device/);
+  expect(refusal.remedy).toMatch(/Developer Mode/);
+});
+
+test('resolveIosPhysicalDevice matches a named udid case-insensitively', () => {
+  expect(resolveIosPhysicalDevice(PHONE.toLowerCase(), [entry()])).toEqual({ udid: PHONE, name: 'Test Phone' });
+});
+
+test('resolveIosPhysicalDevice names what is connected when the requested udid is not', () => {
+  const refusal = resolveIosPhysicalDevice(OTHER, [entry()]);
+  expect(refusal.error).toContain(OTHER);
+  expect(refusal.error).toContain(PHONE);
+  const empty = resolveIosPhysicalDevice(OTHER, []);
+  expect(empty.error).toMatch(/no device at all/);
+});
+
+test('resolveIosPhysicalDevice refuses an unpaired phone and a phone without Developer Mode', () => {
+  const unpaired = resolveIosPhysicalDevice(null, [entry({ pairingState: 'unpaired' })]);
+  expect(unpaired.udid).toBeUndefined();
+  expect(unpaired.remedy).toMatch(/Trust/);
+
+  const noDevMode = resolveIosPhysicalDevice(null, [entry({ developerModeStatus: 'disabled' })]);
+  expect(noDevMode.udid).toBeUndefined();
+  expect(noDevMode.remedy).toMatch(/Developer Mode/);
+});
+
+test('resolveIosPhysicalDevice does not invent a health problem from absent fields', () => {
+  expect(resolveIosPhysicalDevice(null, [entry({ pairingState: null, developerModeStatus: null })])).toEqual({
+    udid: PHONE,
+    name: 'Test Phone',
+  });
+});
+
+test('lanCandidates orders en0 first and the remaining en* by index', () => {
+  expect(
+    lanCandidates({
+      en3: [{ family: 'IPv4', address: '10.0.3.5', internal: false }],
+      en0: [{ family: 'IPv4', address: '10.0.0.5', internal: false }],
+      en10: [{ family: 'IPv4', address: '10.0.10.5', internal: false }],
+      en1: [{ family: 'IPv4', address: '10.0.1.5', internal: false }],
+    }).map((c) => c.interfaceName),
+  ).toEqual(['en0', 'en1', 'en3', 'en10']);
+});
+
+test('lanCandidates keeps a non-en interface but ranks it after every en*', () => {
+  expect(
+    lanCandidates({
+      anpi0: [{ family: 'IPv4', address: '10.9.9.9', internal: false }],
+      en1: [{ family: 'IPv4', address: '10.0.1.5', internal: false }],
+    }).map((c) => c.interfaceName),
+  ).toEqual(['en1', 'anpi0']);
+});
+
+test('lanCandidates drops loopback, IPv6, link-local, and the tunnel interfaces', () => {
+  expect(
+    lanCandidates({
+      lo0: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+      en0: [
+        { family: 'IPv6', address: 'fe80::1', internal: false },
+        { family: 'IPv4', address: '169.254.10.1', internal: false },
+      ],
+      utun4: [{ family: 'IPv4', address: '100.72.66.29', internal: false }],
+      bridge0: [{ family: 'IPv4', address: '192.168.64.1', internal: false }],
+      awdl0: [{ family: 'IPv4', address: '169.254.9.9', internal: false }],
+      en1: [{ family: 'IPv4', address: '10.0.0.132', internal: false }],
+    }),
+  ).toEqual([{ interfaceName: 'en1', address: '10.0.0.132' }]);
+});
+
+test('lanCandidates accepts the numeric family newer Node reports and dedupes addresses', () => {
+  expect(
+    lanCandidates({
+      en0: [
+        { family: 4, address: '10.0.0.7', internal: false },
+        { family: 4, address: '10.0.0.7', internal: false },
+      ],
+      en2: [{ family: 4, address: '10.0.0.7', internal: false }],
+    }),
+  ).toEqual([{ interfaceName: 'en0', address: '10.0.0.7' }]);
+});
+
+test('lanCandidates returns nothing for an offline host', () => {
+  expect(lanCandidates({ lo0: [{ family: 'IPv4', address: '127.0.0.1', internal: true }] })).toEqual([]);
+  expect(lanCandidates(null)).toEqual([]);
+});
+
+test('hostLanCandidates is lanCandidates over the host os.networkInterfaces()', () => {
+  const interfaces = {
+    en0: [{ family: 'IPv4', address: '10.1.2.3', internal: false }],
+    lo0: [{ family: 'IPv4', address: '127.0.0.1', internal: true }],
+  };
+  expect(hostLanCandidates(() => interfaces as never)).toEqual([{ interfaceName: 'en0', address: '10.1.2.3' }]);
+  for (const candidate of hostLanCandidates()) {
+    expect(candidate.address).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+    expect(candidate.interfaceName.length).toBeGreaterThan(0);
+  }
+});

--- a/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
@@ -1,0 +1,494 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
+import {
+  EMBEDDED_PROFILE,
+  findSigningIdentities,
+  gateAppForDevice,
+  readEmbeddedProfile,
+  resealBundle,
+  sealAppForDevice,
+  type ResealFailure,
+  type ResealMode,
+  type ResealSuccess,
+  type SigningGateOptions,
+} from '../engine/ios-signing.ts';
+import {
+  certificateCommonName,
+  parsePlist,
+  parseProvisioningProfilePlist,
+  parseSigningIdentities,
+  provisioningProfileKind,
+  signingGate,
+  type ProvisioningProfile,
+  type SigningIdentity,
+  type SigningRefusalCode,
+} from '../engine/ios-profile.ts';
+
+const PHONE = '00008030-001A2B3C4D5E802E';
+const STRANGER = '00008101-999999999999999E';
+const JANE = 'Apple Development: Jane Fixture (TEAMID5678)';
+const JANE_SHA1 = '3FE19E227EC5BC2EDE3AC52AB02FF46920445C6A';
+
+function fixture(name: string): string {
+  return readFileSync(new URL(`./fixtures/ios-signing/${name}`, import.meta.url), 'utf-8');
+}
+
+function profile(name = 'development-profile.plist'): ProvisioningProfile {
+  const parsed = parseProvisioningProfilePlist(fixture(name));
+  if (!parsed) throw new Error(`fixture ${name} did not parse`);
+  return parsed;
+}
+
+const BEFORE_EXPIRY = Date.parse('2026-09-01T00:00:00Z');
+const IDENTITIES: SigningIdentity[] = parseSigningIdentities(fixture('find-identity.txt'));
+
+test('parsePlist reads the container types security cms -D emits', () => {
+  const value = parsePlist(
+    '<plist version="1.0"><dict><key>a</key><string>x &amp; y</string>' +
+      '<key>n</key><integer>7</integer><key>r</key><real>1.5</real>' +
+      '<key>t</key><true/><key>f</key><false/>' +
+      '<key>list</key><array><string>one</string><string>two</string></array>' +
+      '<key>nested</key><dict><key>deep</key><string>value</string></dict>' +
+      '<key>empty</key><array/></dict></plist>',
+  );
+  expect(value).toEqual({
+    a: 'x & y',
+    n: 7,
+    r: 1.5,
+    t: true,
+    f: false,
+    list: ['one', 'two'],
+    nested: { deep: 'value' },
+    empty: [],
+  });
+});
+
+test('parsePlist refuses what is not a plist rather than guessing', () => {
+  expect(parsePlist('')).toBe(null);
+  expect(parsePlist(null)).toBe(null);
+  expect(parsePlist('<html><body>nope</body></html>')).toBe('');
+});
+
+test('parseProvisioningProfilePlist reads the keys the gate decides on', () => {
+  const parsed = profile();
+  expect(parsed.name).toBe('iOS Team Provisioning Profile: com.example.stim');
+  expect(parsed.uuid).toBe('9d1f8f6a-0e0c-4c33-9a1f-2b6a5c7d8e90');
+  expect(parsed.teamIdentifier).toBe('TEAMID5678');
+  expect(parsed.expirationDate?.toISOString()).toBe('2027-06-01T12:00:00.000Z');
+  expect(parsed.provisionedDevices).toEqual([PHONE, '00008120-000A11223C44201E']);
+  expect(parsed.provisionsAllDevices).toBe(false);
+  expect(parsed.getTaskAllow).toBe(true);
+  expect(parsed.certificates).toHaveLength(1);
+  expect(parsed.certificates[0]!.length).toBeGreaterThan(500);
+});
+
+test('parseProvisioningProfilePlist returns null for input that is not a profile', () => {
+  expect(parseProvisioningProfilePlist('not a plist')).toBe(null);
+  expect(parseProvisioningProfilePlist('<plist version="1.0"><array/></plist>')).toBe(null);
+});
+
+test('provisioningProfileKind names the four shapes the remedy has to distinguish', () => {
+  expect(provisioningProfileKind(profile())).toBe('development');
+  expect(provisioningProfileKind(profile('app-store-profile.plist'))).toBe('App Store');
+  expect(provisioningProfileKind(profile('enterprise-profile.plist'))).toBe('enterprise');
+  expect(provisioningProfileKind({ ...profile(), getTaskAllow: false })).toBe('ad hoc');
+});
+
+test('certificateCommonName pulls the identity name out of a real X509 subject', () => {
+  expect(certificateCommonName(profile().certificates[0])).toBe(JANE);
+  expect(certificateCommonName(Buffer.from('not a certificate'))).toBe(null);
+  expect(certificateCommonName(null)).toBe(null);
+});
+
+test('parseSigningIdentities scrapes what security find-identity prints', () => {
+  expect(IDENTITIES).toEqual([
+    { sha1: JANE_SHA1, name: JANE },
+    { sha1: 'A1B2C3D4E5F60718293A4B5C6D7E8F9012345678', name: 'Apple Distribution: Fixture Inc (TEAMID5678)' },
+  ]);
+  expect(parseSigningIdentities(fixture('find-identity-empty.txt'))).toEqual([]);
+  expect(parseSigningIdentities(null)).toEqual([]);
+});
+
+function gate(overrides: Partial<Parameters<typeof signingGate>[0]> = {}) {
+  return signingGate({
+    profilePresent: true,
+    profile: profile(),
+    identities: IDENTITIES,
+    udid: PHONE,
+    now: BEFORE_EXPIRY,
+    ...overrides,
+  });
+}
+
+test('the gate admits a development profile that names the phone and an identity in the keychain', () => {
+  expect(gate()).toEqual({ ok: true, identity: { sha1: JANE_SHA1, name: JANE } });
+});
+
+test('a bundle with no embedded.mobileprovision is STIM_NO_PROFILE, not a codesign attempt', () => {
+  const refused = gate({ profilePresent: false, profile: null });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_PROFILE' });
+  expect('remedy' in refused && refused.remedy).toMatch(/Signing & Capabilities/);
+  expect('remedy' in refused && refused.remedy).toMatch(/changes your Apple Developer account/);
+});
+
+test('a profile that will not decode is STIM_NO_PROFILE too', () => {
+  expect(gate({ profile: null })).toMatchObject({ ok: false, code: 'STIM_NO_PROFILE' });
+});
+
+test('an expired profile is STIM_PROFILE_MISMATCH and the message names the date', () => {
+  const refused = gate({ profile: profile('expired-profile.plist') });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+  expect('reason' in refused && refused.reason).toContain('2024-02-03');
+});
+
+test('a profile that is still in date but expires before now is refused on the boundary', () => {
+  const expiry = Date.parse('2027-06-01T12:00:00Z');
+  expect(gate({ now: expiry - 1 })).toMatchObject({ ok: true });
+  expect(gate({ now: expiry })).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+});
+
+test('an App Store or enterprise profile is refused by name, because it cannot prove the device', () => {
+  const store = gate({ profile: profile('app-store-profile.plist') });
+  expect(store).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+  expect('reason' in store && store.reason).toContain('App Store');
+  expect('reason' in store && store.reason).toContain('ProvisionedDevices');
+  expect('remedy' in store && store.remedy).toMatch(/development profile/);
+
+  const enterprise = gate({ profile: profile('enterprise-profile.plist') });
+  expect('reason' in enterprise && enterprise.reason).toContain('enterprise');
+});
+
+test('a development profile that does not list this phone is refused with the udid named', () => {
+  const refused = gate({ udid: STRANGER });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+  expect('reason' in refused && refused.reason).toContain(STRANGER);
+  expect('remedy' in refused && refused.remedy).toContain(STRANGER);
+});
+
+test('the device list is matched case-insensitively', () => {
+  expect(gate({ udid: PHONE.toLowerCase() })).toMatchObject({ ok: true });
+});
+
+test('an empty keychain is STIM_NO_SIGNING_IDENTITY', () => {
+  const refused = gate({ identities: [] });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_SIGNING_IDENTITY' });
+  expect('remedy' in refused && refused.remedy).toMatch(/Xcode > Settings > Accounts/);
+});
+
+test('an artifact signed by someone else is detected before any codesign runs', () => {
+  const refused = gate({
+    identities: [{ sha1: 'C'.repeat(40), name: 'Apple Development: Someone Else (OTHERTEAM)' }],
+  });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_SIGNING_IDENTITY' });
+  expect('reason' in refused && refused.reason).toContain(JANE);
+  expect('reason' in refused && refused.reason).toContain('Someone Else');
+});
+
+test('two certificates sharing a common name are refused rather than picked between', () => {
+  const refused = gate({ identities: parseSigningIdentities(fixture('find-identity-duplicate.txt')) });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_SIGNING_IDENTITY' });
+  expect('remedy' in refused && refused.remedy).toContain('ios.signingIdentitySha1');
+});
+
+test('ios.signingIdentitySha1 disambiguates and wins over the name', () => {
+  expect(
+    gate({
+      identities: parseSigningIdentities(fixture('find-identity-duplicate.txt')),
+      pinnedSha1: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    }),
+  ).toEqual({ ok: true, identity: { sha1: 'B'.repeat(40), name: JANE } });
+});
+
+test('a pinned sha1 that is not in the keychain refuses and lists what is', () => {
+  const refused = gate({ pinnedSha1: 'D'.repeat(40) });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_SIGNING_IDENTITY' });
+  expect('reason' in refused && refused.reason).toContain(JANE_SHA1);
+});
+
+test('ios.signingIdentity overrides the identity derived from the profile', () => {
+  expect(gate({ pinnedName: 'Apple Distribution: Fixture Inc (TEAMID5678)' })).toEqual({
+    ok: true,
+    identity: {
+      sha1: 'A1B2C3D4E5F60718293A4B5C6D7E8F9012345678',
+      name: 'Apple Distribution: Fixture Inc (TEAMID5678)',
+    },
+  });
+});
+
+test('a profile whose certificate has no readable subject refuses with the settings escape hatch', () => {
+  const refused = gate({ profile: { ...profile(), certificates: [] } });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_NO_SIGNING_IDENTITY' });
+  expect('remedy' in refused && refused.remedy).toContain('ios.signingIdentity');
+});
+
+test('the gate checks the profile before the keychain, so a bad profile is not masked', () => {
+  const refused = gate({ profile: profile('expired-profile.plist'), identities: [] });
+  expect(refused).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+});
+
+test('the refusal remedies name the manual Xcode step rather than a flag Stim could pass', () => {
+  for (const refused of [
+    gate({ profilePresent: false, profile: null }),
+    gate({ profile: profile('expired-profile.plist') }),
+    gate({ profile: profile('app-store-profile.plist') }),
+    gate({ udid: STRANGER }),
+  ]) {
+    expect('remedy' in refused && refused.remedy).toMatch(/build once from Xcode/);
+  }
+});
+
+const SCRATCH_INFO_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.stimcli.scratch</string>
+<key>CFBundleExecutable</key><string>Scratch</string>
+<key>CFBundleName</key><string>Scratch</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+`;
+
+const SCRATCH_ENTITLEMENTS = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>get-task-allow</key><true/>
+<key>keychain-access-groups</key><array><string>TEAMID5678.*</string></array>
+</dict></plist>
+`;
+
+const AD_HOC: SigningIdentity = { sha1: '', name: '-' };
+
+function toolsAvailable(): boolean {
+  if (process.platform !== 'darwin') return false;
+  const exec = getExecutor();
+  return ['codesign', 'security', 'clang', 'openssl'].every((tool) => exec.runQuiet(`command -v ${tool}`) !== null);
+}
+
+const LIVE = toolsAvailable() ? false : 'codesign, security, clang and openssl are not all available here';
+
+describe('the re-seal primitive against the real codesign and security', { skip: LIVE as unknown as boolean }, () => {
+  let dir: string;
+  let appPath: string;
+
+  function writeScratchApp(): void {
+    appPath = join(dir, 'Scratch.app');
+    mkdirSync(appPath, { recursive: true });
+    writeFileSync(join(dir, 'main.c'), 'int main(void) { return 0; }\n');
+    writeFileSync(join(appPath, 'Info.plist'), SCRATCH_INFO_PLIST);
+    writeFileSync(join(dir, 'entitlements.plist'), SCRATCH_ENTITLEMENTS);
+    writeFileSync(join(appPath, 'ip.txt'), '10.0.0.132:8081');
+    const exec = getExecutor();
+    exec.runFile('clang', ['-o', join(appPath, 'Scratch'), join(dir, 'main.c')]);
+    exec.runFile('codesign', [
+      '--force',
+      '--sign',
+      '-',
+      '--entitlements',
+      join(dir, 'entitlements.plist'),
+      '--timestamp=none',
+      appPath,
+    ]);
+  }
+
+  function sealIsValid(): boolean {
+    return getExecutor().runQuiet(`codesign --verify --strict ${JSON.stringify(appPath)}`) !== null;
+  }
+
+  function entitlementsOf(): string {
+    return getExecutor().runFile('codesign', ['-d', '--entitlements', '-', '--xml', appPath]);
+  }
+
+  beforeEach(() => {
+    resetExecutor();
+    dir = mkdtempSync(join(tmpdir(), 'stim-reseal-'));
+    writeScratchApp();
+  });
+
+  afterEach(() => {
+    resetExecutor();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('rewriting a sealed resource really does break the seal, which is why the re-seal exists', () => {
+    expect(sealIsValid()).toBe(true);
+    writeFileSync(join(appPath, 'ip.txt'), '192.168.1.42:8085');
+    expect(sealIsValid()).toBe(false);
+  });
+
+  test('the preferred form re-seals a mutated bundle and carries its entitlements over verbatim', () => {
+    const before = entitlementsOf();
+    writeFileSync(join(appPath, 'ip.txt'), '192.168.1.42:8085');
+    expect(sealIsValid()).toBe(false);
+
+    const result = resealBundle({ appPath, identity: AD_HOC });
+    expect(result).toEqual({ ok: true, identity: AD_HOC, mode: 'preserve-metadata' });
+    expect(sealIsValid()).toBe(true);
+    expect(entitlementsOf()).toBe(before);
+    expect(readFileSync(join(appPath, 'ip.txt'), 'utf-8')).toBe('192.168.1.42:8085');
+    expect(entitlementsOf()).toContain('keychain-access-groups');
+  });
+
+  test('the entitlements fallback re-seals for real when --preserve-metadata is rejected', () => {
+    const real = getExecutor();
+    const before = entitlementsOf();
+    writeFileSync(join(appPath, 'ip.txt'), '192.168.1.42:8085');
+    setExecutor({
+      runFile(file: string, args: string[], opts?: unknown) {
+        if (file === 'codesign' && args.some((a) => a.startsWith('--preserve-metadata='))) {
+          throw Object.assign(new Error('codesign: unknown option --preserve-metadata'), {
+            stderr: 'codesign: unknown option --preserve-metadata',
+          });
+        }
+        return real.runFile(file, args, opts as never);
+      },
+    });
+
+    const result = resealBundle({ appPath, identity: AD_HOC });
+    resetExecutor();
+    expect(result).toEqual({ ok: true, identity: AD_HOC, mode: 'entitlements' });
+    expect(sealIsValid()).toBe(true);
+    expect(entitlementsOf()).toBe(before);
+  });
+
+  test('a bundle codesign will not sign reports STIM_CODESIGN_FAILED with the real stderr', () => {
+    const result = resealBundle({ appPath: join(dir, 'Missing.app'), identity: AD_HOC });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ code: 'STIM_CODESIGN_FAILED' });
+    expect('lastLines' in result && result.lastLines.join(' ')).toMatch(/Missing\.app/);
+  });
+
+  test('readEmbeddedProfile decodes a real CMS-wrapped profile through security cms -D', () => {
+    const exec = getExecutor();
+    const key = join(dir, 'signer.key');
+    const pem = join(dir, 'signer.pem');
+    exec.runFile('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      key,
+      '-out',
+      pem,
+      '-days',
+      '30',
+      '-nodes',
+      '-subj',
+      `/CN=${JANE}/OU=TEAMID5678/O=Fixture Inc/C=US`,
+    ]);
+    const plist = join(dir, 'profile.plist');
+    writeFileSync(plist, fixture('development-profile.plist'));
+    exec.runFile('openssl', [
+      'smime',
+      '-sign',
+      '-nodetach',
+      '-binary',
+      '-in',
+      plist,
+      '-signer',
+      pem,
+      '-inkey',
+      key,
+      '-outform',
+      'DER',
+      '-out',
+      join(appPath, EMBEDDED_PROFILE),
+    ]);
+
+    const read = readEmbeddedProfile(appPath);
+    expect(read.present).toBe(true);
+    expect(read.profile?.provisionedDevices).toContain(PHONE);
+    expect(read.profile?.expirationDate?.toISOString()).toBe('2027-06-01T12:00:00.000Z');
+    expect(certificateCommonName(read.profile?.certificates[0])).toBe(JANE);
+  }, 60_000);
+
+  test('an app with no embedded.mobileprovision reads as absent rather than throwing', () => {
+    expect(readEmbeddedProfile(appPath)).toEqual({ present: false, profile: null });
+  });
+
+  test('a profile that is not CMS at all reads as present but undecodable', () => {
+    writeFileSync(join(appPath, EMBEDDED_PROFILE), 'not a CMS blob');
+    expect(readEmbeddedProfile(appPath)).toEqual({ present: true, profile: null });
+  });
+
+  test('gateAppForDevice refuses a bundle with no profile, without reaching codesign', () => {
+    const options: SigningGateOptions = { appPath, udid: PHONE, configuration: 'Release' };
+    const gated = gateAppForDevice(options);
+    expect(gated).toMatchObject({ ok: false, code: 'STIM_NO_PROFILE' });
+    expect(sealIsValid()).toBe(true);
+  });
+
+  test('sealAppForDevice returns the gate refusal with no lines, so a caller can print one shape', () => {
+    const failure = sealAppForDevice({ appPath, udid: PHONE }) as ResealFailure;
+    expect(failure.ok).toBe(false);
+    const codes: SigningRefusalCode[] = [
+      'STIM_NO_PROFILE',
+      'STIM_PROFILE_MISMATCH',
+      'STIM_NO_SIGNING_IDENTITY',
+      'STIM_CODESIGN_FAILED',
+    ];
+    expect(codes).toContain(failure.code);
+    expect(failure.lastLines).toEqual([]);
+  });
+
+  test('sealAppForDevice refuses a real profile that does not name the target phone', () => {
+    const exec = getExecutor();
+    const key = join(dir, 'signer.key');
+    const pem = join(dir, 'signer.pem');
+    exec.runFile('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      key,
+      '-out',
+      pem,
+      '-days',
+      '30',
+      '-nodes',
+      '-subj',
+      `/CN=${JANE}/OU=TEAMID5678/O=Fixture Inc/C=US`,
+    ]);
+    const plist = join(dir, 'profile.plist');
+    writeFileSync(plist, fixture('development-profile.plist'));
+    exec.runFile('openssl', [
+      'smime',
+      '-sign',
+      '-nodetach',
+      '-binary',
+      '-in',
+      plist,
+      '-signer',
+      pem,
+      '-inkey',
+      key,
+      '-outform',
+      'DER',
+      '-out',
+      join(appPath, EMBEDDED_PROFILE),
+    ]);
+
+    const refused = sealAppForDevice({ appPath, udid: STRANGER, now: BEFORE_EXPIRY });
+    expect(refused).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
+    expect('reason' in refused && refused.reason).toContain(STRANGER);
+  }, 60_000);
+
+  test('a successful re-seal reports which of the two forms sealed it', () => {
+    writeFileSync(join(appPath, 'ip.txt'), '192.168.1.42:8085');
+    const sealed = resealBundle({ appPath, identity: AD_HOC }) as ResealSuccess;
+    const modes: ResealMode[] = ['preserve-metadata', 'entitlements', 'no-entitlements'];
+    expect(modes).toContain(sealed.mode);
+    expect(sealed.identity).toEqual(AD_HOC);
+  });
+
+  test('findSigningIdentities parses whatever this machine really has in its keychain', () => {
+    for (const identity of findSigningIdentities()) {
+      expect(identity.sha1).toMatch(/^[0-9A-F]{40}$/);
+      expect(identity.name.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
@@ -66,6 +66,31 @@ test('parsePlist reads the container types security cms -D emits', () => {
   });
 });
 
+test('parsePlist fails closed on an out-of-range character reference', () => {
+  expect(parsePlist('<plist version="1.0"><string>&#xFFFFFFF;</string></plist>')).toBe(null);
+  expect(parsePlist('<plist version="1.0"><string>&#1114112;</string></plist>')).toBe(null);
+  expect(parsePlist('<plist version="1.0"><string>&#xD800;</string></plist>')).toBe(null);
+  expect(parsePlist('<plist version="1.0"><string>&#65;&#x42;</string></plist>')).toBe('AB');
+});
+
+test('parsePlist ignores XML comments, including markup hiding inside one', () => {
+  expect(
+    parsePlist(
+      '<plist version="1.0"><dict><!-- <key>ghost</key><string>x</string> -->' +
+        '<key>real</key><string>value</string></dict></plist>',
+    ),
+  ).toEqual({ real: 'value' });
+});
+
+test('a key with no value ends its dict instead of swallowing the parent', () => {
+  expect(
+    parsePlist(
+      '<plist version="1.0"><dict><key>outer</key><dict><key>dangling</key></dict>' +
+        '<key>after</key><string>kept</string></dict></plist>',
+    ),
+  ).toEqual({ outer: {}, after: 'kept' });
+});
+
 test('parsePlist refuses what is not a plist rather than guessing', () => {
   expect(parsePlist('')).toBe(null);
   expect(parsePlist(null)).toBe(null);

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -432,6 +432,41 @@ describe('xcodebuildArgs', () => {
     const base = { project, scheme: 'App', udid: 'u', derivedDataPath: '/dd' };
     expect(xcodebuildArgs(base)).toEqual(xcodebuildArgs({ ...base, buildSettings: [] }));
   });
+
+  test('the device slice is -sdk iphoneos plus the phone id, and carries no signing flag', () => {
+    const args = xcodebuildArgs({
+      project,
+      scheme: 'App',
+      udid: '00008030-001A2B3C4D5E802E',
+      sdk: 'iphoneos',
+      configuration: 'Release',
+      derivedDataPath: '/dd',
+    });
+    expect(args).toEqual([
+      '-workspace',
+      '/p/ios/App.xcworkspace',
+      '-scheme',
+      'App',
+      '-configuration',
+      'Release',
+      '-sdk',
+      'iphoneos',
+      '-destination',
+      'id=00008030-001A2B3C4D5E802E',
+      '-derivedDataPath',
+      '/dd',
+      'build',
+    ]);
+    for (const flag of [
+      'CODE_SIGN_IDENTITY',
+      'DEVELOPMENT_TEAM',
+      'PROVISIONING_PROFILE_SPECIFIER',
+      '-allowProvisioningUpdates',
+      'RCT_METRO_PORT',
+    ]) {
+      expect(args.some((a) => a.includes(flag))).toBe(false);
+    }
+  });
 });
 
 describe('compilationCacheSettings', () => {
@@ -1400,6 +1435,34 @@ describe('buildIos against a real xcodebuild', { skip: LIVE as unknown as boolea
     expect(records.at(-1)?.event).toBe('build_done');
     expect(records.filter((r) => r.level === 'error').length).toBe(0);
   }, 120_000);
+
+  test('builds the device slice for real: -sdk iphoneos lands the .app in Debug-iphoneos', async () => {
+    resetExecutor();
+    writeScratchProject(tmp);
+    const logFile = join(workspaceLogsDir(tmp), 'build-ios-device.ndjson');
+    const writer = createNdjsonWriter(logFile);
+    const result = asResult(
+      await buildIos({
+        root: tmp,
+        udid: 'unused-with-an-explicit-destination',
+        sdk: 'iphoneos',
+        destination: 'generic/platform=iOS',
+        logWriter: writer,
+      }),
+    );
+    writer.close();
+
+    expect(result.failed).toBe(undefined);
+    expect(result.appPath).toBe(join(workspaceDerivedData(tmp), 'Build', 'Products', 'Debug-iphoneos', 'Scratch.app'));
+    expect(existsSync(result.appPath)).toBeTruthy();
+    expect(result.bundleId).toBe('com.stimcli.scratch');
+
+    const records = parseNdjsonText(readFileSync(logFile, 'utf-8'));
+    expect(records[0]?.msg).toMatch(/ -sdk iphoneos /);
+    expect(records[0]?.msg).toMatch(/ -destination generic\/platform=iOS /);
+    expect(records[0]?.msg).not.toMatch(/allowProvisioningUpdates|DEVELOPMENT_TEAM|CODE_SIGN_IDENTITY/);
+    expect(records.some((r) => r.msg?.includes('BUILD SUCCEEDED'))).toBeTruthy();
+  }, 180_000);
 
   test('fails for real: a broken source file becomes one diagnostic with file, line and column', async () => {
     resetExecutor();

--- a/packages/stim-cli/src/__tests__/errors-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/errors-xcode.test.ts
@@ -227,12 +227,22 @@ describe('real transcripts', () => {
     expect(extractXcodeDiagnostics(REAL_PODS_FAILURE).length).toBe(1);
   });
 
-  test('a signing failure is recognized as one, and told it should not be signing', () => {
+  test('a signing failure on the simulator slice is told it should not be signing at all', () => {
     const found = extractXcodeDiagnostics(REAL_SIGNING_FAILURE);
     expect(found.length).toBe(1);
     expect(found[0]?.file).toBe('/tmp/stim-xc/Scratch.xcodeproj');
     expect(found[0]?.message).toMatch(/No profiles for 'com\.stimcli\.scratch' were found/);
-    expect(found[0]?.remedy).toMatch(/simulator, which needs no signing/);
+    expect(found[0]?.remedy).toMatch(/simulator here, which needs no signing/);
+    expect(found[0]?.remedy).toMatch(/stim ios --device/);
+  });
+
+  test('the same failure on the device slice is told to set up signing, in Xcode', () => {
+    const found = extractXcodeDiagnostics(REAL_SIGNING_FAILURE, null, 'iphoneos');
+    expect(found.length).toBe(1);
+    expect(found[0]?.remedy).toMatch(/Signing & Capabilities/);
+    expect(found[0]?.remedy).toMatch(/build once from Xcode/);
+    expect(found[0]?.remedy).toMatch(/-allowProvisioningUpdates/);
+    expect(found[0]?.remedy).not.toMatch(/needs no signing/);
   });
 
   test('an xcodebuild invocation error survives its own timestamped log line', () => {

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/app-store-profile.plist
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/app-store-profile.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>Stim Fixture &amp; Co</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>TEAMID5678</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2026-01-01T00:00:00Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>IsXcodeManaged</key>
+	<false/>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data>
+	MIIDWjCCAkICCQCDIsWed7hq9jANBgkqhkiG9w0BAQsFADBvMTUwMwYDVQQDDCxBcHBs
+	ZSBEZXZlbG9wbWVudDogSmFuZSBGaXh0dXJlIChURUFNSUQ1Njc4KTETMBEGA1UECwwK
+	VEVBTUlENTY3ODEUMBIGA1UECgwLRml4dHVyZSBJbmMxCzAJBgNVBAYTAlVTMB4XDTI2
+	MDkwMTExMzEwNloXDTM2MDgyOTExMzEwNlowbzE1MDMGA1UEAwwsQXBwbGUgRGV2ZWxv
+	cG1lbnQ6IEphbmUgRml4dHVyZSAoVEVBTUlENTY3OCkxEzARBgNVBAsMClRFQU1JRDU2
+	NzgxFDASBgNVBAoMC0ZpeHR1cmUgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcN
+	AQEBBQADggEPADCCAQoCggEBAMP5LZGyU1gTvV1QxmyV8VkRQQdvgdEfQZYPNoOaLLt6
+	22ONpdeOoawJfE/DDplwoMeqjzp7fImEF5AHFFlvy21Td2WSxx2EMGffsrLfErr5ViqN
+	2Hf8rDMM5hcytUaDzgdSezcFSVgpbqY6lChuDBTSUn1pN8swqdZy9AtmKdfaWfV5AB1W
+	2KuFDTU0fokuCPMjcf9/l8TfuzUQCVl63uuh7Q7Cte+MCmSX+eKOwP6tppmBokf1k2J8
+	ZNxeR7bkAH55g9mVF/k9hguDfQkH090qATC1ZfViqiiyxEOpz7bAu8wKXhpJ8NTDMyz1
+	jXAxnQTmg+wWWucTqwMKaxajHn0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVbe+sEhl
+	6lozSm0qWESI/z/WPZci0i1CVTqe5FM9dhVTHrDDeZWoGtUm+APakzIRmWlngOmAgexH
+	ZPi1mu1nCIqSPvka06Jb9mL0qS5xg1H0khx5i4/YTZ3Hg2FUhiNSFmL+4CQA77f3wnDE
+	38qjjIGIdVWFsykj9ezkWCTB7mI5haEtfBHVg5cuDs1TxgrjZ9BE2s3cwuyvQdO0ib+q
+	HBIijkzC6tUdpRlzd1bngw7PeegbTDeJYPvO3MdcdGFAkmwVXAlr9r/XgB1jJLgL2D9J
+	JDbbNB5Su5/3VunFgyvTO1XgUoex0NrzPjCuOqDGaBzDrgWXvyTv/zvyvGlE9w==
+		</data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>TEAMID5678.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<false/>
+		<key>application-identifier</key>
+		<string>TEAMID5678.com.example.stim</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>TEAMID5678</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2027-06-01T12:00:00Z</date>
+	<key>Name</key>
+	<string>iOS Team Provisioning Profile: com.example.stim</string>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>TEAMID5678</string>
+	</array>
+	<key>TeamName</key>
+	<string>Fixture Inc</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>9d1f8f6a-0e0c-4c33-9a1f-2b6a5c7d8e90</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/development-profile.plist
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/development-profile.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>Stim Fixture &amp; Co</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>TEAMID5678</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2026-01-01T00:00:00Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>IsXcodeManaged</key>
+	<false/>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data>
+	MIIDWjCCAkICCQCDIsWed7hq9jANBgkqhkiG9w0BAQsFADBvMTUwMwYDVQQDDCxBcHBs
+	ZSBEZXZlbG9wbWVudDogSmFuZSBGaXh0dXJlIChURUFNSUQ1Njc4KTETMBEGA1UECwwK
+	VEVBTUlENTY3ODEUMBIGA1UECgwLRml4dHVyZSBJbmMxCzAJBgNVBAYTAlVTMB4XDTI2
+	MDkwMTExMzEwNloXDTM2MDgyOTExMzEwNlowbzE1MDMGA1UEAwwsQXBwbGUgRGV2ZWxv
+	cG1lbnQ6IEphbmUgRml4dHVyZSAoVEVBTUlENTY3OCkxEzARBgNVBAsMClRFQU1JRDU2
+	NzgxFDASBgNVBAoMC0ZpeHR1cmUgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcN
+	AQEBBQADggEPADCCAQoCggEBAMP5LZGyU1gTvV1QxmyV8VkRQQdvgdEfQZYPNoOaLLt6
+	22ONpdeOoawJfE/DDplwoMeqjzp7fImEF5AHFFlvy21Td2WSxx2EMGffsrLfErr5ViqN
+	2Hf8rDMM5hcytUaDzgdSezcFSVgpbqY6lChuDBTSUn1pN8swqdZy9AtmKdfaWfV5AB1W
+	2KuFDTU0fokuCPMjcf9/l8TfuzUQCVl63uuh7Q7Cte+MCmSX+eKOwP6tppmBokf1k2J8
+	ZNxeR7bkAH55g9mVF/k9hguDfQkH090qATC1ZfViqiiyxEOpz7bAu8wKXhpJ8NTDMyz1
+	jXAxnQTmg+wWWucTqwMKaxajHn0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVbe+sEhl
+	6lozSm0qWESI/z/WPZci0i1CVTqe5FM9dhVTHrDDeZWoGtUm+APakzIRmWlngOmAgexH
+	ZPi1mu1nCIqSPvka06Jb9mL0qS5xg1H0khx5i4/YTZ3Hg2FUhiNSFmL+4CQA77f3wnDE
+	38qjjIGIdVWFsykj9ezkWCTB7mI5haEtfBHVg5cuDs1TxgrjZ9BE2s3cwuyvQdO0ib+q
+	HBIijkzC6tUdpRlzd1bngw7PeegbTDeJYPvO3MdcdGFAkmwVXAlr9r/XgB1jJLgL2D9J
+	JDbbNB5Su5/3VunFgyvTO1XgUoex0NrzPjCuOqDGaBzDrgWXvyTv/zvyvGlE9w==
+		</data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>TEAMID5678.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<true/>
+		<key>application-identifier</key>
+		<string>TEAMID5678.com.example.stim</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>TEAMID5678</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2027-06-01T12:00:00Z</date>
+	<key>Name</key>
+	<string>iOS Team Provisioning Profile: com.example.stim</string>
+	<key>ProvisionedDevices</key>
+	<array>
+		<string>00008030-001A2B3C4D5E802E</string>
+		<string>00008120-000A11223C44201E</string>
+	</array>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>TEAMID5678</string>
+	</array>
+	<key>TeamName</key>
+	<string>Fixture Inc</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>9d1f8f6a-0e0c-4c33-9a1f-2b6a5c7d8e90</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/enterprise-profile.plist
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/enterprise-profile.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>Stim Fixture &amp; Co</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>TEAMID5678</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2026-01-01T00:00:00Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>IsXcodeManaged</key>
+	<false/>
+	<key>ProvisionsAllDevices</key>
+	<true/>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data>
+	MIIDWjCCAkICCQCDIsWed7hq9jANBgkqhkiG9w0BAQsFADBvMTUwMwYDVQQDDCxBcHBs
+	ZSBEZXZlbG9wbWVudDogSmFuZSBGaXh0dXJlIChURUFNSUQ1Njc4KTETMBEGA1UECwwK
+	VEVBTUlENTY3ODEUMBIGA1UECgwLRml4dHVyZSBJbmMxCzAJBgNVBAYTAlVTMB4XDTI2
+	MDkwMTExMzEwNloXDTM2MDgyOTExMzEwNlowbzE1MDMGA1UEAwwsQXBwbGUgRGV2ZWxv
+	cG1lbnQ6IEphbmUgRml4dHVyZSAoVEVBTUlENTY3OCkxEzARBgNVBAsMClRFQU1JRDU2
+	NzgxFDASBgNVBAoMC0ZpeHR1cmUgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcN
+	AQEBBQADggEPADCCAQoCggEBAMP5LZGyU1gTvV1QxmyV8VkRQQdvgdEfQZYPNoOaLLt6
+	22ONpdeOoawJfE/DDplwoMeqjzp7fImEF5AHFFlvy21Td2WSxx2EMGffsrLfErr5ViqN
+	2Hf8rDMM5hcytUaDzgdSezcFSVgpbqY6lChuDBTSUn1pN8swqdZy9AtmKdfaWfV5AB1W
+	2KuFDTU0fokuCPMjcf9/l8TfuzUQCVl63uuh7Q7Cte+MCmSX+eKOwP6tppmBokf1k2J8
+	ZNxeR7bkAH55g9mVF/k9hguDfQkH090qATC1ZfViqiiyxEOpz7bAu8wKXhpJ8NTDMyz1
+	jXAxnQTmg+wWWucTqwMKaxajHn0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVbe+sEhl
+	6lozSm0qWESI/z/WPZci0i1CVTqe5FM9dhVTHrDDeZWoGtUm+APakzIRmWlngOmAgexH
+	ZPi1mu1nCIqSPvka06Jb9mL0qS5xg1H0khx5i4/YTZ3Hg2FUhiNSFmL+4CQA77f3wnDE
+	38qjjIGIdVWFsykj9ezkWCTB7mI5haEtfBHVg5cuDs1TxgrjZ9BE2s3cwuyvQdO0ib+q
+	HBIijkzC6tUdpRlzd1bngw7PeegbTDeJYPvO3MdcdGFAkmwVXAlr9r/XgB1jJLgL2D9J
+	JDbbNB5Su5/3VunFgyvTO1XgUoex0NrzPjCuOqDGaBzDrgWXvyTv/zvyvGlE9w==
+		</data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>TEAMID5678.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<false/>
+		<key>application-identifier</key>
+		<string>TEAMID5678.com.example.stim</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>TEAMID5678</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2027-06-01T12:00:00Z</date>
+	<key>Name</key>
+	<string>iOS Team Provisioning Profile: com.example.stim</string>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>TEAMID5678</string>
+	</array>
+	<key>TeamName</key>
+	<string>Fixture Inc</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>9d1f8f6a-0e0c-4c33-9a1f-2b6a5c7d8e90</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/expired-profile.plist
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/expired-profile.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIDName</key>
+	<string>Stim Fixture &amp; Co</string>
+	<key>ApplicationIdentifierPrefix</key>
+	<array>
+	<string>TEAMID5678</string>
+	</array>
+	<key>CreationDate</key>
+	<date>2026-01-01T00:00:00Z</date>
+	<key>Platform</key>
+	<array>
+		<string>iOS</string>
+	</array>
+	<key>IsXcodeManaged</key>
+	<false/>
+	<key>DeveloperCertificates</key>
+	<array>
+		<data>
+	MIIDWjCCAkICCQCDIsWed7hq9jANBgkqhkiG9w0BAQsFADBvMTUwMwYDVQQDDCxBcHBs
+	ZSBEZXZlbG9wbWVudDogSmFuZSBGaXh0dXJlIChURUFNSUQ1Njc4KTETMBEGA1UECwwK
+	VEVBTUlENTY3ODEUMBIGA1UECgwLRml4dHVyZSBJbmMxCzAJBgNVBAYTAlVTMB4XDTI2
+	MDkwMTExMzEwNloXDTM2MDgyOTExMzEwNlowbzE1MDMGA1UEAwwsQXBwbGUgRGV2ZWxv
+	cG1lbnQ6IEphbmUgRml4dHVyZSAoVEVBTUlENTY3OCkxEzARBgNVBAsMClRFQU1JRDU2
+	NzgxFDASBgNVBAoMC0ZpeHR1cmUgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcN
+	AQEBBQADggEPADCCAQoCggEBAMP5LZGyU1gTvV1QxmyV8VkRQQdvgdEfQZYPNoOaLLt6
+	22ONpdeOoawJfE/DDplwoMeqjzp7fImEF5AHFFlvy21Td2WSxx2EMGffsrLfErr5ViqN
+	2Hf8rDMM5hcytUaDzgdSezcFSVgpbqY6lChuDBTSUn1pN8swqdZy9AtmKdfaWfV5AB1W
+	2KuFDTU0fokuCPMjcf9/l8TfuzUQCVl63uuh7Q7Cte+MCmSX+eKOwP6tppmBokf1k2J8
+	ZNxeR7bkAH55g9mVF/k9hguDfQkH090qATC1ZfViqiiyxEOpz7bAu8wKXhpJ8NTDMyz1
+	jXAxnQTmg+wWWucTqwMKaxajHn0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVbe+sEhl
+	6lozSm0qWESI/z/WPZci0i1CVTqe5FM9dhVTHrDDeZWoGtUm+APakzIRmWlngOmAgexH
+	ZPi1mu1nCIqSPvka06Jb9mL0qS5xg1H0khx5i4/YTZ3Hg2FUhiNSFmL+4CQA77f3wnDE
+	38qjjIGIdVWFsykj9ezkWCTB7mI5haEtfBHVg5cuDs1TxgrjZ9BE2s3cwuyvQdO0ib+q
+	HBIijkzC6tUdpRlzd1bngw7PeegbTDeJYPvO3MdcdGFAkmwVXAlr9r/XgB1jJLgL2D9J
+	JDbbNB5Su5/3VunFgyvTO1XgUoex0NrzPjCuOqDGaBzDrgWXvyTv/zvyvGlE9w==
+		</data>
+	</array>
+	<key>Entitlements</key>
+	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>TEAMID5678.*</string>
+		</array>
+		<key>get-task-allow</key>
+		<true/>
+		<key>application-identifier</key>
+		<string>TEAMID5678.com.example.stim</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>TEAMID5678</string>
+	</dict>
+	<key>ExpirationDate</key>
+	<date>2024-02-03T09:15:00Z</date>
+	<key>Name</key>
+	<string>iOS Team Provisioning Profile: com.example.stim</string>
+	<key>ProvisionedDevices</key>
+	<array>
+		<string>00008030-001A2B3C4D5E802E</string>
+		<string>00008120-000A11223C44201E</string>
+	</array>
+	<key>TeamIdentifier</key>
+	<array>
+		<string>TEAMID5678</string>
+	</array>
+	<key>TeamName</key>
+	<string>Fixture Inc</string>
+	<key>TimeToLive</key>
+	<integer>365</integer>
+	<key>UUID</key>
+	<string>9d1f8f6a-0e0c-4c33-9a1f-2b6a5c7d8e90</string>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity-duplicate.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity-duplicate.txt
@@ -1,0 +1,3 @@
+  1) 3FE19E227EC5BC2EDE3AC52AB02FF46920445C6A "Apple Development: Jane Fixture (TEAMID5678)"
+  2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB "Apple Development: Jane Fixture (TEAMID5678)"
+     2 valid identities found

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity-empty.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity-empty.txt
@@ -1,0 +1,1 @@
+     0 valid identities found

--- a/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-signing/find-identity.txt
@@ -1,0 +1,3 @@
+  1) 3FE19E227EC5BC2EDE3AC52AB02FF46920445C6A "Apple Development: Jane Fixture (TEAMID5678)"
+  2) A1B2C3D4E5F60718293A4B5C6D7E8F9012345678 "Apple Distribution: Fixture Inc (TEAMID5678)"
+     2 valid identities found

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -75,7 +75,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
   assert(lifecycle);
   const advertised = {
     'start.ts': ['--json', '--wait', '--remote'],
-    'ios.ts': ['--json', '--no-metro-check', '--no-build-cache', '--configuration', '--remote'],
+    'ios.ts': ['--json', '--no-metro-check', '--no-build-cache', '--configuration', '--device', '--remote'],
     'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--device', '--remote'],
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -291,12 +291,17 @@ test('no topic teaches a command this binary does not have', () => {
   expect(renderTopic('settings')).toMatch(/no `stim config` command/);
 });
 
-test('the errors topic documents every code the build commands can emit', () => {
+test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {
   const body = renderTopic('errors');
   assert(body);
-  const sources = ['ios.ts', 'android.ts', 'start.ts']
-    .map((f) => readFileSync(new URL(`../commands/${f}`, import.meta.url), 'utf-8'))
-    .join('\n');
+  const sources = [
+    ...['ios.ts', 'android.ts', 'start.ts'].map((f) =>
+      readFileSync(new URL(`../commands/${f}`, import.meta.url), 'utf-8'),
+    ),
+    ...['engine/ios-profile.ts', 'engine/ios-signing.ts'].map((f) =>
+      readFileSync(new URL(`../${f}`, import.meta.url), 'utf-8'),
+    ),
+  ].join('\n');
   const codes = new Set([...sources.matchAll(/STIM_[A-Z_]+/g)].map((m) => m[0]));
   expect(codes.size >= 8).toBeTruthy();
   for (const code of codes) {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
 import { collectorProcessTitle } from '../collector/ownership.ts';
-import { upsertProject } from '../config.ts';
+import { getProject, upsertProject } from '../config.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { workspaceDir, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import type { WorkspaceState } from '../supervisor/run.ts';
@@ -694,6 +694,21 @@ describe('the cache', () => {
     reserve();
     const { calls } = await run({});
     expect(calls.args.storeBuild.options).toEqual({ overwrite: false, sources: [] });
+  });
+
+  test('a build that follows a failed swap REPLACES the entry that just failed (Android form)', async () => {
+    reserve();
+    const cached = join(root, 'cached', 'Fixture.app');
+    const { exitCode, calls } = await run(
+      { configuration: 'Release' },
+      {
+        resolveBuild: () => cached,
+        swapJsBundle: async () => ({ ok: false, step: 'codesign', reason: 'the seal would not take', lastLines: [] }),
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(calls.order.includes('buildIos')).toBeTruthy();
+    expect(calls.args.storeBuild.options).toEqual({ overwrite: true, sources: [] });
   });
 
   test('a cache store that fails does not fail a successful build', async () => {
@@ -3192,5 +3207,130 @@ describe('an app the simulator already holds', () => {
 
     expect(stderr).not.toMatch(/skipped/);
     expect(parseFirst(logs).installSkipped).toBe(false);
+  });
+});
+
+describe('ios --device: selecting a phone and building the device slice', () => {
+  const PHONE = '00008030-001A2B3C4D5E802E';
+
+  function connected(devices: Array<Record<string, unknown>> = [{ udid: PHONE, name: 'Test Phone' }]) {
+    return {
+      listIosDevices: () =>
+        devices.map((d) => ({
+          udid: PHONE,
+          name: 'Test Phone',
+          bootState: 'booted',
+          developerModeStatus: 'enabled',
+          pairingState: 'paired',
+          transportType: 'wired',
+          ...d,
+        })),
+    };
+  }
+
+  test('--device with an empty udid refuses before anything is spawned', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run({ device: '' }, connected());
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
+    expect(errs.join('\n')).toMatch(/empty UDID/);
+    expect(calls.order.includes('fingerprintProject')).toBe(false);
+  });
+
+  test('--device and --remote together refuse, because they name two different devices', async () => {
+    reserve();
+    const { errs, exitCode } = await run({ device: true, remote: 'proxy' }, connected());
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
+    expect(errs.join('\n')).toMatch(/Pass only one of --device and --remote/);
+  });
+
+  test('no connected phone is STIM_NO_DEVICE, and nothing is created to make one', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run({ device: true }, { listIosDevices: () => [] });
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
+    expect(errs.join('\n')).toMatch(/Developer Mode/);
+    expect(calls.order.includes('ensureOwnedDevice')).toBe(false);
+    expect(calls.order.includes('checkDeviceCapacity')).toBe(false);
+  });
+
+  test('several connected phones refuse with the candidate list', async () => {
+    reserve();
+    const { errs, exitCode } = await run(
+      { device: true },
+      connected([{ udid: PHONE }, { udid: '00008120-000A11223C44201E', name: 'Second' }]),
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
+    expect(errs.join('\n')).toMatch(/stim ios --device <udid>/);
+  });
+
+  test('the one connected phone is used, never owned, and never booted', async () => {
+    reserve();
+    const { calls } = await run({ device: true }, connected());
+    expect(calls.order.includes('ensureOwnedDevice')).toBe(false);
+    expect(calls.order.includes('ensureBooted')).toBe(false);
+    expect(calls.order.includes('checkDeviceCapacity')).toBe(false);
+    expect(getProject(root)?.deviceUdid ?? null).toBe(null);
+  });
+
+  test('the build is the iphoneos slice, keyed -device, and carries no signing flag', async () => {
+    reserve();
+    const { calls } = await run({ device: true, configuration: 'Release' }, connected());
+    const build = calls.args.buildIos as Record<string, unknown>;
+    expect(build?.sdk).toBe('iphoneos');
+    expect(build?.udid).toBe(PHONE);
+    expect(build?.destination).toBe(null);
+    expect(build?.configuration).toBe('Release');
+    const store = calls.args.storeBuild as { key: string };
+    expect(store.key).toBe(`${FINGERPRINT}-release-device`);
+    const lookup = calls.args.resolveBuild as { key: string };
+    expect(lookup.key).toBe(`${FINGERPRINT}-release-device`);
+  });
+
+  test('the simulator path is unchanged and still keys -sim, so no cache entry moves', async () => {
+    reserve();
+    const { calls } = await run({ configuration: 'Release' });
+    const store = calls.args.storeBuild as { key: string };
+    expect(store.key).toBe(`${FINGERPRINT}-release-sim`);
+    const build = calls.args.buildIos as Record<string, unknown>;
+    expect(build?.sdk).toBe(undefined);
+  });
+
+  test('it stops at the install boundary rather than sending a device app to simctl', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run({ device: true }, connected());
+    expect(exitCode).toBe(1);
+    expect(calls.order.includes('buildIos')).toBe(true);
+    expect(calls.order.includes('storeBuild')).toBe(true);
+    expect(calls.order.includes('installIosApp')).toBe(false);
+    expect(calls.order.includes('launchIosApp')).toBe(false);
+    expect(calls.order.includes('replaceCollector')).toBe(false);
+    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
+    expect(errs.join('\n')).toMatch(/not wired yet/);
+    expect(errs.join('\n')).toMatch(new RegExp(`${FINGERPRINT}-debug-device`));
+  });
+
+  test('a malformed ios.lanHost refuses the run before the phone is looked for', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run(
+      { device: true },
+      { ...connected(), resolveSettings: () => ({ ios: { lanHost: 'http://192.168.1.42' } }) },
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
+    expect(errs.join('\n')).toMatch(/Invalid ios\.lanHost/);
+    expect(calls.order.includes('fingerprintProject')).toBe(false);
+  });
+
+  test('a malformed ios.signingIdentitySha1 refuses the same way', async () => {
+    reserve();
+    const { errs, exitCode } = await run(
+      { device: true },
+      { ...connected(), resolveSettings: () => ({ ios: { signingIdentitySha1: 'ABCDEF' } }) },
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/Invalid ios\.signingIdentitySha1/);
   });
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3324,6 +3324,114 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(calls.order.includes('fingerprintProject')).toBe(false);
   });
 
+  test('a device run never touches the Expo provider, in either direction', async () => {
+    reserve();
+    let loadProjectProviderCalls = 0;
+    let resolveRemoteCalls = 0;
+    let uploadCalls = 0;
+    const { calls, errs } = await run(
+      { device: true, configuration: 'Release' },
+      {
+        ...connected(),
+        detectIsExpo: () => true,
+        loadProjectProvider: async () => {
+          loadProjectProviderCalls += 1;
+          return { provider: { plugin: {}, options: {} }, name: 'eas' };
+        },
+        resolveRemote: async () => {
+          resolveRemoteCalls += 1;
+          return { appPath: join(root, 'downloaded', 'Fixture.app') };
+        },
+        uploadRemote: async () => {
+          uploadCalls += 1;
+          return { uploaded: true };
+        },
+      },
+    );
+    expect(loadProjectProviderCalls).toBe(0);
+    expect(resolveRemoteCalls).toBe(0);
+    expect(uploadCalls).toBe(0);
+    expect(calls.order.includes('buildIos')).toBe(true);
+    expect((calls.args.storeBuild as { key: string }).key).toBe(`${FINGERPRINT}-release-device`);
+    expect(errs.join('\n')).toMatch(/local-tier only/);
+  });
+
+  test('a device run never loads the build-cache provider, for the read or the upload', async () => {
+    reserve();
+    let loads = 0;
+    const { calls } = await run(
+      { device: true },
+      {
+        ...connected(),
+        resolveCacheProviderConfig: () => ({ provider: './cache.cjs', options: {}, baseDir: root }),
+        loadCacheProvider: async () => {
+          loads += 1;
+          return { name: './cache.cjs', provider: { builds: {} } };
+        },
+      },
+    );
+    expect(loads).toBe(0);
+    expect(calls.order.filter((c) => ['resolveBuild', 'storeBuild'].includes(c))).toEqual([
+      'resolveBuild',
+      'storeBuild',
+    ]);
+  });
+
+  test('the same providers ARE consulted without --device, so the gate is not vacuous', async () => {
+    reserve();
+    let loadProjectProviderCalls = 0;
+    let resolveRemoteCalls = 0;
+    await run(
+      {},
+      {
+        detectIsExpo: () => true,
+        loadProjectProvider: async () => {
+          loadProjectProviderCalls += 1;
+          return { provider: { plugin: {}, options: {} }, name: 'eas' };
+        },
+        resolveRemote: async () => {
+          resolveRemoteCalls += 1;
+          return null;
+        },
+      },
+    );
+    expect(loadProjectProviderCalls).toBe(1);
+    expect(resolveRemoteCalls).toBe(1);
+
+    let loads = 0;
+    await run(
+      {},
+      {
+        resolveCacheProviderConfig: () => ({ provider: './cache.cjs', options: {}, baseDir: root }),
+        loadCacheProvider: async () => {
+          loads += 1;
+          return { none: true };
+        },
+      },
+    );
+    expect(loads).toBeGreaterThan(0);
+  });
+
+  test('a device release cache hit does not run the JS swap it cannot re-seal yet', async () => {
+    reserve();
+    let swaps = 0;
+    const { calls, errs } = await run(
+      { device: true, configuration: 'Release' },
+      {
+        ...connected(),
+        resolveBuild: () => join(root, 'cached', 'Fixture.app'),
+        swapJsBundle: async () => {
+          swaps += 1;
+          return { ok: true, appPath: join(root, 'js-swap', 'Fixture.app'), tmpDir: null, hermes: true, durationMs: 1 };
+        },
+      },
+    );
+    expect(swaps).toBe(0);
+    expect(calls.order.includes('buildIos')).toBe(false);
+    expect(calls.order.includes('installIosApp')).toBe(false);
+    expect(errs.join('\n')).toMatch(/js swap\s+skipped for --device/);
+  });
+
   test('a malformed ios.signingIdentitySha1 refuses the same way', async () => {
     reserve();
     const { errs, exitCode } = await run(

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3353,13 +3353,13 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(uploadCalls).toBe(0);
     expect(calls.order.includes('buildIos')).toBe(true);
     expect((calls.args.storeBuild as { key: string }).key).toBe(`${FINGERPRINT}-release-device`);
-    expect(errs.join('\n')).toMatch(/local-tier only/);
+    expect(errs.join('\n')).not.toMatch(/local-tier only/);
   });
 
   test('a device run never loads the build-cache provider, for the read or the upload', async () => {
     reserve();
     let loads = 0;
-    const { calls } = await run(
+    const { calls, errs } = await run(
       { device: true },
       {
         ...connected(),
@@ -3375,6 +3375,32 @@ describe('ios --device: selecting a phone and building the device slice', () => 
       'resolveBuild',
       'storeBuild',
     ]);
+    expect(errs.filter((line) => line.includes('local-tier only'))).toHaveLength(1);
+  });
+
+  test('a device run with no provider configured says nothing about providers', async () => {
+    reserve();
+    const { errs } = await run({ device: true }, connected());
+    expect(errs.join('\n')).not.toMatch(/local-tier only/);
+    expect(errs.join('\n')).not.toMatch(/provider/);
+  });
+
+  test('the refusal says what actually happened: built, or restored from the cache', async () => {
+    reserve();
+    const built = await run({ device: true }, connected());
+    expect(built.errs.join('\n')).toMatch(
+      new RegExp(`Built the Debug iphoneos slice[^\n]*and cached it under ${FINGERPRINT}-debug-device`),
+    );
+
+    const restored = await run(
+      { device: true },
+      { ...connected(), resolveBuild: () => join(root, 'cached', 'Fixture.app') },
+    );
+    expect(restored.calls.order.includes('buildIos')).toBe(false);
+    expect(restored.errs.join('\n')).toMatch(
+      new RegExp(`Restored the Debug iphoneos slice[^\n]*from the cache under ${FINGERPRINT}-debug-device`),
+    );
+    expect(restored.errs.join('\n')).not.toMatch(/Built the/);
   });
 
   test('the same providers ARE consulted without --device, so the gate is not vacuous', async () => {

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -9,6 +9,12 @@ import {
   androidDataPartitionSizeBytes,
   androidDataPartitionSizeGbSetting,
   androidDataPartitionSizeGbSettingError,
+  iosLanHostSetting,
+  iosLanHostSettingError,
+  iosSigningIdentitySetting,
+  iosSigningIdentitySettingError,
+  iosSigningIdentitySha1Setting,
+  iosSigningIdentitySha1SettingError,
   iosSimSlimProfileSetting,
   iosSimSlimProfileSettingError,
   mergeSettingsLayers,
@@ -487,4 +493,65 @@ test('cache.provider and cache.options are known settings', () => {
     unknownSettingKeys({ cache: { provider: './cache.cjs', options: { bucket: 'a', nested: { deep: true } } } }),
   ).toEqual([]);
   expect(unknownSettingKeys({ cache: { unknown: true } })).toEqual(['cache.unknown']);
+});
+
+test('ios.signingIdentity reads a trimmed identity name and refuses a shape codesign cannot take', () => {
+  expect(iosSigningIdentitySetting({ ios: { signingIdentity: '  Apple Development: Jane (TEAMID5678)  ' } })).toBe(
+    'Apple Development: Jane (TEAMID5678)',
+  );
+  expect(iosSigningIdentitySetting({})).toBe(null);
+  expect(iosSigningIdentitySetting({ ios: [] })).toBe(null);
+
+  expect(iosSigningIdentitySettingError({})).toBe(null);
+  expect(iosSigningIdentitySettingError({ ios: { signingIdentity: 'Apple Development: Jane' } })).toBe(null);
+  expect(iosSigningIdentitySettingError({ ios: { signingIdentity: '  ' } })).toMatch(/Invalid ios\.signingIdentity/);
+  expect(iosSigningIdentitySettingError({ ios: { signingIdentity: 42 } })).toMatch(/Invalid ios\.signingIdentity/);
+  expect(iosSigningIdentitySettingError({ ios: { signingIdentity: 'two\nlines' } })).toMatch(
+    /Invalid ios\.signingIdentity/,
+  );
+});
+
+test('ios.signingIdentitySha1 takes exactly the 40-hex hash find-identity prints, upper-cased', () => {
+  const sha1 = '3fe19e227ec5bc2ede3ac52ab02ff46920445c6a';
+  expect(iosSigningIdentitySha1Setting({ ios: { signingIdentitySha1: ` ${sha1} ` } })).toBe(sha1.toUpperCase());
+  expect(iosSigningIdentitySha1Setting({})).toBe(null);
+
+  expect(iosSigningIdentitySha1SettingError({})).toBe(null);
+  expect(iosSigningIdentitySha1SettingError({ ios: { signingIdentitySha1: sha1 } })).toBe(null);
+  expect(iosSigningIdentitySha1SettingError({ ios: { signingIdentitySha1: 'ABCDEF' } })).toMatch(
+    /Invalid ios\.signingIdentitySha1/,
+  );
+  expect(iosSigningIdentitySha1SettingError({ ios: { signingIdentitySha1: `${sha1}00` } })).toMatch(
+    /Invalid ios\.signingIdentitySha1/,
+  );
+});
+
+test('ios.lanHost takes a bare address and refuses everything that would break serverRootWithHostPort', () => {
+  expect(iosLanHostSetting({ ios: { lanHost: ' 192.168.1.42 ' } })).toBe('192.168.1.42');
+  expect(iosLanHostSettingError({ ios: { lanHost: ' 192.168.1.42 ' } })).toBe(null);
+  expect(iosLanHostSetting({ ios: { lanHost: 'mac-studio.local' } })).toBe('mac-studio.local');
+  expect(iosLanHostSetting({})).toBe(null);
+
+  expect(iosLanHostSettingError({})).toBe(null);
+  expect(iosLanHostSettingError({ ios: { lanHost: '192.168.1.42' } })).toBe(null);
+  for (const bad of [
+    'http://192.168.1.42',
+    'https://foo.ngrok.app',
+    '192.168.1.42:8085',
+    '192.168.1.42/',
+    'a b',
+    '',
+    42,
+  ]) {
+    expect(iosLanHostSettingError({ ios: { lanHost: bad } })).toMatch(/Invalid ios\.lanHost/);
+  }
+});
+
+test('the three iOS device settings are known keys', () => {
+  expect(
+    unknownSettingKeys({
+      ios: { signingIdentity: 'a', signingIdentitySha1: 'b', lanHost: 'c' },
+    }),
+  ).toEqual([]);
+  expect(unknownSettingKeys({ ios: { lanPort: 1 } })).toEqual(['ios.lanPort']);
 });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -793,11 +793,14 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   with no package.json above it, or an android/app/build.gradle that
   declares product flavors with
   no variant selected (the refusal names the debug variants).
-  \`ios --device\` also refuses HERE after a successful build, because it
-  selects a phone and builds the iphoneos slice for it but cannot yet install
-  onto one; the message names the cache key the artifact was stored under.
   These errors are caught before the port is reserved and before anything is
   spawned, so nothing was started.
+  ONE EXCEPTION, and it is temporary: \`ios --device\` also refuses with this
+  code AFTER a successful build. It selects a phone and builds the iphoneos
+  slice for it, but installing onto hardware is not implemented yet, so the
+  run stops there and the message names the cache key the artifact was stored
+  under -- the build is kept and the next run reuses it. This exception goes
+  away when device install lands; see appandflow/stim#178.
 
 "@stim-cli/metro is not installed ... so bundler and client logs will not be
 captured"  (in metro.ndjson, bare RN)
@@ -1249,14 +1252,23 @@ THE OPTION SURFACE, IN FULL
   hardware -- there is no capacity check, no simulator creation, no boot wait,
   and no device record, so \`stop\` and \`gc\` never see the phone.
 
+  A device build is LOCAL-TIER ONLY. Its cache key is
+  \`<fingerprint>-<configuration>-device\`, so a device app can never collide
+  with the simulator one, and neither the build-cache provider nor the Expo
+  remote cache is read or written on a \`--device\` run: every entry they hold
+  is keyed for the simulator, so consulting them would either install a
+  simulator slice on a phone or publish an iphoneos app under a key simulator
+  builds resolve.
+
   IT IS NOT FINISHED. Today it builds the \`iphoneos\` slice for the selected
-  phone -- \`-sdk iphoneos\`, the project's own signing settings, cache key
-  \`<fingerprint>-<configuration>-device\` so a device app can never collide
-  with a simulator one -- stores that artifact, and then REFUSES with
+  phone -- \`-sdk iphoneos\`, the project's own signing settings, no signing
+  flags on the argv -- stores that artifact, and then REFUSES with
   STIM_BAD_ARG, because installing and launching on hardware are not wired yet
-  (appandflow/stim#178). Use it to prove a project signs for a device and to
-  warm the device cache; use \`stim ios\` with no --device for a run that ends
-  with an app on screen.
+  (appandflow/stim#178). A release cache hit does not run the JS swap either:
+  the swap ends in a signature, and the device re-seal that would make it
+  installable is not wired in yet. Use \`--device\` to prove a project signs
+  for a device and to warm the device cache; use \`stim ios\` with no --device
+  for a run that ends with an app on screen.
 
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -182,8 +182,9 @@ RULES
   - Never assume "booted" is your simulator. Other agents have theirs booted
     too.
   - Every device Stim creates or boots is one Stim created, named
-    stim-<label>. The exception is \`android --device\`, which installs on a
-    connected physical device Stim never creates, boots, or deletes.`,
+    stim-<label>. The exceptions are \`android --device\` and
+    \`ios --device\`, which use a connected physical device Stim never
+    creates, boots, or deletes.`,
   },
 
   metro: {
@@ -592,9 +593,62 @@ STIM_NO_SCHEME
   No buildable Xcode scheme was found in ios/. A scheme has to be shared to be
   visible to xcodebuild.
 
+--- iOS SIGNING CODES (\`ios --device\`, and only there) ---
+
+A simulator build needs no signature, which is why none of these can fire on
+the normal path. A device build carries one, and Stim re-seals any bundle it
+modifies with the identity the bundle already names -- so it checks, before
+spending a build or a bundle, that the check can succeed.
+
+STIM_NO_PROFILE
+  The built or cached .app has no embedded.mobileprovision, or
+  \`security cms -D\` could not decode the one it has. The first means the build
+  produced an unsigned app -- almost always a simulator-sliced artifact.
+  Set a team and a Development profile for the target's configuration in
+  Xcode > Signing & Capabilities, then BUILD ONCE FROM XCODE to install the
+  profile. Stim will not do that step: registering a device or minting a
+  profile changes your Apple Developer account, so Stim never passes
+  -allowProvisioningUpdates.
+
+STIM_PROFILE_MISMATCH
+  The profile inside the app cannot admit this phone. Three shapes, and the
+  message names which one and the profile type it found:
+    - it expired, or carries no ExpirationDate at all;
+    - it is an App Store or enterprise profile, which carries no
+      ProvisionedDevices list -- so Stim cannot PROVE the phone is admitted and
+      refuses rather than guessing. Local device runs need a development
+      profile;
+    - it is a development or ad hoc profile whose device list does not name
+      this UDID. Register the UDID at developer.apple.com, regenerate the
+      profile, and build once from Xcode.
+
+STIM_NO_SIGNING_IDENTITY
+  No single keychain identity could be resolved to re-seal with. Either
+  \`security find-identity -v -p codesigning\` lists nothing, or the identity
+  the artifact's own profile names is absent, or two certificates share that
+  common name and Stim -- being non-interactive -- will not pick one.
+  Open Xcode > Settings > Accounts and download your certificates, or unlock
+  the login keychain with \`security unlock-keychain\`. For the two-certificate
+  case, set ios.signingIdentitySha1 to the SHA-1 hash beside the one you want.
+
+STIM_CODESIGN_FAILED
+  \`codesign --force --sign\` or \`codesign --verify --strict\` exited non-zero
+  on the modified copy. The verbatim codesign stderr is quoted, because it is
+  the answer: a locked login keychain reports errSecInternalComponent, an
+  ambiguous identity reports that it matched more than one. Unlock the keychain
+  and confirm exactly one identity matches the name. The cache entry itself is
+  never modified -- the failure is on a temporary copy, and the run builds
+  fresh.
+
 STIM_NO_DEVICE
-  The owned simulator/emulator could not be created or could not reach a booted
-  state. \`stim doctor\` checks the toolchain; \`stim status\` says what
+  With \`--device\`, no physical device answered the selection: none connected,
+  a named serial/UDID that is not connected, several connected with none named
+  (the refusal lists them), or one that is connected but unusable -- an
+  unauthorized Android device, or an iPhone that is unpaired or has Developer
+  Mode off. Hardware is never created or booted, so there is nothing to retry
+  into existence: fix the cable, the trust prompt, or Developer Mode.
+  Otherwise the owned simulator/emulator could not be created or could not
+  reach a booted state. \`stim doctor\` checks the toolchain; \`stim status\` says what
   Stim thinks it owns. Re-running the command creates a fresh owned device
   when the recorded one is gone.
   On iOS a slow first boot is waited out for up to ten minutes while the
@@ -733,9 +787,15 @@ STIM_SUPERVISOR_EXITED
 STIM_BAD_ARG / STIM_NO_PROJECT
   The command refused before doing anything: an unusable --wait value, an invalid
   Metro tunnel setting, an invalid android.dataPartitionSizeGb value, an unsafe
-  android.avdConfig key or fragment, a working directory with no package.json
-  above it, or an android/app/build.gradle that declares product flavors with
+  android.avdConfig key or fragment, a malformed ios.signingIdentity,
+  ios.signingIdentitySha1 or ios.lanHost value, \`--device\` with an empty
+  serial or UDID, \`--device\` together with \`--remote\`, a working directory
+  with no package.json above it, or an android/app/build.gradle that
+  declares product flavors with
   no variant selected (the refusal names the debug variants).
+  \`ios --device\` also refuses HERE after a successful build, because it
+  selects a phone and builds the iphoneos slice for it but cannot yet install
+  onto one; the message names the cache key the artifact was stored under.
   These errors are caught before the port is reserved and before anything is
   spawned, so nothing was started.
 
@@ -1142,7 +1202,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
 
 THE OPTION SURFACE, IN FULL
   start           --json --wait <seconds> --remote
-  ios             --json --no-metro-check --no-build-cache --configuration <name> --remote <proxy|eas>
+  ios             --json --no-metro-check --no-build-cache --configuration <name> --device [udid] --remote <proxy|eas>
   android         --json --no-metro-check --no-build-cache --variant <name> --device [serial] --remote <proxy|eas>
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
@@ -1180,6 +1240,23 @@ THE OPTION SURFACE, IN FULL
   so \`stop\` and \`gc\` never touch the phone. The app is pointed at
   localhost:<port>, which the adb reverse serves, instead of the emulator's
   10.0.2.2. Stim never creates, boots, shuts down, or deletes hardware.
+
+  \`ios --device [udid]\` selects a connected iPhone, the same way
+  \`android --device\` selects a connected phone: with no UDID the one
+  connected device is used, several is a refusal listing them, and an iPhone
+  that is unpaired or has Developer Mode off is refused with the fix. It
+  cannot be combined with --remote, and it never creates, boots, or deletes
+  hardware -- there is no capacity check, no simulator creation, no boot wait,
+  and no device record, so \`stop\` and \`gc\` never see the phone.
+
+  IT IS NOT FINISHED. Today it builds the \`iphoneos\` slice for the selected
+  phone -- \`-sdk iphoneos\`, the project's own signing settings, cache key
+  \`<fingerprint>-<configuration>-device\` so a device app can never collide
+  with a simulator one -- stores that artifact, and then REFUSES with
+  STIM_BAD_ARG, because installing and launching on hardware are not wired yet
+  (appandflow/stim#178). Use it to prove a project signs for a device and to
+  warm the device cache; use \`stim ios\` with no --device for a run that ends
+  with an app on screen.
 
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second
@@ -1250,8 +1327,10 @@ THE OPTION SURFACE, IN FULL
   re-signs it and installs that; any swap failure falls back to a full build
   rather than ever installing stale JS. Device logs are still collected, so
   \`logs --errors\` answers "does it repro in release/Hermes bytecode".
-  Simulator only -- device builds, signing and distribution stay out of
-  scope.
+  A run with no \`--device\` installs on the simulator only. \`ios --device\`
+  builds the \`iphoneos\` slice for a cabled iPhone and keys its cache
+  \`-device\` instead of \`-sim\`, but does not install it yet. Archives,
+  \`.ipa\` export, store signing and distribution stay out of scope.
 
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
@@ -1493,6 +1572,31 @@ KEYS STIM READS
                         symlink escapes, and missing files are refused before
                         simulator creation. Remote and unowned simulators are
                         never changed.
+  ios.signingIdentity   e.g. "Apple Development: Jane (TEAMID5678)" -- the
+                        keychain identity to re-seal a \`--device\` build with,
+                        overriding the one Stim derives from the artifact's own
+                        embedded.mobileprovision. Discovery is zero-config, so
+                        this exists only for the case discovery cannot cover.
+                        The name must be one \`security find-identity -v -p
+                        codesigning\` prints.
+  ios.signingIdentitySha1
+                        the 40-character hex SHA-1 hash printed beside that
+                        name. Set it when two certificates share one common
+                        name: Stim is non-interactive, so it refuses an
+                        ambiguous identity rather than picking one. It wins
+                        over ios.signingIdentity.
+  ios.lanHost           e.g. "192.168.1.42" -- the address a phone uses to
+                        reach this workspace's Metro on an \`ios --device\`
+                        Debug run, pinning the interface on a multi-NIC Mac
+                        whose en0 is not the one the phone shares. A bare
+                        address or hostname ONLY: never a scheme, a port, or a
+                        URL, because the channels that carry it to the phone
+                        (the dev-client deep link and the bundle's ip.txt)
+                        compose the URL themselves. Unset means Stim orders the
+                        host's non-internal IPv4 interfaces en0 first, then the
+                        remaining en* by index -- react-native-xcode.sh's own
+                        heuristic, so Stim and a plain Xcode run pick the same
+                        interface.
   android.systemImage   e.g. "system-images;android-36;google_apis;arm64-v8a"
   android.dataPartitionSizeGb
                         whole GiB for a newly created owned AVD's data

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1233,7 +1233,8 @@ async function finishIosRun({
     return fail({
       code: 'STIM_BAD_ARG',
       message:
-        `Built the ${configuration || 'Debug'} iphoneos slice for ${deviceLabel(device, udid)} and cached it under ${storeKey}, ` +
+        `${cacheHit ? 'Restored' : 'Built'} the ${configuration || 'Debug'} iphoneos slice for ` +
+        `${deviceLabel(device, udid)} ${cacheHit ? 'from the cache under' : 'and cached it under'} ${storeKey}, ` +
         'but installing and launching on a phone are not wired yet.',
       remedy:
         'Device install and launch land with appandflow/stim#178. Run `stim ios` without --device to install on this workspace owned simulator.',
@@ -1770,10 +1771,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   }
 
   async function resolveRemoteArtifact(): Promise<void> {
-    if (physical) {
-      if (!appPath) note(chalk.dim(phaseLine('cache', PROVIDER_SKIPPED_ON_DEVICE)));
-      return;
-    }
+    if (physical) return;
     if (!appPath) {
       const loaded: LoadProjectProviderResult = await d.loadProjectProvider(root, { isExpo });
       if (loaded?.unavailable) {

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -64,6 +64,7 @@ import {
   remoteIosDeps,
   resolveRemoteContext,
 } from '../engine/device-remote.ts';
+import { listIosDevices, resolveIosPhysicalDevice } from '../engine/ios-device.ts';
 import { detectProviders } from '../engine/metro-reach.ts';
 import { ownedSessionName } from '../engine/eas-simulator.ts';
 import { type Diagnostic, describeDiagnostic } from '../engine/errors-xcode.ts';
@@ -98,6 +99,9 @@ import { ensureWorkspaceStorage, workspaceDir, workspaceLogsDir } from '../paths
 import { detectBundleId, detectIsExpo, findProjectRoot, isPackageResolvable, projectShortcut } from '../project.ts';
 import {
   cacheProviderSettingError,
+  iosLanHostSettingError,
+  iosSigningIdentitySettingError,
+  iosSigningIdentitySha1SettingError,
   publicUrlSetting,
   REMOTE_DEVICE_BACKENDS,
   remoteDeviceSettingError,
@@ -125,6 +129,7 @@ export const PLATFORM = 'ios';
 
 // xcodebuild cannot target a remote simulator UDID, so remote builds use the generic destination.
 const GENERIC_SIM_DESTINATION = 'generic/platform=iOS Simulator';
+const IPHONEOS_SDK = 'iphoneos';
 
 interface DeviceLike {
   deviceName?: string | null;
@@ -199,6 +204,7 @@ interface IosCommandOptions {
   metroCheck?: boolean;
   buildCache?: boolean;
   configuration?: string;
+  device?: string | boolean;
   remote?: RemoteDeviceBackend;
 }
 
@@ -697,6 +703,7 @@ interface IosDeps {
   podsAreStale: typeof podsAreStale;
   runPodInstall: typeof runPodInstall;
   buildIos: typeof buildIos;
+  listIosDevices: typeof listIosDevices;
   readBundleId: typeof readBundleId;
   swapJsBundle: typeof swapJsBundle;
   installIosApp: typeof installIosApp;
@@ -756,6 +763,7 @@ const DEFAULT_DEPS: IosDeps = {
   podsAreStale,
   runPodInstall,
   buildIos,
+  listIosDevices,
   readBundleId,
   swapJsBundle,
   installIosApp,
@@ -788,7 +796,13 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     )
     .option(
       '--configuration <name>',
-      'Xcode configuration to build (e.g. Release; simulator only). A non-Debug configuration embeds the JS bundle and skips Metro entirely. Overrides the ios.configuration setting. Default: Debug',
+      'Xcode configuration to build (e.g. Release). A non-Debug configuration embeds the JS bundle and skips Metro entirely. Overrides the ios.configuration setting. Default: Debug',
+    )
+    .option(
+      '--device [udid]',
+      "Build the iphoneos slice for a connected iPhone instead of this workspace's owned simulator. With no UDID, " +
+        'the one connected device is used. Stim never creates, boots, or deletes a physical device. ' +
+        'Installing and launching on hardware are not wired yet (appandflow/stim#178), so the run stops after the build.',
     )
     .option(
       '--remote <backend>',
@@ -1113,6 +1127,7 @@ interface FinishIosRunArgs {
   logFile: string;
   device: DeviceLike;
   udid: string;
+  physical: boolean;
   remoteDevice: ReturnType<IosDeps['remoteIosDeps']> | null;
   bootPromise: Promise<IosBootLike | null | undefined>;
   bootDuration: () => string;
@@ -1153,6 +1168,7 @@ async function finishIosRun({
   logFile,
   device,
   udid,
+  physical,
   remoteDevice,
   bootPromise,
   bootDuration,
@@ -1203,7 +1219,23 @@ async function finishIosRun({
       remedy: booted?.remedy || 'Run `stim ios` again to re-establish an owned simulator for this workspace.',
     });
   }
-  phase('device', `${deviceLabel(device, udid)} booted ${bootDuration()}`);
+  phase('device', `${deviceLabel(device, udid)} ${physical ? 'connected' : `booted ${bootDuration()}`}`);
+
+  if (physical) {
+    if (swapDir) {
+      try {
+        rmSync(swapDir, { recursive: true, force: true });
+      } catch {}
+    }
+    return fail({
+      code: 'STIM_BAD_ARG',
+      message:
+        `Built the ${configuration || 'Debug'} iphoneos slice for ${deviceLabel(device, udid)} and cached it under ${storeKey}, ` +
+        'but installing and launching on a phone are not wired yet.',
+      remedy:
+        'Device install and launch land with appandflow/stim#178. Run `stim ios` without --device to install on this workspace owned simulator.',
+    });
+  }
 
   const scheme = release ? undefined : d.devClientScheme(root, appPath);
   const installTimer = stepTimer(d.now);
@@ -1428,11 +1460,42 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     });
   }
 
+  for (const settingError of [
+    iosSigningIdentitySettingError(settings),
+    iosSigningIdentitySha1SettingError(settings),
+    iosLanHostSettingError(settings),
+  ]) {
+    if (settingError) {
+      return fail({
+        code: 'STIM_BAD_ARG',
+        message: settingError,
+        remedy: 'Run `stim guide settings` for the shape each ios.* key takes.',
+      });
+    }
+  }
+
   const configuration = resolveConfiguration(opts.configuration, settings);
   const release = isReleaseConfiguration(configuration);
 
+  const deviceFlag = opts.device;
+  const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;
+  if (physical && deviceFlag === '') {
+    return fail({
+      code: 'STIM_BAD_ARG',
+      message: '--device was given an empty UDID.',
+      remedy: 'Pass `--device` on its own to use the one connected device, or `--device <udid>` to name one.',
+    });
+  }
+  if (physical && opts.remote) {
+    return fail({
+      code: 'STIM_BAD_ARG',
+      message: '--device builds for a phone cabled to this machine, and --remote installs on a remote one.',
+      remedy: 'Pass only one of --device and --remote.',
+    });
+  }
+
   const isExpo = d.detectIsExpo(root);
-  const remoteBackend = opts.remote ?? remoteIosSetting(settings);
+  const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
   const registerProject = () => d.upsertProject(root, { bundleId: d.detectBundleId(root) ?? undefined, isExpo });
   if (remoteBackend !== 'eas') registerProject();
   const proj = d.getProject(root);
@@ -1462,35 +1525,50 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
 
   const limits = d.getConcurrencyLimits();
 
-  const capacity = d.checkDeviceCapacity({
-    platform: PLATFORM,
-    project: proj,
-    max: limits.maxDevices,
-  });
-  if (capacity) return fail(capacity);
+  let physicalDevice: { udid: string; name: string } | null = null;
+  if (physical) {
+    const resolved = resolveIosPhysicalDevice(typeof deviceFlag === 'string' ? deviceFlag : null, d.listIosDevices());
+    if (!resolved.udid) {
+      return fail({ code: 'STIM_NO_DEVICE', message: resolved.error!, remedy: resolved.remedy! });
+    }
+    physicalDevice = { udid: resolved.udid, name: resolved.name ?? resolved.udid };
+  } else {
+    const capacity = d.checkDeviceCapacity({
+      platform: PLATFORM,
+      project: proj,
+      max: limits.maxDevices,
+    });
+    if (capacity) return fail(capacity);
+  }
 
   let metroPort = proj?.metroPort ?? null;
   if (!(await resolveMetroPort())) return null;
 
   let device: Awaited<ReturnType<typeof ensureOwnedDevice>>;
-  try {
-    device = await d.ensureOwnedDevice({
-      platform: PLATFORM,
-      project: proj,
-      projectPath: root,
-      settingsRoot: settingsRepoRoot ?? root,
-      label,
-      settings,
-      flags: {},
-      note,
-      out: note,
-    });
-  } catch (e) {
-    return fail({
-      code: 'STIM_NO_DEVICE',
-      message: `Could not ensure an owned iOS simulator: ${(e as Error)?.message || e}`,
-      remedy: 'Run `stim doctor` to check the simulator toolchain, then try again.',
-    });
+  if (physicalDevice) {
+    device = { deviceUdid: physicalDevice.udid, deviceName: physicalDevice.name, owned: false } as Awaited<
+      ReturnType<typeof ensureOwnedDevice>
+    >;
+  } else {
+    try {
+      device = await d.ensureOwnedDevice({
+        platform: PLATFORM,
+        project: proj,
+        projectPath: root,
+        settingsRoot: settingsRepoRoot ?? root,
+        label,
+        settings,
+        flags: {},
+        note,
+        out: note,
+      });
+    } catch (e) {
+      return fail({
+        code: 'STIM_NO_DEVICE',
+        message: `Could not ensure an owned iOS simulator: ${(e as Error)?.message || e}`,
+        remedy: 'Run `stim doctor` to check the simulator toolchain, then try again.',
+      });
+    }
   }
 
   let bootDuration = '';
@@ -1518,6 +1596,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     : null;
   let waitedForBuild: WaitedForBuild | null = null;
   let swapDir: string | null = null;
+  let swapFellBack = false;
   let buildFailure: BuildFailureFields = {};
 
   async function resolveMetroPort(): Promise<boolean> {
@@ -1582,10 +1661,12 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   async function resolveInitialFingerprint(): Promise<boolean> {
     const bootTimer = stepTimer(d.now);
     const boot = (): Promise<IosBootLike> =>
-      Promise.resolve(d.ensureBooted({ platform: PLATFORM, device, out: note })).catch((e) => ({
-        ok: false,
-        reason: String((e as Error)?.message || e),
-      }));
+      physicalDevice
+        ? Promise.resolve({ ok: true, udid: physicalDevice.udid })
+        : Promise.resolve(d.ensureBooted({ platform: PLATFORM, device, out: note })).catch((e) => ({
+            ok: false,
+            reason: String((e as Error)?.message || e),
+          }));
     bootPromise = (
       remoteDevice?.ctx.backend === 'eas'
         ? d.ensureRemoteBootOwned({
@@ -1630,7 +1711,10 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       return false;
     }
     fingerprint = computedFingerprint;
-    cacheKey = buildCacheKey(PLATFORM, fingerprint, configuration ? { configuration } : {});
+    cacheKey = buildCacheKey(PLATFORM, fingerprint, {
+      ...(configuration ? { configuration } : {}),
+      isSimulator: !physical,
+    });
     storeHash = fingerprint;
     storeKey = cacheKey;
     storeSources = fingerprintSources;
@@ -1827,6 +1911,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       ),
     );
     for (const line of swap?.lastLines ?? []) note(chalk.dim(phaseLine('', line)));
+    swapFellBack = true;
     return null;
   };
 
@@ -1911,7 +1996,10 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
           if (after?.moved) {
             storeHash = after.hash;
             storeSources = after.sources;
-            storeKey = buildCacheKey(PLATFORM, after.hash, configuration ? { configuration } : {});
+            storeKey = buildCacheKey(PLATFORM, after.hash, {
+              ...(configuration ? { configuration } : {}),
+              isSimulator: !physical,
+            });
             note(
               chalk.dim(
                 phaseLine(
@@ -1943,6 +2031,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             root,
             udid,
             destination: remoteDevice ? GENERIC_SIM_DESTINATION : null,
+            ...(physical ? { sdk: IPHONEOS_SDK } : {}),
             logWriter: logWriter(),
             ...(configuration ? { configuration } : {}),
           });
@@ -1970,7 +2059,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
               loadProvider,
               target: { projectRoot: root, platform: PLATFORM, key: storeKey },
               sourcePath: appPath!,
-              overwrite: !useBuildCache,
+              overwrite: !useBuildCache || swapFellBack,
               warn: cacheWarn,
             });
             providerUpload = stored.providerUpload;
@@ -2018,6 +2107,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     logFile,
     device,
     udid,
+    physical,
     remoteDevice,
     bootPromise,
     bootDuration: () => bootDuration,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -131,6 +131,9 @@ export const PLATFORM = 'ios';
 const GENERIC_SIM_DESTINATION = 'generic/platform=iOS Simulator';
 const IPHONEOS_SDK = 'iphoneos';
 
+const PROVIDER_SKIPPED_ON_DEVICE =
+  'a device build is local-tier only: its cache key names the iphoneos slice, and a remote or provider entry is keyed for the simulator';
+
 interface DeviceLike {
   deviceName?: string | null;
   name?: string | null;
@@ -1591,9 +1594,13 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   let providerName: string | null = null;
   let providerLoad: Promise<LoadCacheProviderResult> | null = null;
   const cacheWarn = createWarnOnce((line) => note(chalk.yellow(phaseLine('cache', line))));
-  const loadProvider = cacheProviderConfig
-    ? () => (providerLoad ??= d.loadCacheProvider({ projectRoot: root, config: cacheProviderConfig }))
-    : null;
+  const loadProvider =
+    cacheProviderConfig && !physical
+      ? () => (providerLoad ??= d.loadCacheProvider({ projectRoot: root, config: cacheProviderConfig }))
+      : null;
+  if (cacheProviderConfig && physical) {
+    note(chalk.dim(phaseLine('cache', PROVIDER_SKIPPED_ON_DEVICE)));
+  }
   let waitedForBuild: WaitedForBuild | null = null;
   let swapDir: string | null = null;
   let swapFellBack = false;
@@ -1763,6 +1770,10 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   }
 
   async function resolveRemoteArtifact(): Promise<void> {
+    if (physical) {
+      if (!appPath) note(chalk.dim(phaseLine('cache', PROVIDER_SKIPPED_ON_DEVICE)));
+      return;
+    }
     if (!appPath) {
       const loaded: LoadProjectProviderResult = await d.loadProjectProvider(root, { isExpo });
       if (loaded?.unavailable) {
@@ -1890,6 +1901,14 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
 
   const installableCachedApp = async (cachedPath: string): Promise<string | null> => {
     if (!release) return cachedPath;
+    if (physical) {
+      phase(
+        'js swap',
+        `skipped for --device: the device swap re-seals with the artifact's own identity, which is not built yet, ` +
+          'so this run stops before installing rather than injecting JS under an ad-hoc signature',
+      );
+      return cachedPath;
+    }
     phase('js swap', `regenerating this workspace's JS for the cached ${configuration} app`);
     const swap = await d.swapJsBundle({ root, isExpo, cachedAppPath: cachedPath, logWriter: logWriter() });
     if (swap?.ok && swap.appPath) {
@@ -2068,7 +2087,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             note(chalk.yellow(`Could not store the build in the shared cache: ${(e as Error)?.message || e}`));
           }
 
-          if (remote) {
+          if (remote && !physical) {
             uploadPending = d.uploadRemote({
               logWriter: logWriter(),
               provider: remote.provider,

--- a/packages/stim-cli/src/engine/errors-xcode.ts
+++ b/packages/stim-cli/src/engine/errors-xcode.ts
@@ -43,7 +43,13 @@ const NO_SUCH_SCHEME = /does not contain a scheme named/;
 // wrong node kind. See appandflow/stim#138.
 const CAS_CORRUPT = /not a IncludeTreeRoot node kind/;
 
-function remedyFor(message: string, root: string | null): string | null {
+const DEVICE_SIGNING_REMEDY =
+  "Set a team and a Development profile for the target's configuration in Xcode > Signing & Capabilities, then build once from Xcode to install the profile. Stim never passes -allowProvisioningUpdates, because registering a device or minting a profile changes your Apple Developer account.";
+
+const SIMULATOR_SIGNING_REMEDY =
+  "Stim builds for the simulator here, which needs no signing. Check CODE_SIGNING_REQUIRED / DEVELOPMENT_TEAM in the target's configuration, or build for a phone with `stim ios --device`.";
+
+function remedyFor(message: string, root: string | null, sdk: string): string | null {
   if (CAS_CORRUPT.test(message)) {
     return 'The compilation cache holds a damaged object. Run `stim gc --delete --cache "compilation cache"` to empty that cache, then build again. The next build is a cold one.';
   }
@@ -56,7 +62,7 @@ function remedyFor(message: string, root: string | null): string | null {
   }
   for (const pattern of SIGNING) {
     if (pattern.test(message)) {
-      return "Stim builds Debug for the simulator, which needs no signing. Check CODE_SIGNING_REQUIRED / DEVELOPMENT_TEAM in the target's Debug configuration.";
+      return sdk.startsWith('iphoneos') ? DEVICE_SIGNING_REMEDY : SIMULATOR_SIGNING_REMEDY;
     }
   }
   return null;
@@ -86,6 +92,7 @@ function makeDiagnostic(
     message: string;
   },
   root: string | null,
+  sdk: string,
 ): Diagnostic {
   const text = String(message).trim();
   const out: Diagnostic = { message: text };
@@ -93,7 +100,7 @@ function makeDiagnostic(
   if (line !== null && line !== undefined) out.line = line;
   if (column !== null && column !== undefined) out.column = column;
   out.message = text;
-  const remedy = remedyFor(text, root);
+  const remedy = remedyFor(text, root, sdk);
   if (remedy) out.remedy = remedy;
   return out;
 }
@@ -102,7 +109,11 @@ function dedupeKey(d: Diagnostic): string {
   return `${d.file || ''}|${d.line || ''}|${d.column || ''}|${d.message}`;
 }
 
-export function extractXcodeDiagnostics(transcript: string, root: string | null = null): Diagnostic[] {
+export function extractXcodeDiagnostics(
+  transcript: string,
+  root: string | null = null,
+  sdk: string = 'iphonesimulator',
+): Diagnostic[] {
   if (typeof transcript !== 'string' || transcript === '') return [];
 
   const lines = transcript.split('\n');
@@ -129,7 +140,7 @@ export function extractXcodeDiagnostics(transcript: string, root: string | null 
         const sym = UNDEFINED_SYMBOL.exec(symLine.replace(/\r$/, ''));
         if (sym) {
           const symbol = sym[1];
-          if (symbol !== undefined) push(makeDiagnostic({ message: undefinedSymbolMessage(symbol) }, root));
+          if (symbol !== undefined) push(makeDiagnostic({ message: undefinedSymbolMessage(symbol) }, root, sdk));
           continue;
         }
         if (/^\s+\S/.test(symLine) && !/^\S/.test(symLine)) continue;
@@ -141,7 +152,7 @@ export function extractXcodeDiagnostics(transcript: string, root: string | null 
 
     const ld = LD_ERROR.exec(raw);
     if (ld) {
-      push(makeDiagnostic({ message: `ld: ${ld[1]}` }, root));
+      push(makeDiagnostic({ message: `ld: ${ld[1]}` }, root, sdk));
       continue;
     }
 
@@ -158,6 +169,7 @@ export function extractXcodeDiagnostics(transcript: string, root: string | null 
             message: posMsg,
           },
           root,
+          sdk,
         ),
       );
       continue;
@@ -167,7 +179,7 @@ export function extractXcodeDiagnostics(transcript: string, root: string | null 
     if (plain) {
       const plainMsg = plain[2];
       if (plainMsg === undefined) continue;
-      push(makeDiagnostic({ file: fileFromPrefix(plain[1] || ''), message: plainMsg }, root));
+      push(makeDiagnostic({ file: fileFromPrefix(plain[1] || ''), message: plainMsg }, root, sdk));
     }
   }
 

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -77,9 +77,26 @@ export interface ResolvedIosDevice {
 const DEVELOPER_MODE_REMEDY =
   'Turn on Settings > Privacy & Security > Developer Mode on the phone, restart it, then reconnect.';
 const PAIRING_REMEDY = 'Unlock the phone, tap Trust on the pairing prompt, then reconnect the cable.';
+const CABLE_REMEDY = 'Connect the phone with a cable and check `xcrun devicectl list devices`, then retry.';
+
+// devicectl reports transportType 'wired' for a cabled device and 'localNetwork'
+// for one it reached over Wi-Fi. v1 installs over the cable only, so a device
+// paired only over the network is not a candidate.
+const WIRED_TRANSPORTS = new Set(['wired', 'usb']);
+
+function isWired(device: IosDeviceEntry): boolean {
+  return device.transportType === null || WIRED_TRANSPORTS.has(device.transportType.toLowerCase());
+}
 
 function describe(device: IosDeviceEntry): string {
   return `${device.udid} (${device.name})`;
+}
+
+function wirelessRefusal(device: IosDeviceEntry): ResolvedIosDevice {
+  return {
+    error: `${describe(device)} is paired over ${device.transportType}, not a cable, and Stim installs over the cable only.`,
+    remedy: CABLE_REMEDY,
+  };
 }
 
 function unhealthy(device: IosDeviceEntry): ResolvedIosDevice | null {
@@ -99,27 +116,33 @@ function unhealthy(device: IosDeviceEntry): ResolvedIosDevice | null {
 }
 
 export function resolveIosPhysicalDevice(requested: string | null, devices: IosDeviceEntry[]): ResolvedIosDevice {
-  const connected = Array.isArray(devices) ? devices : [];
+  const listed = Array.isArray(devices) ? devices : [];
+  const cabled = listed.filter(isWired);
+  const wireless = listed.filter((d) => !isWired(d));
   if (requested) {
-    const match = connected.find((d) => d.udid.toLowerCase() === requested.toLowerCase());
+    const match = cabled.find((d) => d.udid.toLowerCase() === requested.toLowerCase());
     if (match) return unhealthy(match) ?? { udid: match.udid, name: match.name };
+    const overNetwork = wireless.find((d) => d.udid.toLowerCase() === requested.toLowerCase());
+    if (overNetwork) return wirelessRefusal(overNetwork);
     return {
-      error: connected.length
-        ? `${requested} is not connected. devicectl reports these devices: ${connected.map(describe).join(', ')}.`
-        : `${requested} is not connected, and devicectl reports no device at all.`,
+      error: cabled.length
+        ? `${requested} is not connected. devicectl reports these cabled devices: ${cabled.map(describe).join(', ')}.`
+        : `${requested} is not connected by cable, and devicectl reports no cabled device at all.`,
       remedy: 'Check the cable and `xcrun devicectl list devices`, then retry with a UDID it lists.',
     };
   }
-  if (connected.length === 1) {
-    const only = connected[0]!;
+  if (cabled.length === 1) {
+    const only = cabled[0]!;
     return unhealthy(only) ?? { udid: only.udid, name: only.name };
   }
-  if (connected.length > 1) {
+  if (cabled.length > 1) {
     return {
-      error: `Several devices are connected: ${connected.map(describe).join(', ')}.`,
+      error: `Several devices are connected: ${cabled.map(describe).join(', ')}.`,
       remedy: 'Name the one to build for with `stim ios --device <udid>`.',
     };
   }
+  const onlyWireless = wireless[0];
+  if (onlyWireless) return wirelessRefusal(onlyWireless);
   return {
     error: 'No physical iOS device is connected.',
     remedy:

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getExecutor, type Executor } from '../exec.ts';
+
+const DEVICECTL_TIMEOUT_MS = 30_000;
+
+export interface IosDeviceEntry {
+  udid: string;
+  name: string;
+  bootState: string | null;
+  developerModeStatus: string | null;
+  pairingState: string | null;
+  transportType: string | null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+export function parseDevicectlDevices(payload: unknown): IosDeviceEntry[] {
+  let data: unknown = payload;
+  if (typeof payload === 'string') {
+    try {
+      data = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+  }
+  const devices = record(record(data).result).devices;
+  if (!Array.isArray(devices)) return [];
+  const out: IosDeviceEntry[] = [];
+  for (const raw of devices) {
+    const entry = record(raw);
+    const hardware = record(entry.hardwareProperties);
+    const properties = record(entry.deviceProperties);
+    const connection = record(entry.connectionProperties);
+    const udid = text(hardware.udid);
+    if (!udid) continue;
+    out.push({
+      udid,
+      name: text(properties.name) ?? udid,
+      bootState: text(properties.bootState),
+      developerModeStatus: text(properties.developerModeStatus),
+      pairingState: text(connection.pairingState),
+      transportType: text(connection.transportType),
+    });
+  }
+  return out;
+}
+
+export function listIosDevices({ exec = null }: { exec?: Executor | null } = {}): IosDeviceEntry[] {
+  const executor = exec || getExecutor();
+  const dir = mkdtempSync(join(tmpdir(), 'stim-devicectl-'));
+  const out = join(dir, 'devices.json');
+  try {
+    executor.runFile('xcrun', ['devicectl', 'list', 'devices', '-j', out], { timeoutMs: DEVICECTL_TIMEOUT_MS });
+    return parseDevicectlDevices(readFileSync(out, 'utf-8'));
+  } catch {
+    return [];
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export interface ResolvedIosDevice {
+  udid?: string;
+  name?: string;
+  error?: string;
+  remedy?: string;
+}
+
+const DEVELOPER_MODE_REMEDY =
+  'Turn on Settings > Privacy & Security > Developer Mode on the phone, restart it, then reconnect.';
+const PAIRING_REMEDY = 'Unlock the phone, tap Trust on the pairing prompt, then reconnect the cable.';
+
+function describe(device: IosDeviceEntry): string {
+  return `${device.udid} (${device.name})`;
+}
+
+function unhealthy(device: IosDeviceEntry): ResolvedIosDevice | null {
+  if (device.pairingState !== null && device.pairingState.toLowerCase() !== 'paired') {
+    return {
+      error: `${describe(device)} is connected but ${device.pairingState}, so devicectl cannot drive it.`,
+      remedy: PAIRING_REMEDY,
+    };
+  }
+  if (device.developerModeStatus !== null && device.developerModeStatus.toLowerCase() !== 'enabled') {
+    return {
+      error: `${describe(device)} has Developer Mode ${device.developerModeStatus}, so it will not run a development build.`,
+      remedy: DEVELOPER_MODE_REMEDY,
+    };
+  }
+  return null;
+}
+
+export function resolveIosPhysicalDevice(requested: string | null, devices: IosDeviceEntry[]): ResolvedIosDevice {
+  const connected = Array.isArray(devices) ? devices : [];
+  if (requested) {
+    const match = connected.find((d) => d.udid.toLowerCase() === requested.toLowerCase());
+    if (match) return unhealthy(match) ?? { udid: match.udid, name: match.name };
+    return {
+      error: connected.length
+        ? `${requested} is not connected. devicectl reports these devices: ${connected.map(describe).join(', ')}.`
+        : `${requested} is not connected, and devicectl reports no device at all.`,
+      remedy: 'Check the cable and `xcrun devicectl list devices`, then retry with a UDID it lists.',
+    };
+  }
+  if (connected.length === 1) {
+    const only = connected[0]!;
+    return unhealthy(only) ?? { udid: only.udid, name: only.name };
+  }
+  if (connected.length > 1) {
+    return {
+      error: `Several devices are connected: ${connected.map(describe).join(', ')}.`,
+      remedy: 'Name the one to build for with `stim ios --device <udid>`.',
+    };
+  }
+  return {
+    error: 'No physical iOS device is connected.',
+    remedy:
+      'Plug the phone in, unlock it, tap Trust, turn on Settings > Privacy & Security > Developer Mode, then check `xcrun devicectl list devices`.',
+  };
+}

--- a/packages/stim-cli/src/engine/ios-profile.ts
+++ b/packages/stim-cli/src/engine/ios-profile.ts
@@ -1,0 +1,366 @@
+import { X509Certificate } from 'node:crypto';
+
+export type PlistValue = string | number | boolean | Date | Buffer | PlistValue[] | { [key: string]: PlistValue };
+
+interface Cursor {
+  xml: string;
+  pos: number;
+}
+
+interface Tag {
+  name: string;
+  closing: boolean;
+  selfClosing: boolean;
+  end: number;
+}
+
+const TAG = /<(\/?)\s*([A-Za-z0-9_]+)(?:\s[^>]*?)?(\/?)>/g;
+
+const ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+function decodeEntities(raw: string): string {
+  return raw.replace(/&(#x?[0-9A-Fa-f]+|[a-z]+);/g, (match, body: string) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) return String.fromCodePoint(Number.parseInt(body.slice(2), 16));
+    if (body.startsWith('#')) return String.fromCodePoint(Number.parseInt(body.slice(1), 10));
+    return ENTITIES[body] ?? match;
+  });
+}
+
+function peekTag(cursor: Cursor): Tag | null {
+  TAG.lastIndex = cursor.pos;
+  const match = TAG.exec(cursor.xml);
+  if (!match) return null;
+  return {
+    name: (match[2] ?? '').toLowerCase(),
+    closing: match[1] === '/',
+    selfClosing: match[3] === '/',
+    end: TAG.lastIndex,
+  };
+}
+
+function takeTag(cursor: Cursor): Tag | null {
+  const tag = peekTag(cursor);
+  if (tag) cursor.pos = tag.end;
+  return tag;
+}
+
+function takeText(cursor: Cursor, name: string): string {
+  const close = cursor.xml.indexOf(`</${name}>`, cursor.pos);
+  if (close < 0) {
+    cursor.pos = cursor.xml.length;
+    return '';
+  }
+  const raw = cursor.xml.slice(cursor.pos, close);
+  cursor.pos = close + name.length + 3;
+  return raw;
+}
+
+function parseValue(cursor: Cursor): PlistValue | undefined {
+  const tag = takeTag(cursor);
+  if (!tag || tag.closing) return undefined;
+  if (tag.selfClosing) {
+    if (tag.name === 'true') return true;
+    if (tag.name === 'false') return false;
+    if (tag.name === 'array') return [];
+    if (tag.name === 'dict') return {};
+    return '';
+  }
+  switch (tag.name) {
+    case 'plist': {
+      const inner = parseValue(cursor);
+      return inner;
+    }
+    case 'dict': {
+      const out: { [key: string]: PlistValue } = {};
+      for (;;) {
+        const next = peekTag(cursor);
+        if (!next) break;
+        if (next.closing) {
+          cursor.pos = next.end;
+          break;
+        }
+        cursor.pos = next.end;
+        if (next.name !== 'key') continue;
+        const key = decodeEntities(next.selfClosing ? '' : takeText(cursor, 'key'));
+        const value = parseValue(cursor);
+        if (value !== undefined) out[key] = value;
+      }
+      return out;
+    }
+    case 'array': {
+      const out: PlistValue[] = [];
+      for (;;) {
+        const next = peekTag(cursor);
+        if (!next) break;
+        if (next.closing) {
+          cursor.pos = next.end;
+          break;
+        }
+        const value = parseValue(cursor);
+        if (value === undefined) break;
+        out.push(value);
+      }
+      return out;
+    }
+    case 'string':
+    case 'key':
+      return decodeEntities(takeText(cursor, tag.name));
+    case 'integer':
+      return Number.parseInt(takeText(cursor, 'integer').trim(), 10);
+    case 'real':
+      return Number.parseFloat(takeText(cursor, 'real').trim());
+    case 'date':
+      return new Date(takeText(cursor, 'date').trim());
+    case 'data':
+      return Buffer.from(takeText(cursor, 'data').replace(/\s+/g, ''), 'base64');
+    case 'true':
+      takeText(cursor, 'true');
+      return true;
+    case 'false':
+      takeText(cursor, 'false');
+      return false;
+    default:
+      takeText(cursor, tag.name);
+      return '';
+  }
+}
+
+export function parsePlist(xml: unknown): PlistValue | null {
+  if (typeof xml !== 'string' || xml.trim() === '') return null;
+  const start = xml.indexOf('<plist');
+  const cursor: Cursor = { xml, pos: start < 0 ? 0 : start };
+  const value = parseValue(cursor);
+  return value === undefined ? null : value;
+}
+
+export interface ProvisioningProfile {
+  name: string | null;
+  uuid: string | null;
+  teamIdentifier: string | null;
+  expirationDate: Date | null;
+  provisionedDevices: string[] | null;
+  provisionsAllDevices: boolean;
+  getTaskAllow: boolean;
+  certificates: Buffer[];
+}
+
+function isDict(value: PlistValue | null): value is { [key: string]: PlistValue } {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    !Buffer.isBuffer(value) &&
+    !(value instanceof Date)
+  );
+}
+
+function stringsOf(value: PlistValue | undefined): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+export function parseProvisioningProfilePlist(xml: unknown): ProvisioningProfile | null {
+  const root = parsePlist(xml);
+  if (!isDict(root)) return null;
+  const entitlements = isDict(root.Entitlements ?? null) ? (root.Entitlements as { [key: string]: PlistValue }) : {};
+  const teamIdentifier = stringsOf(root.TeamIdentifier);
+  const expiration = root.ExpirationDate;
+  const certificates = Array.isArray(root.DeveloperCertificates)
+    ? root.DeveloperCertificates.filter((v): v is Buffer => Buffer.isBuffer(v))
+    : [];
+  return {
+    name: typeof root.Name === 'string' ? root.Name : null,
+    uuid: typeof root.UUID === 'string' ? root.UUID : null,
+    teamIdentifier: teamIdentifier?.[0] ?? null,
+    expirationDate: expiration instanceof Date && !Number.isNaN(expiration.getTime()) ? expiration : null,
+    provisionedDevices: stringsOf(root.ProvisionedDevices),
+    provisionsAllDevices: root.ProvisionsAllDevices === true,
+    getTaskAllow: entitlements['get-task-allow'] === true,
+    certificates,
+  };
+}
+
+export type ProfileKind = 'development' | 'ad hoc' | 'enterprise' | 'App Store';
+
+export function provisioningProfileKind(profile: ProvisioningProfile): ProfileKind {
+  if (profile.provisionedDevices) return profile.getTaskAllow ? 'development' : 'ad hoc';
+  return profile.provisionsAllDevices ? 'enterprise' : 'App Store';
+}
+
+export function certificateCommonName(der: unknown): string | null {
+  if (!Buffer.isBuffer(der) || der.length === 0) return null;
+  let subject: string;
+  try {
+    subject = new X509Certificate(der).subject;
+  } catch {
+    return null;
+  }
+  for (const part of String(subject).split(/\r?\n/)) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith('CN=')) return trimmed.slice(3).trim() || null;
+  }
+  const inline = /(?:^|,)\s*CN=([^,]+)/.exec(String(subject));
+  return inline?.[1]?.trim() || null;
+}
+
+export interface SigningIdentity {
+  sha1: string;
+  name: string;
+}
+
+// `security find-identity -v -p codesigning` prints one numbered line per valid
+// identity: `  1) <40 hex SHA-1> "Apple Development: Name (TEAMID)"`.
+const IDENTITY_LINE = /^\s*\d+\)\s+([0-9A-Fa-f]{40})\s+"(.+)"\s*$/;
+
+export function parseSigningIdentities(text: unknown): SigningIdentity[] {
+  if (typeof text !== 'string') return [];
+  const out: SigningIdentity[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const match = IDENTITY_LINE.exec(line);
+    if (!match) continue;
+    out.push({ sha1: (match[1] as string).toUpperCase(), name: match[2] as string });
+  }
+  return out;
+}
+
+export const SIGNING_CODES = {
+  noProfile: 'STIM_NO_PROFILE',
+  profileMismatch: 'STIM_PROFILE_MISMATCH',
+  noIdentity: 'STIM_NO_SIGNING_IDENTITY',
+  codesignFailed: 'STIM_CODESIGN_FAILED',
+} as const;
+
+export type SigningRefusalCode = (typeof SIGNING_CODES)[keyof typeof SIGNING_CODES];
+
+export interface SigningGateInput {
+  profilePresent: boolean;
+  profile: ProvisioningProfile | null;
+  identities: SigningIdentity[];
+  udid: string | null;
+  configuration?: string | null;
+  now?: number;
+  pinnedName?: string | null;
+  pinnedSha1?: string | null;
+}
+
+export interface SigningRefusal {
+  ok: false;
+  code: SigningRefusalCode;
+  reason: string;
+  remedy: string;
+}
+
+export type SigningGateResult = { ok: true; identity: SigningIdentity } | SigningRefusal;
+
+const XCODE_STEP =
+  'build once from Xcode to install it -- Stim will not, because registering a device or minting a profile changes your Apple Developer account.';
+
+const KEYCHAIN_REMEDY =
+  'Open Xcode > Settings > Accounts and download your certificates, or unlock the login keychain with `security unlock-keychain`. `security find-identity -v -p codesigning` should list `Apple Development: ...`.';
+
+function signingConfiguration(input: SigningGateInput): string {
+  return input.configuration ?? 'Debug';
+}
+
+export function signingGate(input: SigningGateInput): SigningGateResult {
+  const now = input.now ?? Date.now();
+  if (!input.profilePresent) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.noProfile,
+      reason: 'The app bundle has no embedded.mobileprovision, so it was built unsigned or for the simulator.',
+      remedy: `Set a team and profile for the target's ${signingConfiguration(input)} configuration in Xcode > Signing & Capabilities, then ${XCODE_STEP}`,
+    };
+  }
+  if (!input.profile) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.noProfile,
+      reason: "`security cms -D` could not decode the app bundle's embedded.mobileprovision.",
+      remedy: `The profile inside the app is corrupt. Delete the build cache entry with \`stim gc --delete\`, then ${XCODE_STEP}`,
+    };
+  }
+  const profile = input.profile;
+  const named = profile.name ? `"${profile.name}"` : 'the embedded profile';
+  if (!profile.expirationDate || profile.expirationDate.getTime() <= now) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.profileMismatch,
+      reason: profile.expirationDate
+        ? `The ${provisioningProfileKind(profile)} profile ${named} expired on ${profile.expirationDate.toISOString()}.`
+        : `The ${provisioningProfileKind(profile)} profile ${named} carries no ExpirationDate, so Stim cannot prove it is still valid.`,
+      remedy: `Renew the profile under Signing & Capabilities, then ${XCODE_STEP}`,
+    };
+  }
+  if (!profile.provisionedDevices) {
+    const kind = provisioningProfileKind(profile);
+    return {
+      ok: false,
+      code: SIGNING_CODES.profileMismatch,
+      reason: `${named} is an ${kind} profile, which carries no ProvisionedDevices list, so Stim cannot prove ${input.udid ?? 'the target device'} is admitted.`,
+      remedy: `Local device runs need a development profile. Select one under Signing & Capabilities, then ${XCODE_STEP}`,
+    };
+  }
+  const udid = input.udid;
+  if (!udid || !profile.provisionedDevices.some((d) => d.toLowerCase() === udid.toLowerCase())) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.profileMismatch,
+      reason: `The ${provisioningProfileKind(profile)} profile ${named} lists ${profile.provisionedDevices.length} device(s) and ${udid ?? 'the target device'} is not one of them.`,
+      remedy: `Register ${udid ?? 'the device'} at developer.apple.com, regenerate the profile, then ${XCODE_STEP}`,
+    };
+  }
+
+  const identities = Array.isArray(input.identities) ? input.identities : [];
+  if (identities.length === 0) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.noIdentity,
+      reason: '`security find-identity -v -p codesigning` lists no codesigning identity on this machine.',
+      remedy: KEYCHAIN_REMEDY,
+    };
+  }
+  if (input.pinnedSha1) {
+    const wanted = input.pinnedSha1.trim().toUpperCase();
+    const match = identities.find((i) => i.sha1 === wanted);
+    if (match) return { ok: true, identity: match };
+    return {
+      ok: false,
+      code: SIGNING_CODES.noIdentity,
+      reason: `ios.signingIdentitySha1 is ${wanted}, which is not in the keychain. Available: ${identities.map((i) => `${i.sha1} "${i.name}"`).join(', ')}.`,
+      remedy: KEYCHAIN_REMEDY,
+    };
+  }
+  const wantedName = input.pinnedName?.trim() || certificateCommonName(profile.certificates[0] ?? null);
+  if (!wantedName) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.noIdentity,
+      reason: `Stim could not read a signing-identity name out of ${named}: its DeveloperCertificates entry has no readable subject CN.`,
+      remedy:
+        'Set ios.signingIdentity in .stim.json to the identity name to re-sign with, or ios.signingIdentitySha1 to its SHA-1 hash.',
+    };
+  }
+  const matches = identities.filter((i) => i.name === wantedName);
+  if (matches.length === 1) return { ok: true, identity: matches[0] as SigningIdentity };
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.noIdentity,
+      reason: `The app was signed by "${wantedName}", which is not in this machine's keychain. Available: ${identities.map((i) => `"${i.name}"`).join(', ')}.`,
+      remedy: `${KEYCHAIN_REMEDY} Or set ios.signingIdentity in .stim.json to one of the identities listed above.`,
+    };
+  }
+  return {
+    ok: false,
+    code: SIGNING_CODES.noIdentity,
+    reason: `${matches.length} keychain identities share the name "${wantedName}", so Stim cannot pick one: ${matches.map((i) => i.sha1).join(', ')}.`,
+    remedy: 'Set ios.signingIdentitySha1 in .stim.json to the SHA-1 hash of the certificate to sign with.',
+  };
+}

--- a/packages/stim-cli/src/engine/ios-profile.ts
+++ b/packages/stim-cli/src/engine/ios-profile.ts
@@ -24,10 +24,19 @@ const ENTITIES: Record<string, string> = {
   apos: "'",
 };
 
+class PlistError extends Error {}
+
+function codePoint(value: number): string {
+  if (!Number.isInteger(value) || value < 0 || value > 0x10ffff || (value >= 0xd800 && value <= 0xdfff)) {
+    throw new PlistError(`character reference out of range: ${value}`);
+  }
+  return String.fromCodePoint(value);
+}
+
 function decodeEntities(raw: string): string {
   return raw.replace(/&(#x?[0-9A-Fa-f]+|[a-z]+);/g, (match, body: string) => {
-    if (body.startsWith('#x') || body.startsWith('#X')) return String.fromCodePoint(Number.parseInt(body.slice(2), 16));
-    if (body.startsWith('#')) return String.fromCodePoint(Number.parseInt(body.slice(1), 10));
+    if (body.startsWith('#x') || body.startsWith('#X')) return codePoint(Number.parseInt(body.slice(2), 16));
+    if (body.startsWith('#')) return codePoint(Number.parseInt(body.slice(1), 10));
     return ENTITIES[body] ?? match;
   });
 }
@@ -62,8 +71,9 @@ function takeText(cursor: Cursor, name: string): string {
 }
 
 function parseValue(cursor: Cursor): PlistValue | undefined {
-  const tag = takeTag(cursor);
-  if (!tag || tag.closing) return undefined;
+  const peeked = peekTag(cursor);
+  if (!peeked || peeked.closing) return undefined;
+  const tag = takeTag(cursor) as Tag;
   if (tag.selfClosing) {
     if (tag.name === 'true') return true;
     if (tag.name === 'false') return false;
@@ -133,10 +143,15 @@ function parseValue(cursor: Cursor): PlistValue | undefined {
 
 export function parsePlist(xml: unknown): PlistValue | null {
   if (typeof xml !== 'string' || xml.trim() === '') return null;
-  const start = xml.indexOf('<plist');
-  const cursor: Cursor = { xml, pos: start < 0 ? 0 : start };
-  const value = parseValue(cursor);
-  return value === undefined ? null : value;
+  const stripped = xml.replace(/<!--[\s\S]*?-->/g, '');
+  const start = stripped.indexOf('<plist');
+  const cursor: Cursor = { xml: stripped, pos: start < 0 ? 0 : start };
+  try {
+    const value = parseValue(cursor);
+    return value === undefined ? null : value;
+  } catch {
+    return null;
+  }
 }
 
 export interface ProvisioningProfile {

--- a/packages/stim-cli/src/engine/ios-signing.ts
+++ b/packages/stim-cli/src/engine/ios-signing.ts
@@ -1,0 +1,186 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getExecutor, type Executor } from '../exec.ts';
+import {
+  parseProvisioningProfilePlist,
+  parseSigningIdentities,
+  SIGNING_CODES,
+  signingGate,
+  type ProvisioningProfile,
+  type SigningGateResult,
+  type SigningIdentity,
+  type SigningRefusal,
+} from './ios-profile.ts';
+
+export const EMBEDDED_PROFILE = 'embedded.mobileprovision';
+
+const SIGNING_TIMEOUT_MS = 120_000;
+
+function lastLines(text: unknown, count = 5): string[] {
+  return String(text ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() !== '')
+    .slice(-count);
+}
+
+function errorText(error: unknown): string {
+  const withOutput = error as { stderr?: unknown; stdout?: unknown; message?: unknown };
+  const stderr = String(withOutput?.stderr ?? '').trim();
+  const stdout = String(withOutput?.stdout ?? '').trim();
+  return stderr || stdout || String(withOutput?.message ?? error);
+}
+
+export interface EmbeddedProfileRead {
+  present: boolean;
+  profile: ProvisioningProfile | null;
+}
+
+export function readEmbeddedProfile(
+  appPath: string,
+  { exec = null }: { exec?: Executor | null } = {},
+): EmbeddedProfileRead {
+  const executor = exec || getExecutor();
+  const path = join(appPath, EMBEDDED_PROFILE);
+  if (!existsSync(path)) return { present: false, profile: null };
+  try {
+    const plist = executor.runFile('security', ['cms', '-D', '-i', path], { timeoutMs: SIGNING_TIMEOUT_MS });
+    return { present: true, profile: parseProvisioningProfilePlist(plist) };
+  } catch {
+    return { present: true, profile: null };
+  }
+}
+
+export function findSigningIdentities({ exec = null }: { exec?: Executor | null } = {}): SigningIdentity[] {
+  const executor = exec || getExecutor();
+  try {
+    return parseSigningIdentities(
+      executor.runFile('security', ['find-identity', '-v', '-p', 'codesigning'], { timeoutMs: SIGNING_TIMEOUT_MS }),
+    );
+  } catch {
+    return [];
+  }
+}
+
+export interface SigningGateOptions {
+  appPath: string;
+  udid: string | null;
+  configuration?: string | null;
+  pinnedName?: string | null;
+  pinnedSha1?: string | null;
+  now?: number;
+  exec?: Executor | null;
+}
+
+export function gateAppForDevice(options: SigningGateOptions): SigningGateResult {
+  const read = readEmbeddedProfile(options.appPath, { exec: options.exec ?? null });
+  return signingGate({
+    profilePresent: read.present,
+    profile: read.profile,
+    identities: read.present ? findSigningIdentities({ exec: options.exec ?? null }) : [],
+    udid: options.udid,
+    configuration: options.configuration ?? null,
+    pinnedName: options.pinnedName ?? null,
+    pinnedSha1: options.pinnedSha1 ?? null,
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+}
+
+export type ResealMode = 'preserve-metadata' | 'entitlements' | 'no-entitlements';
+
+export interface ResealSuccess {
+  ok: true;
+  identity: SigningIdentity;
+  mode: ResealMode;
+}
+
+export interface ResealFailure extends SigningRefusal {
+  lastLines: string[];
+}
+
+export type ResealResult = ResealSuccess | ResealFailure;
+
+function extractEntitlements(appPath: string, executor: Executor): string {
+  try {
+    return String(
+      executor.runFile('codesign', ['-d', '--entitlements', '-', '--xml', appPath], { timeoutMs: SIGNING_TIMEOUT_MS }),
+    ).trim();
+  } catch {
+    return '';
+  }
+}
+
+export function resealBundle({
+  appPath,
+  identity,
+  exec = null,
+}: {
+  appPath: string;
+  identity: SigningIdentity;
+  exec?: Executor | null;
+}): ResealResult {
+  const executor = exec || getExecutor();
+  const signAs = identity.sha1 || identity.name;
+  let mode: ResealMode = 'preserve-metadata';
+  let preserveError: unknown = null;
+  try {
+    executor.runFile(
+      'codesign',
+      ['--force', '--sign', signAs, '--preserve-metadata=identifier,entitlements,flags,runtime', appPath],
+      { timeoutMs: SIGNING_TIMEOUT_MS },
+    );
+  } catch (error) {
+    preserveError = error;
+  }
+
+  let tempDir: string | null = null;
+  if (preserveError) {
+    const entitlements = extractEntitlements(appPath, executor);
+    const args = ['--force', '--sign', signAs];
+    if (entitlements !== '') {
+      tempDir = mkdtempSync(join(tmpdir(), 'stim-entitlements-'));
+      const plist = join(tempDir, 'entitlements.plist');
+      writeFileSync(plist, `${entitlements}\n`, 'utf-8');
+      args.push('--entitlements', plist);
+      mode = 'entitlements';
+    } else {
+      mode = 'no-entitlements';
+    }
+    args.push(appPath);
+    try {
+      executor.runFile('codesign', args, { timeoutMs: SIGNING_TIMEOUT_MS });
+    } catch (error) {
+      return {
+        ok: false,
+        code: SIGNING_CODES.codesignFailed,
+        reason: `codesign could not re-seal ${appPath} with "${identity.name}": ${errorText(error)}`,
+        remedy: `Unlock the login keychain (\`security unlock-keychain\`) and confirm exactly one identity matches "${identity.name}".`,
+        lastLines: [...lastLines(errorText(preserveError)), ...lastLines(errorText(error))],
+      };
+    } finally {
+      if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  try {
+    executor.runFile('codesign', ['--verify', '--strict', appPath], { timeoutMs: SIGNING_TIMEOUT_MS });
+  } catch (error) {
+    return {
+      ok: false,
+      code: SIGNING_CODES.codesignFailed,
+      reason: `codesign --verify --strict rejected ${appPath} after re-sealing it with "${identity.name}": ${errorText(error)}`,
+      remedy:
+        'The bundle signed but did not seal. Delete the cached artifact with `stim gc --delete` and build fresh, then retry.',
+      lastLines: lastLines(errorText(error)),
+    };
+  }
+
+  return { ok: true, identity, mode };
+}
+
+export function sealAppForDevice(options: SigningGateOptions): ResealResult {
+  const gate = gateAppForDevice(options);
+  if (!gate.ok) return { ...gate, lastLines: [] };
+  return resealBundle({ appPath: options.appPath, identity: gate.identity, exec: options.exec ?? null });
+}

--- a/packages/stim-cli/src/engine/lan-address.ts
+++ b/packages/stim-cli/src/engine/lan-address.ts
@@ -1,0 +1,62 @@
+import { networkInterfaces } from 'node:os';
+
+export interface NetworkAddressLike {
+  address?: unknown;
+  family?: unknown;
+  internal?: unknown;
+}
+
+export interface LanCandidate {
+  interfaceName: string;
+  address: string;
+}
+
+// react-native/scripts/react-native-xcode.sh probes en0 through en8 with
+// `ipconfig getifaddr` and keeps the first that answers. Stim orders its
+// candidates the same way so a Stim run and a plain Xcode run pick the same
+// interface.
+const EN_INTERFACE = /^en(\d+)$/;
+const EXCLUDED_INTERFACE = /^(?:utun|bridge|awdl)/;
+const LINK_LOCAL = /^169\.254\./;
+
+function isIpv4(entry: NetworkAddressLike): boolean {
+  return entry.family === 'IPv4' || entry.family === 4;
+}
+
+export function lanCandidates(
+  interfaces: Record<string, readonly NetworkAddressLike[] | undefined> | null | undefined,
+): LanCandidate[] {
+  const ranked: Array<LanCandidate & { rank: number; index: number }> = [];
+  const seen = new Set<string>();
+  for (const [interfaceName, entries] of Object.entries(interfaces ?? {})) {
+    if (EXCLUDED_INTERFACE.test(interfaceName)) continue;
+    const en = EN_INTERFACE.exec(interfaceName);
+    for (const entry of entries ?? []) {
+      if (!entry || typeof entry !== 'object' || !isIpv4(entry) || entry.internal === true) continue;
+      const address = typeof entry.address === 'string' ? entry.address.trim() : '';
+      if (address === '' || LINK_LOCAL.test(address)) continue;
+      if (seen.has(address)) continue;
+      seen.add(address);
+      ranked.push({
+        interfaceName,
+        address,
+        rank: en ? 0 : 1,
+        index: en ? Number(en[1]) : 0,
+      });
+    }
+  }
+  ranked.sort(
+    (a, b) =>
+      a.rank - b.rank ||
+      a.index - b.index ||
+      a.interfaceName.localeCompare(b.interfaceName) ||
+      a.address.localeCompare(b.address),
+  );
+  return ranked.map(({ interfaceName, address }) => ({ interfaceName, address }));
+}
+
+export function hostLanCandidates(
+  interfaces: () => ReturnType<typeof networkInterfaces> = networkInterfaces,
+): LanCandidate[] {
+  return lanCandidates(interfaces());
+}

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -686,7 +686,7 @@ export async function buildIos({
   }
 
   if (outcome.code !== 0) {
-    const diagnostics = extractXcodeDiagnostics(text, root);
+    const diagnostics = extractXcodeDiagnostics(text, root, sdk);
     const capped = capDiagnostics(diagnostics);
     for (const d of capped.diagnostics) reportError(describeDiagnostic(d), d.remedy);
     if (capped.diagnostics.length === 0) {

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -31,6 +31,9 @@ const KNOWN_SETTINGS = new Set([
   'ios.configuration',
   'ios.remote',
   'ios.simslimProfile',
+  'ios.signingIdentity',
+  'ios.signingIdentitySha1',
+  'ios.lanHost',
   'android.systemImage',
   'android.dataPartitionSizeGb',
   'android.avdConfigFile',
@@ -329,6 +332,60 @@ export function iosSimSlimProfileSettingError(settings: unknown, settingsRoot: s
   } catch (error) {
     return String((error as Error)?.message || error);
   }
+}
+
+function iosString(settings: unknown, key: string): unknown {
+  if (!isPlainObject(settings) || !isPlainObject(settings.ios)) return undefined;
+  return settings.ios[key];
+}
+
+export function iosSigningIdentitySetting(settings: unknown): string | null {
+  const raw = iosString(settings, 'signingIdentity');
+  return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null;
+}
+
+export function iosSigningIdentitySettingError(settings: unknown): string | null {
+  const raw = iosString(settings, 'signingIdentity');
+  if (raw === undefined) return null;
+  if (typeof raw !== 'string' || raw.trim() === '' || /[\r\n\0]/.test(raw)) {
+    return `Invalid ios.signingIdentity setting ${JSON.stringify(raw)}. Expected the identity name \`security find-identity -v -p codesigning\` prints, such as "Apple Development: Jane (TEAMID5678)".`;
+  }
+  return null;
+}
+
+const SIGNING_IDENTITY_SHA1 = /^[0-9A-Fa-f]{40}$/;
+
+export function iosSigningIdentitySha1Setting(settings: unknown): string | null {
+  const raw = iosString(settings, 'signingIdentitySha1');
+  return typeof raw === 'string' && SIGNING_IDENTITY_SHA1.test(raw.trim()) ? raw.trim().toUpperCase() : null;
+}
+
+export function iosSigningIdentitySha1SettingError(settings: unknown): string | null {
+  const raw = iosString(settings, 'signingIdentitySha1');
+  if (raw === undefined) return null;
+  if (typeof raw !== 'string' || !SIGNING_IDENTITY_SHA1.test(raw.trim())) {
+    return `Invalid ios.signingIdentitySha1 setting ${JSON.stringify(raw)}. Expected the 40-character hex SHA-1 hash \`security find-identity -v -p codesigning\` prints beside the identity name.`;
+  }
+  return null;
+}
+
+// RCTBundleURLProvider.mm:70 serverRootWithHostPort prefixes the scheme itself
+// and appends the compiled default port when the value carries no colon, so
+// this setting holds a bare host and never a URL.
+const LAN_HOST = /^(?!-)[A-Za-z0-9-]+(?:\.(?!-)[A-Za-z0-9-]+)*$/;
+
+export function iosLanHostSetting(settings: unknown): string | null {
+  const raw = iosString(settings, 'lanHost');
+  return typeof raw === 'string' && LAN_HOST.test(raw.trim()) ? raw.trim() : null;
+}
+
+export function iosLanHostSettingError(settings: unknown): string | null {
+  const raw = iosString(settings, 'lanHost');
+  if (raw === undefined) return null;
+  if (typeof raw !== 'string' || !LAN_HOST.test(raw.trim())) {
+    return `Invalid ios.lanHost setting ${JSON.stringify(raw)}. Expected a bare address or hostname the phone can reach, such as "192.168.1.42" -- never a URL, a scheme, or a port.`;
+  }
+  return null;
 }
 
 export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -73,10 +73,15 @@ machine, including remote-device workflows.
 
 A non-Debug configuration embeds its JavaScript bundle.
 
+A device build is local-tier only. Its cache key ends `-device`, so it cannot
+collide with a simulator build, and no build-cache provider or Expo remote cache
+is read or written on a `--device` run, because every entry they hold is keyed
+for the simulator.
+
 `--device` is incomplete. It selects the phone and builds the `iphoneos` slice
-for it, under a `-device` cache key that cannot collide with a simulator build,
-and then refuses: installing and launching on hardware are not implemented yet.
-Run `stim ios` without `--device` for a run that ends with an app on screen.
+for it, and then refuses: installing and launching on hardware are not
+implemented yet. Run `stim ios` without `--device` for a run that ends with an
+app on screen.
 
 ## `android`
 

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -53,7 +53,7 @@ project is reused.
 ## `ios`
 
 ```text
-stim ios [--configuration <name>] [--remote <proxy|eas>]
+stim ios [--configuration <name>] [--device [udid]] [--remote <proxy|eas>]
          [--no-metro-check] [--no-build-cache] [--json]
 ```
 
@@ -62,14 +62,21 @@ app, opens it, and checks launch logs. The build always runs on the local
 machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
+- `--device [udid]` selects a connected iPhone instead of the owned simulator.
+  With no UDID the one connected device is used. Stim never creates, boots, or
+  deletes hardware.
 - `--remote proxy` uses a configured Agent Device daemon.
 - `--remote eas` uses an EAS remote simulator.
 - `--no-metro-check` skips the Debug dev-server gate.
 - `--no-build-cache` ignores cached artifacts and replaces the matching entry.
 - `--json` prints one stable result object on stdout.
 
-A non-Debug configuration embeds its JavaScript bundle and supports iOS
-Simulator targets only.
+A non-Debug configuration embeds its JavaScript bundle.
+
+`--device` is incomplete. It selects the phone and builds the `iphoneos` slice
+for it, under a `-device` cache key that cannot collide with a simulator build,
+and then refuses: installing and launching on hardware are not implemented yet.
+Run `stim ios` without `--device` for a run that ends with an app on screen.
 
 ## `android`
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -30,6 +30,9 @@ keys produce a warning.
 | `ios.configuration`           | Xcode configuration, such as `Debug` or `Release`    |
 | `ios.remote`                  | Default remote backend, `proxy` or `eas`             |
 | `ios.simslimProfile`          | SimSlim profile for local iOS devices                |
+| `ios.signingIdentity`         | Keychain identity used to re-seal a device build     |
+| `ios.signingIdentitySha1`     | SHA-1 of that identity, when two share a name        |
+| `ios.lanHost`                 | Address a phone uses to reach this workspace's Metro |
 | `android.systemImage`         | Android SDK system image                             |
 | `android.dataPartitionSizeGb` | AVD data partition size                              |
 | `android.avdConfigFile`       | Additional AVD config file                           |


### PR DESCRIPTION
## Description

`stim ios` can only reach an owned simulator (#178). The design for changing that is
[`docs/specs/2026-09-01-ios-device-release-design.md`](https://github.com/appandflow/stim/blob/7649555/docs/specs/2026-09-01-ios-device-release-design.md),
which splits the work into seven phases and marks 1, 2 and 4 as the ones needing no phone. This is
those three.

**Where this could hurt.** The cache-key fix touches the key every iOS build resolves and stores
under. `buildCacheKey` is `<hash>-<variant>-<target>` and `buildTarget` already returned `'device'`
for `isSimulator: false`, but `commands/ios.ts` never passed it, so every iOS key ever minted ends
`-sim` — meaning `Release-iphoneos/App.app` and `Release-iphonesimulator/App.app` collide on one key
the moment a device slice exists. Both call sites now pass it. If `isSimulator: true` did not map to
the same `'sim'` an absent option produced, every project's iOS cache would go cold at once. It
does, and a test pins the simulator path at `<hash>-release-sim`. Everything else is additive: the
new modules have no caller outside `--device`, and `--device` refuses before it can install
anything.

**The device slice is local-tier only, and that takes three gates, not one.** The spec rules the
device slice out of every remote and provider cache in v1, because a consumer on another machine
would fail the signing gate and fall back to a full build. Two of the three key-composition paths
were obvious; the third was not. `resolveRemoteArtifact` asks the Expo provider with `runOptions`
that carry no `isSimulator`, so a device run would resolve the provider's `-sim` entry and store
that **simulator** `.app` under the local `-device` key — poisoning it for the phase-3 install — and
after a fresh device build the upload would put the `iphoneos` artifact under the provider's `-sim`
key, which every simulator consumer of a shared cache then resolves. All three are gated on
`!physical`, with a control test proving the same providers are still consulted without `--device`
so the gate is not vacuous.

**`--device` is deliberately incomplete and refuses.** Install and launch are phase 3, which needs a
phone. Today `ios --device` selects the phone, builds the `iphoneos` slice, stores it under the
device key, and exits `STIM_BAD_ARG` saying so; that is stated in the flag's own help, in
`guide lifecycle`, in `guide errors`, and in `website/docs/commands.md` rather than left to be
discovered. A release cache hit does not run the JS swap either: the swap ends in an ad-hoc
signature, and the device re-seal that would make it installable is phase 6, so the Metro bundle and
codesign were minutes spent on a path that then refuses.

`STIM_BAD_ARG` after a full build contradicts that code's own framing ("caught before the port is
reserved and before anything is spawned"), so rather than mint a code that would have to be
documented and then deleted when phase 3 lands, `guide errors` carves the exception out explicitly
and says it is temporary. Open to the other call if you'd rather have a dedicated code.

One interim contradiction worth naming: invariant 3 still says "there is no iOS equivalent, because
that needs code signing," while the flag now exists. The spec sequences its rewrites of invariants
2, 3, 9 and 11 with the last phase, so `AGENTS.md` stays untouched here and that sentence is wrong
until then.

## Solution

**Phase 1 — the device slice.** `xcodebuildArgs` already took `sdk`; nothing had ever set it away
from `iphonesimulator`. The device path passes `-sdk iphoneos` and `-destination id=<udid>` and
nothing else — no `CODE_SIGN_IDENTITY`, no `DEVELOPMENT_TEAM`, no `-allowProvisioningUpdates`. The
project's Signing & Capabilities settings decide, which is what invariant 3's "fixed `xcodebuild`
arguments" already required. `-allowProvisioningUpdates` is ruled out permanently, not deferred: a
build must not register a device or mint a profile in an Apple Developer account as a side effect,
so the remedies name the one-time manual Xcode step instead.

The key is per-slice, not per-phone (`-device`, never `on-<udid>`): an `iphoneos` build is identical
for every device its profile admits, and passing `{device: udid}` instead would silently mint a
per-phone key, because a physical UDID matches neither the simulator-UUID nor the `emulator-N` regex
and falls through to `on-<slug>`.

iOS also adopts Android's `overwrite: !useBuildCache || swapFellBack`. iOS used only
`!useBuildCache`, so an entry whose swap failed was never replaced by the build that followed and
would refuse every run forever — which matters much more once a signing gate exists that can refuse.

**Phase 2 — discovery and selection.** A pure parser over `devicectl list devices -j` behind a thin
wrapper, and `resolveIosPhysicalDevice` in the shape of `resolvePhysicalDevice` in `sim/android.ts`:
no UDID uses the one connected device, several is a refusal listing them, a named UDID must be
present. It also refuses a phone that is connected but unusable — unpaired, Developer Mode off, or
paired only over the local network, since v1 installs over the cable — and only when `devicectl`
actually reports the field, so an older `devicectl` that omits it is not turned into a refusal. A
wireless phone is not a candidate at all, so one cabled phone beside it is still unambiguous rather
than a "several devices connected" refusal.

The phone is **used, never owned**: `--device` skips the capacity check, `ensureOwnedDevice` and the
boot wait entirely, and records nothing, so `stop`, `gc` and `teardown.ts` never see it
(invariant 2).

`lanCandidates` orders the host's non-internal IPv4 interfaces `en0` first, then the remaining `en*`
by index, dropping link-local and the `utun`/`bridge`/`awdl` interfaces — deliberately
[`react-native-xcode.sh`'s own heuristic](https://github.com/facebook/react-native/blob/ee90a754201cfdfefcc5e458a10906c9952cf26c/packages/react-native/scripts/react-native-xcode.sh#L15-L28),
so Stim and a plain Xcode run pick the same interface. Ordering is the whole decision: macOS routes
a host's connection to any of its own addresses over loopback, so probing each candidate proves
nothing — every one answers, including one the phone cannot see.

**Phase 4 — the re-seal primitive.** Standalone, with no opinion about why a bundle was modified,
split pure-from-I/O per the architecture rule. `engine/ios-profile.ts` is pure: a small plist-XML
parser over what `security cms -D` emits, the profile fields the gate decides on,
`crypto.X509Certificate` subject `CN=` extraction, the `find-identity` scrape, and `signingGate`.
`engine/ios-signing.ts` is the I/O and the codesign ladder —
`--force --sign <identity> --preserve-metadata=identifier,entitlements,flags,runtime`, falling back
to extracting entitlements with `codesign -d --entitlements - --xml` and passing them explicitly,
then `codesign --verify --strict`.

`--preserve-metadata=entitlements` is the answer to "do entitlements survive a re-seal": yes, by
construction — the existing entitlement blob is carried over verbatim, so app groups,
keychain-access-groups, associated-domains and `get-task-allow` are preserved without Stim having to
know what they are. No `--deep`: only the outer bundle's seal is invalidated, and re-signing nested
code with a different team is exactly what makes a phone reject an app at launch.

The gate refuses rather than guesses, and two of its refusals are behavioral limits someone will
hit. An App Store or enterprise profile carries no `ProvisionedDevices`, so Stim cannot *prove* the
phone is admitted — refusal, with the profile type named. Two keychain certificates sharing one
common name are also a refusal: Stim is non-interactive and cannot prompt the way Rock does, so the
remedy points at `ios.signingIdentitySha1`. (The spec's table lists two causes for
`STIM_NO_SIGNING_IDENTITY`; this is a third, caught in ~50 ms of `security` rather than surfacing as
a confusing `codesign` error.)

Three new settings, documented in `guide settings` and `website/docs/settings.md`:
`ios.signingIdentity`, `ios.signingIdentitySha1`, and `ios.lanHost` (a bare address or hostname
only, never a URL — both channels that carry it to a phone compose the URL themselves).

One parser choice worth flagging: `security cms -D` emits XML, and piping it through
`plutil -convert json` does not work — `plutil` refuses a plist containing an `NSDate`, and
`ExpirationDate` is the field the gate most needs. The alternatives were a new npm dependency or a
small parser over Apple's own stable output; this takes the parser, pure and fixture-tested. It
fails closed on an out-of-range character reference rather than throwing `RangeError` out of a pure
function, strips XML comments before parsing, and does not let a valueless `<key>` swallow its
parent's tags.

**Not here:** phases 3 (install and launch), 5 (Debug over the LAN), 6 (the Release swap's device
branch) and 7 (device logs, #179). The spec's rewrites of invariants 2, 3, 9 and 11 land with the
last phase, so `AGENTS.md` is untouched.

## Test plan

**Real-tool verification (invariant 9).** Every changed tool call is exercised against the real tool,
in the suite rather than one-shot, gated on the tools being present:

- Real `xcodebuild -sdk iphoneos -destination generic/platform=iOS ... build` on the scratch project
  `engine-xcode.test.ts` already generates. Succeeds and lands the `.app` in `Debug-iphoneos/`,
  which is what `productsDir` predicts. No phone needed, per the spec.
- `listIosDevices` twice over: a mocked-executor test pinning the argv, the temp-file mechanics and
  the directory cleanup (including on failure), and a tool-gated test that runs the real
  `xcrun devicectl list devices -j <tmp>` and asserts every entry it returns is well formed — gated
  the same way the codesign ladder is. On this machine the real call returns an empty
  `result.devices` with `jsonVersion` 3.
- Real `security find-identity -v -p codesigning`, and real `security cms -D` against a CMS-wrapped
  profile the test builds with `openssl smime -sign`.
- **The re-seal, proven on disk.** A scratch `.app` (clang-built binary, `Info.plist`, `ip.txt`) is
  ad-hoc signed with entitlements, `ip.txt` is rewritten, and the real ladder re-seals it:

```
$ codesign --verify --strict Scratch.app          # after signing
(clean)
                                                  # rewrite ip.txt
$ codesign --verify --strict Scratch.app
Scratch.app: a sealed resource is missing or invalid
$ codesign --force --sign - --preserve-metadata=identifier,entitlements,flags,runtime Scratch.app
Scratch.app: replacing existing signature
$ codesign --verify --strict Scratch.app
(clean)
$ codesign -d --entitlements - --xml Scratch.app
...<key>get-task-allow</key><true/><key>keychain-access-groups</key><array><string>TEAMID5678.*</string></array>...
```

  Entitlements survive `--preserve-metadata` byte for byte. The `--entitlements` fallback runs for
  real too, by failing only the `--preserve-metadata` call and letting every other `codesign` call
  through, so the extraction, the re-sign and the verify are all the real tool.

  This does **not** discharge the acceptance test the spec calls the riskiest unverified assumption:
  a phone accepting a re-sealed bundle. That needs hardware, and nothing downstream of it is built
  here.

- The three refusals, run against the built CLI: no phone connected gives `STIM_NO_DEVICE` naming
  Developer Mode and the trust prompt; `--device=` and `--device --remote proxy` each give
  `STIM_BAD_ARG`. Each printed exactly one JSON payload on stdout (invariant 7).

**The `lsof` experiment the spec designates as the first host-testable unknown — settled.** The spec
was unsure whether bare Metro binds all interfaces, since `server-bare.ts:308` hardcodes
`const hostname = 'localhost'`, and anticipated a one-line `config.server.host = '0.0.0.0'` fix if it
did not. Against a live `bare-inproc` supervisor on a real bare RN app, `lsof -nP -iTCP:8082` reports
`TCP *:8082 (LISTEN)`, not `127.0.0.1:8082`, and `curl http://10.0.0.132:8082/status` returns
`packager-status:running`. **No `server-bare.ts` change is needed**, and phase 5 is unblocked. That
host is also the multi-NIC case `lanCandidates` exists for — `en0` through `en7` with no IPv4 on
`en0`, its only LAN address on `en1`, plus a Tailscale `utun4` — and the ordering picks `en1` and
drops `utun4`, as `react-native-xcode.sh` would.

**Ablations.** Each new contract was checked by breaking it: deleting `STIM_PROFILE_MISMATCH`'s
`guide errors` block fails the errors contract test (it did not before — the scrape did not read
`engine/ios-profile.ts`); removing the three provider gates fails both provider tests; reverting the
three parser hardenings fails all three fuzz tests. One assertion was vacuous when first written —
overriding `loadProjectProvider` in the harness replaces the recorder, so `calls.order` never saw it
— and now counts calls directly.

**Suite.** `build`, `typecheck`, `lint`, `format:check`, `knip`, `test` (2813 passing) and
`test:e2e` (19 passing) all green. A full `run-native-e2e.mjs --framework expo --platform ios` loop
also passes, which is the evidence that matters for the cache-key change: worktree 1 builds
(`cacheHit=false`), worktree 2 resolves the same key and installs from cache with no compiler
invocation in its build log (`cacheHit="local"`, "CACHE PROOF: second worktree installed from cache
without compiling"), both launch verified, and all five cleanup checks pass with no `stim-*`
simulator left behind.

Progresses #178.
