### PR TITLE
Install, launch, and debug over the LAN on a physical iPhone

### DIFF
--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -214,8 +214,8 @@ phone has to settle, and what is already settled:
    **PASSED 2026-09-01** on the phone above.
 2. **The device pid, never a host pid.** The run's `launch` line names a pid read
    from `devicectl device info processes`, and a Release run's proof is that
-   probe repeated, not `process.kill`. **PASSED 2026-09-01** (Debug; the Release
-   variant is exercised by the same probe).
+   probe repeated, not `process.kill`. **PASSED 2026-09-01** for Debug;
+   `verifyIosDeviceReleaseLaunch` itself has not run on hardware.
 3. **The two human, one-time steps.** A first launch of a build whose developer
    the phone has not trusted is refused with `FBSOpenApplicationErrorDomain 3`
    and reason `Security`; the remedy must name Settings > General > VPN & Device
@@ -238,6 +238,15 @@ phone has to settle, and what is already settled:
    lands (phase 6), because a cached Release app carries its builder's JS.
    Prove `metroPort` is null, no LAN machinery runs, and the process is alive on
    the phone three seconds after launch.
+7. **The app dies with its collector.** `stop` (or `gc --delete`, or pulling the
+   cable) ends the collector, and because the collector is the launch, the app
+   closes on the phone. Confirm the app is still INSTALLED, that `status` and
+   `gc` report no device, and that the next `ios --device` starts it again.
+   **OBSERVED 2026-09-01**: SIGTERM to the collector alone terminates the app.
+8. **An uninstall costs the developer trust.** After any uninstall -- including
+   the signer-conflict retry -- the next launch is refused until the trust is
+   granted again, and the Local Network permission has to be re-tapped.
+   **OBSERVED 2026-09-01** (issue #178).
 
 ## Launch-status contract
 

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -158,6 +158,14 @@ Record the verify output, the install result, and whether the app ran. A
 failure here invalidates `ip.txt` ownership, the Debug path, and the Release
 JS swap together, so report it as CRITICAL and stop.
 
+**PASSED 2026-09-01** on an iPhone 12 Pro (iPhone13,3, cabled, iOS Developer
+Mode on), against the real `stim ios --device` artifact: the mutation broke the
+seal, `codesign --force --sign <sha1>
+--preserve-metadata=identifier,entitlements,flags,runtime` re-made it,
+`--verify --strict` passed, and both install and launch were accepted. A
+pristine control behaved identically. Rerun it only when the re-seal ladder
+itself changes.
+
 **B. Device log capture** (appandflow/stim#179). The collector's parser is
 tested against a real `os_log` stderr mirror captured on macOS, not on a
 phone. What a phone has to settle:
@@ -196,11 +204,40 @@ phone. What a phone has to settle:
    again and confirm the previous pid was proven this workspace's and
    signalled, and that `stop` reaps the survivor.
 
-**C. Install, launch and Debug over the LAN**, once #178 wires them: the
-signer-conflict uninstall-and-retry, the device-side process probe that
-replaces the host `process.kill` for release launch proof, and the evidence
-that the phone fetched from Metro rather than falling back to its embedded
-bundle (the run's own `ready: bundle loaded` line).
+**C. Install, launch and Debug over the LAN** (#178 phases 3 and 5). What a
+phone has to settle, and what is already settled:
+
+1. **The dev-client Debug loop, end to end.** `stim ios --device` on a
+   provisioned expo-dev-client project: cache HIT on the `-device` key, install,
+   launch through the collector with the deep link on `--payload-url`, a bundle
+   request from the phone in `logs --source metro`, and `launched: true`.
+   **PASSED 2026-09-01** on the phone above.
+2. **The device pid, never a host pid.** The run's `launch` line names a pid read
+   from `devicectl device info processes`, and a Release run's proof is that
+   probe repeated, not `process.kill`. **PASSED 2026-09-01** (Debug; the Release
+   variant is exercised by the same probe).
+3. **The two human, one-time steps.** A first launch of a build whose developer
+   the phone has not trusted is refused with `FBSOpenApplicationErrorDomain 3`
+   and reason `Security`; the remedy must name Settings > General > VPN & Device
+   Management first. The Local Network permission prompt must be tapped before
+   the phone can reach Metro at all; it cannot be pre-granted from the host and
+   it survives an upgrade install. **Both OBSERVED 2026-09-01**; the refusal
+   classifier is unit-tested against the recorded text rather than re-provoked.
+4. **The bare `ip.txt` path.** NOT YET RUN ON HARDWARE: it needs a bare RN
+   project with a development profile that names the phone, and the available
+   one is a dev-client app. On-disk verification (the copy carries
+   `<addr>:<port>`, the cache entry does not, the copy re-seals and verifies)
+   plus RN's own producer/consumer (`react-native-xcode.sh:16-28`,
+   `RCTBundleURLProvider.mm:70,206`) is what stands behind it today. A phone run
+   is the outstanding evidence.
+5. **The signer-conflict uninstall-and-retry.** NOT YET RUN ON HARDWARE: a
+   genuine `MismatchedApplicationIdentifierEntitlement` needs a second signing
+   team. The classifier and the one-uninstall-one-retry ladder are unit-tested
+   against Apple's documented text.
+6. **The Release device run.** Builds fresh every time until the device JS swap
+   lands (phase 6), because a cached Release app carries its builder's JS.
+   Prove `metroPort` is null, no LAN machinery runs, and the process is alive on
+   the phone three seconds after launch.
 
 ## Launch-status contract
 

--- a/docs/specs/2026-09-01-ios-device-release-design.md
+++ b/docs/specs/2026-09-01-ios-device-release-design.md
@@ -241,6 +241,18 @@ anything anywhere. The artifact never leaves the machine that built it.
 Developer Mode on, or delete a phone. It installs, launches, and observes. The
 UDID never enters the project registry.
 
+**Amendment, 2026-09-01 (#189).** "Observes" is weaker than what the
+implementation does, and the difference is worth stating: `devicectl device
+process launch --console` keeps the launched app attached to the launching
+process, and on hardware that process is the log collector (#186). So **the
+app's lifetime is bound to the observing collector** — `stop`, `gc --delete`,
+`worktree remove`, the next `ios --device` stopping its predecessor, a crash,
+the host sleeping, or the cable coming out all close the app on the phone.
+Measured: SIGTERM to the collector alone terminates the app; a detached launch
+without `--console` survives, which is the trade the log collector buys. Nothing
+is uninstalled and nothing is recorded, so "used, never owned" holds — but
+"Stim never touches a phone's state" would not.
+
 ## The build: one new slice
 
 `xcodebuildArgs()` in `engine/xcode.ts:265` already takes `sdk` and
@@ -967,6 +979,13 @@ Exact sentences, in the manner of #141.
 > install, launch, and read what logs they can, and nothing more. They record
 > no device, so `stop`, `gc`, and `teardown.ts` never see them. Keep it that
 > way: a physical serial or UDID must never enter the project registry.
+
+**Amendment, 2026-09-01 (#189).** "`stop` never sees them" is about the
+registry, not about the phone: on iOS the log read _is_ the launch, so ending
+the collector ends the running app. The delta above stays as written — nothing
+is recorded and nothing is deleted — but an implementer reading it as "`stop`
+leaves the phone untouched" would be wrong. `guide cleanup` and `guide
+lifecycle` state the consequence.
 
 ### Invariant 3 — five sentences, one of which is easy to miss
 

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -102,9 +102,9 @@ Stim creates, boots, and deletes only devices it created. Owned devices use
 the `stim-<label>` name. Never point Stim at a user-created emulator or
 simulator.
 
-`stim android --device [serial]` installs on a connected physical device. Stim
-never creates, boots, or deletes hardware, and records nothing about it, so
-`stop` and `gc` leave it alone.
+`stim android --device [serial]` and `stim ios --device [udid]` install on a
+connected physical device. Stim never creates, boots, or deletes hardware, and
+records nothing about it, so `stop` and `gc` leave it alone.
 
 Treat a refusal as an ownership or state mismatch. Read its code and remedy.
 Do not add `--force` as a first response.

--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, test } from 'vitest';
@@ -435,15 +435,29 @@ test("a failure that is not a signer conflict never uninstalls the user's app", 
 });
 
 test('iosLaunchRefusalKind reads the untrusted-developer refusal a real phone produced', () => {
-  expect(
-    iosLaunchRefusalKind(
-      'ERROR: The request to open "com.example.app" failed. Underlying error (FBSOpenApplicationErrorDomain, code 3): Security',
-    ),
-  ).toBe('untrusted-developer');
-  expect(iosLaunchRefusalKind('its profile has not been explicitly trusted by the user')).toBe('untrusted-developer');
-  expect(iosLaunchRefusalKind('FBSOpenApplicationErrorDomain, code 3')).toBe(null);
+  const refusal = readFileSync(
+    new URL('./fixtures/ios-device/launch-untrusted-developer.txt', import.meta.url),
+    'utf-8',
+  );
+  expect(iosLaunchRefusalKind(refusal)).toBe('untrusted-developer');
+  const carriers = refusal
+    .split('\n')
+    .filter((line) =>
+      /profile has not been explicitly trusted|FBSOpenApplicationErrorDomain error 3|for reason: Security/.test(line),
+    );
+  expect(carriers.length).toBeGreaterThan(0);
+  for (const line of carriers) expect(iosLaunchRefusalKind(line)).toBe('untrusted-developer');
   expect(iosLaunchRefusalKind('the device is locked')).toBe('locked');
   expect(iosLaunchRefusalKind('nothing recognisable')).toBe(null);
+});
+
+// The domain, the code and the reason are printed on separate lines of one
+// error block, so a classifier that tested the joined text could pair a code
+// from one line with a reason from another.
+test('iosLaunchRefusalKind never pairs a code on one line with a reason on another', () => {
+  expect(iosLaunchRefusalKind('FBSOpenApplicationErrorDomain error 7\nBSErrorCodeDescription = Security')).toBe(null);
+  expect(iosLaunchRefusalKind('the app logged 3 things\nSecurity checks passed')).toBe(null);
+  expect(iosLaunchRefusalKind('BSErrorCodeDescription = Security')).toBe(null);
 });
 
 test('the untrusted-developer remedy names the Settings screen that fixes it', () => {
@@ -488,7 +502,10 @@ test('a console that ends before the app appears is a launch failure with its ow
       { ts: 1, event: 'collector_started', msg: 'device log collector pid 99 launching com.example.app on device X' },
       {
         ts: 2,
-        msg: 'ERROR: The request to open "com.example.app" failed. (FBSOpenApplicationErrorDomain, code 3) Security',
+        msg:
+          'The operation could not be completed. Unable to launch com.example.app because it has an invalid code ' +
+          'signature, inadequate entitlements or its profile has not been explicitly trusted by the user. ' +
+          '(FBSOpenApplicationErrorDomain error 3 (0x03))',
       },
       { ts: 3, event: 'collector_failed', msg: 'the devicectl console ended with exit code 1' },
     ],

--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -4,9 +4,20 @@ import { tmpdir } from 'node:os';
 import { describe, expect, test } from 'vitest';
 import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import {
+  awaitIosDeviceLaunch,
+  collectorRecordsFor,
+  deviceProcessPid,
+  installIosDeviceApp,
+  iosDeviceProcess,
+  iosInstallFailureKind,
+  iosInstallRemedy,
+  iosLaunchRefusalKind,
+  iosLaunchRemedy,
   listIosDevices,
   parseDevicectlDevices,
+  parseDeviceProcesses,
   resolveIosPhysicalDevice,
+  verifyIosDeviceReleaseLaunch,
   type IosDeviceEntry,
 } from '../engine/ios-device.ts';
 import { hostLanCandidates, lanCandidates } from '../engine/lan-address.ts';
@@ -271,6 +282,272 @@ function devicectlAvailable(): boolean {
 
 const LIVE = devicectlAvailable() ? false : 'xcrun is not available on this machine';
 
+const APP = '/private/var/containers/Bundle/Application/9C1/Fixture.app/Fixture';
+
+function processPayload(processes: unknown[]): string {
+  return JSON.stringify({
+    info: { outcome: 'success' },
+    result: { deviceIdentifier: 'X', runningProcesses: processes },
+  });
+}
+
+test('parseDeviceProcesses reads the pid and executable devicectl nests, and drops the rest', () => {
+  const parsed = parseDeviceProcesses(
+    processPayload([
+      { executable: 'file:///sbin/launchd', processIdentifier: 1 },
+      { executable: `file://${APP}`, processIdentifier: 767 },
+      { processIdentifier: 88 },
+      { executable: 'file:///usr/libexec/logd' },
+      { executable: 'file:///bin/x', processIdentifier: 0 },
+    ]),
+  );
+  expect(parsed).toEqual([
+    { pid: 1, executable: 'file:///sbin/launchd' },
+    { pid: 767, executable: `file://${APP}` },
+  ]);
+});
+
+test('parseDeviceProcesses tolerates junk instead of throwing', () => {
+  expect(parseDeviceProcesses('not json')).toEqual([]);
+  expect(parseDeviceProcesses({ result: {} })).toEqual([]);
+  expect(parseDeviceProcesses(null)).toEqual([]);
+});
+
+test('deviceProcessPid matches the app bundle, not a process that merely mentions it', () => {
+  const processes = [
+    { pid: 12, executable: 'file:///usr/libexec/Fixture-helper' },
+    { pid: 767, executable: `file://${APP}` },
+  ];
+  expect(deviceProcessPid(processes, 'Fixture')).toBe(767);
+  expect(deviceProcessPid(processes, 'Other')).toBe(null);
+  expect(deviceProcessPid([], 'Fixture')).toBe(null);
+});
+
+test('iosDeviceProcess passes the udid and cleans its temp directory up', () => {
+  const calls: string[][] = [];
+  let outPath = '';
+  setExecutor({
+    runFile(_file: string, args: string[]) {
+      calls.push(args);
+      outPath = args[args.length - 1] as string;
+      writeFileSync(outPath, processPayload([{ executable: `file://${APP}`, processIdentifier: 767 }]));
+      return '';
+    },
+  });
+  try {
+    expect(iosDeviceProcess({ udid: PHONE, appName: 'Fixture' })).toBe(767);
+  } finally {
+    resetExecutor();
+  }
+  expect(calls[0]?.slice(0, 6)).toEqual(['devicectl', 'device', 'info', 'processes', '--device', PHONE]);
+  expect(existsSync(outPath)).toBe(false);
+});
+
+test('iosDeviceProcess reports undefined -- not "gone" -- when the probe itself fails', () => {
+  setExecutor({
+    runFile() {
+      throw new Error('devicectl: device not found');
+    },
+  });
+  try {
+    expect(iosDeviceProcess({ udid: PHONE, appName: 'Fixture' })).toBe(undefined);
+  } finally {
+    resetExecutor();
+  }
+});
+
+test('iosInstallFailureKind names the causes devicectl reports, and nothing it does not', () => {
+  expect(
+    iosInstallFailureKind(
+      "Upgrade's application-identifier entitlement string (TEAM.com.x) does not match installed application's",
+    ),
+  ).toBe('signer');
+  expect(iosInstallFailureKind('MismatchedApplicationIdentifierEntitlement')).toBe('signer');
+  expect(iosInstallFailureKind('The device is locked.')).toBe('locked');
+  expect(iosInstallFailureKind('The device is not paired with this host.')).toBe('untrusted-host');
+  expect(iosInstallFailureKind('Developer Mode is disabled on this device.')).toBe('developer-mode');
+  expect(iosInstallFailureKind('There is not enough disk space on the device.')).toBe('storage');
+  expect(iosInstallFailureKind('some other failure')).toBe(null);
+  expect(iosInstallFailureKind(undefined)).toBe(null);
+});
+
+test('installIosDeviceApp installs once and reports the path it installed', () => {
+  const calls: string[][] = [];
+  setExecutor({
+    runFile(_file: string, args: string[]) {
+      calls.push(args);
+      return '';
+    },
+  });
+  try {
+    expect(installIosDeviceApp({ udid: PHONE, appPath: '/tmp/Fixture.app', bundleId: 'com.example.app' })).toEqual({
+      ok: true,
+      appPath: '/tmp/Fixture.app',
+    });
+  } finally {
+    resetExecutor();
+  }
+  expect(calls).toEqual([['devicectl', 'device', 'install', 'app', '--device', PHONE, '/tmp/Fixture.app']]);
+});
+
+test('a signer conflict uninstalls once, retries once, and says the data went with it', () => {
+  const calls: string[][] = [];
+  setExecutor({
+    runFile(_file: string, args: string[]) {
+      calls.push(args);
+      if (args[2] === 'install' && calls.filter((c) => c[2] === 'install').length === 1) {
+        throw new Error('MismatchedApplicationIdentifierEntitlement');
+      }
+      return '';
+    },
+  });
+  let result;
+  try {
+    result = installIosDeviceApp({ udid: PHONE, appPath: '/tmp/Fixture.app', bundleId: 'com.example.app' });
+  } finally {
+    resetExecutor();
+  }
+  expect(result.ok).toBe(true);
+  expect(result.uninstalled).toBe(true);
+  expect(result.note).toMatch(/its data went with it/);
+  expect(calls.map((c) => c[2])).toEqual(['install', 'uninstall', 'install']);
+  expect(calls[1]).toEqual(['devicectl', 'device', 'uninstall', 'app', '--device', PHONE, 'com.example.app']);
+});
+
+test("a failure that is not a signer conflict never uninstalls the user's app", () => {
+  const calls: string[][] = [];
+  setExecutor({
+    runFile(_file: string, args: string[]) {
+      calls.push(args);
+      throw new Error('The device is locked.');
+    },
+  });
+  let result;
+  try {
+    result = installIosDeviceApp({ udid: PHONE, appPath: '/tmp/Fixture.app', bundleId: 'com.example.app' });
+  } finally {
+    resetExecutor();
+  }
+  expect(result.failed).toBe(true);
+  expect(result.code).toBe('STIM_INSTALL_FAILED');
+  expect(result.remedy).toBe(iosInstallRemedy('locked', { udid: PHONE, bundleId: 'com.example.app' }));
+  expect(calls.map((c) => c[2])).toEqual(['install']);
+});
+
+test('iosLaunchRefusalKind reads the untrusted-developer refusal a real phone produced', () => {
+  expect(
+    iosLaunchRefusalKind(
+      'ERROR: The request to open "com.example.app" failed. Underlying error (FBSOpenApplicationErrorDomain, code 3): Security',
+    ),
+  ).toBe('untrusted-developer');
+  expect(iosLaunchRefusalKind('its profile has not been explicitly trusted by the user')).toBe('untrusted-developer');
+  expect(iosLaunchRefusalKind('FBSOpenApplicationErrorDomain, code 3')).toBe(null);
+  expect(iosLaunchRefusalKind('the device is locked')).toBe('locked');
+  expect(iosLaunchRefusalKind('nothing recognisable')).toBe(null);
+});
+
+test('the untrusted-developer remedy names the Settings screen that fixes it', () => {
+  expect(iosLaunchRemedy('untrusted-developer', { udid: PHONE, bundleId: 'com.example.app' })).toMatch(
+    /Settings > General > VPN & Device Management/,
+  );
+});
+
+test('collectorRecordsFor ignores the predecessor a fresh run just signalled', () => {
+  const records = [
+    { ts: 1, event: 'collector_stopped', msg: 'device log collector received SIGTERM; detaching' },
+    { ts: 2, event: 'collector_started', msg: 'device log collector pid 99 launching com.example.app on device X' },
+    { ts: 3, msg: 'hello' },
+  ];
+  expect(collectorRecordsFor(records, 99).map((r) => r.ts)).toEqual([2, 3]);
+  expect(collectorRecordsFor(records, 12)).toEqual([]);
+  expect(collectorRecordsFor(records, null)).toEqual([]);
+});
+
+test('awaitIosDeviceLaunch returns the device pid as soon as the phone reports it', async () => {
+  const pids = [null, null, 767];
+  const result = await awaitIosDeviceLaunch({
+    udid: PHONE,
+    bundleId: 'com.example.app',
+    appName: 'Fixture',
+    collectorPid: 99,
+    readRecords: () => [],
+    probe: () => pids.shift() ?? null,
+    sleep: async () => {},
+    pollMs: 0,
+  });
+  expect(result).toEqual({ pid: 767 });
+});
+
+test('a console that ends before the app appears is a launch failure with its own evidence', async () => {
+  const result = await awaitIosDeviceLaunch({
+    udid: PHONE,
+    bundleId: 'com.example.app',
+    appName: 'Fixture',
+    collectorPid: 99,
+    readRecords: () => [
+      { ts: 1, event: 'collector_started', msg: 'device log collector pid 99 launching com.example.app on device X' },
+      {
+        ts: 2,
+        msg: 'ERROR: The request to open "com.example.app" failed. (FBSOpenApplicationErrorDomain, code 3) Security',
+      },
+      { ts: 3, event: 'collector_failed', msg: 'the devicectl console ended with exit code 1' },
+    ],
+    probe: () => null,
+    sleep: async () => {},
+  });
+  expect(result.failed).toBe(true);
+  expect(result.remedy).toMatch(/VPN & Device Management/);
+  expect(result.lines?.join('\n')).toMatch(/FBSOpenApplicationErrorDomain/);
+});
+
+test('a launch nothing reports at all times out with the generic devicectl remedy', async () => {
+  let clock = 0;
+  const result = await awaitIosDeviceLaunch({
+    udid: PHONE,
+    bundleId: 'com.example.app',
+    appName: 'Fixture',
+    collectorPid: 99,
+    readRecords: () => [],
+    probe: () => null,
+    timeoutMs: 10,
+    pollMs: 5,
+    now: () => (clock += 5),
+    sleep: async () => {},
+  });
+  expect(result.failed).toBe(true);
+  expect(result.remedy).toMatch(/devicectl device process launch --console/);
+});
+
+test('verifyIosDeviceReleaseLaunch re-probes the phone rather than a host pid', async () => {
+  const alive = await verifyIosDeviceReleaseLaunch({
+    udid: PHONE,
+    appName: 'Fixture',
+    waitMs: 0,
+    probe: () => 767,
+    sleep: async () => {},
+  });
+  expect(alive.verified).toBe(true);
+  expect(alive.pid).toBe(767);
+
+  const gone = await verifyIosDeviceReleaseLaunch({
+    udid: PHONE,
+    appName: 'Fixture',
+    waitMs: 0,
+    probe: () => null,
+    sleep: async () => {},
+  });
+  expect(gone).toMatchObject({ verified: false, reason: 'exited', pid: null });
+
+  const blind = await verifyIosDeviceReleaseLaunch({
+    udid: PHONE,
+    appName: 'Fixture',
+    waitMs: 0,
+    probe: () => undefined,
+    sleep: async () => {},
+  });
+  expect(blind).toMatchObject({ verified: false, reason: 'probe-failed' });
+});
+
 describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as boolean }, () => {
   test('the argv is accepted and every entry it returns is well formed', () => {
     resetExecutor();
@@ -282,4 +559,12 @@ describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as b
     }
     expect(readdirSync(tmpdir()).filter((e) => e.startsWith('stim-devicectl-'))).toEqual([]);
   }, 60_000);
