### PR TITLE
Collect device runtime logs through the devicectl console

### DIFF
--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -133,11 +133,69 @@ is only for shapes the release actually changes and automation cannot model.
 | Release build                 | Release selection, bundling, signing, or cached-artifact swapping changed | iOS `--configuration Release` and/or Android `--variant <name>Release`; prove Metro is skipped, `metroPort` is null, the process stays alive, and the installed artifact contains this workspace's JS.                                                                 |
 | Android flavor                | Variant or APK discovery changed                                          | A repository with real product flavors; prove `assemble<Variant>`, APK selection, application id from the built APK, and a distinct cache key per variant. Do not manufacture a flavor and call it field evidence.                                                     |
 | Launch evidence               | Launch/status/remedy UX changed                                           | Exercise first launch and warm launch on the affected platform, record the JSON value, follow any remedy, and confirm the foreground app and bundle request with the owned device.                                                                                     |
+| Physical iPhone               | `ios --device` build, signing, install, launch, or device logging changed | A cabled, unlocked iPhone with Developer Mode on and a provisioning profile that names it. Run the staged checklist below; a step you did not run is a skip, never a pass.                                                                                             |
 
 For a cached release, use a unique JS sentinel. On iOS, confirm the copied and
 re-signed `.app` contains the regenerated bundle. On Android, confirm the APK
 bundle remains stored rather than deflated, is zipaligned and signed, and that
 a changed asset set refuses the swap and falls back to a full build.
