### PR TITLE
Ignore the paths a native build never reads

### DIFF
--- a/packages/expo-build-cache/README.md
+++ b/packages/expo-build-cache/README.md
@@ -2,6 +2,11 @@
 
 A local Expo build-cache provider that shares `.app` and `.apk` artifacts across
 worktrees and direct Expo builds.
+Stim and Expo CLI compute the fingerprint that keys this cache separately, and
+Stim ignores two machine-local Android paths (`android/local.properties`,
+`android/.idea`) that Expo CLI does not. On a machine where those exist, the
+two hashes differ and each side fills its own entry. List them in the project's
+`.fingerprintignore` to bring the hashes back together.
 
 If Stim is not installed globally, replace `stim` with `npx stim-cli`.
 

--- a/packages/stim-cli/src/__tests__/build-cache.test.ts
+++ b/packages/stim-cli/src/__tests__/build-cache.test.ts
@@ -27,6 +27,7 @@ import {
   entryDir,
   fingerprintDiffRecord,
   fingerprintDiffSuffix,
+  DEFAULT_FINGERPRINT_IGNORES,
   fingerprintProject,
   prepareProviderDownloadDir,
   providerDownloadPath,
@@ -299,6 +300,32 @@ test('fingerprintProject without a platform passes no platforms option', async (
   expect((await fingerprintProject(root, { createFingerprint }))?.hash).toBe('h');
   const seen = options as { platforms?: string[] } | undefined | 'unset';
   expect(typeof seen === 'object' ? seen?.platforms : undefined).toBe(undefined);
+});
+
+test('fingerprintProject ignores the paths a native build never reads', async () => {
+  let options: FingerprintOptions | undefined;
+  const createFingerprint = async (_dir: string, opts?: FingerprintOptions) => {
+    options = opts;
+    return { hash: 'h', sources: [] };
+  };
+  await fingerprintProject(root, { platform: 'ios', createFingerprint });
+  expect(options?.ignorePaths).toEqual(DEFAULT_FINGERPRINT_IGNORES);
+  // The three that exist in a working checkout and not in a fresh one.
+  expect(options?.ignorePaths).toContain('**/ios/**/Package.resolved');
+  expect(options?.ignorePaths).toContain('**/android/local.properties');
+  expect(options?.ignorePaths).toContain('**/android/.idea/**');
+  // And it still scopes to the platform.
+  expect(options?.platforms).toEqual(['ios']);
+});
+
+test('a caller can replace the ignore list', async () => {
+  let options: FingerprintOptions | undefined;
+  const createFingerprint = async (_dir: string, opts?: FingerprintOptions) => {
+    options = opts;
+    return { hash: 'h', sources: [] };
+  };
+  await fingerprintProject(root, { createFingerprint, ignorePaths: ['**/only-this/**'] });
+  expect(options?.ignorePaths).toEqual(['**/only-this/**']);
 });
 
 test('fingerprintProject ignores a platform it does not know', async () => {

--- a/packages/stim-cli/src/__tests__/build-cache.test.ts
+++ b/packages/stim-cli/src/__tests__/build-cache.test.ts
@@ -302,30 +302,24 @@ test('fingerprintProject without a platform passes no platforms option', async (
   expect(typeof seen === 'object' ? seen?.platforms : undefined).toBe(undefined);
 });
 
-test('fingerprintProject ignores the paths a native build never reads', async () => {
+test('fingerprintProject ignores the paths a fresh checkout does not have', async () => {
   let options: FingerprintOptions | undefined;
   const createFingerprint = async (_dir: string, opts?: FingerprintOptions) => {
     options = opts;
     return { hash: 'h', sources: [] };
   };
   await fingerprintProject(root, { platform: 'ios', createFingerprint });
-  expect(options?.ignorePaths).toEqual(DEFAULT_FINGERPRINT_IGNORES);
-  // The three that exist in a working checkout and not in a fresh one.
-  expect(options?.ignorePaths).toContain('**/ios/**/Package.resolved');
-  expect(options?.ignorePaths).toContain('**/android/local.properties');
-  expect(options?.ignorePaths).toContain('**/android/.idea/**');
-  // And it still scopes to the platform.
+  expect(options?.ignorePaths).toEqual(['**/android/local.properties', '**/android/.idea/**']);
   expect(options?.platforms).toEqual(['ios']);
 });
 
-test('a caller can replace the ignore list', async () => {
-  let options: FingerprintOptions | undefined;
-  const createFingerprint = async (_dir: string, opts?: FingerprintOptions) => {
-    options = opts;
-    return { hash: 'h', sources: [] };
-  };
-  await fingerprintProject(root, { createFingerprint, ignorePaths: ['**/only-this/**'] });
-  expect(options?.ignorePaths).toEqual(['**/only-this/**']);
+test('the ignore list holds only paths no native build reads', async () => {
+  // A path that any project could read belongs in that project's
+  // .fingerprintignore, not here: ignoring it machine-wide turns a slow build
+  // into a wrong one.
+  for (const risky of ['**/*.map', '**/node_modules/**/lib/**', '**/ios/**/Package.resolved']) {
+    expect(DEFAULT_FINGERPRINT_IGNORES).not.toContain(risky);
+  }
 });
 
 test('fingerprintProject ignores a platform it does not know', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { readdirSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_FINGERPRINT_IGNORES } from '../build-cache.ts';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
@@ -556,6 +557,15 @@ test('the skill still carries the rules an agent must not have to look up', () =
     'worktree remove',
   ]) {
     expect(skill.includes(must)).toBeTruthy();
+  }
+});
+
+test('the guide names every path Stim ignores by default', () => {
+  const lifecycle = renderTopic('lifecycle') ?? '';
+  for (const path of DEFAULT_FINGERPRINT_IGNORES) {
+    // The guide prints them without the glob, e.g. android/local.properties.
+    const bare = path.replace(/^\*\*\//, '').replace(/\/\*\*$/, '');
+    expect(lifecycle).toContain(bare);
   }
 });
 

--- a/packages/stim-cli/src/build-cache.ts
+++ b/packages/stim-cli/src/build-cache.ts
@@ -45,28 +45,20 @@ export type ProjectFingerprint = Fingerprint;
 const FINGERPRINT_PLATFORMS = new Set(['ios', 'android']);
 
 /**
- * Paths a native build never reads, which @expo/fingerprint does not ignore on
- * its own. The first three exist in a working checkout and not in a fresh one,
- * so a fingerprint that counts them cannot match across checkouts. The last two
- * are the bulk of the files a fingerprint walks in a typical app.
+ * Paths that exist in a working checkout and not in a fresh one, which
+ * @expo/fingerprint does not ignore on its own. A fingerprint that counts them
+ * cannot match across checkouts, which is the parity failure `doctor` reports.
  *
- * A project's own `.fingerprintignore` still applies and is the place for
- * entries only that project can judge.
+ * The list stays narrow on purpose: a path belongs here only when no native
+ * build on any project can read it. Anything a single project can judge --
+ * a lockfile with machine paths, a generated report -- belongs in that
+ * project's `.fingerprintignore`, which still applies on top of this.
  */
 export const DEFAULT_FINGERPRINT_IGNORES: string[] = [
-  // Written by Xcode the first time it resolves Swift packages. The pods and
-  // the checked-in project define what compiles.
-  '**/ios/**/Package.resolved',
   // Generated, and carries this machine's absolute sdk.dir.
   '**/android/local.properties',
   // Appears the first time someone opens the project in Android Studio.
   '**/android/.idea/**',
-  // A debugging artifact for JavaScript.
-  '**/*.map',
-  // Built JavaScript in a dependency. Autolinking reads native sources --
-  // cpp/, apple/, android/, the podspec -- and config plugins live under
-  // plugin/build/, not lib/.
-  '**/node_modules/**/lib/**',
 ];
 
 export async function fingerprintProject(
@@ -74,18 +66,13 @@ export async function fingerprintProject(
   {
     platform,
     createFingerprint = expoFingerprint.createFingerprintAsync,
-    ignorePaths = DEFAULT_FINGERPRINT_IGNORES,
-  }: {
-    platform?: string;
-    createFingerprint?: typeof expoFingerprint.createFingerprintAsync;
-    ignorePaths?: string[];
-  } = {},
+  }: { platform?: string; createFingerprint?: typeof expoFingerprint.createFingerprintAsync } = {},
 ): Promise<ProjectFingerprint | null> {
   const platforms =
     platform && FINGERPRINT_PLATFORMS.has(platform)
       ? { platforms: [platform] as FingerprintOptions['platforms'] }
       : undefined;
-  const options: FingerprintOptions = { ...platforms, ignorePaths };
+  const options: FingerprintOptions = { ...platforms, ignorePaths: DEFAULT_FINGERPRINT_IGNORES };
   const result = await createFingerprint(projectRoot, options);
   const hash = result?.hash ?? null;
   if (!hash) return null;

--- a/packages/stim-cli/src/build-cache.ts
+++ b/packages/stim-cli/src/build-cache.ts
@@ -44,17 +44,48 @@ export type ProjectFingerprint = Fingerprint;
 
 const FINGERPRINT_PLATFORMS = new Set(['ios', 'android']);
 
+/**
+ * Paths a native build never reads, which @expo/fingerprint does not ignore on
+ * its own. The first three exist in a working checkout and not in a fresh one,
+ * so a fingerprint that counts them cannot match across checkouts. The last two
+ * are the bulk of the files a fingerprint walks in a typical app.
+ *
+ * A project's own `.fingerprintignore` still applies and is the place for
+ * entries only that project can judge.
+ */
+export const DEFAULT_FINGERPRINT_IGNORES: string[] = [
+  // Written by Xcode the first time it resolves Swift packages. The pods and
+  // the checked-in project define what compiles.
+  '**/ios/**/Package.resolved',
+  // Generated, and carries this machine's absolute sdk.dir.
+  '**/android/local.properties',
+  // Appears the first time someone opens the project in Android Studio.
+  '**/android/.idea/**',
+  // A debugging artifact for JavaScript.
+  '**/*.map',
+  // Built JavaScript in a dependency. Autolinking reads native sources --
+  // cpp/, apple/, android/, the podspec -- and config plugins live under
+  // plugin/build/, not lib/.
+  '**/node_modules/**/lib/**',
+];
+
 export async function fingerprintProject(
   projectRoot: string,
   {
     platform,
     createFingerprint = expoFingerprint.createFingerprintAsync,
-  }: { platform?: string; createFingerprint?: typeof expoFingerprint.createFingerprintAsync } = {},
+    ignorePaths = DEFAULT_FINGERPRINT_IGNORES,
+  }: {
+    platform?: string;
+    createFingerprint?: typeof expoFingerprint.createFingerprintAsync;
+    ignorePaths?: string[];
+  } = {},
 ): Promise<ProjectFingerprint | null> {
-  const options: FingerprintOptions | undefined =
+  const platforms =
     platform && FINGERPRINT_PLATFORMS.has(platform)
       ? { platforms: [platform] as FingerprintOptions['platforms'] }
       : undefined;
+  const options: FingerprintOptions = { ...platforms, ignorePaths };
   const result = await createFingerprint(projectRoot, options);
   const hash = result?.hash ?? null;
   if (!hash) return null;

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1169,6 +1169,10 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   BUILD is what breaks that, and it fails silently -- a cache that never hits
   looks exactly like a cache that is not there.
 
+  Stim already ignores what a native build never reads and a fresh checkout
+  never has: Package.resolved, android/local.properties, android/.idea, every
+  .map, and lib/ inside a dependency. A project does not repeat those.
+
   \`.fingerprintignore\` at the project root (same syntax as .gitignore) is the
   answer. Put in it only what genuinely cannot change the native build: a
   generated report, a local env file, a lockfile whose checksums embed absolute

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1169,9 +1169,11 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   BUILD is what breaks that, and it fails silently -- a cache that never hits
   looks exactly like a cache that is not there.
 
-  Stim already ignores what a native build never reads and a fresh checkout
-  never has: Package.resolved, android/local.properties, android/.idea, every
-  .map, and lib/ inside a dependency. A project does not repeat those.
+  Stim ignores two paths a fresh checkout never has and no native build reads:
+  android/local.properties and android/.idea. A project does not repeat those.
+  Everything else is the project's call, including a lockfile whose checksums
+  embed machine paths -- ignoring a path any project might read turns a slow
+  build into a wrong one.
 
   \`.fingerprintignore\` at the project root (same syntax as .gitignore) is the
   answer. Put in it only what genuinely cannot change the native build: a

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -722,7 +722,7 @@ export function checkFingerprintParity({
     'note',
     'This checkout does not fingerprint like a fresh worktree of HEAD',
     `A clean detached worktree of HEAD computes a different @expo/fingerprint hash than this checkout, so worktrees will MISS the cache entries this checkout fills (and vice versa) until the two agree.${differing} ${cause} (To measure this, doctor ran a real fingerprint twice and briefly created a temporary git worktree -- .git/worktrees metadata was touched and cleaned up.)`,
-    'Commit the dirty fingerprint inputs, or list the build-irrelevant ones in .fingerprintignore (same syntax as .gitignore, at the project root). Only the ones that genuinely cannot change the native build belong there -- generated reports, local env files, a lockfile whose checksums embed absolute machine paths. Never ignore a real native input (a Podfile, a gradle file, the app config) to force a hit: that trades a slow build for a wrong one.',
+    'Commit the dirty fingerprint inputs, or list the build-irrelevant ones in .fingerprintignore (same syntax as .gitignore, at the project root; Stim already ignores android/local.properties and android/.idea). Only the ones that genuinely cannot change the native build belong there -- generated reports, local env files, a lockfile whose checksums embed absolute machine paths. Never ignore a real native input (a Podfile, a gradle file, the app config) to force a hit: that trades a slow build for a wrong one.',
   );
 }
 

--- a/website/docs/cache-packages.md
+++ b/website/docs/cache-packages.md
@@ -30,6 +30,11 @@ config.cacheStores = sharedCacheStores('my-app');
 
 This package is a local Expo build-cache provider. It lets direct Expo builds
 share native artifacts with Stim.
+Stim and Expo CLI compute the fingerprint that keys this cache separately, and
+Stim ignores two machine-local Android paths (`android/local.properties`,
+`android/.idea`) that Expo CLI does not. On a machine where those exist, the
+two hashes differ and each side fills its own entry. List them in the project's
+`.fingerprintignore` to bring the hashes back together.
 
 ```bash
 npm install --save-dev @stim-cli/expo-build-cache


### PR DESCRIPTION
Closes #187.

## Description

A fresh checkout and a working checkout of the same commit fingerprint differently, so the build cache cannot hit across them — the parity failure `doctor` reports. Two of the causes are the same in every project: `android/local.properties`, which is generated and carries this machine's `sdk.dir`, and `android/.idea`, which appears the first time someone opens Android Studio. `@expo/fingerprint` ignores 37 paths by default; neither of these.

## Solution

`fingerprintProject` passes both as `ignorePaths`. It is the one place every Stim fingerprint goes through — the build cache key and `doctor`'s parity check — so the two cannot disagree. `ignorePaths` merges with the built-in defaults and with the project's `.fingerprintignore`, which still applies on top and remains the place for anything only that project can judge.

The list is deliberately just these two. An earlier version also ignored `**/*.map`, `**/node_modules/**/lib/**` and `**/ios/**/Package.resolved`; review found a real counterexample for each. An Expo config plugin can ship under a dependency's `lib/` (`react-native-vision-camera` resolves `app.plugin.js` to `lib/commonjs/…`), and fingerprint records every loaded plugin as a source, so on a CNG project that can hide a plugin-only dependency change. `.map` is also a bundled-asset extension — offline map data lives under `android/app/src/main/assets`. `Package.resolved` pins the revision an SPM version range resolved to, so ignoring it can serve a stale build. A test now asserts none of the three comes back.

## Two consequences worth knowing

**Hashes diverge from Expo CLI.** Stim computes this fingerprint itself, so on a machine that has these files, Stim's hash and the hash Expo CLI hands `@stim-cli/expo-build-cache` differ, and each side fills its own cache entry. Both provider docs now say so, and a project that wants them aligned lists the same paths in its `.fingerprintignore`.

**Existing cache entries go cold once.** The default fingerprint changes, so entries under `~/.stim/build-cache` from before the upgrade are unreachable: one cold build per project, platform and variant, and the old entries linger until `stim gc`.

## Test plan

- `pnpm test` — 2840 pass, including: the defaults reach `@expo/fingerprint` alongside platform scoping; the three rejected paths stay out of the list; and the guide names every path the list holds, so prose and code cannot drift
- `format:check`, `lint`, `build`, `typecheck` — clean
- Verified in `@expo/fingerprint@0.20.10` (`Options.js:collectIgnorePathsAsync`) that `ignorePaths` is concatenated with `DEFAULT_IGNORE_PATHS` and the project's `.fingerprintignore` rather than replacing either, and that a `!pattern` line can still un-ignore one of these