+
+  test('the process-probe argv is accepted by the real devicectl when a phone is connected', () => {
+    resetExecutor();
+    const [connected] = listIosDevices();
+    if (!connected) return;
+    const pid = iosDeviceProcess({ udid: connected.udid, appName: 'NoSuchAppStimWouldEverBuild' });
+    expect(pid).toBe(null);
+  }, 120_000);
 });

--- a/packages/stim-cli/src/__tests__/engine-ios-lan.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-lan.test.ts
@@ -1,0 +1,138 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { resetExecutor } from '../exec.ts';
+import {
+  chooseLanAddress,
+  copyAppAside,
+  ensureLanReachable,
+  ipTxtContents,
+  lanOriginUrlFor,
+  writeIpTxt,
+} from '../engine/ios-lan.ts';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stim-ios-lan-'));
+});
+
+afterEach(() => {
+  resetExecutor();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('chooseLanAddress takes the first candidate, which lanCandidates already ordered', () => {
+  expect(
+    chooseLanAddress({
+      candidates: [
+        { interfaceName: 'en0', address: '192.168.1.5' },
+        { interfaceName: 'en1', address: '10.0.0.4' },
+      ],
+    }),
+  ).toEqual({ address: '192.168.1.5', interfaceName: 'en0', pinned: false, candidates: 2 });
+});
+
+test('chooseLanAddress refuses when the host has no candidate at all', () => {
+  expect(chooseLanAddress({ candidates: [] })).toBe(null);
+});
+
+test('ios.lanHost wins over the ordering, even for an address no interface reports', () => {
+  expect(
+    chooseLanAddress({ pinned: '10.0.0.9', candidates: [{ interfaceName: 'en0', address: '192.168.1.5' }] }),
+  ).toEqual({ address: '10.0.0.9', interfaceName: null, pinned: true, candidates: 1 });
+  expect(chooseLanAddress({ pinned: '10.0.0.9', candidates: [] })).toEqual({
+    address: '10.0.0.9',
+    interfaceName: null,
+    pinned: true,
+    candidates: 0,
+  });
+});
+
+// RCTBundleURLProvider.mm:70 interpolates the value into a URL string verbatim,
+// so a stray space produces `http://192.168.1.5:8082 /` and a silent fall-back
+// to the embedded bundle.
+test('ip.txt holds exactly <addr>:<port> and one newline', () => {
+  expect(ipTxtContents('192.168.1.5', 8082)).toBe('192.168.1.5:8082\n');
+  expect(ipTxtContents('  192.168.1.5  ', ' 8082 ')).toBe('192.168.1.5:8082\n');
+  expect(/^[!-~]+:[0-9]+\n$/.test(ipTxtContents('192.168.1.5', '8082'))).toBe(true);
+});
+
+test('writeIpTxt writes into the bundle root and returns the path it wrote', () => {
+  const app = join(dir, 'Fixture.app');
+  mkdirSync(app);
+  const path = writeIpTxt(app, '192.168.1.5', 8082);
+  expect(path).toBe(join(app, 'ip.txt'));
+  expect(readFileSync(path, 'utf-8')).toBe('192.168.1.5:8082\n');
+});
+
+test('writeIpTxt replaces whatever the build baked in', () => {
+  const app = join(dir, 'Fixture.app');
+  mkdirSync(app);
+  writeFileSync(join(app, 'ip.txt'), '10.9.9.9\n');
+  writeIpTxt(app, '192.168.1.5', 8082);
+  expect(readFileSync(join(app, 'ip.txt'), 'utf-8')).toBe('192.168.1.5:8082\n');
+});
+
+test('lanOriginUrlFor is the http origin the phone dials', () => {
+  expect(lanOriginUrlFor('192.168.1.5', 8082)).toBe('http://192.168.1.5:8082');
+});
+
+test('copyAppAside copies with the real cp, preserving a symlink and the exec bit', () => {
+  const app = join(dir, 'Fixture.app');
+  mkdirSync(join(app, 'Frameworks'), { recursive: true });
+  writeFileSync(join(app, 'Fixture'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  symlinkSync('Fixture', join(app, 'Current'));
+  const copy = copyAppAside(app);
+  try {
+    expect(copy.appPath).toBe(join(copy.tmpDir, 'Fixture.app'));
+    expect(existsSync(join(copy.appPath, 'Frameworks'))).toBe(true);
+    expect(readFileSync(join(copy.appPath, 'Current'), 'utf-8')).toBe('#!/bin/sh\nexit 0\n');
+    expect(existsSync(join(app, 'ip.txt'))).toBe(false);
+    writeIpTxt(copy.appPath, '192.168.1.5', 8082);
+    expect(existsSync(join(app, 'ip.txt'))).toBe(false);
+  } finally {
+    rmSync(copy.tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ensureLanReachable passes when the gate proves the origin is this workspace Metro', async () => {
+  const gated: Array<Record<string, unknown>> = [];
+  const result = await ensureLanReachable({
+    origin: 'http://192.168.1.5:8082',
+    metroPort: 8082,
+    root: dir,
+    isExpo: false,
+    logsDir: join(dir, 'logs'),
+    gateOrigin: async (args) => {
+      gated.push(args as unknown as Record<string, unknown>);
+      return { ok: true };
+    },
+  });
+  expect(result).toEqual({ ok: true });
+  expect(gated[0]?.origin).toBe('http://192.168.1.5:8082');
+  expect(gated[0]?.platform).toBe('ios');
+  expect(gated[0]?.entryPoint).toBe('index');
+});
+
+test('a gate miss keeps its own reason and gets a LAN remedy, not a tunnel one', async () => {
+  const result = await ensureLanReachable({
+    origin: 'http://192.168.1.5:8082',
+    metroPort: 8082,
+    root: dir,
+    isExpo: false,
+    logsDir: join(dir, 'logs'),
+    gateOrigin: async () => ({
+      failed: true,
+      reason: 'http://192.168.1.5:8082 did not answer, so it cannot be this workspace Metro (port 8082).',
+      remedy: 'a tunnel remedy that does not apply here',
+    }),
+  });
+  expect('failed' in result).toBe(true);
+  if (!('failed' in result)) return;
+  expect(result.failed).toMatch(/did not answer/);
+  expect(result.remedy).toMatch(/ios\.lanHost/);
+  expect(result.remedy).toMatch(/stim start` prints the port/);
+  expect(result.remedy).not.toMatch(/tunnel/);
+});

--- a/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-signing.test.ts
@@ -7,6 +7,7 @@ import {
   EMBEDDED_PROFILE,
   findSigningIdentities,
   gateAppForDevice,
+  gateProfileForDevice,
   readEmbeddedProfile,
   resealBundle,
   sealAppForDevice,
@@ -20,6 +21,7 @@ import {
   parsePlist,
   parseProvisioningProfilePlist,
   parseSigningIdentities,
+  profileGate,
   provisioningProfileKind,
   signingGate,
   type ProvisioningProfile,
@@ -150,6 +152,21 @@ function gate(overrides: Partial<Parameters<typeof signingGate>[0]> = {}) {
 
 test('the gate admits a development profile that names the phone and an identity in the keychain', () => {
   expect(gate()).toEqual({ ok: true, identity: { sha1: JANE_SHA1, name: JANE } });
+});
+
+test('profileGate stops at the profile: an install that modifies nothing needs no identity', () => {
+  const admitted = profileGate({
+    profilePresent: true,
+    profile: profile(),
+    identities: [],
+    udid: PHONE,
+    now: BEFORE_EXPIRY,
+  });
+  expect(admitted).toMatchObject({ ok: true });
+  expect('profile' in admitted && admitted.profile.name).toBe(profile().name);
+  expect(
+    profileGate({ profilePresent: true, profile: profile(), identities: [], udid: STRANGER, now: BEFORE_EXPIRY }),
+  ).toMatchObject({ ok: false, code: 'STIM_PROFILE_MISMATCH' });
 });
 
 test('a bundle with no embedded.mobileprovision is STIM_NO_PROFILE, not a codesign attempt', () => {
@@ -509,6 +526,64 @@ describe('the re-seal primitive against the real codesign and security', { skip:
     expect(modes).toContain(sealed.mode);
     expect(sealed.identity).toEqual(AD_HOC);
   });
+
+  test('gateProfileForDevice decodes the real profile and never asks the keychain', () => {
+    const exec = getExecutor();
+    const key = join(dir, 'gate.key');
+    const pem = join(dir, 'gate.pem');
+    exec.runFile('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      key,
+      '-out',
+      pem,
+      '-days',
+      '30',
+      '-nodes',
+      '-subj',
+      `/CN=${JANE}/OU=TEAMID5678/O=Fixture Inc/C=US`,
+    ]);
+    const plist = join(dir, 'gate-profile.plist');
+    writeFileSync(plist, fixture('development-profile.plist'));
+    exec.runFile('openssl', [
+      'smime',
+      '-sign',
+      '-nodetach',
+      '-binary',
+      '-in',
+      plist,
+      '-signer',
+      pem,
+      '-inkey',
+      key,
+      '-outform',
+      'DER',
+      '-out',
+      join(appPath, EMBEDDED_PROFILE),
+    ]);
+
+    const calls: string[][] = [];
+    const real = getExecutor();
+    setExecutor({
+      runFile(file: string, args: string[], opts?: Record<string, unknown>) {
+        calls.push([file, ...args]);
+        return real.runFile(file, args, opts as never);
+      },
+    });
+    let gated;
+    try {
+      gated = gateProfileForDevice({ appPath, udid: PHONE, now: BEFORE_EXPIRY });
+    } finally {
+      resetExecutor();
+    }
+    expect(gated).toMatchObject({ ok: true });
+    expect(calls.some((c) => c.includes('cms'))).toBe(true);
+    expect(calls.some((c) => c.includes('find-identity'))).toBe(false);
+    expect(sealIsValid()).toBe(false);
+  }, 60_000);
 
   test('findSigningIdentities parses whatever this machine really has in its keychain', () => {
     for (const identity of findSigningIdentities()) {

--- a/packages/stim-cli/src/__tests__/fixtures/ios-device/launch-untrusted-developer.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ios-device/launch-untrusted-developer.txt
@@ -1,0 +1,11 @@
+ERROR: The application failed to launch. (com.apple.dt.CoreDeviceError error 10002 (0x2712))
+       BundleIdentifier = com.appandflow.trailhead
+       ----------------------------------------
+           The request to open "com.appandflow.trailhead" failed. (FBSOpenApplicationServiceErrorDomain error 1 (0x01))
+           NSLocalizedFailureReason = The request was denied by service delegate (SBMainWorkspace) for reason: Security ("Unable to launch com.appandflow.trailhead because it has an invalid code signature, inadequate entitlements or its profile has not been explicitly trusted by the user").
+           BSErrorCodeDescription = RequestDenied
+           FBSOpenApplicationRequestID = 0xdb32
+       ----------------------------------------
+               The operation couldn't be completed. Unable to launch com.appandflow.trailhead because it has an invalid code signature, inadequate entitlements or its profile has not been explicitly trusted by the user. (FBSOpenApplicationErrorDomain error 3 (0x03))
+               BSErrorCodeDescription = Security
+               NSLocalizedFailureReason = Unable to launch com.appandflow.trailhead because it has an invalid code signature, inadequate entitlements or its profile has not been explicitly trusted by the user.

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -315,7 +315,7 @@ test('the guide states the physical-iPhone device-log losses, and states them as
   expect(cleanup).toMatch(/on\s+hardware the collector IS the launch/);
   expect(cleanup).toMatch(/proven and replaced by the same pid rules/);
   expect(cleanup).toMatch(/Unplugging the phone[\s\S]*collector_stopped/);
-  expect(cleanup).toContain('appandflow/stim#178');
+  expect(cleanup).not.toMatch(/not started yet/);
   expect(logs).toMatch(/lines that OPEN with a marker[\s\S]*anchored[\s\S]*app logging ABOUT a crash stays\s+info/);
   expect(logs).toMatch(/only on a line with no mirror\s+prefix/);
   expect(cleanup).toMatch(
@@ -324,9 +324,34 @@ test('the guide states the physical-iPhone device-log losses, and states them as
 
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);
-  expect(lifecycle).toMatch(/THE DEVICE LOG COLLECTOR IS BUILT BUT NOT YET STARTED/);
-  expect(lifecycle).toMatch(/the collector IS the launch/);
+  expect(lifecycle).toMatch(/THE DEVICE LOG COLLECTOR IS THE LAUNCH/);
   expect(lifecycle).toContain('appandflow/stim#179');
+});
+
+test('the guide teaches the device install and launch that #178 phases 3 and 5 wired', () => {
+  const lifecycle = renderTopic('lifecycle');
+  const errors = renderTopic('errors');
+  assert(lifecycle);
+  assert(errors);
+
+  expect(lifecycle).not.toMatch(/IT IS NOT FINISHED/);
+  expect(lifecycle).not.toMatch(/REFUSES with\s+STIM_BAD_ARG/);
+  expect(lifecycle).toMatch(/devicectl device install app/);
+  expect(lifecycle).toMatch(/--payload-url/);
+  expect(lifecycle).toMatch(/STORE, THEN COPY, THEN\s+MUTATE/);
+  expect(lifecycle).toMatch(/never consults the compiled RCT_METRO_PORT/);
+  expect(lifecycle).toMatch(/NO INSTALL SKIP ON A PHONE/);
+  expect(lifecycle).toMatch(/device pid means nothing to the host/);
+
+  expect(errors).not.toMatch(/ONE EXCEPTION, and it is temporary/);
+  expect(errors).toMatch(/STIM_NO_LAN_ADDRESS[\s\S]*Deliberately NOT "set metro\.publicUrl"/);
+  expect(errors).toMatch(/STIM_LAN_METRO_UNREACHABLE[\s\S]*ios\.lanHost/);
+  expect(errors).toMatch(
+    /STIM_LAN_METRO_UNREACHABLE[\s\S]*routes a host connection to its own address over\s+loopback/,
+  );
+  expect(errors).toMatch(/FBSOpenApplicationErrorDomain 3/);
+  expect(errors).toMatch(/VPN & Device Management/);
+  expect(errors).toMatch(/devicectl device uninstall app[\s\S]*data went with it/);
 });
 
 test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -352,6 +352,25 @@ test('the guide teaches the device install and launch that #178 phases 3 and 5 w
   expect(errors).toMatch(/FBSOpenApplicationErrorDomain 3/);
   expect(errors).toMatch(/VPN & Device Management/);
   expect(errors).toMatch(/devicectl device uninstall app[\s\S]*data went with it/);
+  expect(errors).toMatch(/THE DEVICE FALLBACKS[\s\S]*building fresh instead/);
+  expect(errors).toMatch(/FRESHLY BUILT app is a code/);
+  expect(errors).toMatch(/an uninstall clears it, including the one Stim's own\s+signer-conflict retry performs/);
+});
+
+// devicectl keeps the app attached to the process that launched it, so the
+// collector holding it is a fact about `stop`, not only about logs.
+test('the guide says a phone loses its running app when the collector ends', () => {
+  const cleanup = renderTopic('cleanup');
+  const lifecycle = renderTopic('lifecycle');
+  assert(cleanup);
+  assert(lifecycle);
+
+  expect(cleanup).toMatch(/THE APP'S LIFETIME IS BOUND TO THAT COLLECTOR/);
+  expect(cleanup).toMatch(/anything that\s+ends the collector ends the APP ON THE PHONE/);
+  expect(cleanup).toMatch(/leaves no RECORD of the\s+phone -- it never had one -- but it does close the app/);
+  expect(cleanup).toMatch(/Nothing is uninstalled/);
+  expect(lifecycle).toMatch(/THE APP RUNS FOR AS LONG AS THE COLLECTOR DOES/);
+  expect(lifecycle).toMatch(/stays INSTALLED/);
 });
 
 test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -41,6 +41,18 @@ import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroReso
 
 const UDID = 'BF2A1C3D-4E5F-6071-8293-A4B5C6D7E8F9';
 const FINGERPRINT = 'a3f9b1c2d3e4f5';
+const DEVICE_PID = 4242;
+const IDENTITY = { sha1: 'A'.repeat(40), name: 'Apple Development: Tester (TEAMID5678)' };
+const PROFILE = {
+  name: 'Stim Development',
+  uuid: 'a-uuid',
+  teamIdentifier: 'TEAMID5678',
+  expirationDate: new Date('2099-01-01T00:00:00Z'),
+  provisionedDevices: ['00008030-001A2B3C4D5E802E'],
+  provisionsAllDevices: false,
+  getTaskAllow: true,
+  certificates: [],
+};
 
 type IosDeps = NonNullable<Parameters<typeof registerIos>[1]>;
 
@@ -235,6 +247,10 @@ function harness(overrides: LooseDeps = {}) {
       record('replaceCollector', args);
       return { killed: null, pid: 5150 };
     },
+    stopPreviousCollector: async (args) => {
+      record('stopPreviousCollector', args);
+      return { killed: null };
+    },
     resolveMetroWithRetry: (resolve, port, path, opts) =>
       resolveMetroWithRetry(resolve, port, path, { ...opts, sleep: async () => {} }),
     verifyLaunch: async (args) => {
@@ -254,6 +270,35 @@ function harness(overrides: LooseDeps = {}) {
     verifyReleaseLaunch: async (args) => {
       record('verifyReleaseLaunch', args);
       return { verified: true, waitedMs: 3000 };
+    },
+    hostLanCandidates: () => [{ interfaceName: 'en0', address: '192.168.1.5' }],
+    ensureLanReachable: async (args) => {
+      record('ensureLanReachable', args);
+      return { ok: true as const };
+    },
+    gateProfileForDevice: (args) => {
+      record('gateProfileForDevice', args);
+      return { ok: true as const, profile: PROFILE };
+    },
+    sealAppForDevice: (args) => {
+      record('sealAppForDevice', args);
+      return { ok: true as const, identity: IDENTITY, mode: 'preserve-metadata' as const };
+    },
+    installIosDeviceApp: (args) => {
+      record('installIosDeviceApp', args);
+      return { ok: true, appPath: args.appPath };
+    },
+    awaitIosDeviceLaunch: async (args) => {
+      record('awaitIosDeviceLaunch', args);
+      return { pid: DEVICE_PID };
+    },
+    iosDeviceProcess: (args) => {
+      record('iosDeviceProcess', args);
+      return DEVICE_PID;
+    },
+    verifyIosDeviceReleaseLaunch: async (args) => {
+      record('verifyIosDeviceReleaseLaunch', args);
+      return { verified: true, waitedMs: 3000, pid: DEVICE_PID };
     },
     ensureWorkspaceStorage: async (dir) => {
       record('ensureWorkspaceStorage', dir);
@@ -3213,6 +3258,12 @@ describe('an app the simulator already holds', () => {
 describe('ios --device: selecting a phone and building the device slice', () => {
   const PHONE = '00008030-001A2B3C4D5E802E';
 
+  // The device path copies the bundle aside with the real `cp`, so the fixture
+  // has to exist on disk.
+  beforeEach(() => {
+    mkdirSync(join(root, 'build', 'Fixture.app'), { recursive: true });
+  });
+
   function connected(devices: Array<Record<string, unknown>> = [{ udid: PHONE, name: 'Test Phone' }]) {
     return {
       listIosDevices: () =>
@@ -3298,18 +3349,97 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(build?.sdk).toBe(undefined);
   });
 
-  test('it stops at the install boundary rather than sending a device app to simctl', async () => {
+  test('it installs and launches with devicectl, never with simctl', async () => {
     reserve();
-    const { errs, exitCode, calls } = await run({ device: true }, connected());
-    expect(exitCode).toBe(1);
+    const { errs, exitCode, calls, logs } = await run({ device: true, json: true }, connected());
+    expect(exitCode).toBe(null);
     expect(calls.order.includes('buildIos')).toBe(true);
     expect(calls.order.includes('storeBuild')).toBe(true);
+    expect(calls.order.includes('installIosDeviceApp')).toBe(true);
     expect(calls.order.includes('installIosApp')).toBe(false);
     expect(calls.order.includes('launchIosApp')).toBe(false);
-    expect(calls.order.includes('replaceCollector')).toBe(false);
-    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
-    expect(errs.join('\n')).toMatch(/not wired yet/);
-    expect(errs.join('\n')).toMatch(new RegExp(`${FINGERPRINT}-debug-device`));
+    expect(calls.order.includes('replaceCollector')).toBe(true);
+    expect(errs.join('\n')).not.toMatch(/STIM_BAD_ARG/);
+    const facts = parseFirst(logs);
+    expect(facts.udid).toBe(PHONE);
+    expect(facts.launched).toBe(true);
+    expect(facts.cacheKey).toBe(`${FINGERPRINT}-debug-device`);
+  });
+
+  test('the collector is the launch: it carries --physical and the run reads the device pid', async () => {
+    reserve();
+    const { calls } = await run({ device: true }, connected());
+    const collector = calls.args.replaceCollector as Record<string, unknown>;
+    expect(collector.physical).toBe(true);
+    expect(collector.udid).toBe(PHONE);
+    const launch = calls.args.awaitIosDeviceLaunch as Record<string, unknown>;
+    expect(launch.udid).toBe(PHONE);
+    expect(calls.order.indexOf('replaceCollector')).toBeLessThan(calls.order.indexOf('awaitIosDeviceLaunch'));
+  });
+
+  // An upgrade install terminates the running app, which ends the console the
+  // previous collector holds: stopping it first keeps a normal reinstall from
+  // recording a failure.
+  test('the previous collector is stopped BEFORE the install, not as part of the launch', async () => {
+    reserve();
+    const { calls } = await run({ device: true }, connected());
+    expect(calls.order.indexOf('stopPreviousCollector')).toBeLessThan(calls.order.indexOf('installIosDeviceApp'));
+    expect(calls.order.indexOf('installIosDeviceApp')).toBeLessThan(calls.order.indexOf('replaceCollector'));
+  });
+
+  test('the simulator path does not stop its collector early: nothing there holds a console', async () => {
+    reserve();
+    const { calls } = await run({});
+    expect(calls.order.includes('stopPreviousCollector')).toBe(false);
+    expect(calls.order.includes('replaceCollector')).toBe(true);
+  });
+
+  test('a dev-client app is launched on the LAN payload URL and its ip.txt is left alone', async () => {
+    reserve();
+    const { calls, errs } = await run(
+      { device: true },
+      { ...connected(), detectIsExpo: () => true, devClientScheme: () => 'com.example.app' },
+    );
+    const collector = calls.args.replaceCollector as Record<string, unknown>;
+    expect(collector.payloadUrl).toBe(
+      `com.example.app://expo-development-client/?url=${encodeURIComponent('http://192.168.1.5:8082')}`,
+    );
+    expect(calls.order.includes('sealAppForDevice')).toBe(false);
+    expect(calls.order.includes('gateProfileForDevice')).toBe(true);
+    expect(errs.join('\n')).not.toMatch(/ip\.txt/);
+  });
+
+  test('a bare app gets <addr>:<port> in ip.txt on a copy, re-sealed, and no payload URL', async () => {
+    reserve();
+    let sealedIpTxt: string | null = null;
+    const { calls, errs } = await run(
+      { device: true },
+      {
+        ...connected(),
+        sealAppForDevice: (args) => {
+          sealedIpTxt = readFileSync(join(args.appPath, 'ip.txt'), 'utf-8');
+          return { ok: true as const, identity: IDENTITY, mode: 'preserve-metadata' as const };
+        },
+      },
+    );
+    expect(sealedIpTxt).toBe('192.168.1.5:8082\n');
+    const sealed = calls.args.installIosDeviceApp as Record<string, unknown>;
+    expect(String(sealed.appPath)).not.toBe(join(root, 'build', 'Fixture.app'));
+    expect(String(sealed.appPath).endsWith('Fixture.app')).toBe(true);
+    const collector = calls.args.replaceCollector as Record<string, unknown>;
+    expect(collector.payloadUrl).toBe(null);
+    expect(errs.join('\n')).toMatch(/ip\.txt\s+192\.168\.1\.5:8082 written into the install copy/);
+  });
+
+  test('the pristine artifact is stored before the copy is mutated, and the copy is deleted', async () => {
+    reserve();
+    const { calls } = await run({ device: true }, connected());
+    expect(calls.order.indexOf('storeBuild')).toBeLessThan(calls.order.indexOf('sealAppForDevice'));
+    const stored = calls.args.storeBuild as { path: string };
+    expect(stored.path).toBe(join(root, 'build', 'Fixture.app'));
+    expect(existsSync(join(root, 'build', 'Fixture.app', 'ip.txt'))).toBe(false);
+    const installed = calls.args.installIosDeviceApp as { appPath: string };
+    expect(existsSync(installed.appPath)).toBe(false);
   });
 
   test('a malformed ios.lanHost refuses the run before the phone is looked for', async () => {
@@ -3385,22 +3515,17 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(errs.join('\n')).not.toMatch(/provider/);
   });
 
-  test('the refusal says what actually happened: built, or restored from the cache', async () => {
+  test('a cached device app installs without building, and the cache entry is not the copy', async () => {
     reserve();
-    const built = await run({ device: true }, connected());
-    expect(built.errs.join('\n')).toMatch(
-      new RegExp(`Built the Debug iphoneos slice[^\n]*and cached it under ${FINGERPRINT}-debug-device`),
-    );
-
-    const restored = await run(
-      { device: true },
-      { ...connected(), resolveBuild: () => join(root, 'cached', 'Fixture.app') },
-    );
-    expect(restored.calls.order.includes('buildIos')).toBe(false);
-    expect(restored.errs.join('\n')).toMatch(
-      new RegExp(`Restored the Debug iphoneos slice[^\n]*from the cache under ${FINGERPRINT}-debug-device`),
-    );
-    expect(restored.errs.join('\n')).not.toMatch(/Built the/);
+    const cached = join(root, 'cached', 'Fixture.app');
+    mkdirSync(cached, { recursive: true });
+    const { calls, exitCode } = await run({ device: true }, { ...connected(), resolveBuild: () => cached });
+    expect(exitCode).toBe(null);
+    expect(calls.order.includes('buildIos')).toBe(false);
+    const sealed = calls.args.sealAppForDevice as { appPath: string };
+    expect(sealed.appPath).not.toBe(cached);
+    expect(existsSync(join(cached, 'ip.txt'))).toBe(false);
+    expect(calls.order.includes('installIosDeviceApp')).toBe(true);
   });
 
   test('the same providers ARE consulted without --device, so the gate is not vacuous', async () => {
@@ -3438,7 +3563,7 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(loads).toBeGreaterThan(0);
   });
 
-  test('a device release cache hit does not run the JS swap it cannot re-seal yet', async () => {
+  test('a device release cache hit is refused and rebuilt, so no builder JS reaches the phone', async () => {
     reserve();
     let swaps = 0;
     const { calls, errs } = await run(
@@ -3453,9 +3578,205 @@ describe('ios --device: selecting a phone and building the device slice', () => 
       },
     );
     expect(swaps).toBe(0);
-    expect(calls.order.includes('buildIos')).toBe(false);
+    expect(calls.order.includes('buildIos')).toBe(true);
     expect(calls.order.includes('installIosApp')).toBe(false);
-    expect(errs.join('\n')).toMatch(/js swap\s+skipped for --device/);
+    expect(calls.order.includes('installIosDeviceApp')).toBe(true);
+    expect(errs.join('\n')).toMatch(/carries its builder's JS[\s\S]*building fresh instead/);
+  });
+
+  test('a release device run proves the launch with a device process, never a host pid', async () => {
+    reserve();
+    const { calls, logs } = await run({ device: true, configuration: 'Release', json: true }, connected());
+    expect(calls.order.includes('verifyReleaseLaunch')).toBe(false);
+    const verified = calls.args.verifyIosDeviceReleaseLaunch as Record<string, unknown>;
+    expect(verified.udid).toBe(PHONE);
+    expect(verified.appName).toBe('Fixture');
+    const facts = parseFirst(logs);
+    expect(facts.launched).toBe(true);
+    expect(facts.metroPort).toBe(null);
+    const collector = calls.args.replaceCollector as Record<string, unknown>;
+    expect(collector.payloadUrl).toBe(null);
+  });
+
+  test('a phone is used, never recorded: no device claim survives a full install and launch', async () => {
+    reserve();
+    const { exitCode } = await run({ device: true }, connected());
+    expect(exitCode).toBe(null);
+    expect(getProject(root)?.deviceUdid ?? null).toBe(null);
+    expect(getProject(root)?.deviceName ?? null).toBe(null);
+  });
+
+  test('an install refusal keeps its remedy, and a signer conflict is reported as a data loss', async () => {
+    reserve();
+    const refused = await run(
+      { device: true },
+      {
+        ...connected(),
+        installIosDeviceApp: () => ({
+          failed: true,
+          code: 'STIM_INSTALL_FAILED',
+          reason: 'devicectl could not install the app: the device is locked',
+          remedy: 'Unlock the phone and keep it awake, then run the command again.',
+        }),
+      },
+    );
+    expect(refused.exitCode).toBe(1);
+    expect(refused.errs.join('\n')).toMatch(/STIM_INSTALL_FAILED/);
+    expect(refused.errs.join('\n')).toMatch(/Unlock the phone/);
+    expect(refused.calls.order.includes('replaceCollector')).toBe(false);
+
+    const retried = await run(
+      { device: true },
+      {
+        ...connected(),
+        installIosDeviceApp: (args) => ({
+          ok: true,
+          appPath: args.appPath,
+          uninstalled: true,
+          note: 'com.example.app was already installed on the phone under a different team, so it was uninstalled (its data went with it) before this app could be installed',
+        }),
+      },
+    );
+    expect(retried.exitCode).toBe(null);
+    expect(retried.errs.join('\n')).toMatch(/its data went with it/);
+  });
+
+  test('a launch the phone refuses fails with the trust remedy and the devicectl evidence', async () => {
+    reserve();
+    const { errs, exitCode } = await run(
+      { device: true },
+      {
+        ...connected(),
+        awaitIosDeviceLaunch: async () => ({
+          failed: true,
+          reason: 'devicectl could not keep com.example.app running on the phone.',
+          remedy:
+            "The phone has not trusted this build's developer certificate. On the phone open Settings > General > VPN & Device Management, tap the developer profile under DEVELOPER APP, tap Trust, then run the command again.",
+          lines: ['ERROR: FBSOpenApplicationErrorDomain error 3 (Security)'],
+        }),
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_LAUNCH_FAILED/);
+    expect(errs.join('\n')).toMatch(/VPN & Device Management/);
+    expect(errs.join('\n')).toMatch(/FBSOpenApplicationErrorDomain error 3/);
+  });
+
+  test('no LAN address refuses before the build, and names the shared network', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run({ device: true }, { ...connected(), hostLanCandidates: () => [] });
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_NO_LAN_ADDRESS/);
+    expect(errs.join('\n')).toMatch(/Join a Wi-Fi or Ethernet network/);
+    expect(calls.order.includes('fingerprintProject')).toBe(false);
+  });
+
+  test('a LAN origin that is not this workspace Metro refuses before the build', async () => {
+    reserve();
+    const { errs, exitCode, calls } = await run(
+      { device: true },
+      {
+        ...connected(),
+        ensureLanReachable: async () => ({
+          failed: 'http://192.168.1.5:8082 answered 200, but the request never reached THIS workspace Metro.',
+          remedy: '`stim start` prints the port it reserved.',
+        }),
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_LAN_METRO_UNREACHABLE/);
+    expect(calls.order.includes('fingerprintProject')).toBe(false);
+  });
+
+  test('ios.lanHost pins the address written into ip.txt and gated', async () => {
+    reserve();
+    let sealedIpTxt: string | null = null;
+    const { calls, errs } = await run(
+      { device: true },
+      {
+        ...connected(),
+        resolveSettings: () => ({ ios: { lanHost: '10.0.0.9' } }),
+        sealAppForDevice: (args) => {
+          sealedIpTxt = readFileSync(join(args.appPath, 'ip.txt'), 'utf-8');
+          return { ok: true as const, identity: IDENTITY, mode: 'preserve-metadata' as const };
+        },
+      },
+    );
+    const gate = calls.args.ensureLanReachable as Record<string, unknown>;
+    expect(gate.origin).toBe('http://10.0.0.9:8082');
+    expect(sealedIpTxt).toBe('10.0.0.9:8082\n');
+    expect(errs.join('\n')).toMatch(/lan\s+http:\/\/10\.0\.0\.9:8082 \(ios\.lanHost\)/);
+  });
+
+  test('a refused signing gate on a fresh build exits on its own code instead of building again', async () => {
+    reserve();
+    let builds = 0;
+    const { errs, exitCode } = await run(
+      { device: true },
+      {
+        ...connected(),
+        buildIos: async () => {
+          builds += 1;
+          return { appPath: join(root, 'build', 'Fixture.app'), bundleId: 'com.example.app', durationMs: 1000 };
+        },
+        sealAppForDevice: () => ({
+          ok: false as const,
+          code: 'STIM_PROFILE_MISMATCH',
+          reason: 'The development profile lists 1 device and this phone is not one of them.',
+          remedy: 'Register the UDID at developer.apple.com, regenerate the profile, then build once from Xcode.',
+          lastLines: [],
+        }),
+      },
+    );
+    expect(builds).toBe(1);
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_PROFILE_MISMATCH/);
+    expect(errs.join('\n')).toMatch(/developer\.apple\.com/);
+  });
+
+  test('a refused signing gate on a CACHED app falls back to a full build', async () => {
+    reserve();
+    let seals = 0;
+    const cached = join(root, 'cached', 'Fixture.app');
+    mkdirSync(cached, { recursive: true });
+    const { calls, errs, exitCode } = await run(
+      { device: true },
+      {
+        ...connected(),
+        resolveBuild: () => cached,
+        sealAppForDevice: (args) => {
+          seals += 1;
+          if (seals === 1) {
+            return {
+              ok: false as const,
+              code: 'STIM_NO_SIGNING_IDENTITY',
+              reason: 'The app was signed by "Apple Development: Someone Else", which is not in this keychain.',
+              remedy: 'Open Xcode > Settings > Accounts and download your certificates.',
+              lastLines: [],
+            };
+          }
+          return { ok: true as const, identity: IDENTITY, mode: 'preserve-metadata' as const, appPath: args.appPath };
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(calls.order.includes('buildIos')).toBe(true);
+    expect(errs.join('\n')).toMatch(/not in this keychain[\s\S]*building fresh instead/);
+  });
+
+  test('the unverified remedy names all three causes the LAN gate cannot tell apart', async () => {
+    reserve();
+    const { errs } = await run(
+      { device: true },
+      { ...connected(), verifyLaunch: async () => ({ verified: false, timedOut: true, waitedMs: 20000 }) },
+    );
+    const out = errs.join('\n');
+    expect(out).toMatch(/UNVERIFIED/);
+    expect(out).toMatch(/Local Network/);
+    expect(out).toMatch(/same Wi-Fi SSID/);
+    expect(out).toMatch(/socketfilterfw --getglobalstate/);
+    expect(out).toMatch(/ios\.lanHost/);
+    expect(out).toMatch(/bare Debug device build carries the JS bundle baked in/);
   });
 
   test('a malformed ios.signingIdentitySha1 refuses the same way', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3764,6 +3764,73 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(errs.join('\n')).toMatch(/not in this keychain[\s\S]*building fresh instead/);
   });
 
+  // The install path routes on the dev-client scheme, so the remedy has to as
+  // well: an Expo project without expo-dev-client takes ip.txt and needs the
+  // stale-fallback warning, not the server picker.
+  // The LAN gate fetches the bundle URL from the HOST, which lands in the same
+  // Metro timeline verifyLaunch reads. If the launch window opened before that
+  // fetch, the gate's own record would prove the phone had launched.
+  test('the launch window opens after the LAN gate and after the install', async () => {
+    reserve();
+    let clock = 1_000_000;
+    let gatedAt = 0;
+    let installedAt = 0;
+    const { calls } = await run(
+      { device: true },
+      {
+        ...connected(),
+        now: () => (clock += 1000),
+        ensureLanReachable: async () => {
+          gatedAt = clock;
+          return { ok: true as const };
+        },
+        installIosDeviceApp: (args) => {
+          installedAt = clock;
+          return { ok: true, appPath: args.appPath };
+        },
+      },
+    );
+    const since = Number((calls.args.verifyLaunch as { since?: unknown }).since);
+    expect(gatedAt).toBeGreaterThan(0);
+    expect(installedAt).toBeGreaterThan(gatedAt);
+    expect(since).toBeGreaterThan(installedAt);
+  });
+
+  test('an Expo app WITHOUT a dev client gets the bare remedy, not the picker', async () => {
+    reserve();
+    const { errs, calls } = await run(
+      { device: true },
+      {
+        ...connected(),
+        detectIsExpo: () => true,
+        devClientScheme: () => undefined,
+        verifyLaunch: async () => ({ verified: false, timedOut: true, waitedMs: 20000 }),
+      },
+    );
+    const out = errs.join('\n');
+    expect(calls.order.includes('sealAppForDevice')).toBe(true);
+    expect(out).toMatch(/carries the JS bundle baked in/);
+    expect(out).not.toMatch(/DEVELOPMENT SERVERS picker/);
+    expect(out).not.toMatch(/Retry the deep link/);
+  });
+
+  test('a dev-client app gets the picker and the deep-link retry, not the bare warning', async () => {
+    reserve();
+    const { errs } = await run(
+      { device: true },
+      {
+        ...connected(),
+        detectIsExpo: () => true,
+        devClientScheme: () => 'com.example.app',
+        verifyLaunch: async () => ({ verified: false, timedOut: true, waitedMs: 20000 }),
+      },
+    );
+    const out = errs.join('\n');
+    expect(out).toMatch(/DEVELOPMENT SERVERS picker/);
+    expect(out).toMatch(/Retry the deep link: xcrun devicectl device process launch/);
+    expect(out).not.toMatch(/carries the JS bundle baked in/);
+  });
+
   test('the unverified remedy names all three causes the LAN gate cannot tell apart', async () => {
     reserve();
     const { errs } = await run(
@@ -3776,7 +3843,7 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(out).toMatch(/same Wi-Fi SSID/);
     expect(out).toMatch(/socketfilterfw --getglobalstate/);
     expect(out).toMatch(/ios\.lanHost/);
-    expect(out).toMatch(/bare Debug device build carries the JS bundle baked in/);
+    expect(out).toMatch(/carries the JS bundle baked in/);
   });
 
   test('a malformed ios.signingIdentitySha1 refuses the same way', async () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -612,6 +612,27 @@ FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
   bug than the one it fixes. A debug run fails with STIM_INSTALL_FAILED and
   hands you the uninstall to run yourself.
 
+  ON A PHONE the same uninstall costs one thing more: iOS drops the Settings >
+  General > VPN & Device Management trust entry when the last app from that
+  developer goes, and it clears the app's Local Network permission with it. The
+  note says so, because the reinstall succeeds and then the LAUNCH is refused
+  until someone taps Trust again. The retry is one uninstall and one install --
+  it is not a way around a tap that has no API.
+
+  THE DEVICE FALLBACKS are the fourth, and both print a \`device app\` note and
+  build fresh rather than failing:
+
+    device app  a cached Release device app carries its builder's JS, and the
+                device JS swap lands with phase 6 of appandflow/stim#178 --
+                building fresh instead, which bakes in this workspace's JS
+
+  and a signing-gate refusal on a CACHED artifact -- an expired or foreign
+  profile, a phone the profile does not name, an identity this keychain does not
+  hold -- which prints the gate's own reason with \`-- building fresh instead\`.
+  The same refusal on a FRESHLY BUILT app is a code (STIM_NO_PROFILE,
+  STIM_PROFILE_MISMATCH, STIM_NO_SIGNING_IDENTITY), not a note: building again
+  would produce the same app and refuse again.
+
 STIM_BUILD_WAIT_TIMEOUT
   This run was waiting for ANOTHER workspace's build of the same fingerprint
   (see \`guide lifecycle\`), and after ~90 minutes that process was still alive
@@ -630,8 +651,11 @@ STIM_INSTALL_FAILED
   trusted, Developer Mode is off, storage is full, or the app already on the
   phone was signed by a different team. Only that last one is retried -- one
   \`devicectl device uninstall app\`, one reinstall, and a warning that the
-  app's data went with it. This is gated on \`--device\` rather than on the
-  configuration, because every device run is signed, Debug included.
+  app's data went with it -- along with the phone's developer trust and its
+  Local Network permission, which iOS clears on an uninstall, so the launch
+  after it may need the trust tap again. This is gated on \`--device\` rather
+  than on the configuration, because every device run is signed, Debug
+  included.
   On Android a signature or downgrade conflict names the package that is really
   installed -- the built APK's applicationId, which on a flavored project is
   the flavor's id and not the gradle namespace -- and gives you the
@@ -649,7 +673,8 @@ STIM_LAUNCH_FAILED
   the only one a human has to perform on the phone: Settings > General >
   VPN & Device Management, tap the developer profile under DEVELOPER APP, tap
   Trust, then run the command again. It is a per-developer-certificate tap, not
-  a per-build one.
+  a per-build one -- but an uninstall clears it, including the one Stim's own
+  signer-conflict retry performs.
 
 STIM_NO_SCHEME
   No buildable Xcode scheme was found in ios/. A scheme has to be shared to be
@@ -1402,6 +1427,12 @@ THE OPTION SURFACE, IN FULL
   cable-pull produce yet. See \`guide logs\` for what the device stream can
   and cannot carry, and appandflow/stim#179.
 
+  THE APP RUNS FOR AS LONG AS THE COLLECTOR DOES. Because the collector is the
+  launch, the app is attached to it: \`stop\` (and any other end of that
+  collector -- a crash, the host sleeping, the cable coming out) closes the app
+  on the phone. It stays INSTALLED and Stim still records nothing about the
+  device; only the running process goes. See \`guide cleanup\`.
+
   THERE IS NO INSTALL SKIP ON A PHONE. The simulator path skips the install
   when the device already holds the same bundle byte for byte, which it proves
   by hashing the installed container; there is no cheap equivalent through
@@ -1562,9 +1593,21 @@ WHAT ELSE STOP REAPS
   runs \`devicectl device process launch --console\` itself rather than
   attaching after the fact. It registers under the same \`ios\` key, carries
   the same --root in its title, is proven and replaced by the same pid rules,
-  and is reaped by the same \`stop\`. Unplugging the phone ends devicectl,
-  which ends the collector: it unregisters itself and exits either way, so
-  \`gc\` has nothing to find, because a phone is never recorded as a device.
+  and is reaped by the same \`stop\`.
+
+  THE APP'S LIFETIME IS BOUND TO THAT COLLECTOR, and this is the one place a
+  phone behaves worse than a simulator. \`devicectl device process launch
+  --console\` keeps the app attached to the launching process, so anything that
+  ends the collector ends the APP ON THE PHONE: \`stop\`, \`gc --delete\`,
+  \`worktree remove\`, a fresh \`ios --device\` run stopping its predecessor,
+  a crash, the host sleeping, or the cable coming out. Measured: SIGTERM to the
+  collector alone terminates the app. \`stop\` therefore leaves no RECORD of the
+  phone -- it never had one -- but it does close the app that was running on it.
+  Nothing is uninstalled, and the next \`ios --device\` starts it again.
+
+  Unplugging the phone ends devicectl, which ends the collector: it unregisters
+  itself and exits either way, so \`gc\` has nothing to find, because a phone is
+  never recorded as a device.
   WHICH record it writes on the way out depends on devicectl's exit code, and
   that code is unverified until someone pulls a cable: a zero exit is
   collector_stopped, a non-zero one is collector_failed, because on hardware

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -27,7 +27,10 @@ other line goes to stderr, so it is always safe to pipe.
   stim ios --json
 
   platform        "ios"
-  udid            the owned simulator this workspace installed onto
+  udid            the owned simulator this workspace installed onto, or the
+                  phone's UDID on \`--device\` -- reported, never recorded: a
+                  physical device gets no config entry, so \`stop\` and \`gc\`
+                  never see it
   deviceName      its name, or null
   fingerprint     the @expo/fingerprint hash of the native inputs, AS STORED.
                   A run that had to \`expo prebuild\` or \`pod install\`
@@ -80,7 +83,9 @@ other line goes to stderr, so it is always safe to pipe.
   bundleId        the iOS bundle id that was launched
   installSkipped  true when the artifact was ALREADY on the device byte for
                   byte, so nothing was installed and the run went straight to
-                  launch (see \`guide lifecycle\`). false means an install ran
+                  launch (see \`guide lifecycle\`). false means an install ran.
+                  Always false on \`--device\`: proving a phone already holds
+                  the bundle would cost more than installing it
   launched        true, "bundling", or "unverified". THE THREE ARE DIFFERENT
                   FACTS and only the last one is a problem.
                     true         Metro finished the bundle, then the app stayed
@@ -617,8 +622,16 @@ STIM_BUILD_WAIT_TIMEOUT
   building, remove that directory and run the command again.
 
 STIM_INSTALL_FAILED
-  The artifact built or came from cache, but \`simctl install\` / \`adb install\`
-  refused it. A signature or architecture mismatch, or a full device.
+  The artifact built or came from cache, but \`simctl install\` / \`adb install\` /
+  \`devicectl device install app\` refused it. A signature or architecture
+  mismatch, or a full device.
+  On a PHONE (\`ios --device\`) the message carries devicectl's own text and the
+  remedy names the cause it recognises: the phone is locked, the host is not
+  trusted, Developer Mode is off, storage is full, or the app already on the
+  phone was signed by a different team. Only that last one is retried -- one
+  \`devicectl device uninstall app\`, one reinstall, and a warning that the
+  app's data went with it. This is gated on \`--device\` rather than on the
+  configuration, because every device run is signed, Debug included.
   On Android a signature or downgrade conflict names the package that is really
   installed -- the built APK's applicationId, which on a flavored project is
   the flavor's id and not the gradle namespace -- and gives you the
@@ -628,6 +641,15 @@ STIM_INSTALL_FAILED
 STIM_LAUNCH_FAILED
   Installed, but the app would not start. On Android this usually means no
   launchable activity resolved.
+  On a PHONE it means the app never appeared in the device's own process list
+  after \`devicectl device process launch\`, and the devicectl lines that
+  explain it are quoted under the message. The refusal a first launch usually
+  hits is the DEVELOPER TRUST one -- SpringBoard reports
+  FBSOpenApplicationErrorDomain 3 with the reason Security -- and its remedy is
+  the only one a human has to perform on the phone: Settings > General >
+  VPN & Device Management, tap the developer profile under DEVELOPER APP, tap
+  Trust, then run the command again. It is a per-developer-certificate tap, not
+  a per-build one.
 
 STIM_NO_SCHEME
   No buildable Xcode scheme was found in ios/. A scheme has to be shared to be
@@ -679,6 +701,33 @@ STIM_CODESIGN_FAILED
   and confirm exactly one identity matches the name. The cache entry itself is
   never modified -- the failure is on a temporary copy, and the run builds
   fresh.
+
+--- iOS DEVICE DEBUG REACHABILITY CODES (\`ios --device\` in Debug) ---
+
+A phone does not share the host's loopback and USB carries no reverse forward,
+so a Debug run on one is wired to a LAN origin instead of localhost. Both codes
+fire BEFORE the build, because a refusal that costs a build is a bad refusal.
+
+STIM_NO_LAN_ADDRESS
+  This Mac reports no non-internal IPv4 interface, so there is no address to
+  give the phone: it is offline, or on nothing but utun/awdl/bridge. Join a
+  Wi-Fi or Ethernet network, or connect this Mac by cable, and run again.
+  Deliberately NOT "set metro.publicUrl": neither channel to a phone carries a
+  URL. The dev-client deep link composes http://<host>:<port> itself, and
+  ip.txt is read by RCTBundleURLProvider, which prefixes the scheme. A tunnel
+  cannot be expressed to a phone, so --device ignores metro.publicUrl,
+  metro.tunnel and metro.ngrokUrl and says so when one is set.
+
+STIM_LAN_METRO_UNREACHABLE
+  The chosen LAN origin did not answer as THIS workspace's Metro: no answer, a
+  5xx, or a dev server that is not this one -- the message says which.
+  \`stim start\` prints the port it reserved. On a Mac with several interfaces
+  the first en* is not necessarily the one the phone shares: set ios.lanHost to
+  the address it can reach (see \`guide settings\`).
+  What this gate CANNOT prove is that the phone can reach the origin: macOS
+  routes a host connection to its own address over loopback, so the gate passes
+  through a firewall that will block the phone. That evidence only ever arrives
+  from the phone's own bundle request, which is what \`launched\` reports.
 
 STIM_NO_DEVICE
   With \`--device\`, no physical device answered the selection: none connected,
@@ -835,12 +884,6 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   no variant selected (the refusal names the debug variants).
   These errors are caught before the port is reserved and before anything is
   spawned, so nothing was started.
-  ONE EXCEPTION, and it is temporary: \`ios --device\` also refuses with this
-  code AFTER a successful build. It selects a phone and builds the iphoneos
-  slice for it, but installing onto hardware is not implemented yet, so the
-  run stops there and the message names the cache key the artifact was stored
-  under -- the build is kept and the next run reuses it. This exception goes
-  away when device install lands; see appandflow/stim#178.
 
 "@stim-cli/metro is not installed ... so bundler and client logs will not be
 captured"  (in metro.ndjson, bare RN)
@@ -1306,31 +1349,64 @@ THE OPTION SURFACE, IN FULL
   simulator slice on a phone or publish an iphoneos app under a key simulator
   builds resolve.
 
-  IT IS NOT FINISHED. Today it builds the \`iphoneos\` slice for the selected
-  phone -- \`-sdk iphoneos\`, the project's own signing settings, no signing
-  flags on the argv -- stores that artifact, and then REFUSES with
-  STIM_BAD_ARG, because installing and launching on hardware are not wired yet
-  (appandflow/stim#178). A release cache hit does not run the JS swap either:
-  the swap ends in a signature, and the device re-seal that would make it
-  installable is not wired in yet. Use \`--device\` to prove a project signs
-  for a device and to warm the device cache; use \`stim ios\` with no --device
-  for a run that ends with an app on screen.
+  THE BUILD is the \`iphoneos\` slice for the selected phone -- \`-sdk
+  iphoneos\`, the project's own signing settings, no signing flags on the argv.
+  It is installed with \`devicectl device install app\` and launched with
+  \`devicectl device process launch\`. Every device install is SIGNED, Debug
+  included, so the signing gate runs before it: the app's own
+  embedded.mobileprovision must be unexpired and must name this phone, and when
+  Stim modifies the bundle the identity that profile names must be in this
+  machine's keychain (see \`guide errors\`). A gate refusal on a CACHED app
+  falls back to a full build; on a freshly built one it exits on its own code,
+  because building again would produce the same app.
 
-  THE DEVICE LOG COLLECTOR IS BUILT BUT NOT YET STARTED, for the same reason:
-  on hardware the collector IS the launch. \`devicectl\` connects an app's
+  DEBUG REACHES METRO OVER THE LAN, because a phone shares no loopback with
+  the host and USB carries no reverse forward. Stim picks a non-internal IPv4
+  address (en0 first, RN's own order from react-native-xcode.sh), gates it as
+  this workspace's Metro, and then wires the app to it: an expo-dev-client app
+  through the deep link, passed to devicectl as \`--payload-url\`, and a bare
+  app by writing \`<addr>:<port>\` into the app bundle's ip.txt --
+  RCTBundleURLProvider's own mechanism, which honours a colon-bearing value
+  verbatim and never consults the compiled RCT_METRO_PORT. Stim never sets
+  that define: it would put the reserved port into a compiled input and fork
+  the device cache per workspace.
+  ip.txt is a sealed resource, so Stim writes it on a COPY of the artifact and
+  re-seals that copy with \`codesign\`. THE ORDER IS STORE, THEN COPY, THEN
+  MUTATE: the cache entry stays the pristine, shareable artifact, and the
+  per-run address lives only in the copy that is installed and then deleted.
+
+  A RELEASE device run builds fresh every time for now. A cached Release app
+  carries its BUILDER's JS, and the device JS swap (which has to re-seal what
+  it injects) lands with phase 6 of appandflow/stim#178, so the cache hit is
+  refused rather than installed with someone else's JavaScript.
+
+  THE DEVICE LOG COLLECTOR IS THE LAUNCH. \`devicectl\` connects an app's
   streams only when it is the process that starts the app, so the collector
-  runs \`devicectl device process launch --console\` itself rather than
-  attaching after the fact the way the simulator collector does. It is spawned
-  with the launch that #178 has still to wire. Once running it is the same
-  process as every other collector -- one per platform per workspace, titled
-  with its --root, killed and replaced on the next \`ios\` run whose pid still
-  proves it is this workspace's, and reaped by \`stop\`. Unplugging the phone
-  ends devicectl, which ends the collector: it removes its own registration
-  and exits, leaving nothing for \`gc\` to find, because a phone is never
-  recorded as a device. Whether it closes with collector_stopped or
+  runs \`devicectl device process launch --console --terminate-existing\`
+  itself rather than attaching after the fact the way the simulator collector
+  does. The run then reads the app's pid from the phone's own process list
+  (\`devicectl device info processes\`), because \`--console\` blocks until
+  the app exits and its \`--json-output\` is written only then. That device pid
+  is also what proves a RELEASE launch: a device pid means nothing to the host,
+  so nothing on the host is ever signalled with it. Otherwise the collector is
+  the same process as every other collector -- one per platform per workspace,
+  titled with its --root, killed and replaced on the next \`ios\` run whose pid
+  still proves it is this workspace's, and reaped by \`stop\`. One difference in
+  the ordering: a device run stops the PREVIOUS collector before it installs,
+  not while starting its own, because an upgrade install terminates the running
+  app -- which would end that collector's devicectl non-zero and record a
+  failure for a normal reinstall. Unplugging the phone ends devicectl, which
+  ends the collector: it removes its own registration and exits, leaving
+  nothing for \`gc\` to find, because a phone is never recorded as a device. Whether it closes with collector_stopped or
   collector_failed follows devicectl's exit code, which no one has watched a
   cable-pull produce yet. See \`guide logs\` for what the device stream can
   and cannot carry, and appandflow/stim#179.
+
+  THERE IS NO INSTALL SKIP ON A PHONE. The simulator path skips the install
+  when the device already holds the same bundle byte for byte, which it proves
+  by hashing the installed container; there is no cheap equivalent through
+  devicectl, so a device run always installs. It is an upgrade install: the
+  app's data, and the Local Network permission the phone granted it, survive.
 
   A VARIANT WHOSE NAME ENDS IN "Release" IS A RELEASE BUILD (\`release\`,
   \`productionRelease\`), and that is the whole opt-in -- there is no second
@@ -1493,7 +1569,6 @@ WHAT ELSE STOP REAPS
   that code is unverified until someone pulls a cable: a zero exit is
   collector_stopped, a non-zero one is collector_failed, because on hardware
   a non-zero devicectl exit is the only evidence a launch or console failed.
-  It is not started yet -- the launch it would ride on is appandflow/stim#178.
   See \`guide logs\` for what it can and cannot carry.
 
   Before signalling a recorded collector pid, \`stop\`, \`gc --delete\`,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -41,6 +41,7 @@ import {
   installIosApp,
   iosAppProcess,
   launchIosApp,
+  readCollectorRecords,
   unverifiedLaunchLines,
   verifyLaunch,
   verifyReleaseLaunch,
@@ -64,7 +65,17 @@ import {
   remoteIosDeps,
   resolveRemoteContext,
 } from '../engine/device-remote.ts';
-import { listIosDevices, resolveIosPhysicalDevice } from '../engine/ios-device.ts';
+import {
+  awaitIosDeviceLaunch,
+  installIosDeviceApp,
+  iosDeviceProcess,
+  listIosDevices,
+  resolveIosPhysicalDevice,
+  verifyIosDeviceReleaseLaunch,
+} from '../engine/ios-device.ts';
+import { gateProfileForDevice, sealAppForDevice } from '../engine/ios-signing.ts';
+import { chooseLanAddress, copyAppAside, ensureLanReachable, lanOriginUrlFor, writeIpTxt } from '../engine/ios-lan.ts';
+import { hostLanCandidates } from '../engine/lan-address.ts';
 import { detectProviders } from '../engine/metro-reach.ts';
 import { ownedSessionName } from '../engine/eas-simulator.ts';
 import { type Diagnostic, describeDiagnostic } from '../engine/errors-xcode.ts';
@@ -99,8 +110,11 @@ import { ensureWorkspaceStorage, workspaceDir, workspaceLogsDir } from '../paths
 import { detectBundleId, detectIsExpo, findProjectRoot, isPackageResolvable, projectShortcut } from '../project.ts';
 import {
   cacheProviderSettingError,
+  iosLanHostSetting,
   iosLanHostSettingError,
+  iosSigningIdentitySetting,
   iosSigningIdentitySettingError,
+  iosSigningIdentitySha1Setting,
   iosSigningIdentitySha1SettingError,
   publicUrlSetting,
   REMOTE_DEVICE_BACKENDS,
@@ -580,6 +594,8 @@ interface ReplaceCollectorArgs {
   udid: string;
   bundleId: string;
   appName?: string | null;
+  physical?: boolean;
+  payloadUrl?: string | null;
   spawn?: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => ChildProcess;
   kill?: (pid: number, signal: NodeJS.Signals) => boolean;
   alive?: (pid: number) => boolean;
@@ -589,19 +605,27 @@ interface ReplaceCollectorArgs {
   note?: (line: string) => void;
 }
 
-export async function replaceCollector({
+// On hardware the collector holds the devicectl console of a running app, and
+// an upgrade install terminates that app -- which ends devicectl non-zero and
+// records a failure for a normal action. So a device run stops the previous
+// collector before it installs, rather than as part of starting its own.
+export async function stopPreviousCollector({
   root,
-  udid,
-  bundleId,
-  appName,
-  spawn = (cmd, args, opts) => getExecutor().spawn(cmd, args, opts),
   kill = (pid, signal) => process.kill(pid, signal),
   alive = isPidAlive,
   readState = readWorkspaceState,
   verify = verifyCollectorOwnership,
   waitMs = COLLECTOR_EXIT_WAIT_MS,
   note = (_line: string) => {},
-}: ReplaceCollectorArgs): Promise<{ killed: number | null; pid: number | null }> {
+}: {
+  root: string;
+  kill?: (pid: number, signal: NodeJS.Signals) => boolean;
+  alive?: (pid: number) => boolean;
+  readState?: typeof readWorkspaceState;
+  verify?: typeof verifyCollectorOwnership;
+  waitMs?: number;
+  note?: (line: string) => void;
+}): Promise<{ killed: number | null }> {
   const previous = (readState(root)?.collectors as Record<string, { pid?: number }> | undefined)?.[PLATFORM] || null;
   const previousPid = Number(previous?.pid) || null;
   let killed: number | null = null;
@@ -633,9 +657,30 @@ export async function replaceCollector({
       );
     }
   }
+  return { killed };
+}
+
+export async function replaceCollector({
+  root,
+  udid,
+  bundleId,
+  appName,
+  physical = false,
+  payloadUrl = null,
+  spawn = (cmd, args, opts) => getExecutor().spawn(cmd, args, opts),
+  kill = (pid, signal) => process.kill(pid, signal),
+  alive = isPidAlive,
+  readState = readWorkspaceState,
+  verify = verifyCollectorOwnership,
+  waitMs = COLLECTOR_EXIT_WAIT_MS,
+  note = (_line: string) => {},
+}: ReplaceCollectorArgs): Promise<{ killed: number | null; pid: number | null }> {
+  const { killed } = await stopPreviousCollector({ root, kill, alive, readState, verify, waitMs, note });
 
   const args = [collectorEntry(), '--platform', PLATFORM, '--root', root, '--udid', udid, '--bundle', bundleId];
   if (appName) args.push('--app-name', appName);
+  if (physical) args.push('--physical');
+  if (payloadUrl) args.push('--payload-url', payloadUrl);
 
   let stdio: 'ignore' | (number | 'ignore')[] = 'ignore';
   try {
@@ -707,6 +752,14 @@ interface IosDeps {
   runPodInstall: typeof runPodInstall;
   buildIos: typeof buildIos;
   listIosDevices: typeof listIosDevices;
+  hostLanCandidates: typeof hostLanCandidates;
+  ensureLanReachable: typeof ensureLanReachable;
+  gateProfileForDevice: typeof gateProfileForDevice;
+  sealAppForDevice: typeof sealAppForDevice;
+  installIosDeviceApp: typeof installIosDeviceApp;
+  awaitIosDeviceLaunch: typeof awaitIosDeviceLaunch;
+  iosDeviceProcess: typeof iosDeviceProcess;
+  verifyIosDeviceReleaseLaunch: typeof verifyIosDeviceReleaseLaunch;
   readBundleId: typeof readBundleId;
   swapJsBundle: typeof swapJsBundle;
   installIosApp: typeof installIosApp;
@@ -715,6 +768,7 @@ interface IosDeps {
   verifyReleaseLaunch: typeof verifyReleaseLaunch;
   ensureWorkspaceStorage: typeof ensureWorkspaceStorageSafely;
   replaceCollector: typeof replaceCollector;
+  stopPreviousCollector: typeof stopPreviousCollector;
   writeWorkspaceState: typeof writeWorkspaceState;
   createWriter: typeof createNdjsonWriter;
   now: () => number;
@@ -767,6 +821,14 @@ const DEFAULT_DEPS: IosDeps = {
   runPodInstall,
   buildIos,
   listIosDevices,
+  hostLanCandidates,
+  ensureLanReachable,
+  gateProfileForDevice,
+  sealAppForDevice,
+  installIosDeviceApp,
+  awaitIosDeviceLaunch,
+  iosDeviceProcess,
+  verifyIosDeviceReleaseLaunch,
   readBundleId,
   swapJsBundle,
   installIosApp,
@@ -775,6 +837,7 @@ const DEFAULT_DEPS: IosDeps = {
   verifyReleaseLaunch,
   ensureWorkspaceStorage: ensureWorkspaceStorageSafely,
   replaceCollector,
+  stopPreviousCollector,
   writeWorkspaceState,
   createWriter: createNdjsonWriter,
   now: () => Date.now(),
@@ -803,9 +866,9 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     )
     .option(
       '--device [udid]',
-      "Build the iphoneos slice for a connected iPhone instead of this workspace's owned simulator. With no UDID, " +
-        'the one connected device is used. Stim never creates, boots, or deletes a physical device. ' +
-        'Installing and launching on hardware are not wired yet (appandflow/stim#178), so the run stops after the build.',
+      "Build the iphoneos slice for a connected iPhone, install it, and launch it, instead of using this workspace's " +
+        'owned simulator. With no UDID, the one connected device is used. In Debug the app is wired to this ' +
+        "workspace's Metro over the LAN. Stim never creates, boots, or deletes a physical device.",
     )
     .option(
       '--remote <backend>',
@@ -835,6 +898,10 @@ interface VerifyIosRunArgs {
   bundleId: string;
   udid: string;
   scheme?: string;
+  physical: boolean;
+  appName: string | null;
+  lanAddress: string | null;
+  lanOrigin: string | null;
   remoteDevice: boolean;
   metroOrigin: string | null;
 }
@@ -854,11 +921,24 @@ async function verifyIosRun({
   bundleId,
   udid,
   scheme,
+  physical,
+  appName,
+  lanAddress,
+  lanOrigin,
   remoteDevice,
   metroOrigin,
 }: VerifyIosRunArgs): Promise<boolean | string> {
+  // Invariant 11: a device pid means nothing to the host, so a phone's release
+  // launch is proven by re-probing the phone's own process list.
+  const deviceProcess = (): boolean | null => {
+    const pid = d.iosDeviceProcess({ udid, appName: appName ?? bundleId });
+    return pid === undefined ? null : pid !== null;
+  };
+
   if (release) {
-    const processCheck = await d.verifyReleaseLaunch({ pid: launched?.pid ?? null });
+    const processCheck = physical
+      ? await d.verifyIosDeviceReleaseLaunch({ udid, appName: appName ?? bundleId })
+      : await d.verifyReleaseLaunch({ pid: launched?.pid ?? null });
     if (processCheck?.verified) {
       phase(
         'verify',
@@ -871,7 +951,9 @@ async function verifyIosRun({
       chalk.yellow(
         processCheck?.reason === 'exited'
           ? `UNVERIFIED: the app process exited within ${formatDuration(processCheck.waitedMs ?? 0)} of launch`
-          : 'UNVERIFIED: simctl launch reported no process id to check',
+          : physical
+            ? `UNVERIFIED: devicectl could not read ${udid}'s process list`
+            : 'UNVERIFIED: simctl launch reported no process id to check',
       ),
     );
     note(
@@ -894,11 +976,13 @@ async function verifyIosRun({
         mode: isExpo ? MODE_EXPO : MODE_BARE,
         processAlive: remoteDevice
           ? null
-          : () => {
-              if (launched?.pid) return d.isPidAlive(launched.pid);
-              const pid = iosAppProcess(udid, bundleId);
-              return pid === undefined ? null : pid !== null;
-            },
+          : physical
+            ? deviceProcess
+            : () => {
+                if (launched?.pid) return d.isPidAlive(launched.pid);
+                const pid = iosAppProcess(udid, bundleId);
+                return pid === undefined ? null : pid !== null;
+              },
       })
     : { verified: false, skipped: true };
   if (verification?.fatal) {
@@ -946,9 +1030,11 @@ async function verifyIosRun({
     waitedMs: verification?.waitedMs,
     bundleId,
     udid,
-    devClientUrl: scheme ? devClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT) : null,
+    devClientUrl: scheme ? devClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT, lanAddress ?? undefined) : null,
     mode: isExpo ? MODE_EXPO : MODE_BARE,
     remote: remoteDevice,
+    physical,
+    lanOrigin,
     metroOrigin,
   }))
     note(chalk.yellow(phaseLine('', line)));
@@ -1131,6 +1217,8 @@ interface FinishIosRunArgs {
   device: DeviceLike;
   udid: string;
   physical: boolean;
+  lanAddress: string | null;
+  lanOriginUrl: string | null;
   remoteDevice: ReturnType<IosDeps['remoteIosDeps']> | null;
   bootPromise: Promise<IosBootLike | null | undefined>;
   bootDuration: () => string;
@@ -1172,6 +1260,8 @@ async function finishIosRun({
   device,
   udid,
   physical,
+  lanAddress,
+  lanOriginUrl,
   remoteDevice,
   bootPromise,
   bootDuration,
@@ -1224,60 +1314,124 @@ async function finishIosRun({
   }
   phase('device', `${deviceLabel(device, udid)} ${physical ? 'connected' : `booted ${bootDuration()}`}`);
 
-  if (physical) {
-    if (swapDir) {
-      try {
-        rmSync(swapDir, { recursive: true, force: true });
-      } catch {}
-    }
-    return fail({
-      code: 'STIM_BAD_ARG',
-      message:
-        `${cacheHit ? 'Restored' : 'Built'} the ${configuration || 'Debug'} iphoneos slice for ` +
-        `${deviceLabel(device, udid)} ${cacheHit ? 'from the cache under' : 'and cached it under'} ${storeKey}, ` +
-        'but installing and launching on a phone are not wired yet.',
-      remedy:
-        'Device install and launch land with appandflow/stim#178. Run `stim ios` without --device to install on this workspace owned simulator.',
-    });
-  }
-
   const scheme = release ? undefined : d.devClientScheme(root, appPath);
-  const installTimer = stepTimer(d.now);
-  const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme });
-  if (installed?.failed) {
-    return fail({
-      code: installed.code || 'STIM_INSTALL_FAILED',
-      message: installed.reason,
-      remedy: 'Check that the simulator is booted and that the app was built for the simulator SDK.',
-      build: { ...buildFailure, appPath, bundleId },
-    });
-  }
-  const installSkipped = Boolean(installed?.skipped);
-  phase(
-    'install',
-    installSkipped
-      ? `skipped; ${deviceLabel(device, udid)} already holds this app ${installTimer()}`
-      : `-> ${deviceLabel(device, udid)} ${installTimer()}`,
-  );
-
-  if (swapDir) {
+  const appName = appNameFromPath(appPath);
+  const dropSwapDir = () => {
+    if (!swapDir) return;
     try {
       rmSync(swapDir, { recursive: true, force: true });
     } catch {}
-  }
+  };
+  let installSkipped = false;
+  let launched: ReturnType<IosDeps['launchIosApp']> | null = null;
+  let launchedAt = d.now();
 
-  const launchTimer = stepTimer(d.now);
-  const launchedAt = d.now();
-  const launched = d.launchIosApp({ udid, bundleId: bundleId!, metroPort, devClientScheme: scheme });
-  if (launched?.failed) {
-    return fail({
-      code: launched.code || 'STIM_LAUNCH_FAILED',
-      message: launched.reason,
-      remedy: `Run \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`,
-      build: { ...buildFailure, appPath, bundleId },
+  if (physical) {
+    await d.stopPreviousCollector({ root, note });
+    const installTimer = stepTimer(d.now);
+    const installed = d.installIosDeviceApp({ udid, appPath: appPath!, bundleId });
+    if (installed?.failed) {
+      dropSwapDir();
+      return fail({
+        code: installed.code || 'STIM_INSTALL_FAILED',
+        message: installed.reason ?? `devicectl could not install ${appPath} on ${udid}.`,
+        remedy: installed.remedy ?? null,
+        build: { ...buildFailure, appPath, bundleId },
+      });
+    }
+    phase('install', `-> ${deviceLabel(device, udid)} ${installTimer()}`);
+    if (installed?.note) {
+      note(chalk.yellow(phaseLine('install', installed.note)));
+      logWriter().write({ src: 'build', level: 'warn', event: 'install_uninstalled_first', msg: installed.note });
+    }
+    dropSwapDir();
+
+    const payloadUrl = scheme && metroPort !== null && lanAddress ? devClientUrl(scheme, metroPort, lanAddress) : null;
+    const launchTimer = stepTimer(d.now);
+    launchedAt = d.now();
+    // On hardware the collector IS the launch: devicectl connects an app's
+    // standard streams only when it is the process that starts the app.
+    const collector = await d.replaceCollector({
+      root,
+      udid,
+      bundleId: bundleId!,
+      appName,
+      physical: true,
+      payloadUrl,
+      note,
     });
+    if (!collector?.pid) {
+      return fail({
+        code: 'STIM_LAUNCH_FAILED',
+        message: `The device log collector, which is what launches ${bundleId} on a phone, could not be started.`,
+        remedy: `Check ${logFile} and the workspace collector log, then run the command again.`,
+        build: { ...buildFailure, appPath, bundleId },
+      });
+    }
+    const started = await d.awaitIosDeviceLaunch({
+      udid,
+      bundleId: bundleId!,
+      appName: appName ?? bundleId!,
+      collectorPid: collector.pid,
+      readRecords: () => readCollectorRecords(logsDir).filter((entry) => Number(entry.ts) >= launchedAt),
+    });
+    if (started.failed || !started.pid) {
+      return fail({
+        code: 'STIM_LAUNCH_FAILED',
+        message: started.reason ?? `${bundleId} did not start on ${udid}.`,
+        remedy: started.remedy ?? null,
+        lines: started.lines ?? [],
+        logPath: logsDir,
+        build: { ...buildFailure, appPath, bundleId },
+      });
+    }
+    launched = {
+      ok: true,
+      mode: payloadUrl ? 'payload-url' : 'launch',
+      pid: started.pid,
+      ...(payloadUrl ? { url: payloadUrl } : {}),
+      ...(lanOriginUrl ? { jsLocation: lanOriginUrl } : {}),
+    };
+    phase(
+      'launch',
+      `${bundleId!} pid ${started.pid} on the phone` +
+        (payloadUrl ? ', opened on the dev-client URL' : '') +
+        ` ${launchTimer()}`,
+    );
+  } else {
+    const installTimer = stepTimer(d.now);
+    const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme });
+    if (installed?.failed) {
+      return fail({
+        code: installed.code || 'STIM_INSTALL_FAILED',
+        message: installed.reason,
+        remedy: 'Check that the simulator is booted and that the app was built for the simulator SDK.',
+        build: { ...buildFailure, appPath, bundleId },
+      });
+    }
+    installSkipped = Boolean(installed?.skipped);
+    phase(
+      'install',
+      installSkipped
+        ? `skipped; ${deviceLabel(device, udid)} already holds this app ${installTimer()}`
+        : `-> ${deviceLabel(device, udid)} ${installTimer()}`,
+    );
+
+    dropSwapDir();
+
+    const launchTimer = stepTimer(d.now);
+    launchedAt = d.now();
+    launched = d.launchIosApp({ udid, bundleId: bundleId!, metroPort, devClientScheme: scheme });
+    if (launched?.failed) {
+      return fail({
+        code: launched.code || 'STIM_LAUNCH_FAILED',
+        message: launched.reason,
+        remedy: `Run \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`,
+        build: { ...buildFailure, appPath, bundleId },
+      });
+    }
+    phase('launch', `${bundleId!} ${launchTimer()}`);
   }
-  phase('launch', `${bundleId!} ${launchTimer()}`);
 
   logWriter().write({
     src: 'build',
@@ -1286,11 +1440,11 @@ async function finishIosRun({
     event: 'launch',
     msg: release
       ? `launched ${bundleId} on ${udid} (${configuration}, embedded JS bundle, no Metro)`
-      : `launched ${bundleId} on ${udid} against Metro port ${metroPort}` +
-        (launched?.mode === 'openurl' ? ' (expo-dev-client)' : ''),
+      : `launched ${bundleId} on ${udid} against Metro ${lanOriginUrl ?? `port ${metroPort}`}` +
+        (launched?.mode === 'openurl' || launched?.mode === 'payload-url' ? ' (expo-dev-client)' : ''),
   });
 
-  await d.replaceCollector({ root, udid, bundleId: bundleId!, appName: appNameFromPath(appPath), note });
+  if (!physical) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, note });
 
   const launchState = await verifyIosRun({
     d,
@@ -1307,6 +1461,10 @@ async function finishIosRun({
     bundleId: bundleId!,
     udid,
     scheme,
+    physical,
+    appName,
+    lanAddress,
+    lanOrigin: lanOriginUrl,
     remoteDevice: Boolean(remoteDevice),
     metroOrigin: typeof launched?.jsLocation === 'string' ? launched.jsLocation : null,
   });
@@ -1546,6 +1704,8 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   }
 
   let metroPort = proj?.metroPort ?? null;
+  let lanAddress: string | null = null;
+  let lanOriginUrl: string | null = null;
   if (!(await resolveMetroPort())) return null;
 
   let device: Awaited<ReturnType<typeof ensureOwnedDevice>>;
@@ -1645,6 +1805,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       metroPort = DEFAULT_METRO_PORT;
       note(chalk.yellow(`No Metro port is reserved for this workspace; wiring the app to ${metroPort}.`));
     }
+    if (physical && metroPort !== null && !(await resolveLanOrigin())) return false;
     if (remoteDevice && metroPort !== null) {
       const reachable = await d.ensureMetroReachable({
         ctx: remoteDevice.ctx,
@@ -1663,6 +1824,55 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         return false;
       }
     }
+    return true;
+  }
+
+  async function resolveLanOrigin(): Promise<boolean> {
+    const port = metroPort as number;
+    const pinned = iosLanHostSetting(settings);
+    const candidates = d.hostLanCandidates();
+    const chosen = chooseLanAddress({ pinned, candidates });
+    if (!chosen) {
+      fail({
+        code: 'STIM_NO_LAN_ADDRESS',
+        message:
+          'A Debug run on a phone needs an address the phone can reach, and this Mac has no non-internal IPv4 interface.',
+        remedy:
+          'The phone reaches Metro over the network you share, because USB carries no reverse forward. ' +
+          'Join a Wi-Fi or Ethernet network, or connect this Mac by cable, then run the command again.',
+      });
+      return false;
+    }
+    lanAddress = chosen.address;
+    lanOriginUrl = lanOriginUrlFor(chosen.address, port);
+    const source = chosen.pinned
+      ? 'ios.lanHost'
+      : `${chosen.interfaceName ?? 'interface'}${chosen.candidates > 1 ? ` of ${chosen.candidates} candidates` : ''}`;
+    phase('lan', `${lanOriginUrl} (${source})`);
+    if (publicUrlSetting(settings) || tunnelModeSetting(settings)) {
+      note(
+        chalk.dim(
+          phaseLine(
+            'lan',
+            'metro.publicUrl and metro.tunnel are ignored on --device: neither channel to a phone carries a URL, ' +
+              'only a host and a port. They still apply to --remote.',
+          ),
+        ),
+      );
+    }
+    if (!metroCheck) return true;
+    const reachable = await d.ensureLanReachable({
+      origin: lanOriginUrl,
+      metroPort: port,
+      root,
+      isExpo,
+      logsDir,
+    });
+    if ('failed' in reachable) {
+      fail({ code: 'STIM_LAN_METRO_UNREACHABLE', message: reachable.failed, remedy: reachable.remedy });
+      return false;
+    }
+    phase('lan', `gated: ${lanOriginUrl} answered as this workspace's Metro`);
     return true;
   }
 
@@ -1897,16 +2107,88 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return true;
   }
 
-  const installableCachedApp = async (cachedPath: string): Promise<string | null> => {
-    if (!release) return cachedPath;
-    if (physical) {
-      phase(
-        'js swap',
-        `skipped for --device: the device swap re-seals with the artifact's own identity, which is not built yet, ` +
-          'so this run stops before installing rather than injecting JS under an ad-hoc signature',
-      );
-      return cachedPath;
+  // The gate refuses a cached artifact by falling back to a full build, which is
+  // only an answer when the artifact came from the cache: on an app xcodebuild
+  // produced seconds ago the same build would refuse again, so a fresh one exits
+  // on the gate's own code.
+  const prepareDeviceApp = async (path: string, { fresh }: { fresh: boolean }): Promise<string | null> => {
+    const refuse = (code: string, reason: string, remedy: string): null => {
+      if (fresh) {
+        fail({ code, message: reason, remedy, build: { ...buildFailure, appPath: path } });
+        return null;
+      }
+      note(chalk.yellow(phaseLine('device app', `${reason} -- building fresh instead`)));
+      note(chalk.dim(phaseLine('', remedy)));
+      swapFellBack = true;
+      return null;
+    };
+    const gateProfile = (): string | null => {
+      const gate = d.gateProfileForDevice({ appPath: path, udid, configuration });
+      return gate.ok ? path : refuse(gate.code, gate.reason, gate.remedy);
+    };
+
+    if (release) {
+      if (!fresh) {
+        note(
+          chalk.yellow(
+            phaseLine(
+              'device app',
+              `a cached ${configuration} device app carries its builder's JS, and the device JS swap lands with ` +
+                "phase 6 of appandflow/stim#178 -- building fresh instead, which bakes in this workspace's JS",
+            ),
+          ),
+        );
+        swapFellBack = true;
+        return null;
+      }
+      return gateProfile();
     }
+
+    const scheme = d.devClientScheme(root, path);
+    if (scheme) return gateProfile();
+
+    let copy: { tmpDir: string; appPath: string };
+    try {
+      copy = copyAppAside(path);
+    } catch (e) {
+      return refuse(
+        'STIM_INSTALL_FAILED',
+        `Could not copy ${path} aside to write its ip.txt: ${(e as Error)?.message || e}`,
+        'Free space in the temporary directory and run the command again.',
+      );
+    }
+    writeIpTxt(copy.appPath, lanAddress as string, metroPort as number);
+    const sealed = d.sealAppForDevice({
+      appPath: copy.appPath,
+      udid,
+      configuration,
+      pinnedName: iosSigningIdentitySetting(settings),
+      pinnedSha1: iosSigningIdentitySha1Setting(settings),
+    });
+    if (!sealed.ok) {
+      try {
+        rmSync(copy.tmpDir, { recursive: true, force: true });
+      } catch {}
+      for (const line of sealed.lastLines ?? []) note(chalk.dim(phaseLine('', line)));
+      return refuse(sealed.code, sealed.reason, sealed.remedy);
+    }
+    if (swapDir) {
+      try {
+        rmSync(swapDir, { recursive: true, force: true });
+      } catch {}
+    }
+    swapDir = copy.tmpDir;
+    phase(
+      'ip.txt',
+      `${lanAddress}:${metroPort} written into the install copy and re-sealed with "${sealed.identity.name}"` +
+        `${sealed.mode === 'preserve-metadata' ? '' : ` (${sealed.mode})`}`,
+    );
+    return copy.appPath;
+  };
+
+  const installableCachedApp = async (cachedPath: string): Promise<string | null> => {
+    if (physical) return prepareDeviceApp(cachedPath, { fresh: false });
+    if (!release) return cachedPath;
     phase('js swap', `regenerating this workspace's JS for the cached ${configuration} app`);
     const swap = await d.swapJsBundle({ root, isExpo, cachedAppPath: cachedPath, logWriter: logWriter() });
     if (swap?.ok && swap.appPath) {
@@ -2085,6 +2367,12 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             note(chalk.yellow(`Could not store the build in the shared cache: ${(e as Error)?.message || e}`));
           }
 
+          if (physical) {
+            const prepared = await prepareDeviceApp(appPath!, { fresh: true });
+            if (!prepared) return false;
+            appPath = prepared;
+          }
+
           if (remote && !physical) {
             uploadPending = d.uploadRemote({
               logWriter: logWriter(),
@@ -2125,6 +2413,8 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     device,
     udid,
     physical,
+    lanAddress,
+    lanOriginUrl,
     remoteDevice,
     bootPromise,
     bootDuration: () => bootDuration,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -928,8 +928,6 @@ async function verifyIosRun({
   remoteDevice,
   metroOrigin,
 }: VerifyIosRunArgs): Promise<boolean | string> {
-  // Invariant 11: a device pid means nothing to the host, so a phone's release
-  // launch is proven by re-probing the phone's own process list.
   const deviceProcess = (): boolean | null => {
     const pid = d.iosDeviceProcess({ udid, appName: appName ?? bundleId });
     return pid === undefined ? null : pid !== null;
@@ -1034,6 +1032,7 @@ async function verifyIosRun({
     mode: isExpo ? MODE_EXPO : MODE_BARE,
     remote: remoteDevice,
     physical,
+    devClient: Boolean(scheme),
     lanOrigin,
     metroOrigin,
   }))
@@ -1349,8 +1348,6 @@ async function finishIosRun({
     const payloadUrl = scheme && metroPort !== null && lanAddress ? devClientUrl(scheme, metroPort, lanAddress) : null;
     const launchTimer = stepTimer(d.now);
     launchedAt = d.now();
-    // On hardware the collector IS the launch: devicectl connects an app's
-    // standard streams only when it is the process that starts the app.
     const collector = await d.replaceCollector({
       root,
       udid,
@@ -2107,10 +2104,6 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return true;
   }
 
-  // The gate refuses a cached artifact by falling back to a full build, which is
-  // only an answer when the artifact came from the cache: on an app xcodebuild
-  // produced seconds ago the same build would refuse again, so a fresh one exits
-  // on the gate's own code.
   const prepareDeviceApp = async (path: string, { fresh }: { fresh: boolean }): Promise<string | null> => {
     const refuse = (code: string, reason: string, remedy: string): null => {
       if (fresh) {

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
-import { MODE_BARE } from '../supervisor/state.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -944,6 +943,7 @@ export function unverifiedLaunchLines({
   mode = null,
   remote = false,
   physical = false,
+  devClient = false,
   lanOrigin = null,
   metroOrigin = null,
 }: {
@@ -957,6 +957,7 @@ export function unverifiedLaunchLines({
   mode?: string | null;
   remote?: boolean;
   physical?: boolean;
+  devClient?: boolean;
   lanOrigin?: string | null;
   metroOrigin?: string | null;
   // Explicit return type: isolatedDeclarations requires one at every module
@@ -1002,13 +1003,10 @@ export function unverifiedLaunchLines({
       `If this Mac has several network interfaces, ${target} may not be the one the phone shares: set ios.lanHost in ` +
         '.stim.json to the address it can reach.',
     );
-    if (mode === MODE_BARE) {
-      lines.push(
-        'AND READ THIS: a bare Debug device build carries the JS bundle baked in when the artifact was built, so an ' +
-          'unreachable Metro is silent. The app on screen is not broken -- it is running THAT bundle, which on a cache ' +
-          "hit is another workspace's JS, not this workspace's.",
-      );
-    } else {
+    // The app takes ip.txt when it has no dev-client scheme, which is what the
+    // install path routes on -- an Expo project without expo-dev-client is a
+    // bare app here even though its dev server is expo-child.
+    if (devClient) {
       push(picker);
       if (url && udid) {
         push(
@@ -1016,6 +1014,12 @@ export function unverifiedLaunchLines({
             `--payload-url '${url}' ${bundleId}`,
         );
       }
+    } else {
+      lines.push(
+        'AND READ THIS: a Debug device build with no dev client carries the JS bundle baked in when the artifact was ' +
+          'built, so an unreachable Metro is silent. The app on screen is not broken -- it is running THAT bundle, ' +
+          "which on a cache hit is another workspace's JS, not this workspace's.",
+      );
     }
     lines.push(`Then check \`stim logs --source metro\`${mode ? ` (${mode})` : ''} for a bundle request.`);
     return lines;

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
+import { MODE_BARE } from '../supervisor/state.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -919,6 +920,10 @@ export function readMetroRecords(logsDir: string | undefined): NdjsonRecord[] {
   return readNdjson(logsDir, 'metro.ndjson');
 }
 
+export function readCollectorRecords(logsDir: string | undefined): NdjsonRecord[] {
+  return readNdjson(logsDir, 'device.ndjson');
+}
+
 function readNdjson(logsDir: string | undefined, name: string): NdjsonRecord[] {
   if (!logsDir) return [];
   try {
@@ -938,6 +943,8 @@ export function unverifiedLaunchLines({
   devClientUrl: url = null,
   mode = null,
   remote = false,
+  physical = false,
+  lanOrigin = null,
   metroOrigin = null,
 }: {
   platform: string;
@@ -949,6 +956,8 @@ export function unverifiedLaunchLines({
   devClientUrl?: string | null;
   mode?: string | null;
   remote?: boolean;
+  physical?: boolean;
+  lanOrigin?: string | null;
   metroOrigin?: string | null;
   // Explicit return type: isolatedDeclarations requires one at every module
   // boundary.
@@ -969,6 +978,45 @@ export function unverifiedLaunchLines({
     push(
       'If an "Open in <app>?" alert or the expo-dev-launcher picker is showing on the remote device, confirm it with your device tool (`agent-device snapshot -i`, then `agent-device press`).',
     );
+    lines.push(`Then check \`stim logs --source metro\`${mode ? ` (${mode})` : ''} for a bundle request.`);
+    return lines;
+  }
+  if (platform === 'ios' && physical) {
+    const target = lanOrigin || origin;
+    push(
+      `Tap Allow on the phone's "would like to find and connect to devices on your local network" prompt if it is showing, ` +
+        'or turn the app on under Settings > Privacy & Security > Local Network. iOS gates every LAN connection behind ' +
+        'that permission, it cannot be granted from this machine, and until it is granted nothing the app sends reaches ' +
+        `${target}.`,
+    );
+    push(
+      'Check the phone is on the same network as this Mac -- the same Wi-Fi SSID, not cellular, not a VPN -- and that ' +
+        'the network does not isolate clients from each other.',
+    );
+    push(
+      'Check macOS is not blocking inbound connections: System Settings > Network > Firewall, or ' +
+        '`/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate`. The gate on this machine passes either way, ' +
+        'because macOS routes a host connection to its own address over loopback.',
+    );
+    push(
+      `If this Mac has several network interfaces, ${target} may not be the one the phone shares: set ios.lanHost in ` +
+        '.stim.json to the address it can reach.',
+    );
+    if (mode === MODE_BARE) {
+      lines.push(
+        'AND READ THIS: a bare Debug device build carries the JS bundle baked in when the artifact was built, so an ' +
+          'unreachable Metro is silent. The app on screen is not broken -- it is running THAT bundle, which on a cache ' +
+          "hit is another workspace's JS, not this workspace's.",
+      );
+    } else {
+      push(picker);
+      if (url && udid) {
+        push(
+          `Retry the deep link: xcrun devicectl device process launch --device ${udid} --terminate-existing ` +
+            `--payload-url '${url}' ${bundleId}`,
+        );
+      }
+    }
     lines.push(`Then check \`stim logs --source metro\`${mode ? ` (${mode})` : ''} for a bundle request.`);
     return lines;
   }

--- a/packages/stim-cli/src/engine/device-remote.ts
+++ b/packages/stim-cli/src/engine/device-remote.ts
@@ -971,7 +971,7 @@ export async function ensureMetroReachable({
   return { ok: true };
 }
 
-function bundleEntryPoint(root: string, isExpo: boolean): string {
+export function bundleEntryPoint(root: string, isExpo: boolean): string {
   if (!isExpo) return 'index';
   try {
     const pkg = JSON.parse(readFileSync(resolvePath(root, 'package.json'), 'utf-8')) as { main?: unknown };

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -2,6 +2,8 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
+import type { NdjsonRecord } from '../ndjson.ts';
+import { INSTALL_ERROR } from './app-install.ts';
 
 const DEVICECTL_TIMEOUT_MS = 30_000;
 
@@ -148,4 +150,331 @@ export function resolveIosPhysicalDevice(requested: string | null, devices: IosD
     remedy:
       'Plug the phone in, unlock it, tap Trust, turn on Settings > Privacy & Security > Developer Mode, then check `xcrun devicectl list devices`.',
   };
+}
+
+const DEVICECTL_INSTALL_TIMEOUT_MS = 300_000;
+
+const LOCKED_REMEDY = 'Unlock the phone and keep it awake, then run the command again.';
+
+function errorText(error: unknown): string {
+  const withOutput = error as { stderr?: unknown; stdout?: unknown; message?: unknown };
+  const stderr = String(withOutput?.stderr ?? '').trim();
+  const stdout = String(withOutput?.stdout ?? '').trim();
+  const message = String(withOutput?.message ?? error).trim();
+  return [message, stderr, stdout].filter(Boolean).join('\n');
+}
+
+export type IosInstallFailureKind = 'signer' | 'locked' | 'untrusted-host' | 'developer-mode' | 'storage' | null;
+
+export function iosInstallFailureKind(output: unknown): IosInstallFailureKind {
+  const out = String(output ?? '');
+  if (/MismatchedApplicationIdentifierEntitlement|application-identifier entitlement[^\n]*does not match/i.test(out)) {
+    return 'signer';
+  }
+  if (/device is locked|is locked\b|passcode/i.test(out)) return 'locked';
+  if (/not paired|pairing|trust this computer|untrusted host/i.test(out)) return 'untrusted-host';
+  if (/developer mode/i.test(out)) return 'developer-mode';
+  if (/not enough (?:free )?(?:disk )?space|insufficient (?:disk )?space|storage is full/i.test(out)) return 'storage';
+  return null;
+}
+
+export function iosInstallRemedy(
+  kind: IosInstallFailureKind,
+  { udid, bundleId }: { udid: string; bundleId: string | null },
+): string {
+  switch (kind) {
+    case 'signer':
+      return `${bundleId ?? 'The app'} is already installed on ${udid} under a different team, and Stim could not remove it. Delete the app on the phone (its data goes with it), then run the command again.`;
+    case 'locked':
+      return LOCKED_REMEDY;
+    case 'untrusted-host':
+      return 'Unlock the phone, tap Trust on the pairing prompt, then run the command again.';
+    case 'developer-mode':
+      return 'Turn on Settings > Privacy & Security > Developer Mode on the phone, restart it, then run the command again.';
+    case 'storage':
+      return 'Free space on the phone (Settings > General > iPhone Storage), then run the command again.';
+    default:
+      return `Check that ${udid} is still connected and unlocked (\`xcrun devicectl list devices\`), and that the app was built for the iphoneos SDK.`;
+  }
+}
+
+export interface IosDeviceInstallResult {
+  ok?: boolean;
+  appPath?: string;
+  uninstalled?: boolean;
+  note?: string;
+  failed?: boolean;
+  code?: string;
+  reason?: string;
+  remedy?: string;
+}
+
+export function installIosDeviceApp(
+  { udid, appPath, bundleId = null }: { udid: string; appPath: string; bundleId?: string | null },
+  { exec = null }: { exec?: Executor | null } = {},
+): IosDeviceInstallResult {
+  const e = exec || getExecutor();
+  const install = () => {
+    e.runFile('xcrun', ['devicectl', 'device', 'install', 'app', '--device', udid, appPath], {
+      timeoutMs: DEVICECTL_INSTALL_TIMEOUT_MS,
+    });
+  };
+  try {
+    install();
+    return { ok: true, appPath };
+  } catch (err) {
+    const failure = errorText(err);
+    const kind = iosInstallFailureKind(failure);
+    if (kind !== 'signer' || !bundleId) {
+      return {
+        failed: true,
+        code: INSTALL_ERROR,
+        reason: `devicectl could not install ${appPath} on ${udid}: ${failure}`,
+        remedy: iosInstallRemedy(kind, { udid, bundleId }),
+      };
+    }
+    try {
+      e.runFile('xcrun', ['devicectl', 'device', 'uninstall', 'app', '--device', udid, bundleId], {
+        timeoutMs: DEVICECTL_INSTALL_TIMEOUT_MS,
+      });
+    } catch (uninstallErr) {
+      return {
+        failed: true,
+        code: INSTALL_ERROR,
+        reason:
+          `devicectl refused to install ${appPath} over the copy of ${bundleId} already on ${udid}, ` +
+          `which a different team signed, and the uninstall failed too: ${errorText(uninstallErr)}`,
+        remedy: iosInstallRemedy('signer', { udid, bundleId }),
+      };
+    }
+    try {
+      install();
+    } catch (retryErr) {
+      return {
+        failed: true,
+        code: INSTALL_ERROR,
+        reason: `devicectl could not install ${appPath} on ${udid} even after uninstalling ${bundleId}: ${errorText(retryErr)}`,
+        remedy: iosInstallRemedy(null, { udid, bundleId }),
+      };
+    }
+    return {
+      ok: true,
+      appPath,
+      uninstalled: true,
+      note: `${bundleId} was already installed on ${udid} under a different team, so it was uninstalled (its data went with it) before this app could be installed`,
+    };
+  }
+}
+
+export interface IosDeviceProcess {
+  pid: number;
+  executable: string;
+}
+
+export function parseDeviceProcesses(payload: unknown): IosDeviceProcess[] {
+  let data: unknown = payload;
+  if (typeof payload === 'string') {
+    try {
+      data = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+  }
+  const running = record(record(data).result).runningProcesses;
+  if (!Array.isArray(running)) return [];
+  const out: IosDeviceProcess[] = [];
+  for (const raw of running) {
+    const entry = record(raw);
+    const pid = Number(entry.processIdentifier);
+    const executable = text(entry.executable);
+    if (!Number.isInteger(pid) || pid <= 0 || !executable) continue;
+    out.push({ pid, executable });
+  }
+  return out;
+}
+
+export function deviceProcessPid(processes: readonly IosDeviceProcess[], appName: string): number | null {
+  const marker = `/${appName}.app/`;
+  for (const entry of processes) {
+    if (entry.executable.includes(marker)) return entry.pid;
+  }
+  return null;
+}
+
+export function iosDeviceProcess(
+  { udid, appName }: { udid: string; appName: string },
+  { exec = null }: { exec?: Executor | null } = {},
+): number | null | undefined {
+  const executor = exec || getExecutor();
+  const dir = mkdtempSync(join(tmpdir(), 'stim-devicectl-'));
+  const out = join(dir, 'processes.json');
+  try {
+    executor.runFile(
+      'xcrun',
+      ['devicectl', 'device', 'info', 'processes', '--device', udid, '--quiet', '--json-output', out],
+      {
+        timeoutMs: DEVICECTL_TIMEOUT_MS,
+      },
+    );
+    return deviceProcessPid(parseDeviceProcesses(readFileSync(out, 'utf-8')), appName);
+  } catch {
+    return undefined;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export type IosLaunchRefusalKind = 'untrusted-developer' | 'locked' | 'not-installed' | null;
+
+// Observed on a real phone (appandflow/stim#178): SpringBoard refuses the first
+// launch of a development build whose developer the phone has not trusted with
+// `FBSOpenApplicationErrorDomain 3` and the reason `Security`.
+export function iosLaunchRefusalKind(output: unknown): IosLaunchRefusalKind {
+  const out = String(output ?? '');
+  if (/profile has not been explicitly trusted by the user/i.test(out)) return 'untrusted-developer';
+  if (/FBSOpenApplicationErrorDomain[^\n]*\b3\b/.test(out) && /Security/.test(out)) return 'untrusted-developer';
+  if (/device is locked|is locked\b|passcode/i.test(out)) return 'locked';
+  if (/(?:application|app)[^\n]*\b(?:is )?(?:unknown to FrontBoard|not installed)/i.test(out)) return 'not-installed';
+  return null;
+}
+
+export function iosLaunchRemedy(
+  kind: IosLaunchRefusalKind,
+  { udid, bundleId }: { udid: string; bundleId: string },
+): string {
+  switch (kind) {
+    case 'untrusted-developer':
+      return (
+        "The phone has not trusted this build's developer certificate, which it refuses to do without a human. " +
+        'On the phone open Settings > General > VPN & Device Management, tap the developer profile under DEVELOPER APP, ' +
+        'tap Trust, then run the command again.'
+      );
+    case 'locked':
+      return LOCKED_REMEDY;
+    case 'not-installed':
+      return `${bundleId} is not installed on ${udid} any more. Run the command again to install it.`;
+    default:
+      return `Run \`xcrun devicectl device process launch --console --device ${udid} ${bundleId}\` to see what the phone reports.`;
+  }
+}
+
+export interface IosDeviceLaunchResult {
+  pid?: number | null;
+  failed?: boolean;
+  reason?: string;
+  remedy?: string;
+  lines?: string[];
+}
+
+const LAUNCH_PROBE_TIMEOUT_MS = 45_000;
+const LAUNCH_PROBE_POLL_MS = 1000;
+const COLLECTOR_ENDED_EVENTS = new Set(['collector_failed', 'collector_stopped']);
+
+function launchEvidence(records: readonly NdjsonRecord[]): string[] {
+  const lines: string[] = [];
+  for (const entry of records) {
+    const msg = typeof entry.msg === 'string' ? entry.msg.trim() : '';
+    if (!msg) continue;
+    if (entry.event === 'collector_started' || entry.event === 'collector_empty') continue;
+    lines.push(msg);
+  }
+  return lines.slice(-6);
+}
+
+// The collector this run started is the one whose end means the launch ended:
+// `replaceCollector` signals its predecessor, whose own closing record lands in
+// the same device.ndjson moments later.
+export function collectorRecordsFor(records: readonly NdjsonRecord[], collectorPid: number | null): NdjsonRecord[] {
+  if (!collectorPid) return [];
+  const marker = new RegExp(`\\bcollector pid ${collectorPid}\\b`);
+  const start = records.findIndex(
+    (entry) => entry.event === 'collector_started' && typeof entry.msg === 'string' && marker.test(entry.msg),
+  );
+  return start < 0 ? [] : records.slice(start);
+}
+
+export async function awaitIosDeviceLaunch({
+  udid,
+  bundleId,
+  appName,
+  collectorPid = null,
+  readRecords,
+  probe,
+  timeoutMs = LAUNCH_PROBE_TIMEOUT_MS,
+  pollMs = LAUNCH_PROBE_POLL_MS,
+  now = Date.now,
+  sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
+}: {
+  udid: string;
+  bundleId: string;
+  appName: string;
+  collectorPid?: number | null;
+  readRecords: () => NdjsonRecord[];
+  probe?: () => number | null | undefined;
+  timeoutMs?: number;
+  pollMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<unknown>;
+}): Promise<IosDeviceLaunchResult> {
+  const probeProcess = probe ?? (() => iosDeviceProcess({ udid, appName }));
+  const deadline = now() + Math.max(0, timeoutMs);
+  for (;;) {
+    const records = collectorRecordsFor(readRecords(), collectorPid);
+    const ended = records.find((entry) => typeof entry.event === 'string' && COLLECTOR_ENDED_EVENTS.has(entry.event));
+    const pid = probeProcess();
+    if (typeof pid === 'number') return { pid };
+    if (ended) {
+      const lines = launchEvidence(records);
+      const kind = iosLaunchRefusalKind(lines.join('\n'));
+      return {
+        failed: true,
+        reason: `devicectl could not keep ${bundleId} running on ${udid}: the console ended before the app appeared in the device's process list.`,
+        remedy: iosLaunchRemedy(kind, { udid, bundleId }),
+        lines,
+      };
+    }
+    if (now() >= deadline) {
+      const lines = launchEvidence(records);
+      return {
+        failed: true,
+        reason: `${bundleId} did not appear in ${udid}'s process list within ${Math.round(timeoutMs / 1000)}s of the launch.`,
+        remedy: iosLaunchRemedy(iosLaunchRefusalKind(lines.join('\n')), { udid, bundleId }),
+        lines,
+      };
+    }
+    await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
+  }
+}
+
+export interface IosDeviceReleaseVerification {
+  verified: boolean;
+  reason?: 'exited' | 'probe-failed';
+  waitedMs: number;
+  pid?: number | null;
+}
+
+// Invariant 11: a device pid is meaningless to `process.kill` on the host, so a
+// release launch is proven by re-probing the phone's own process list.
+export async function verifyIosDeviceReleaseLaunch({
+  udid,
+  appName,
+  waitMs = 3000,
+  probe,
+  now = Date.now,
+  sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
+}: {
+  udid: string;
+  appName: string;
+  waitMs?: number;
+  probe?: () => number | null | undefined;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<unknown>;
+}): Promise<IosDeviceReleaseVerification> {
+  const probeProcess = probe ?? (() => iosDeviceProcess({ udid, appName }));
+  const startedAt = now();
+  await sleep(Math.max(0, waitMs));
+  const pid = probeProcess();
+  const waitedMs = now() - startedAt;
+  if (pid === undefined) return { verified: false, reason: 'probe-failed', waitedMs };
+  return pid === null ? { verified: false, reason: 'exited', waitedMs, pid: null } : { verified: true, waitedMs, pid };
 }

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -261,7 +261,10 @@ export function installIosDeviceApp(
       ok: true,
       appPath,
       uninstalled: true,
-      note: `${bundleId} was already installed on ${udid} under a different team, so it was uninstalled (its data went with it) before this app could be installed`,
+      note:
+        `${bundleId} was already installed on ${udid} under a different team, so it was uninstalled (its data went ` +
+        "with it) before this app could be installed. An uninstall also clears the phone's developer trust and its " +
+        'Local Network permission, so the launch below may need Settings > General > VPN & Device Management again',
     };
   }
 }
@@ -326,15 +329,25 @@ export function iosDeviceProcess(
 
 export type IosLaunchRefusalKind = 'untrusted-developer' | 'locked' | 'not-installed' | null;
 
-// Observed on a real phone (appandflow/stim#178): SpringBoard refuses the first
-// launch of a development build whose developer the phone has not trusted with
-// `FBSOpenApplicationErrorDomain 3` and the reason `Security`.
+// Each pattern matches within ONE line of devicectl's output: the domain, the
+// code and the reason are printed on separate lines of the same error block, so
+// testing them against the joined text would let a code from one line pair with
+// a reason from another. The shapes are
+// __tests__/fixtures/ios-device/launch-untrusted-developer.txt.
+const LAUNCH_REFUSALS: Array<[IosLaunchRefusalKind, RegExp]> = [
+  ['untrusted-developer', /profile has not been explicitly trusted by the user/i],
+  ['untrusted-developer', /FBSOpenApplicationErrorDomain error 3\b/],
+  ['untrusted-developer', /denied by service delegate[^\n]*for reason: Security/],
+  ['locked', /device is locked|is locked\b|passcode/i],
+  ['not-installed', /(?:application|app)[^\n]*\b(?:is )?(?:unknown to FrontBoard|not installed)/i],
+];
+
 export function iosLaunchRefusalKind(output: unknown): IosLaunchRefusalKind {
-  const out = String(output ?? '');
-  if (/profile has not been explicitly trusted by the user/i.test(out)) return 'untrusted-developer';
-  if (/FBSOpenApplicationErrorDomain[^\n]*\b3\b/.test(out) && /Security/.test(out)) return 'untrusted-developer';
-  if (/device is locked|is locked\b|passcode/i.test(out)) return 'locked';
-  if (/(?:application|app)[^\n]*\b(?:is )?(?:unknown to FrontBoard|not installed)/i.test(out)) return 'not-installed';
+  for (const line of String(output ?? '').split(/\r?\n/)) {
+    for (const [kind, pattern] of LAUNCH_REFUSALS) {
+      if (pattern.test(line)) return kind;
+    }
+  }
   return null;
 }
 
@@ -381,9 +394,6 @@ function launchEvidence(records: readonly NdjsonRecord[]): string[] {
   return lines.slice(-6);
 }
 
-// The collector this run started is the one whose end means the launch ended:
-// `replaceCollector` signals its predecessor, whose own closing record lands in
-// the same device.ndjson moments later.
 export function collectorRecordsFor(records: readonly NdjsonRecord[], collectorPid: number | null): NdjsonRecord[] {
   if (!collectorPid) return [];
   const marker = new RegExp(`\\bcollector pid ${collectorPid}\\b`);

--- a/packages/stim-cli/src/engine/ios-lan.ts
+++ b/packages/stim-cli/src/engine/ios-lan.ts
@@ -94,10 +94,8 @@ export async function ensureLanReachable({
   return { ok: true };
 }
 
-// The cache entry is never modified: the per-run address lives only in the copy
-// that gets installed and deleted. `cp -R` preserves the symlinks and the exec
-// bit a code signature seals over; `-c` clones the blocks when the filesystem
-// can.
+// `cp -R` preserves the symlinks and the exec bit a code signature seals over;
+// `-c` clones the blocks when the filesystem can.
 export function copyAppAside(
   appPath: string,
   {

--- a/packages/stim-cli/src/engine/ios-lan.ts
+++ b/packages/stim-cli/src/engine/ios-lan.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { getExecutor, type Executor } from '../exec.ts';
+import type { NdjsonRecord } from '../ndjson.ts';
+import { isBundleProof, readMetroRecords } from './app-install.ts';
+import { bundleEntryPoint } from './device-remote.ts';
+import { gateMetroOrigin } from './metro-gate.ts';
+import type { LanCandidate } from './lan-address.ts';
+
+const IP_TXT = 'ip.txt';
+
+export interface LanSelection {
+  address: string;
+  interfaceName: string | null;
+  pinned: boolean;
+  candidates: number;
+}
+
+export function chooseLanAddress({
+  pinned = null,
+  candidates,
+}: {
+  pinned?: string | null;
+  candidates: readonly LanCandidate[];
+}): LanSelection | null {
+  const list = Array.isArray(candidates) ? candidates : [];
+  if (pinned) {
+    const known = list.find((candidate) => candidate.address === pinned);
+    return { address: pinned, interfaceName: known?.interfaceName ?? null, pinned: true, candidates: list.length };
+  }
+  const first = list[0];
+  if (!first) return null;
+  return { address: first.address, interfaceName: first.interfaceName, pinned: false, candidates: list.length };
+}
+
+export function lanOriginUrlFor(address: string, port: number | string): string {
+  return `http://${address}:${port}`;
+}
+
+// RCTBundleURLProvider.mm:206 guessPackagerHost trims newlines and nothing else,
+// then hands the value to serverRootWithHostPort (line 70), which interpolates
+// it into a URL verbatim and consults the compiled RCT_METRO_PORT default only
+// when the value carries no colon. So the file holds exactly `<addr>:<port>`.
+export function ipTxtContents(address: string, port: number | string): string {
+  return `${String(address).trim()}:${String(port).trim()}\n`;
+}
+
+export function writeIpTxt(
+  appPath: string,
+  address: string,
+  port: number | string,
+  { write = writeFileSync }: { write?: typeof writeFileSync } = {},
+): string {
+  const path = join(appPath, IP_TXT);
+  write(path, ipTxtContents(address, port), 'utf-8');
+  return path;
+}
+
+export async function ensureLanReachable({
+  origin,
+  metroPort,
+  root,
+  isExpo,
+  logsDir,
+  gateOrigin = gateMetroOrigin,
+  readRecords = null,
+}: {
+  origin: string;
+  metroPort: number | string;
+  root: string;
+  isExpo: boolean;
+  logsDir: string;
+  gateOrigin?: typeof gateMetroOrigin;
+  readRecords?: (() => NdjsonRecord[]) | null;
+}): Promise<{ ok: true } | { failed: string; remedy: string }> {
+  const result = await gateOrigin({
+    origin,
+    metroPort,
+    platform: 'ios',
+    entryPoint: bundleEntryPoint(root, isExpo),
+    readRecords: readRecords ?? (() => readMetroRecords(logsDir)),
+    isProof: isBundleProof,
+  });
+  if (result.failed) {
+    return {
+      failed: result.reason ?? `${origin} is not this workspace's Metro.`,
+      remedy:
+        `The phone reaches Metro at ${origin}, so that address has to serve THIS workspace's dev server. ` +
+        '`stim start` prints the port it reserved. Set ios.lanHost in .stim.json when this Mac has several ' +
+        'network interfaces and the phone shares one that is not the first.',
+    };
+  }
+  return { ok: true };
+}
+
+// The cache entry is never modified: the per-run address lives only in the copy
+// that gets installed and deleted. `cp -R` preserves the symlinks and the exec
+// bit a code signature seals over; `-c` clones the blocks when the filesystem
+// can.
+export function copyAppAside(
+  appPath: string,
+  {
+    exec = null,
+    mkdtemp = () => mkdtempSync(join(tmpdir(), 'stim-ios-device-')),
+  }: { exec?: Executor | null; mkdtemp?: () => string } = {},
+): { tmpDir: string; appPath: string } {
+  const e = exec || getExecutor();
+  const tmpDir = mkdtemp();
+  const copy = join(tmpDir, basename(appPath));
+  try {
+    e.runFile('cp', ['-c', '-R', appPath, copy]);
+  } catch {
+    e.runFile('cp', ['-R', appPath, copy]);
+  }
+  return { tmpDir, appPath: copy };
+}

--- a/packages/stim-cli/src/engine/ios-profile.ts
+++ b/packages/stim-cli/src/engine/ios-profile.ts
@@ -283,7 +283,12 @@ function signingConfiguration(input: SigningGateInput): string {
   return input.configuration ?? 'Debug';
 }
 
-export function signingGate(input: SigningGateInput): SigningGateResult {
+export type ProfileGateResult = { ok: true; profile: ProvisioningProfile } | SigningRefusal;
+
+// The profile half of the gate, which is all a bundle Stim does not modify
+// needs: it turns an opaque `devicectl install` rejection into a refusal that
+// names the phone and the profile.
+export function profileGate(input: SigningGateInput): ProfileGateResult {
   const now = input.now ?? Date.now();
   if (!input.profilePresent) {
     return {
@@ -332,6 +337,14 @@ export function signingGate(input: SigningGateInput): SigningGateResult {
     };
   }
 
+  return { ok: true, profile };
+}
+
+export function signingGate(input: SigningGateInput): SigningGateResult {
+  const gated = profileGate(input);
+  if (!gated.ok) return gated;
+  const profile = gated.profile;
+  const named = profile.name ? `"${profile.name}"` : 'the embedded profile';
   const identities = Array.isArray(input.identities) ? input.identities : [];
   if (identities.length === 0) {
     return {

--- a/packages/stim-cli/src/engine/ios-profile.ts
+++ b/packages/stim-cli/src/engine/ios-profile.ts
@@ -285,9 +285,6 @@ function signingConfiguration(input: SigningGateInput): string {
 
 export type ProfileGateResult = { ok: true; profile: ProvisioningProfile } | SigningRefusal;
 
-// The profile half of the gate, which is all a bundle Stim does not modify
-// needs: it turns an opaque `devicectl install` rejection into a refusal that
-// names the phone and the profile.
 export function profileGate(input: SigningGateInput): ProfileGateResult {
   const now = input.now ?? Date.now();
   if (!input.profilePresent) {

--- a/packages/stim-cli/src/engine/ios-signing.ts
+++ b/packages/stim-cli/src/engine/ios-signing.ts
@@ -75,8 +75,6 @@ export interface SigningGateOptions {
   exec?: Executor | null;
 }
 
-// A bundle Stim installs without modifying needs the profile checks only: no
-// re-seal happens, so the keychain is not consulted.
 export function gateProfileForDevice(options: SigningGateOptions): ProfileGateResult {
   const read = readEmbeddedProfile(options.appPath, { exec: options.exec ?? null });
   return profileGate({

--- a/packages/stim-cli/src/engine/ios-signing.ts
+++ b/packages/stim-cli/src/engine/ios-signing.ts
@@ -5,8 +5,10 @@ import { getExecutor, type Executor } from '../exec.ts';
 import {
   parseProvisioningProfilePlist,
   parseSigningIdentities,
+  profileGate,
   SIGNING_CODES,
   signingGate,
+  type ProfileGateResult,
   type ProvisioningProfile,
   type SigningGateResult,
   type SigningIdentity,
@@ -71,6 +73,20 @@ export interface SigningGateOptions {
   pinnedSha1?: string | null;
   now?: number;
   exec?: Executor | null;
+}
+
+// A bundle Stim installs without modifying needs the profile checks only: no
+// re-seal happens, so the keychain is not consulted.
+export function gateProfileForDevice(options: SigningGateOptions): ProfileGateResult {
+  const read = readEmbeddedProfile(options.appPath, { exec: options.exec ?? null });
+  return profileGate({
+    profilePresent: read.present,
+    profile: read.profile,
+    identities: [],
+    udid: options.udid,
+    configuration: options.configuration ?? null,
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
 }
 
 export function gateAppForDevice(options: SigningGateOptions): SigningGateResult {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -62,9 +62,9 @@ app, opens it, and checks launch logs. The build always runs on the local
 machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
-- `--device [udid]` selects a connected iPhone instead of the owned simulator.
-  With no UDID the one connected device is used. Stim never creates, boots, or
-  deletes hardware.
+- `--device [udid]` builds, installs, and launches on a connected iPhone instead
+  of the owned simulator. With no UDID the one connected device is used. Stim
+  never creates, boots, or deletes hardware.
 - `--remote proxy` uses a configured Agent Device daemon.
 - `--remote eas` uses an EAS remote simulator.
 - `--no-metro-check` skips the Debug dev-server gate.
@@ -78,10 +78,29 @@ collide with a simulator build, and no build-cache provider or Expo remote cache
 is read or written on a `--device` run, because every entry they hold is keyed
 for the simulator.
 
-`--device` is incomplete. It selects the phone and builds the `iphoneos` slice
-for it, and then refuses: installing and launching on hardware are not
-implemented yet. Run `stim ios` without `--device` for a run that ends with an
-app on screen.
+A `--device` run installs with `devicectl device install app` and launches with
+`devicectl device process launch`. Every device install is signed, Debug
+included, so the app's own `embedded.mobileprovision` must be unexpired and must
+name the phone, and the identity it names must be in this machine's keychain
+whenever Stim modifies the bundle.
+
+In Debug the phone reaches Metro over the LAN, because it shares no loopback
+with the host and USB carries no reverse forward. Stim gates a non-internal IPv4
+address as this workspace's Metro, then hands it to the app: an expo-dev-client
+app through the deep link (`--payload-url`), a bare app by writing
+`<addr>:<port>` into a copy of the bundle's `ip.txt` and re-sealing that copy.
+The cache entry is never modified. Set `ios.lanHost` when this Mac has several
+interfaces and the phone shares one that is not the first.
+
+Two things a phone needs that a simulator does not, both one-time and both
+human: trusting the developer certificate under Settings > General > VPN &
+Device Management, and allowing the Local Network prompt the first time the app
+looks for Metro. Until the second one is granted, `launched` comes back
+`unverified`.
+
+A `--device` run in a Release configuration builds fresh every time: a cached
+Release app carries its builder's JavaScript, and the device JS swap lands with
+a later phase of [#178](https://github.com/appandflow/stim/issues/178).
 
 ## `android`
 


### PR DESCRIPTION
## Description

`ios --device` has, since #185, built the `iphoneos` slice for a selected phone and then refused with `STIM_BAD_ARG`, because nothing installed or launched on hardware. This is phases 3 and 5 of `docs/specs/2026-09-01-ios-device-release-design.md`: the run now installs with `devicectl device install app`, launches through #186's console collector, and in Debug wires the app to this workspace's Metro over the LAN — dev-client apps through the deep link, bare apps through RN's own `ip.txt` mechanism.

**Three behaviour changes a reviewer should weigh:**

1. **A Release device cache hit is refused and rebuilt** instead of installed. A cached Release app carries its *builder's* JS, and the device JS swap that would replace it is phase 6, so installing it would violate invariant 3. Every Release device run compiles for now — correct if slow. This replaces the old `js swap skipped for --device` note, which would now mean installing another workspace's JavaScript on a phone.
2. **`installSkipped` is always `false` on `--device`.** The simulator path proves the device already holds the bundle by hashing the installed container; `devicectl` has no cheap equivalent, so a device run always installs (an upgrade install — app data and the granted Local Network permission survive). Documented in `guide facts` rather than faked.
3. **`stop` now closes the running app on the phone** (see Test plan item 4), and **`replaceCollector` gained two flags and lost its kill half to `stopPreviousCollector`.** That is the one shared, non-device-only change; the simulator path calls the same code and is covered by the existing collector tests plus a full loop-suite run.

**The one path with no hardware evidence** is the bare-app `ip.txt` write. `trailhead-bench` is a dev client, and a bare fixture needs its own provisioning profile naming the phone. What stands behind it instead is on-disk verification and RN's own source — details in the Test plan, and `docs/field-test-protocol.md` C.4 records it as outstanding.

## Solution

**Install and launch.** `devicectl device install app`, with a pure `iosInstallFailureKind` classifier giving a remedy per cause (locked, untrusted host, Developer Mode off, storage full, signer conflict). Only a signer conflict is retried — one uninstall, one reinstall, one warned note that the app's data went with it — and it is gated on `--device` rather than on the configuration, because every device install is signed, Debug included.

On hardware the collector *is* the launch: `devicectl` connects an app's standard streams only when it is the process that starts the app (#186), so `replaceCollector({physical: true, payloadUrl})` performs the launch. `--console` blocks until the app exits, so its `--json-output` cannot supply a pid at launch time; `awaitIosDeviceLaunch` polls `devicectl device info processes` for the app's pid instead, watching this run's collector records for an early exit. That device pid is also what proves a Release launch — invariant 11, never `process.kill` on the host. A refusal is `STIM_LAUNCH_FAILED` with the devicectl lines quoted and the developer-trust remedy (Settings > General > VPN & Device Management) named first, which is the refusal a real phone produced while proving #185.

**The collector is stopped before the install, not as part of the launch.** That ordering is a finding from the phone: an upgrade install terminates the running app, which ends the console the previous collector holds, which recorded `collector_failed` — a reported failure for a normal reinstall. Stopping it first makes that the `collector_stopped` it should always have been.

**Debug over the LAN.** The address comes from the merged `lanCandidates` ordering (`ios.lanHost` overrides), is gated once with `gateMetroOrigin`, and is refused before the build with `STIM_NO_LAN_ADDRESS` or `STIM_LAN_METRO_UNREACHABLE`. A bare app then gets **store, then copy, then mutate**: the pristine artifact is stored under the post-mutation cache key, copied to a `mkdtemp`, given its `ip.txt`, re-sealed with phase 4's primitive, installed, and deleted — so the cache entry stays generic and shareable. The `<addr>:<port>` form is what lets Stim leave `RCT_METRO_PORT` unset: `serverRootWithHostPort` uses a colon-bearing value verbatim, so the reserved port never enters a compiled input and the device cache is not forked per workspace.

**The signing gate runs as a pre-install check.** A bundle Stim does not modify needs the profile half only, so `profileGate` was split out of `signingGate` and `gateProfileForDevice` runs without touching the keychain. A refusal on a *cached* app falls back to a full build; on a *freshly built* one it exits on its own `STIM_*` code, because building again produces the same app.

`'unverified'` on a device Debug run now names all three causes the host cannot distinguish — the Local Network prompt (one tap per app per phone, ungrantable from the host), a phone on another network, and the macOS firewall — plus `ios.lanHost` for a multi-NIC Mac and, on a bare project, the stale-fallback consequence.

Docs: `guide errors` loses the temporary `STIM_BAD_ARG` exception and gains the two reachability codes and the device halves of `STIM_INSTALL_FAILED` / `STIM_LAUNCH_FAILED`. `guide lifecycle`, `guide cleanup`, `guide facts`, `SKILL.md` and `website/docs/commands.md` lose their "not wired yet" notes.

## Test plan

**On a real phone** — Old iPhone (iPhone13,3), cabled, Developer Mode on, developer trusted, against `trailhead-bench` (Expo SDK 57, expo-dev-client, committed `ios/`, a development profile naming this phone). Invariant 9: every `devicectl` call in this PR was made by these runs, not by a mock.

**1. The Debug loop, end to end** (`stim ios --device`, full output):

```
  lan         http://10.0.0.132:8082 (en1)
  lan         gated: http://10.0.0.132:8082 answered as this workspace's Metro
  fingerprint ab703f.. hit (2.9s)
  device      Old iPhone (0000..) connected
  install     -> Old iPhone (0000..) (3.7s)
  launch      com.appandflow.trailhead pid 776 on the phone, opened on the dev-client URL (1.4s)
  verify      ready: bundle loaded, stable for 3s, process alive (2.9s total)
OK: com.appandflow.trailhead on Old iPhone (0000..), Metro port 8082 (from cache, 17.4s)
```

Cache HIT on the device key `ab703f..-debug-device` minted by #185; pid 776 read off the phone; `launched: true` from the phone's own bundle request, which lands in the timeline as `16:48:13.636 info metro iOS Bundled 71ms node_modules/expo-router/entry.js (1 module)` followed by `com.appandflow.trailhead fetched a bundle from this workspace's Metro on port 8082`. #186's collector started with it and captured 235 device records.

**2. A second run**, `--json`: 8.3s, same cache key, upgrade install, relaunch as pid 777, `"launched": true`, `"installSkipped": false`, `"cacheHit": "local"`, `"appPath"` pointing at the cache entry itself — a dev-client app is installed pristine, with no copy and no `ip.txt` rewrite.

**3. The collector-ordering bug, found here.** Before the fix, every second run left an `error` record for a normal reinstall; after it, the same sequence reads correctly:

```
before: 16:50:04.006 error collector_failed  | the devicectl console ended with exit code 1; treat the run as failed
after:  16:52:04.505 info  collector_stopped | device log collector received SIGTERM; detaching
        16:52:06.362 info  collector_started | device log collector pid 2993 launching com.appandflow.trailhead ...
```

**4. `stop` records nothing about the phone — but it does close the app on it** (invariant 2, the `android --device` precedent from #141). `stop` reported `collectors: stopped ios pid 2993` and `port: released 8082` and nothing else; the project's config entry carries `"platforms": {}` and no `deviceUdid`; `gc` lists no device of any kind; `devicectl list devices` still shows the phone connected.

The app itself does **not** survive that. `devicectl device process launch --console` keeps the app attached to the launching process, and on hardware that process is the collector — so `stop`, `gc --delete`, `worktree remove`, the next `ios --device`, a crash, the host sleeping or the cable coming out all end the running app (measured: SIGTERM to the collector alone terminates it; a detached launch without `--console` survives). Nothing is uninstalled and nothing is recorded, so "used, never owned" holds — but "`stop` leaves the phone untouched" would be wrong. Stated in `guide cleanup`, `guide lifecycle`, and a dated amendment to the spec's "Used, never owned" paragraph and its invariant-2 delta.

**5. The developer-trust refusal, reproduced live.** A later run landed on a phone whose trust had just been cleared by an uninstall (issue #178's second hardware finding: iOS drops the "Developer App" trust entry when the developer's last app is removed). The install succeeded and the launch was refused, which is exactly the path the classifier and remedy exist for:

```
  install     -> Old iPhone (0000..) (2.3s)
  error       devicectl could not keep com.appandflow.trailhead running on 00008101-...: the console ended before the app appeared in the device's process list.
              ... Unable to launch com.appandflow.trailhead because it has an invalid code signature, inadequate entitlements or its profile has not been explicitly trusted by the user. (FBSOpenApplicationErrorDomain error 3 (0x03))
              BSErrorCodeDescription = Security
  remedy      The phone has not trusted this build's developer certificate ... Settings > General > VPN & Device Management, tap the developer profile under DEVELOPER APP, tap Trust, then run the command again.
  failed      STIM_LAUNCH_FAILED
```

The collector unregistered itself and exited; no stray process, no device record. It reproduced identically on a second run ten minutes later, and a green launch now waits on the Trust tap, which has no API — so the last runs of this session end here rather than at `launched: true`. The green runs above (items 1-3) were made with the same install and launch code; what changed after them is the refusal classifier, the remedy routing, and comments, all covered by unit tests. That transcript is now the classifier's fixture (`fixtures/ios-device/launch-untrusted-developer.txt`), and because an uninstall clears the trust, the signer-conflict retry's own note and the `STIM_INSTALL_FAILED` remedy say so — the retry is one uninstall and one install, not a way around a tap that has no API.

**6. #179's negative severity check, on hardware.** Of 235 device records, 234 are `info` and the one `error` is the collector's own. Lines `os_log` emitted above info — `bundle scheme is file - unable to connect to sharedPackageConnection from EXDevLauncherController`, `nw_endpoint_flow_failed_with_error`, `TCP Conn 0x301ad7ca0 Failed : error 0:61` — all recorded at `info`. The measured level loss holds on a phone, and the collector does not guess.

**Known limits, deliberately left:**

- **The device pid matches any executable under `<AppName>.app/`**, including an app extension in `PlugIns/`. An app that launches an appex before its own main process could report the extension's pid. It is a pid used for liveness, not for signalling, so the failure mode is a launch reported alive slightly too eagerly.
- **`appPath` in the facts names the temp copy** on a bare device Debug run, and that copy is deleted after the install. This is the existing behaviour of the simulator Release swap path, not something this PR introduces; fixing it means deciding what the field should mean on a swapped run, which belongs with phase 6.

**Not settled by a phone, and not claimed:**

- **The bare `ip.txt` path.** Behind it: `engine-ios-lan.test.ts` (exact file bytes, the copy carries `ip.txt` and the source does not, the real `cp` preserves symlink and exec bit), `ios-command.test.ts` (the copy is what installs, the pristine artifact is what stores, the copy is deleted), phase 4's live `codesign` tests, and #185's own hardware run, which installed and launched a re-sealed bundle whose `ip.txt` had been rewritten.
- **The signer-conflict retry.** A genuine `MismatchedApplicationIdentifierEntitlement` needs a second signing team; this machine has one. Classifier and ladder are unit-tested against Apple's documented text.
- **The developer-trust refusal** was observed on this phone during #185 (`FBSOpenApplicationErrorDomain 3`, reason `Security`); the classifier is tested against that recorded text rather than re-provoked, since untrusting a certificate is a manual change to the phone.

**Suites:** unit 2891 passed (10 new in `engine-ios-device.test.ts`, 10 in the new `engine-ios-lan.test.ts`, 2 in `engine-ios-signing.test.ts`, 15 device cases in `ios-command.test.ts`); `test:e2e` 19 passed; build, typecheck, lint, format:check and knip clean. Real tools beyond the phone: `iosDeviceProcess`'s argv against the real `devicectl` (live test, skips with no phone), `gateProfileForDevice` against real `security cms -D` on a real CMS-wrapped profile, `copyAppAside` against the real `cp`.

**No regression on the owned-device path:** `node test/e2e/native/run-native-e2e.mjs --framework expo --platform ios` → `PASS expo-ios`, exit 0. Cold build 178s, second worktree a local cache HIT with `no-compile proof: the second worktree build log holds no compiler invocation`, both launches verified, all five cleanup checks green. `xcrun simctl list devices | grep -i stim` is empty afterwards.

Progresses #178.