+
+### The staged physical-iPhone checklist
+
+Everything on this list needs a phone and nothing else does, so it is staged
+rather than run every release. Design and reasoning:
+`docs/specs/2026-09-01-ios-device-release-design.md`.
+
+**A. The re-seal acceptance test** (the spec's riskiest unverified assumption;
+run it first, before anything downstream is trusted). Take any signed device
+`.app`, mutate its `ip.txt`, re-seal it with Stim's ladder, then:
+
+```
+codesign --verify --strict <app>   ->   devicectl device install   ->   launch
+```
+
+Record the verify output, the install result, and whether the app ran. A
+failure here invalidates `ip.txt` ownership, the Debug path, and the Release
+JS swap together, so report it as CRITICAL and stop.
+
+**B. Device log capture** (appandflow/stim#179). The collector's parser is
+tested against a real `os_log` stderr mirror captured on macOS, not on a
+phone. What a phone has to settle:
+
+1. **Fields observed live vs. the fixtures.** Run the collector against the
+   app and quote real lines from `device.ndjson`. Confirm each claim the
+   `guide logs` table makes: `ts` is the device's own clock and not the
+   host's; `proc` is `name(pid)`; `category` is present for React Native's
+   `javascript` / `native` calls and absent for `NSLog`; `subsystem` is
+   absent; and an `os_log` call made at the error level is **still recorded
+   at info**, which is the loss the guide claims. A field that survives on
+   hardware but is documented as lost is a HIGH finding, not a bonus.
+2. **The os_log mirror actually mirrors.** Without `OS_ACTIVITY_DT_MODE` the
+   stream carries plain `stdout`/`stderr` writes only. Prove the variable is
+   doing work: a `console.log` from JS must appear. If it does not, the
+   collector is capturing almost nothing and the gap is still open.
+3. **Timeline integration.** `logs --source device` shows the records in one
+   timeline with `metro` and `build`, ordered by `ts` across sources.
+   `logs --errors` with no `--source` still excludes them. A native crash
+   before JS starts appears with level `fatal`.
+4. **Launch coupling.** On hardware the collector performs the launch, so
+   confirm exactly one app instance starts, that `--terminate-existing`
+   replaced a running one, and that a dev-client deep link passed as
+   `--payload-url` opened the right URL.
+5. **Cleanup on unplug.** Pull the cable with the collector running. It must
+   write `collector_stopped`, remove its own `collectors.ios` registration,
+   and exit; `status` must stop reporting it and `gc` must find nothing,
+   because a phone is never recorded as a device. Then reconnect and run
+   `ios --device` again: the replacement must start cleanly.
+6. **Replacement and ownership.** With a collector live, run `ios --device`
+   again and confirm the previous pid was proven this workspace's and
+   signalled, and that `stop` reaps the survivor.
+
+**C. Install, launch and Debug over the LAN**, once #178 wires them: the
+signer-conflict uninstall-and-retry, the device-side process probe that
+replaces the host `process.kill` for release launch proof, and the evidence
+that the phone fetched from Metro rather than falling back to its embedded
+bundle (the run's own `ready: bundle loaded` line).
 
 ## Launch-status contract
 

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -183,10 +183,15 @@ phone. What a phone has to settle:
    replaced a running one, and that a dev-client deep link passed as
    `--payload-url` opened the right URL.
 5. **Cleanup on unplug.** Pull the cable with the collector running. It must
-   write `collector_stopped`, remove its own `collectors.ios` registration,
-   and exit; `status` must stop reporting it and `gc` must find nothing,
-   because a phone is never recorded as a device. Then reconnect and run
-   `ios --device` again: the replacement must start cleanly.
+   remove its own `collectors.ios` registration and exit; `status` must stop
+   reporting it and `gc` must find nothing, because a phone is never recorded
+   as a device. Then reconnect and run `ios --device` again: the replacement
+   must start cleanly. **Which closing record does it write?** A non-zero
+   devicectl exit becomes `collector_failed`, a zero exit becomes
+   `collector_stopped`, and nobody has observed which one a cable-pull
+   produces. Record the exit code and the record. If unplugging reports a
+   failure, that is a wrong error on a normal action and the classification
+   needs to change.
 6. **Replacement and ownership.** With a collector live, run `ios --device`
    again and confirm the previous pid was proven this workspace's and
    signalled, and that `stop` reaps the survivor.

--- a/docs/specs/2026-09-01-ios-device-release-design.md
+++ b/docs/specs/2026-09-01-ios-device-release-design.md
@@ -873,6 +873,28 @@ several is a refusal listing the candidates.
 
 Either way `process.processIdentifier` is read out of the JSON.
 
+**Amendment, 2026-09-01 (#179).** Two details of that sketch are wrong, found
+while interrogating `devicectl` 518.33 for phase 7, and phase 3 should follow
+this paragraph rather than the bullets above.
+
+1. **The deep link is not the positional argument.** `devicectl device process
+launch` documents its positional as "the bundle identifier of or path to the
+   remote application"; a URL for the app to open on launch travels in
+   `--payload-url`. The dev-client launch is therefore
+   `... --device <udid> --terminate-existing --payload-url <devClientUrl(...)>
+<bundleId>`.
+2. **`--json-output` cannot supply the pid when the console is attached.**
+   Phase 7 needs `--console` on the same launch, and `--console` "waits for the
+   app to terminate", so its JSON is written at exit rather than at launch. The
+   device-side process probe this section already specifies —
+   `devicectl device info processes` — becomes the only source of a device pid,
+   for Debug as well as Release. It is no longer release-only plumbing.
+
+Phase 7 also inverts who launches: because `devicectl` connects an app's
+standard streams only when it is the process that starts the app, the log
+collector runs this launch itself rather than attaching after it. Phase 3 wires
+the collector as the launch step; see #179.
+
 **Proof of launch — this is an invariant 11 change, and only for release.**
 `verifyReleaseLaunch` (`app-install.ts:567`) sleeps 3 s then calls
 `process.kill(pid, 0)` on the **host**. That works on a simulator because a

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -28,6 +28,7 @@ import {
   parseDeviceConsoleLine,
   CONSOLE_ENV,
   FATAL_MARKERS,
+  TOOL_ERROR_PREFIX,
 } from '../collector/ios-device.ts';
 import { LEVELS, SOURCES } from '../ndjson.ts';
 
@@ -219,11 +220,29 @@ describe('ios: the physical-device console', () => {
 
   test("devicectl's own refusal is recorded at error rather than as app output", () => {
     const record = parseDeviceConsoleLine(
-      'ERROR: The specified device was not found. (Name: 00008030-DEAD) (com.apple.dt.CoreDeviceError error 1000 (0x3E8))',
+      `${TOOL_ERROR_PREFIX}The specified device was not found. (Name: 00008030-DEAD) (com.apple.dt.CoreDeviceError error 1000 (0x3E8))`,
       { now: at },
     );
     assert(record);
     expect(record.level).toBe('error');
+  });
+
+  test('an app that logs the ERROR: prefix is not devicectl, because the mirror prefixed it', () => {
+    const record = parseDeviceConsoleLine(
+      '2026-09-01 10:03:46.971897-0400 StimFixture[431:1049622] [javascript] ERROR: request failed',
+      { now: at },
+    );
+    assert(record);
+    expect(record.level).toBe('info');
+    expect(record.msg).toBe('ERROR: request failed');
+  });
+
+  test('a product name with a space keeps its process, category and timestamp', () => {
+    const record = parsed.find((r) => r.msg === 'a product name with a space still mirrors');
+    assert(record);
+    expect(record.proc).toBe('My App(512)');
+    expect(record.category).toBe('javascript');
+    expect(record.ts).not.toBe(at());
   });
 
   test('blank lines and non-strings are not records', () => {
@@ -233,9 +252,19 @@ describe('ios: the physical-device console', () => {
     expect(parseDeviceConsoleLine('2026-09-01 10:03:46.971266-0400 App[1:2] ', { now: at })).toBe(null);
   });
 
-  test('every fatal marker is matched by substring, wherever it sits in the line', () => {
-    for (const marker of FATAL_MARKERS) {
-      expect(deviceConsoleLevel(`prefix ${marker} suffix`)).toBe('fatal');
+  test('a fatal marker counts only where the runtime puts it: at the start of the message', () => {
+    const starts = [
+      "*** Terminating app due to uncaught exception 'NSRangeException', reason: '...'",
+      'libc++abi: terminating due to uncaught exception of type NSException',
+      '*** Assertion failure in -[UIView layoutSubviews], UIView.m:1',
+      'Fatal error: Unexpectedly found nil while unwrapping an Optional value',
+      'Screen.swift:42: Fatal error: Unexpectedly found nil while unwrapping an Optional value',
+    ];
+    for (const line of starts) expect(deviceConsoleLevel(line)).toBe('fatal');
+    expect(starts.every((line) => FATAL_MARKERS.some((m) => m.test(line)))).toBeTruthy();
+
+    for (const line of starts) {
+      expect(deviceConsoleLevel(`retrying after a crash report that said "${line}"`)).toBe('info');
     }
     expect(deviceConsoleLevel('nothing alarming')).toBe('info');
     expect(deviceConsoleLevel(42)).toBe('info');

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -22,6 +22,13 @@ import {
   watchAppPid,
   NOISE_TAGS,
 } from '../collector/android.ts';
+import {
+  deviceConsoleArgs,
+  deviceConsoleLevel,
+  parseDeviceConsoleLine,
+  CONSOLE_ENV,
+  FATAL_MARKERS,
+} from '../collector/ios-device.ts';
 import { LEVELS, SOURCES } from '../ndjson.ts';
 
 function isNotNull<T>(value: T | null): value is T {
@@ -132,6 +139,129 @@ describe('ios: log stream ndjson', () => {
   test('appNameFromBundleId is the last segment, as a fallback for a caller with only a bundle id', () => {
     expect(appNameFromBundleId('com.example.MyApp')).toBe('MyApp');
     expect(appNameFromBundleId('MyApp')).toBe('MyApp');
+  });
+});
+
+describe('ios: the physical-device console', () => {
+  const capture = fixture('ios-device-console.txt');
+  const lines = capture.split('\n').filter((l) => l !== '');
+  const at = () => 1788271500000;
+  const parsed = lines.map((l) => parseDeviceConsoleLine(l, { now: at })).filter(isNotNull);
+
+  test('every line of the capture becomes a Contract-1 record', () => {
+    expect(parsed.length).toBe(lines.length);
+    for (const record of parsed) {
+      assert(record.src);
+      assert(record.level);
+      expect(record.src).toBe('device');
+      expect(SOURCES.includes(record.src)).toBeTruthy();
+      expect(LEVELS.includes(record.level)).toBeTruthy();
+      expect(typeof record.msg).toBe('string');
+      expect(Number.isFinite(record.ts)).toBeTruthy();
+      expect(record.raw).toBe(true);
+    }
+  });
+
+  test('a mirrored os_log line yields its own timestamp, process, pid and category', () => {
+    const record = parsed[1];
+    assert(record);
+    expect(record.msg).toBe('counter is 1');
+    expect(record.proc).toBe('StimFixture(431)');
+    expect(record.category).toBe('javascript');
+    expect(record.ts).toBe(Date.parse('2026-09-01 10:03:46.971897-0400'));
+  });
+
+  test('a logger with no subsystem mirrors without a category bracket, and none is invented', () => {
+    const record = parsed.find((r) => r.msg === 'a line logged with no subsystem');
+    assert(record);
+    expect('category' in record).toBeFalsy();
+    expect(record.proc).toBe('StimFixture(431)');
+  });
+
+  test('NSLog and os_log are indistinguishable in the mirror, and both parse', () => {
+    const record = parsed.find((r) => r.msg === 'an NSLog line');
+    assert(record);
+    expect(record.proc).toBe('StimFixture(431)');
+  });
+
+  test('a raw stdout or stderr write carries no prefix, so it is timestamped on receipt', () => {
+    const record = parsed.find((r) => r.msg === 'a raw stdout write');
+    assert(record);
+    expect(record.ts).toBe(at());
+    expect('proc' in record).toBeFalsy();
+    expect(record.level).toBe('info');
+  });
+
+  test('the second line of a multi-line message arrives unprefixed and is kept, not dropped', () => {
+    const index = parsed.findIndex((r) => r.msg === 'a message that');
+    expect(index).toBeGreaterThan(-1);
+    const next = parsed[index + 1];
+    assert(next);
+    expect(next.msg).toBe('spans two lines');
+    expect(next.ts).toBe(at());
+  });
+
+  test('the uncaught-exception line is the one severity the console can prove', () => {
+    const fatal = parsed.filter((r) => r.level === 'fatal');
+    expect(fatal.length).toBeGreaterThan(0);
+    const first = fatal[0];
+    assert(first);
+    expect(String(first.msg)).toMatch(/^\*\*\* Terminating app due to uncaught exception 'RCTFatalException/);
+    expect(first.proc).toBe('StimFixture(431)');
+    expect(parsed.some((r) => r.level === 'fatal' && String(r.msg).startsWith('libc++abi: terminating'))).toBeTruthy();
+  });
+
+  test('severity is otherwise info: the mirror renders Default, Error and Fault identically', () => {
+    const warning = parsed.find((r) => String(r.msg).startsWith('Warning: componentWillMount'));
+    assert(warning);
+    expect(warning.level).toBe('info');
+  });
+
+  test("devicectl's own refusal is recorded at error rather than as app output", () => {
+    const record = parseDeviceConsoleLine(
+      'ERROR: The specified device was not found. (Name: 00008030-DEAD) (com.apple.dt.CoreDeviceError error 1000 (0x3E8))',
+      { now: at },
+    );
+    assert(record);
+    expect(record.level).toBe('error');
+  });
+
+  test('blank lines and non-strings are not records', () => {
+    expect(parseDeviceConsoleLine('')).toBe(null);
+    expect(parseDeviceConsoleLine('   ')).toBe(null);
+    expect(parseDeviceConsoleLine(null as unknown as string)).toBe(null);
+    expect(parseDeviceConsoleLine('2026-09-01 10:03:46.971266-0400 App[1:2] ', { now: at })).toBe(null);
+  });
+
+  test('every fatal marker is matched by substring, wherever it sits in the line', () => {
+    for (const marker of FATAL_MARKERS) {
+      expect(deviceConsoleLevel(`prefix ${marker} suffix`)).toBe('fatal');
+    }
+    expect(deviceConsoleLevel('nothing alarming')).toBe('info');
+    expect(deviceConsoleLevel(42)).toBe('info');
+  });
+
+  test('deviceConsoleArgs is the exact argv, and it turns the os_log mirror on', () => {
+    expect(deviceConsoleArgs({ udid: 'U1', bundleId: 'com.example.app' })).toEqual([
+      'devicectl',
+      'device',
+      'process',
+      'launch',
+      '--quiet',
+      '--device',
+      'U1',
+      '--console',
+      '--terminate-existing',
+      '--environment-variables',
+      '{"OS_ACTIVITY_DT_MODE":"enable"}',
+      'com.example.app',
+    ]);
+    expect(CONSOLE_ENV['OS_ACTIVITY_DT_MODE']).toBe('enable');
+  });
+
+  test('a dev-client deep link travels as --payload-url, before the bundle id', () => {
+    const args = deviceConsoleArgs({ udid: 'U1', bundleId: 'com.example.app', payloadUrl: 'stim://x?url=y' });
+    expect(args.slice(-3)).toEqual(['--payload-url', 'stim://x?url=y', 'com.example.app']);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { parseNdjsonText } from '../ndjson.ts';
 import { workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import { parseArgs, readCollectors, registerCollector, runCollector, unregisterCollector } from '../collector/run.ts';
+import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { writeWorkspaceState } from '../supervisor/run.ts';
 import { makeChildProcess } from './_factories.ts';
 
@@ -107,8 +108,48 @@ describe('parseArgs', () => {
         appName: 'MyApp',
         serial: null,
         packageName: null,
+        physical: false,
+        payloadUrl: null,
       },
     );
+  });
+
+  test('--physical selects the devicectl console; it needs the bundle id, not the app name', () => {
+    expect(
+      parseArgs([
+        '--platform',
+        'ios',
+        '--root',
+        '/abs',
+        '--udid',
+        'U1',
+        '--bundle',
+        'com.example.MyApp',
+        '--physical',
+        '--payload-url',
+        'stim://x',
+      ]),
+    ).toEqual({
+      platform: 'ios',
+      root: '/abs',
+      udid: 'U1',
+      bundleId: 'com.example.MyApp',
+      appName: 'MyApp',
+      serial: null,
+      packageName: null,
+      physical: true,
+      payloadUrl: 'stim://x',
+    });
+  });
+
+  test('--physical is refused on android, and --payload-url without it', () => {
+    expect(
+      parseArgs(['--platform', 'android', '--root', '/abs', '--serial', 'S', '--package', 'com.x', '--physical']).error,
+    ).toMatch(/--physical is an iOS option/);
+    expect(
+      parseArgs(['--platform', 'ios', '--root', '/abs', '--udid', 'U1', '--bundle', 'com.x', '--payload-url', 'u'])
+        .error,
+    ).toMatch(/--payload-url only applies to --physical/);
   });
 
   test('an explicit --app-name wins, because the product name is not always the last bundle segment', () => {
@@ -289,6 +330,129 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
     assert(stopped);
     expect(stopped.msg).toMatch(/device log stream ended/);
     expect('collectors' in (state() || {})).toBe(false);
+  });
+});
+
+describe('the ios device collector, spawned for real against a fake devicectl', () => {
+  const consoleLines = () =>
+    readFileSync(fileURLToPath(new URL('./fixtures/ios-device-console.txt', import.meta.url)), 'utf-8')
+      .split('\n')
+      .filter((l) => l !== '');
+
+  test('launches the app itself, parses BOTH streams, and clears the registration on SIGTERM', async () => {
+    const expected =
+      'devicectl device process launch --quiet --device UDID-1 --console --terminate-existing ' +
+      '--environment-variables {"OS_ACTIVITY_DT_MODE":"enable"} --payload-url stim://open com.example.MyApp';
+    writeShim(
+      'xcrun',
+      [
+        `case "$*" in`,
+        `  '${expected}') ;;`,
+        `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
+        `esac`,
+        `echo 'a raw stdout write'`,
+        ...consoleLines().map((l) => `cat >&2 <<'LINE'\n${l}\nLINE`),
+        'exec sleep 30',
+      ].join('\n'),
+    );
+
+    const child = spawnCollector([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      'UDID-1',
+      '--bundle',
+      'com.example.MyApp',
+      '--physical',
+      '--payload-url',
+      'stim://open',
+    ]);
+
+    const registered = await until(() => readCollectors(root).ios as CollectorEntry, {
+      label: 'the device collector registration',
+    });
+    expect(registered.pid).toBe(child.pid);
+
+    const fatals = await until(
+      () => {
+        const r = deviceLog().filter((x) => x.level === 'fatal');
+        return r.length ? r : null;
+      },
+      { label: 'the crash record from the app stderr' },
+    );
+    const crash = fatals[0];
+    assert(crash);
+    expect(crash.msg).toMatch(/Terminating app due to uncaught exception/);
+    expect(crash.proc).toBe('StimFixture(431)');
+    expect(crash.platform).toBe('ios');
+    expect(crash.raw).toBe(true);
+
+    const log = deviceLog();
+    const started = log[0];
+    assert(started);
+    expect(started.event).toBe('collector_started');
+    expect(started.msg).toMatch(/launching com\.example\.MyApp on iPhone UDID-1/);
+    expect(started.msg).toMatch(/subsystem, category and severity are not carried on hardware/);
+    expect(log.some((r) => r.msg === 'a raw stdout write')).toBeTruthy();
+    expect(log.some((r) => r.category === 'javascript' && r.msg === 'counter is 1')).toBeTruthy();
+    expect(log.some((r) => r.event === 'collector_stderr')).toBe(false);
+
+    expect(verifyCollectorOwnership({ pid: childPid(child), platform: 'ios', root })).toEqual({ status: 'ours' });
+
+    process.kill(childPid(child), 'SIGTERM');
+    expect(await exited(child)).toEqual({ code: 0, signal: null });
+    expect('collectors' in (state() || {})).toBe(false);
+    expect(deviceLog().some((r) => r.event === 'collector_empty')).toBe(false);
+  });
+
+  test('a devicectl refusal is a failure, not a silent empty section', async () => {
+    writeShim('xcrun', ['echo "ERROR: The specified device was not found. (Name: UDID-1)" >&2', 'exit 1'].join('\n'));
+    const child = spawnCollector([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      'UDID-1',
+      '--bundle',
+      'com.example.MyApp',
+      '--physical',
+    ]);
+    expect((await exited(child)).code).toBe(1);
+    const log = deviceLog();
+    expect(
+      log.some((r) => r.level === 'error' && String(r.msg).startsWith('ERROR: The specified device')),
+    ).toBeTruthy();
+    const empty = log.find((r) => r.event === 'collector_empty');
+    expect(empty).toBeFalsy();
+    const failed = log.find((r) => r.event === 'collector_failed');
+    assert(failed);
+    expect(failed.level).toBe('error');
+    expect(failed.msg).toMatch(/the devicectl console ended with exit code 1/);
+    expect('collectors' in (state() || {})).toBe(false);
+  });
+
+  test('a clean launch that produced no console output says so rather than reading as a pass', async () => {
+    writeShim('xcrun', 'exit 0\n');
+    const child = spawnCollector([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      'UDID-1',
+      '--bundle',
+      'com.example.MyApp',
+      '--physical',
+    ]);
+    expect((await exited(child)).code).toBe(0);
+    const empty = deviceLog().find((r) => r.event === 'collector_empty');
+    assert(empty);
+    expect(empty.level).toBe('warn');
+    expect(empty.msg).toMatch(/devicectl only connects the app's streams when it starts the app/);
+    expect(deviceLog().some((r) => r.event === 'collector_stopped')).toBeTruthy();
   });
 });
 

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -150,6 +150,9 @@ describe('parseArgs', () => {
       parseArgs(['--platform', 'ios', '--root', '/abs', '--udid', 'U1', '--bundle', 'com.x', '--payload-url', 'u'])
         .error,
     ).toMatch(/--payload-url only applies to --physical/);
+    expect(
+      parseArgs(['--platform', 'ios', '--root', '/abs', '--udid', 'U1', '--bundle', 'com.x', '--payload-url']).error,
+    ).toMatch(/--payload-url needs a URL/);
   });
 
   test('an explicit --app-name wins, because the product name is not always the last bundle segment', () => {
@@ -393,7 +396,7 @@ describe('the ios device collector, spawned for real against a fake devicectl', 
     const started = log[0];
     assert(started);
     expect(started.event).toBe('collector_started');
-    expect(started.msg).toMatch(/launching com\.example\.MyApp on iPhone UDID-1/);
+    expect(started.msg).toMatch(/launching com\.example\.MyApp on device UDID-1/);
     expect(started.msg).toMatch(/subsystem, category and severity are not carried on hardware/);
     expect(log.some((r) => r.msg === 'a raw stdout write')).toBeTruthy();
     expect(log.some((r) => r.category === 'javascript' && r.msg === 'counter is 1')).toBeTruthy();
@@ -432,6 +435,26 @@ describe('the ios device collector, spawned for real against a fake devicectl', 
     expect(failed.level).toBe('error');
     expect(failed.msg).toMatch(/the devicectl console ended with exit code 1/);
     expect('collectors' in (state() || {})).toBe(false);
+  });
+
+  test('a stop signal before any output is a stop, not an empty capture', async () => {
+    writeShim('xcrun', 'exec sleep 30\n');
+    const child = spawnCollector([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      'UDID-1',
+      '--bundle',
+      'com.example.MyApp',
+      '--physical',
+    ]);
+    await until(() => readCollectors(root).ios as CollectorEntry, { label: 'the device collector registration' });
+    process.kill(childPid(child), 'SIGTERM');
+    expect(await exited(child)).toEqual({ code: 0, signal: null });
+    expect(deviceLog().some((r) => r.event === 'collector_empty')).toBe(false);
+    expect(deviceLog().some((r) => r.event === 'collector_stopped')).toBeTruthy();
   });
 
   test('a clean launch that produced no console output says so rather than reading as a pass', async () => {

--- a/packages/stim-cli/src/__tests__/fixtures/ios-device-console.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-device-console.txt
@@ -26,3 +26,5 @@ spans two lines
 	4   dyld                                0x0000000185de7e00 start + 6992
 )
 libc++abi: terminating due to uncaught exception of type NSException
+2026-09-01 10:24:21.163944-0400 My App[512:1049623] [javascript] a product name with a space still mirrors
+2026-09-01 10:24:21.164158-0400 My App[512:1049623] and so does NSLog from it

--- a/packages/stim-cli/src/__tests__/fixtures/ios-device-console.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-device-console.txt
@@ -1,0 +1,28 @@
+2026-09-01 10:03:46.971266-0400 StimFixture[431:1049622] [native] Running application StimFixture ({ initialProps: {}, rootTag: 1 })
+2026-09-01 10:03:46.971897-0400 StimFixture[431:1049622] [javascript] counter is 1
+2026-09-01 10:03:46.971915-0400 StimFixture[431:1049622] [javascript] Warning: componentWillMount has been renamed
+2026-09-01 10:03:46.971926-0400 StimFixture[431:1049622] a line logged with no subsystem
+2026-09-01 10:03:46.971949-0400 StimFixture[431:1049622] an NSLog line
+a raw stdout write
+a raw stderr write
+2026-09-01 10:03:46.971992-0400 StimFixture[431:1049622] [javascript] a message that
+spans two lines
+2026-09-01 10:03:46.972519-0400 StimFixture[431:1049622] *** Terminating app due to uncaught exception 'RCTFatalException: Unhandled JS Exception', reason: 'undefined is not a function'
+*** First throw call stack:
+(
+	0   CoreFoundation                      0x00000001862d11c0 __exceptionPreprocess + 176
+	1   libobjc.A.dylib                     0x0000000185d5a91c objc_exception_throw + 88
+	2   CoreFoundation                      0x00000001862d10b0 +[NSException exceptionWithName:reason:userInfo:] + 0
+	3   StimFixture                            0x0000000100268b28 main + 912
+	4   dyld                                0x0000000185de7e00 start + 6992
+)
+*** Terminating app due to uncaught exception 'RCTFatalException: Unhandled JS Exception', reason: 'undefined is not a function'
+*** First throw call stack:
+(
+	0   CoreFoundation                      0x00000001862d11c0 __exceptionPreprocess + 176
+	1   libobjc.A.dylib                     0x0000000185d5a91c objc_exception_throw + 88
+	2   CoreFoundation                      0x00000001862d10b0 +[NSException exceptionWithName:reason:userInfo:] + 0
+	3   StimFixture                            0x0000000100268b28 main + 912
+	4   dyld                                0x0000000185de7e00 start + 6992
+)
+libc++abi: terminating due to uncaught exception of type NSException

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'node:url';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
+import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
 
 test('every advertised topic renders non-empty content', () => {
   for (const name of topicNames()) {
@@ -289,6 +290,37 @@ test('no topic teaches a command this binary does not have', () => {
   }
   expect(renderTopic('errors')).not.toMatch(/Installed Stim skill/);
   expect(renderTopic('settings')).toMatch(/no `stim config` command/);
+});
+
+test('the guide states the physical-iPhone device-log losses, and states them as losses', () => {
+  const logs = renderTopic('logs');
+  const cleanup = renderTopic('cleanup');
+  assert(logs);
+  assert(cleanup);
+
+  expect(logs).toContain('devicectl device process launch --console');
+  for (const [key, value] of Object.entries(CONSOLE_ENV)) {
+    expect(logs).toContain(key);
+    expect(deviceConsoleArgs({ udid: 'U', bundleId: 'b' }).join(' ')).toContain(`"${key}":"${value}"`);
+  }
+  expect(logs).toMatch(/subsystem LOST/);
+  expect(logs).toMatch(/level {5}LOST/);
+  expect(logs).toMatch(/category {2}KEPT/);
+  expect(logs).toMatch(/Must be root to collect logs from attached device/);
+  expect(logs).toMatch(/libimobiledevice or pymobiledevice3[\s\S]*does not require/);
+  expect(logs).toMatch(/--source device --errors[\s\S]*crash and refusal lines only/);
+  expect(logs).toContain('appandflow/stim#179');
+
+  expect(cleanup).toMatch(/on\s+hardware the collector IS the launch/);
+  expect(cleanup).toMatch(/proven and replaced by the same pid rules/);
+  expect(cleanup).toMatch(/Unplugging the phone[\s\S]*collector_stopped/);
+  expect(cleanup).toContain('appandflow/stim#178');
+
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(lifecycle).toMatch(/THE DEVICE LOG COLLECTOR IS BUILT BUT NOT YET STARTED/);
+  expect(lifecycle).toMatch(/the collector IS the launch/);
+  expect(lifecycle).toContain('appandflow/stim#179');
 });
 
 test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -315,6 +315,11 @@ test('the guide states the physical-iPhone device-log losses, and states them as
   expect(cleanup).toMatch(/proven and replaced by the same pid rules/);
   expect(cleanup).toMatch(/Unplugging the phone[\s\S]*collector_stopped/);
   expect(cleanup).toContain('appandflow/stim#178');
+  expect(logs).toMatch(/lines that OPEN with a marker[\s\S]*anchored[\s\S]*app logging ABOUT a crash stays\s+info/);
+  expect(logs).toMatch(/only on a line with no mirror\s+prefix/);
+  expect(cleanup).toMatch(
+    /unverified until someone pulls a cable[\s\S]*collector_stopped, a non-zero one is\s+collector_failed/,
+  );
 
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);

--- a/packages/stim-cli/src/collector/ios-device.ts
+++ b/packages/stim-cli/src/collector/ios-device.ts
@@ -7,20 +7,23 @@ import type { NdjsonRecord } from '../ndjson.ts';
 // writes alone, and React Native logs through os_log (React/Base/RCTLog.mm).
 export const CONSOLE_ENV: Record<string, string> = { OS_ACTIVITY_DT_MODE: 'enable' };
 
-export const FATAL_MARKERS: string[] = [
-  '*** Terminating app due to uncaught exception',
-  'libc++abi: terminating',
-  '*** Assertion failure in',
-  'Fatal error: ',
+// Anchored, because a message that merely quotes one of these is an app
+// logging about a crash, not a crash. Swift prints its own file:line first.
+export const FATAL_MARKERS: RegExp[] = [
+  /^\*\*\* Terminating app due to uncaught exception/,
+  /^libc\+\+abi: terminating/,
+  /^\*\*\* Assertion failure in/,
+  /^(?:\S+:\d+: )?Fatal error: /,
 ];
 
+export const TOOL_ERROR_PREFIX = 'ERROR: ';
+
 const MIRROR_LINE =
-  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4}) (\S+)\[(\d+):(\d+)\] ?(?:\[([^\]\s]+)\] )?([\s\S]*)$/;
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4}) (.+?)\[(\d+):(\d+)\] ?(?:\[([^\]\s]+)\] )?([\s\S]*)$/;
 
 export function deviceConsoleLevel(message: unknown): string {
   const text = typeof message === 'string' ? message : '';
-  if (FATAL_MARKERS.some((marker) => text.includes(marker))) return 'fatal';
-  return text.startsWith('ERROR: ') ? 'error' : 'info';
+  return FATAL_MARKERS.some((marker) => marker.test(text)) ? 'fatal' : 'info';
 }
 
 export function parseDeviceConsoleLine(
@@ -40,7 +43,9 @@ export function parseDeviceConsoleLine(
     raw: true,
   };
   if (!match) {
-    record.level = deviceConsoleLevel(text);
+    // devicectl's own diagnostics share the app's stderr but never carry a
+    // mirror prefix, so this prefix is only theirs on an unmatched line.
+    record.level = text.startsWith(TOOL_ERROR_PREFIX) ? 'error' : deviceConsoleLevel(text);
     return record;
   }
 

--- a/packages/stim-cli/src/collector/ios-device.ts
+++ b/packages/stim-cli/src/collector/ios-device.ts
@@ -1,0 +1,101 @@
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { getExecutor } from '../exec.ts';
+import type { NdjsonRecord } from '../ndjson.ts';
+
+// os_log only reaches a process's stderr when OS_ACTIVITY_DT_MODE is set in its
+// environment; without it `devicectl --console` carries plain stdout/stderr
+// writes alone, and React Native logs through os_log (React/Base/RCTLog.mm).
+export const CONSOLE_ENV: Record<string, string> = { OS_ACTIVITY_DT_MODE: 'enable' };
+
+export const FATAL_MARKERS: string[] = [
+  '*** Terminating app due to uncaught exception',
+  'libc++abi: terminating',
+  '*** Assertion failure in',
+  'Fatal error: ',
+];
+
+const MIRROR_LINE =
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+[+-]\d{4}) (\S+)\[(\d+):(\d+)\] ?(?:\[([^\]\s]+)\] )?([\s\S]*)$/;
+
+export function deviceConsoleLevel(message: unknown): string {
+  const text = typeof message === 'string' ? message : '';
+  if (FATAL_MARKERS.some((marker) => text.includes(marker))) return 'fatal';
+  return text.startsWith('ERROR: ') ? 'error' : 'info';
+}
+
+export function parseDeviceConsoleLine(
+  line: string,
+  { now = Date.now }: { now?: () => number } = {},
+): NdjsonRecord | null {
+  if (typeof line !== 'string') return null;
+  const text = line.replace(/\r$/, '').trimEnd();
+  if (!text.trim()) return null;
+
+  const match = MIRROR_LINE.exec(text);
+  const record: NdjsonRecord = {
+    ts: now(),
+    src: 'device',
+    level: 'info',
+    msg: text,
+    raw: true,
+  };
+  if (!match) {
+    record.level = deviceConsoleLevel(text);
+    return record;
+  }
+
+  const [, timestamp, proc, pid, , category, message] = match;
+  if (message === undefined || !message.trim()) return null;
+  const parsed = Date.parse(timestamp as string);
+  if (Number.isFinite(parsed)) record.ts = parsed;
+  record.msg = message;
+  record.level = deviceConsoleLevel(message);
+  record.proc = `${proc}(${pid})`;
+  if (category) record.category = category;
+  return record;
+}
+
+export function deviceConsoleArgs({
+  udid,
+  bundleId,
+  payloadUrl = null,
+}: {
+  udid: string;
+  bundleId: string;
+  payloadUrl?: string | null;
+}): string[] {
+  const args = [
+    'devicectl',
+    'device',
+    'process',
+    'launch',
+    '--quiet',
+    '--device',
+    udid,
+    '--console',
+    '--terminate-existing',
+    '--environment-variables',
+    JSON.stringify(CONSOLE_ENV),
+  ];
+  if (payloadUrl) args.push('--payload-url', payloadUrl);
+  args.push(bundleId);
+  return args;
+}
+
+export function startIosDeviceConsole({
+  udid,
+  bundleId,
+  payloadUrl = null,
+  spawnFn = null,
+}: {
+  udid: string;
+  bundleId: string;
+  payloadUrl?: string | null;
+  spawnFn?: ((cmd: string, args: string[], opts: SpawnOptions) => ChildProcess) | null;
+}): ChildProcess {
+  const spawn = spawnFn || ((cmd: string, args: string[], opts: SpawnOptions) => getExecutor().spawn(cmd, args, opts));
+  return spawn('xcrun', deviceConsoleArgs({ udid, bundleId, payloadUrl }), {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+}

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -79,6 +79,7 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
     }
     if (arg === '--payload-url') {
       payloadUrl = argv[++i] ?? null;
+      if (!payloadUrl) return { error: '--payload-url needs a URL.' };
       continue;
     }
     return { error: `Unknown collector argument "${arg}".` };
@@ -177,7 +178,7 @@ function startMessage({
     return `device log collector pid ${pid} streaming ${packageName} (pid ${appPid}) on ${serial}`;
   }
   if (!physical) return `device log collector pid ${pid} streaming ${appName} on ${udid}`;
-  return `device log collector pid ${pid} launching ${bundleId} on iPhone ${udid} and streaming its console; subsystem, category and severity are not carried on hardware -- see \`stim guide logs\``;
+  return `device log collector pid ${pid} launching ${bundleId} on device ${udid} and streaming its console; subsystem, category and severity are not carried on hardware -- see \`stim guide logs\``;
 }
 
 export async function runCollector({
@@ -207,11 +208,11 @@ export async function runCollector({
   let finished = false;
   let captured = 0;
   let watcher: PidWatcher | null = null;
-  const finish = (code: number, level: string, msg: string, event: string) => {
+  const finish = (code: number, level: string, msg: string, event: string, { signalled = false } = {}) => {
     if (finished) return;
     finished = true;
     watcher?.stop();
-    if (physical && captured === 0) {
+    if (physical && captured === 0 && !signalled) {
       writer.write({
         src: 'device',
         platform,
@@ -238,7 +239,9 @@ export async function runCollector({
       process.on(signal, () => {
         flushReaders();
         killChild(child);
-        finish(0, 'info', `device log collector received ${signal}; detaching`, 'collector_stopped');
+        finish(0, 'info', `device log collector received ${signal}; detaching`, 'collector_stopped', {
+          signalled: true,
+        });
       });
     }
   }

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -6,6 +6,7 @@ import type { Executor } from '../exec.ts';
 import { type NdjsonWriter, createNdjsonWriter } from '../ndjson.ts';
 import { workspaceLogsDir } from '../paths.ts';
 import { createLineReader } from '../process-output.ts';
+import { parseDeviceConsoleLine, startIosDeviceConsole } from './ios-device.ts';
 import { appNameFromBundleId, parseLogStreamLine, startIosLogStream } from './ios.ts';
 import { collectorProcessTitle } from './ownership.ts';
 import {
@@ -27,6 +28,8 @@ export interface ParsedCollectorArgs {
   appName?: string;
   serial?: string | null;
   packageName?: string | null;
+  physical?: boolean;
+  payloadUrl?: string | null;
   error?: string;
 }
 
@@ -38,6 +41,8 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
   let appName: string | undefined;
   let serial: string | null = null;
   let packageName: string | null = null;
+  let physical = false;
+  let payloadUrl: string | null = null;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--platform') {
@@ -68,6 +73,14 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
       packageName = argv[++i] ?? null;
       continue;
     }
+    if (arg === '--physical') {
+      physical = true;
+      continue;
+    }
+    if (arg === '--payload-url') {
+      payloadUrl = argv[++i] ?? null;
+      continue;
+    }
     return { error: `Unknown collector argument "${arg}".` };
   }
   if (!platform || !PLATFORMS.includes(platform)) {
@@ -81,10 +94,14 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
     if (!bundleId) return { error: 'Missing --bundle (required for --platform ios).' };
     if (!appName) appName = appNameFromBundleId(bundleId);
   } else {
+    if (physical) return { error: '--physical is an iOS option; --platform android reads a serial.' };
     if (!serial) return { error: 'Missing --serial (required for --platform android).' };
     if (!packageName) return { error: 'Missing --package (required for --platform android).' };
   }
-  return { platform, root, udid, bundleId, appName, serial, packageName };
+  if (payloadUrl && !physical) {
+    return { error: '--payload-url only applies to --physical, which launches the app itself.' };
+  }
+  return { platform, root, udid, bundleId, appName, serial, packageName, physical, payloadUrl };
 }
 
 import { readCollectors, registerCollector, unregisterCollector } from './state.ts';
@@ -98,12 +115,17 @@ export interface RunCollectorOptions {
   bundleId?: string | null;
   serial?: string | null;
   packageName?: string | null;
+  physical?: boolean;
+  payloadUrl?: string | null;
   startStream?:
     | ((opts: {
         platform: string;
         udid?: string | null;
         appName?: string | null;
+        bundleId?: string | null;
         serial?: string | null;
+        physical?: boolean;
+        payloadUrl?: string | null;
         pid?: number | null;
       }) => ChildProcess)
     | null;
@@ -130,13 +152,44 @@ export interface RunCollectorHandle {
 
 const noopFlush = () => {};
 
+function startMessage({
+  platform,
+  physical,
+  pid,
+  appName,
+  bundleId,
+  udid,
+  packageName,
+  serial,
+  appPid,
+}: {
+  platform: string;
+  physical?: boolean;
+  pid: number;
+  appName?: string | null;
+  bundleId?: string | null;
+  udid?: string | null;
+  packageName?: string | null;
+  serial?: string | null;
+  appPid?: number | null;
+}): string {
+  if (platform !== 'ios') {
+    return `device log collector pid ${pid} streaming ${packageName} (pid ${appPid}) on ${serial}`;
+  }
+  if (!physical) return `device log collector pid ${pid} streaming ${appName} on ${udid}`;
+  return `device log collector pid ${pid} launching ${bundleId} on iPhone ${udid} and streaming its console; subsystem, category and severity are not carried on hardware -- see \`stim guide logs\``;
+}
+
 export async function runCollector({
   platform,
   root,
   udid = null,
   appName = null,
+  bundleId = null,
   serial = null,
   packageName = null,
+  physical = false,
+  payloadUrl = null,
   startStream = null,
   resolvePid = null,
   pidTimeoutMs = 30000,
@@ -152,11 +205,21 @@ export async function runCollector({
   const startedAt = new Date(now()).toISOString();
 
   let finished = false;
+  let captured = 0;
   let watcher: PidWatcher | null = null;
   const finish = (code: number, level: string, msg: string, event: string) => {
     if (finished) return;
     finished = true;
     watcher?.stop();
+    if (physical && captured === 0) {
+      writer.write({
+        src: 'device',
+        platform,
+        level: 'warn',
+        event: 'collector_empty',
+        msg: `the device console produced no output for ${bundleId}; devicectl only connects the app's streams when it starts the app, and os_log below the info level never reaches them`,
+      });
+    }
     writer.write({ src: 'device', platform, level, event, msg });
     try {
       unregisterCollector(root, platform, process.pid);
@@ -203,31 +266,55 @@ export async function runCollector({
     platform,
     level: 'info',
     event: 'collector_started',
-    msg:
-      platform === 'ios'
-        ? `device log collector pid ${process.pid} streaming ${appName} on ${udid}`
-        : `device log collector pid ${process.pid} streaming ${packageName} (pid ${pid}) on ${serial}`,
+    msg: startMessage({
+      platform,
+      physical,
+      pid: process.pid,
+      appName,
+      bundleId,
+      udid,
+      packageName,
+      serial,
+      appPid: pid,
+    }),
   });
 
-  const parse = platform === 'ios' ? parseLogStreamLine : parseLogcatLine;
+  const parse = platform === 'ios' ? (physical ? parseDeviceConsoleLine : parseLogStreamLine) : parseLogcatLine;
   const onLine = (line: string) => {
     const record = parse(line, { now });
-    if (record) writer.write({ ...record, platform });
+    if (!record) return;
+    captured++;
+    writer.write({ ...record, platform });
   };
 
   const attach = (streamPid: number | null): ChildProcess => {
     const spawned = startStream
-      ? startStream({ platform, udid, appName, serial, pid: streamPid })
+      ? startStream({ platform, udid, appName, bundleId, serial, physical, payloadUrl, pid: streamPid })
       : platform === 'ios'
-        ? startIosLogStream({ udid: udid as string, appName: appName as string })
+        ? physical
+          ? startIosDeviceConsole({ udid: udid as string, bundleId: bundleId as string, payloadUrl })
+          : startIosLogStream({ udid: udid as string, appName: appName as string })
         : startAndroidLogcat({ serial: serial as string, pid: streamPid as number });
     const outReader = createLineReader(onLine);
-    const errReader = createLineReader((line: string) => {
-      const text = String(line).trimEnd();
-      if (text.trim()) {
-        writer.write({ src: 'device', platform, level: 'debug', raw: true, event: 'collector_stderr', msg: text });
-      }
-    });
+    // devicectl --console connects the app's stderr to its own, and the os_log
+    // mirror and every crash report arrive there rather than on stdout.
+    const errReader = createLineReader(
+      physical
+        ? onLine
+        : (line: string) => {
+            const text = String(line).trimEnd();
+            if (text.trim()) {
+              writer.write({
+                src: 'device',
+                platform,
+                level: 'debug',
+                raw: true,
+                event: 'collector_stderr',
+                msg: text,
+              });
+            }
+          },
+    );
     flushReaders = () => {
       outReader.flush();
       errReader.flush();
@@ -246,6 +333,10 @@ export async function runCollector({
         return;
       }
       const how = signal ? `signal ${signal}` : `exit code ${code}`;
+      if (physical && code) {
+        finish(1, 'error', `the devicectl console ended with ${how}; treat the run as failed`, 'collector_failed');
+        return;
+      }
       finish(0, 'info', `device log stream ended (${how}); the app or device is gone`, 'collector_stopped');
     });
     spawned.on('error', (err) => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -365,7 +365,11 @@ FLAGS
   unhandled NAVIGATE names a route your app has, and is still an error.
   The app's own crashes reach client and metro either way. Opt back in with
   \`--source device\` or \`--source all\`; a plain \`logs\` with no --errors
-  has always shown everything.
+  has always shown everything. ON A PHYSICAL IPHONE opting back in buys less
+  than it does on a simulator: the device console carries no severity, so
+  \`--source device --errors\` there reports crash and refusal lines only,
+  never a level. Read a phone's device records with a plain \`logs
+  --source device\`.
 
   THE WINDOW. A marker closes the window for the sources it can speak for:
     a BUNDLE marker (src metro: bundle_build_done / bundle_build_failed, or
@@ -420,6 +424,40 @@ WHAT WRITES WHAT
                        the app's process also logs. The proven noise sources
                        are recorded at info rather than error; the rest is why
                        --errors leaves this source out unless asked.
+
+  ON A PHYSICAL IPHONE THE SAME FILE CARRIES LESS, and the difference is not
+  cosmetic. \`simctl spawn\` is simulator-only and there is no devicectl
+  console subcommand, so a device run reads
+  \`devicectl device process launch --console\`, which connects the app's own
+  stdout and stderr and nothing else. Stim launches it with
+  OS_ACTIVITY_DT_MODE, which makes os_log mirror itself onto that stderr --
+  without it React Native's own logging, which goes through os_log, would not
+  appear at all. What the mirror carries, and what it drops:
+
+    ts        KEPT   the device's own timestamp, off the mirrored line
+    proc      KEPT   as name(pid), from the mirrored line, not a path
+    category  KEPT   only when the logger has a subsystem; \`javascript\` and
+                     \`native\` for React Native's own log calls
+    msg       KEPT   a multi-line message arrives as separate records
+    subsystem LOST   the mirror never prints it
+    level     LOST   Default, Error and Fault all render identically, and
+                     Debug is not mirrored at all
+
+  So every device record from a phone is \`raw: true\` and \`info\`, except
+  the lines that name their own severity: an uncaught ObjC exception, a
+  libc++abi termination, an assertion failure, a Swift fatal error, and
+  devicectl's own \`ERROR:\`. Severity cannot be recovered, so it is not
+  guessed. The NOISE_RULES that demote Apple's framework chatter key on
+  subsystem and cannot fire either -- but they have less to do, because
+  --console carries only the app's streams rather than every framework
+  logging inside its process.
+
+  \`log collect --device-udid\` WOULD carry all six fields, in the same NDJSON
+  the simulator path parses. It is not used because it requires root
+  (\`log: Must be root to collect logs from attached device\`) and produces an
+  archive rather than a stream. Streaming with full fidelity needs
+  libimobiledevice or pymobiledevice3, which are third-party installs Stim
+  does not require. See appandflow/stim#179.
   build-ios.ndjson     the xcodebuild / gradle transcript at level debug, the
   build-android.ndjson extracted diagnostics at level error, and the launch as
                        a marker record. One RUN's worth: each build starts the
@@ -1270,6 +1308,20 @@ THE OPTION SURFACE, IN FULL
   for a device and to warm the device cache; use \`stim ios\` with no --device
   for a run that ends with an app on screen.
 
+  THE DEVICE LOG COLLECTOR IS BUILT BUT NOT YET STARTED, for the same reason:
+  on hardware the collector IS the launch. \`devicectl\` connects an app's
+  streams only when it is the process that starts the app, so the collector
+  runs \`devicectl device process launch --console\` itself rather than
+  attaching after the fact the way the simulator collector does. It is spawned
+  with the launch that #178 has still to wire. Once running it is the same
+  process as every other collector -- one per platform per workspace, titled
+  with its --root, killed and replaced on the next \`ios\` run whose pid still
+  proves it is this workspace's, and reaped by \`stop\`. Unplugging the phone
+  ends devicectl, which ends the collector: it writes collector_stopped,
+  removes its own registration and exits, leaving nothing for \`gc\` to find,
+  because a phone is never recorded as a device. See \`guide logs\` for what
+  the device stream can and cannot carry, and appandflow/stim#179.
+
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second
   flag. It is the Android half of \`ios --configuration Release\` and behaves
@@ -1417,6 +1469,18 @@ WHAT ELSE STOP REAPS
   so \`stop\` is what stands between a teardown and a log stream that outlives
   the device it was reading. A fresh \`ios\` / \`android\` run also kills the
   previous collector for that platform before starting its own.
+
+  A PHYSICAL IPHONE'S COLLECTOR IS THE SAME PROCESS with one difference: on
+  hardware the collector IS the launch. \`devicectl\` connects an app's
+  streams only when it is the process that starts the app, so the collector
+  runs \`devicectl device process launch --console\` itself rather than
+  attaching after the fact. It registers under the same \`ios\` key, carries
+  the same --root in its title, is proven and replaced by the same pid rules,
+  and is reaped by the same \`stop\`. Unplugging the phone ends devicectl,
+  which ends the collector: it writes collector_stopped, unregisters itself
+  and exits, and \`gc\` has nothing to find, because a phone is never recorded
+  as a device. It is not started yet -- the launch it would ride on is
+  appandflow/stim#178. See \`guide logs\` for what it can and cannot carry.
 
   Before signalling a recorded collector pid, \`stop\`, \`gc --delete\`,
   \`worktree remove\`, and a fresh \`ios\` / \`android\` run each read that

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -444,10 +444,12 @@ WHAT WRITES WHAT
                      Debug is not mirrored at all
 
   So every device record from a phone is \`raw: true\` and \`info\`, except
-  the lines that name their own severity: an uncaught ObjC exception, a
-  libc++abi termination, an assertion failure, a Swift fatal error, and
-  devicectl's own \`ERROR:\`. Severity cannot be recovered, so it is not
-  guessed. The NOISE_RULES that demote Apple's framework chatter key on
+  the lines that OPEN with a marker the runtime itself prints: an uncaught
+  ObjC exception, a libc++abi termination, an assertion failure, or a Swift
+  fatal error. The match is anchored, so an app logging ABOUT a crash stays
+  info. devicectl's own \`ERROR:\` is read only on a line with no mirror
+  prefix, because that is the only kind devicectl writes. Severity cannot be
+  recovered, so it is not guessed. The NOISE_RULES that demote Apple's framework chatter key on
   subsystem and cannot fire either -- but they have less to do, because
   --console carries only the app's streams rather than every framework
   logging inside its process.
@@ -1317,10 +1319,12 @@ THE OPTION SURFACE, IN FULL
   process as every other collector -- one per platform per workspace, titled
   with its --root, killed and replaced on the next \`ios\` run whose pid still
   proves it is this workspace's, and reaped by \`stop\`. Unplugging the phone
-  ends devicectl, which ends the collector: it writes collector_stopped,
-  removes its own registration and exits, leaving nothing for \`gc\` to find,
-  because a phone is never recorded as a device. See \`guide logs\` for what
-  the device stream can and cannot carry, and appandflow/stim#179.
+  ends devicectl, which ends the collector: it removes its own registration
+  and exits, leaving nothing for \`gc\` to find, because a phone is never
+  recorded as a device. Whether it closes with collector_stopped or
+  collector_failed follows devicectl's exit code, which no one has watched a
+  cable-pull produce yet. See \`guide logs\` for what the device stream can
+  and cannot carry, and appandflow/stim#179.
 
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second
@@ -1477,10 +1481,14 @@ WHAT ELSE STOP REAPS
   attaching after the fact. It registers under the same \`ios\` key, carries
   the same --root in its title, is proven and replaced by the same pid rules,
   and is reaped by the same \`stop\`. Unplugging the phone ends devicectl,
-  which ends the collector: it writes collector_stopped, unregisters itself
-  and exits, and \`gc\` has nothing to find, because a phone is never recorded
-  as a device. It is not started yet -- the launch it would ride on is
-  appandflow/stim#178. See \`guide logs\` for what it can and cannot carry.
+  which ends the collector: it unregisters itself and exits either way, so
+  \`gc\` has nothing to find, because a phone is never recorded as a device.
+  WHICH record it writes on the way out depends on devicectl's exit code, and
+  that code is unverified until someone pulls a cable: a zero exit is
+  collector_stopped, a non-zero one is collector_failed, because on hardware
+  a non-zero devicectl exit is the only evidence a launch or console failed.
+  It is not started yet -- the launch it would ride on is appandflow/stim#178.
+  See \`guide logs\` for what it can and cannot carry.
 
   Before signalling a recorded collector pid, \`stop\`, \`gc --delete\`,
   \`worktree remove\`, and a fresh \`ios\` / \`android\` run each read that


### PR DESCRIPTION
## Description

`ios --device` (#178) collects no runtime logs, and #179 is the follow-up that asks whether that gap can be closed. The design's first open question is the one that decides the shape: **is there a `devicectl` invocation that yields the `subsystem` / `category` / `messageType` / `processImagePath` fields `collector/ios.ts` parses?** If yes, phase 7 is a port. If no, the choice is a lossier second parser or a permanent gap.

**The answer is no, and here is the evidence.**

- **There is no `devicectl` console.** The subcommand tree of `devicectl` 518.33 (Xcode 26.6) was enumerated exhaustively — `device {copy,info,install,notification,orientation,process,reboot,sysdiagnose,uninstall}`, `list`, `manage`, `diagnose` and every leaf. No `console`, no `syslog`, no `log`. `xcrun devicectl device console --help` falls through to the `device` help rather than erroring. In the real binary (`/Library/Developer/PrivateFrameworks/CoreDevice.framework/Versions/A/Resources/bin/devicectl`, 3.1 MB — the `usr/bin/devicectl` on `PATH` is a 720-byte zsh shim) the only occurrence of the string `console` is the `--console` **flag** on `device process launch`. #179's premise that `devicectl device console` exists is wrong.
- **`log stream` has no device option.** `--device` / `--device-name` / `--device-udid` exist only on `log collect`, per both `log stream --help` and the man page synopsis.
- **`log collect --device*` requires root.** `log: Must be root to collect logs from attached device`, with `--device` and with `--device-udid` alike. It is also an archive, not a stream. This is the painful one: `log show --archive <a> --style ndjson` emits *exactly* the schema `recordFromLogEvent` already parses (verified against a host archive), so the fidelity is there and locked behind a privilege Stim does not take.
- **Full-fidelity streaming needs a third-party install.** `idevicesyslog` (libimobiledevice — a brew formula with six dependencies) or `pymobiledevice3` (a Python install). Neither is present on this machine and neither is a dependency Stim should require.

So: `devicectl device process launch --console` is the only Apple-supplied, no-root, no-new-dependency source of runtime output from a phone.

## Solution

`--console` alone would capture almost nothing useful. React Native's `RCTDefaultLogFunction` logs through `os_log_with_type` ([RCTLog.mm](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Base/RCTLog.mm)), not stderr, so a plain `--console` capture of an RN app is the handful of raw `stdout`/`stderr` writes and nothing else.

The collector launches the app with `OS_ACTIVITY_DT_MODE` set, which makes `os_log` mirror itself onto stderr — the same mechanism Xcode's own console uses. That turns `--console` from "the app's raw writes" into "the app's whole `os_log` stream", which is the difference between a useless collector and a lossy one. What the mirror carries and what it destroys, all measured against a real `os_log` process:

| field | simulator (`simctl spawn log stream --style ndjson`) | phone (`--console` + the mirror) |
| --- | --- | --- |
| `ts` | `timestamp` | kept — the device's own clock, off the mirrored line |
| `proc` | basename of `processImagePath` | kept, as `name(pid)`; no path |
| `category` | `category` | kept **only** when the logger has a subsystem (`javascript` / `native` for RN); absent for `NSLog` and `OS_LOG_DEFAULT` |
| `msg` | `eventMessage` | kept; a multi-line message arrives as separate unprefixed records |
| `subsystem` | `subsystem` | **lost** — the mirror never prints it |
| `level` | `messageType` | **lost** — `Default`, `Error` and `Fault` render identically, and `Debug` is not mirrored at all |

Losing `messageType` is the consequence that matters, so the parser does not paper over it: every device record from a phone is `raw: true` and `info`, except lines that **open with** a marker the runtime itself prints — an uncaught ObjC exception, a `libc++abi` termination, an assertion failure, a Swift fatal error (keeping its `file:line:` prefix). The match is anchored, so an app logging *about* a crash stays `info`. devicectl's own `ERROR:` is read only on a line with no mirror prefix, since that is the only kind devicectl writes — a `console.log("ERROR: request failed")` is app output and stays `info`. Severity is not guessed anywhere, because a guessed level is exactly the thing that would break `logs --errors`' empty-is-a-pass contract.

`ERROR_SOURCES` is unchanged, so `device` stays out of the default `--errors` scope as it always has. The `guide logs` topic now says what opting in with `--source device` buys on a phone (crash and refusal lines, never a level) and what it does not.

Two shape consequences worth flagging:

- **On hardware the collector *is* the launch.** `devicectl` connects an app's streams only when it is the process that started the app ("If the app is not already running, its standard streams will be connected to devicectl's standard streams"), so unlike `simctl log stream` this cannot attach after the fact. `--physical` therefore runs `device process launch --console --terminate-existing` itself. Registration, process title, `--root`, the pid-ownership proof from #181/#184 and reaping by `stop` are all the simulator collector's, unchanged — a test asserts `verifyCollectorOwnership` returns `ours` for a live `--physical` collector.
- **stderr is parsed, not shunted.** The simulator path records the child's stderr as `collector_stderr` at debug. On a device that stream *is* the app's output, so `--physical` routes both streams through the parser and passes `--quiet` to keep devicectl's own chatter out of it.

Nothing in `commands/ios.ts` starts this. Phase 3 (#178) has to spawn the collector *as* the device launch step, passing `--physical` and, for a dev-client app, the deep link as `--payload-url`.

Two corrections that phase 3 depends on are recorded as a dated amendment in the design's own launch sketch rather than only here, because that is what an implementer reads: the design passes the dev-client URL as the positional argument, but the positional is documented as "the bundle identifier of or path to the remote application" and the URL belongs on `--payload-url`; and `--console` blocks until the app exits, so `--json-output` cannot supply the pid at launch time, which promotes the device-side `devicectl device info processes` probe from release-only plumbing to the sole source of a device pid.

`docs/field-test-protocol.md` gains a **Physical iPhone** row and a staged checklist: the spec's five-step re-seal experiment first, then the log-capture verification — live fields against the fixtures (including the negative check that an error-level `os_log` call is *still* recorded at `info`), proof that `OS_ACTIVITY_DT_MODE` is doing work, timeline integration, launch coupling, and collector cleanup on unplug — including an open question the code cannot settle: a non-zero devicectl exit becomes `collector_failed` and a zero exit `collector_stopped`, and nobody has observed which one a cable-pull produces. If unplugging reports a failure, that classification is wrong and the checklist says so.

## Test plan

**The tool decision, against the real tools, phoneless.** Every claim in the Description above is a command run on this machine (Xcode 26.6 / devicectl 518.33): the exhaustive subcommand enumeration, `devicectl device console --help` falling through, `strings` on the real binary, `log stream --help` and `man 1 log`, both root refusals from `log collect`, and `log show --archive --style ndjson` on a host archive to confirm the schema that root is guarding.

**Invariant 9 — the changed tool call, against the real tool.** The exact argv `deviceConsoleArgs` produces was run against the real `devicectl` with a bogus UDID:

```
$ xcrun devicectl device process launch --quiet --device 00008030-DEADBEEFDEADBEEF \
    --console --terminate-existing -e '{"OS_ACTIVITY_DT_MODE":"enable"}' \
    --payload-url 'stim://expo-development-client/?url=...' com.example.app
ERROR: The specified device was not found. (Name: 00008030-DEADBEEFDEADBEEF) (com.apple.dt.CoreDeviceError error 1000 (0x3E8))
```

It reached device resolution, so every flag parsed. An install or launch on a real phone is #178's invariant-9 obligation and is staged, not claimed.

**The fixture is a capture, not a guess.** `fixtures/ios-device-console.txt` is the real stderr of a real `os_log` process — an RN-shaped one using `os_log_create("com.facebook.react.log", "javascript"/"native")` — run under `OS_ACTIVITY_DT_MODE=enable`, with `NSLog`, a subsystem-less logger, raw `stdout`/`stderr` writes, a multi-line message, and a genuine uncaught-`NSException` termination. The mirror format, the category bracket, the absent subsystem, `Debug` not being mirrored, `Default`/`Error`/`Fault` being indistinguishable, and each crash marker were all measured, not inferred. **Its one honest gap: it was captured on macOS, against the same Foundation / libc++abi / Swift runtime and the same `libsystem_trace` mirror, not on a phone.** The checklist's step B.1 exists to close exactly that gap.

**Suite.** `format:check`, `lint`, `build`, `typecheck`, `knip`, `test` (2837 passing, up from 2813) and `test:e2e` (19 passing) all green.

Four new integration tests spawn the real collector process against a fake `xcrun`, asserting the argv, that both streams are parsed (no `collector_stderr` records), that the ownership proof holds, and the degradation paths: a devicectl refusal becomes `collector_failed` at `error` with the `ERROR:` line preserved; a clean launch that produced nothing writes a `warn` `collector_empty` naming why, so an empty device section can never read as a pass; and a stop signal before any output does *not*, because a stop is not a failure to capture.

**Ablations.** Each new contract was checked by breaking it: moving the `ERROR:` rule back onto mirrored messages, un-anchoring the crash markers, narrowing the process field back to `\S+`, warning on a signalled stop, accepting a valueless `--payload-url`, hardcoding "iPhone", and un-hedging the unplug wording each fail exactly one test.

**Risk.** Contained: nothing in the `--device` run path calls any of it yet, and the simulator and Android paths are untouched except for `runCollector` gaining a branch that is inert unless `--physical` is passed. The exposure is that a phone disagrees with the macOS-captured mirror — in which case the parser is wrong about a field, the guide's table is wrong with it, and both are one commit to correct.

Progresses #179.

