### PR TITLE
Let worktree create take its directory on the command line

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -82,7 +82,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
     'gc.ts': ['--delete', '--older-than', '--cache'],
-    'worktree.ts': ['--carry-ignored', '--base', '--label', '--force'],
+    'worktree.ts': ['--carry-ignored', '--base', '--dir', '--label', '--force'],
   };
   const retired: Record<string, string[]> = { 'gc.ts': ['--all'] };
   for (const [file, flags] of Object.entries(retired)) {

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
-import type { Command } from 'commander';
+import { Command } from 'commander';
 import {
   carriedChangesLine,
   carryConflictWarning,
@@ -300,6 +300,17 @@ test('create action: --dir places the worktree under that directory, resolved ag
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create: rejects a blank --dir instead of falling through to the default directory', async () => {
+  for (const value of ['', '   ']) {
+    const program = new Command();
+    program.exitOverride();
+    registerCreate(program);
+    await expect(() => program.parseAsync(['node', 'stim', 'create', 'x', '--dir', value])).rejects.toThrow(
+      /must name a directory/,
+    );
   }
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync, rmSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { Command } from 'commander';
@@ -292,10 +292,14 @@ test('create action: --dir places the worktree under that directory, resolved ag
   const repo = join(base, 'repo');
   try {
     initScratchRepo(repo);
-    const { logs } = await runCreateInRepo(repo, 'feat-x', { dir: '.worktrees', install: false });
-    const target = join(repo, '.worktrees', 'feat-x');
+    // Run from a subdirectory: a relative --dir must resolve against the cwd,
+    // not the repository root, or this lands at repo/.worktrees instead.
+    mkdirSync(join(repo, 'sub'));
+    const { logs } = await runCreateInRepo(join(repo, 'sub'), 'feat-x', { dir: '.worktrees', install: false });
+    const target = join(repo, 'sub', '.worktrees', 'feat-x');
     expect(logs).toEqual([target]);
     expect(existsSync(join(target, '.git'))).toBeTruthy();
+    expect(existsSync(join(repo, '.worktrees', 'feat-x'))).toBeFalsy();
     expect(existsSync(join(defaultWorktreeDir(repo), 'feat-x'))).toBeFalsy();
   } finally {
     process.exitCode = 0;
@@ -311,6 +315,46 @@ test('create: rejects a blank --dir instead of falling through to the default di
     await expect(() => program.parseAsync(['node', 'stim', 'create', 'x', '--dir', value])).rejects.toThrow(
       /must name a directory/,
     );
+  }
+});
+
+test('create action: --dir through a symlink yields the real path git will report', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-link-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    mkdirSync(join(base, 'real'));
+    symlinkSync(join(base, 'real'), join(base, 'link'));
+    const { logs } = await runCreateInRepo(repo, 'feat-z', { dir: join(base, 'link', 'wts'), install: false });
+    const target = join(base, 'real', 'wts', 'feat-z');
+    expect(logs).toEqual([target]);
+    expect(realpathSync(target)).toBe(target);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: --carry-ignored into a nested --dir does not copy the worktree into itself', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-carry-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    writeFileSync(join(repo, '.gitignore'), '.worktrees/\n');
+    execSync('git add .gitignore && git commit -q -m ignore', { cwd: repo });
+    const { logs } = await runCreateInRepo(repo, 'feat-nest', {
+      dir: '.worktrees',
+      carryIgnored: true,
+      install: false,
+    });
+    const target = join(repo, '.worktrees', 'feat-nest');
+    expect(logs).toEqual([target]);
+    expect(existsSync(join(target, '.worktrees'))).toBeFalsy();
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
   }
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -286,6 +286,39 @@ test('create action: --base takes any ref this repo resolves, and branches from 
   }
 });
 
+test('create action: --dir places the worktree under that directory, resolved against the cwd', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    const { logs } = await runCreateInRepo(repo, 'feat-x', { dir: '.worktrees', install: false });
+    const target = join(repo, '.worktrees', 'feat-x');
+    expect(logs).toEqual([target]);
+    expect(existsSync(join(target, '.git'))).toBeTruthy();
+    expect(existsSync(join(defaultWorktreeDir(repo), 'feat-x'))).toBeFalsy();
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: --dir takes precedence over the worktreeDir setting', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-setting-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: join(base, 'from-setting') }));
+    const { logs } = await runCreateInRepo(repo, 'feat-y', { dir: join(base, 'from-flag'), install: false });
+    expect(logs).toEqual([join(base, 'from-flag', 'feat-y')]);
+    expect(existsSync(join(base, 'from-setting', 'feat-y'))).toBeFalsy();
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: an existing branch is reported as attached, not as branched from --base', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-reuse-')));

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1885,7 +1885,8 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         did not create it, so a Metro request through it is
                         still gated the same way a managed tunnel's is. Set it
                         before Expo start so the manifest advertises it.
-  worktreeDir           where worktrees are created
+  worktreeDir           where worktrees are created; worktree create --dir
+                        overrides it for one run
   worktree.baseRef      "head" (current HEAD) or "fresh" (origin/HEAD).
                         Unset means "head".
   worktree.include      carry-over patterns, same role as .worktreeinclude

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1325,7 +1325,7 @@ THE OPTION SURFACE, IN FULL
   stop            --json --force
   status          --json          (already machine-wide)
   gc              --delete --older-than <days> --cache <name|all>
-  worktree create <name> --carry-ignored --base <ref> --label <label>; remove [path] --force
+  worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
 
   That is the whole surface today, and it is deliberately small. It can grow
   when a flag is genuinely the best answer -- but project-specific knowledge

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -634,7 +634,7 @@ export function removalPath(target: string | undefined): string {
 // The registry keys a worktree by the path git reports, which is the real
 // path. Canonicalize from the deepest ancestor that exists so a symlinked or
 // not-yet-created directory yields the same key git will.
-export function canonicalExistingPath(target: string): string {
+function canonicalExistingPath(target: string): string {
   const resolved = resolve(target);
   let existing = resolved;
   const missing: string[] = [];

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -135,6 +135,10 @@ export function registerCreate(worktree: Command): void {
       '--base <ref>',
       'base ref: "head" (current HEAD, default), "fresh" (origin/HEAD), or any ref this repo resolves (branch, tag, sha)',
     )
+    .option(
+      '--dir <path>',
+      'directory to create the worktree under, resolved against the current directory; overrides the worktreeDir setting for this run',
+    )
     .option('--label <label>', 'Stim shortcut for the worktree (defaults to the worktree name)')
     .option(
       '--carry-ignored',
@@ -163,7 +167,7 @@ export function registerCreate(worktree: Command): void {
 
       const base = opts.base || settings?.worktree?.baseRef || 'head';
 
-      const dir = settings.worktreeDir || defaultWorktreeDir(root);
+      const dir = opts.dir ? resolve(opts.dir) : settings.worktreeDir || defaultWorktreeDir(root);
       const target = worktreePath({ worktreeDir: dir, name });
 
       if (existsSync(target)) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
-import type { Command } from 'commander';
+import { type Command, InvalidArgumentError } from 'commander';
 import { resolveSettings, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
@@ -138,6 +138,10 @@ export function registerCreate(worktree: Command): void {
     .option(
       '--dir <path>',
       'directory to create the worktree under, resolved against the current directory; overrides the worktreeDir setting for this run',
+      (v: string) => {
+        if (!v.trim()) throw new InvalidArgumentError('must name a directory, e.g. --dir .worktrees');
+        return v;
+      },
     )
     .option('--label <label>', 'Stim shortcut for the worktree (defaults to the worktree name)')
     .option(

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -171,7 +171,7 @@ export function registerCreate(worktree: Command): void {
 
       const base = opts.base || settings?.worktree?.baseRef || 'head';
 
-      const dir = opts.dir ? resolve(opts.dir) : settings.worktreeDir || defaultWorktreeDir(root);
+      const dir = canonicalExistingPath(opts.dir || settings.worktreeDir || defaultWorktreeDir(root));
       const target = worktreePath({ worktreeDir: dir, name });
 
       if (existsSync(target)) {
@@ -628,7 +628,14 @@ interface RemovalInspection {
 }
 
 export function removalPath(target: string | undefined): string {
-  const resolved = resolve(target ?? process.cwd());
+  return canonicalExistingPath(target ?? process.cwd());
+}
+
+// The registry keys a worktree by the path git reports, which is the real
+// path. Canonicalize from the deepest ancestor that exists so a symlinked or
+// not-yet-created directory yields the same key git will.
+export function canonicalExistingPath(target: string): string {
+  const resolved = resolve(target);
   let existing = resolved;
   const missing: string[] = [];
   while (!existsSync(existing)) {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -160,8 +160,8 @@ ports, devices, supervisors, builds, logs, capacity, and free disk space.
 ## `worktree create`
 
 ```text
-stim worktree create <name> [--base <head|fresh|ref>] [--label <label>]
-                            [--carry-ignored]
+stim worktree create <name> [--base <head|fresh|ref>] [--dir <path>]
+                            [--label <label>] [--carry-ignored]
 ```
 
 Creates a git worktree and prints its absolute path.
@@ -169,6 +169,10 @@ Creates a git worktree and prints its absolute path.
 - `--base head` uses the current checkout's `HEAD`. This is the default.
 - `--base fresh` uses `origin/HEAD`.
 - `--base <ref>` accepts any branch, tag, or commit that git resolves.
+- `--dir <path>` creates the worktree under that directory instead of the
+  `worktreeDir` setting or the default `<repo>-worktrees/` sibling. A relative
+  path resolves against the current directory. The worktree lands at
+  `<dir>/<name>`.
 - `--label` sets the short Stim name used by the environment and device.
 - `--carry-ignored` copies safe ignored files and compatible uncommitted changes.
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -23,34 +23,34 @@ keys produce a warning.
 
 `.stim.json` supports these keys:
 
-| Key                           | Purpose                                              |
-| ----------------------------- | ---------------------------------------------------- |
-| `ios.deviceType`              | iOS Simulator device type                            |
-| `ios.runtime`                 | iOS Simulator runtime                                |
-| `ios.configuration`           | Xcode configuration, such as `Debug` or `Release`    |
-| `ios.remote`                  | Default remote backend, `proxy` or `eas`             |
-| `ios.simslimProfile`          | SimSlim profile for local iOS devices                |
-| `ios.signingIdentity`         | Keychain identity used to re-seal a device build     |
-| `ios.signingIdentitySha1`     | SHA-1 of that identity, when two share a name        |
-| `ios.lanHost`                 | Address a phone uses to reach this workspace's Metro |
-| `android.systemImage`         | Android SDK system image                             |
-| `android.dataPartitionSizeGb` | AVD data partition size                              |
-| `android.avdConfigFile`       | Additional AVD config file                           |
-| `android.avdConfig`           | Validated AVD config values                          |
-| `android.variant`             | Gradle build variant                                 |
-| `android.keystore`            | Release keystore path                                |
-| `android.keystorePassword`    | Release keystore password source                     |
-| `android.remote`              | Default remote backend, `proxy` or `eas`             |
-| `metro.tunnel`                | Remote tunnel mode                                   |
-| `metro.ngrokUrl`              | Existing ngrok URL                                   |
-| `metro.publicUrl`             | Existing public Metro URL                            |
-| `worktreeDir`                 | Parent directory for created worktrees               |
-| `worktree.baseRef`            | Default worktree base: `head`, `fresh`, or a git ref |
-| `worktree.include`            | Explicit ignored paths to carry                      |
-| `worktree.exclude`            | Ignored paths skipped by `--carry-ignored`           |
-| `cache.provider`              | Optional second-tier cache provider module           |
-| `cache.options`               | Options passed to that provider                      |
-| `caches`                      | Additional cache paths reported by `gc`              |
+| Key                           | Purpose                                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `ios.deviceType`              | iOS Simulator device type                                                                |
+| `ios.runtime`                 | iOS Simulator runtime                                                                    |
+| `ios.configuration`           | Xcode configuration, such as `Debug` or `Release`                                        |
+| `ios.remote`                  | Default remote backend, `proxy` or `eas`                                                 |
+| `ios.simslimProfile`          | SimSlim profile for local iOS devices                                                    |
+| `ios.signingIdentity`         | Keychain identity used to re-seal a device build                                         |
+| `ios.signingIdentitySha1`     | SHA-1 of that identity, when two share a name                                            |
+| `ios.lanHost`                 | Address a phone uses to reach this workspace's Metro                                     |
+| `android.systemImage`         | Android SDK system image                                                                 |
+| `android.dataPartitionSizeGb` | AVD data partition size                                                                  |
+| `android.avdConfigFile`       | Additional AVD config file                                                               |
+| `android.avdConfig`           | Validated AVD config values                                                              |
+| `android.variant`             | Gradle build variant                                                                     |
+| `android.keystore`            | Release keystore path                                                                    |
+| `android.keystorePassword`    | Release keystore password source                                                         |
+| `android.remote`              | Default remote backend, `proxy` or `eas`                                                 |
+| `metro.tunnel`                | Remote tunnel mode                                                                       |
+| `metro.ngrokUrl`              | Existing ngrok URL                                                                       |
+| `metro.publicUrl`             | Existing public Metro URL                                                                |
+| `worktreeDir`                 | Parent directory for created worktrees; `worktree create --dir` overrides it for one run |
+| `worktree.baseRef`            | Default worktree base: `head`, `fresh`, or a git ref                                     |
+| `worktree.include`            | Explicit ignored paths to carry                                                          |
+| `worktree.exclude`            | Ignored paths skipped by `--carry-ignored`                                               |
+| `cache.provider`              | Optional second-tier cache provider module                                               |
+| `cache.options`               | Options passed to that provider                                                          |
+| `caches`                      | Additional cache paths reported by `gc`                                                  |
 
 Do not put secrets in a committed `.stim.json`. Keep secrets in ignored files
 and carry those files into a worktree.


### PR DESCRIPTION
Closes #195.

## Description

`worktree create` puts every worktree under the `worktreeDir` setting or the default `<repo>-worktrees/` sibling, and nothing on the command chooses a location for a single run. That matters under a sandboxed harness: the sibling directory is outside the repository tree the sandbox permits writes to, so every edit in such a worktree needs the sandbox turned off, while a worktree nested inside the tree does not. A committed relative `worktreeDir` would cover it, but #193 shows a relative value resolves against the cwd today, so it is not yet committable.

## Solution

`--dir <path>` on `worktree create`. Precedence mirrors `--base` over `worktree.baseRef`: the flag wins for this run, the setting is the default, `defaultWorktreeDir` is the fallback. A relative path resolves against the cwd, as a command-line path does — which is the opposite of what a committed setting should do, and is why this PR leaves #193 to its own fix rather than folding it in. The worktree lands at `<dir>/<name>`; nothing else in the create action reads the directory, so the flag reaches everything that does.

The chosen directory is canonicalized from its deepest existing ancestor before use — the walk `removalPath` already did, now shared. The registry keys a worktree by the path git reports, which is the real path, so a symlinked `--dir` (`/tmp` on macOS is `/private/tmp`) otherwise produced a key that `status` and `remove` could not match: the worktree listed twice, and removal left its entry behind. The same canonicalization now covers an absolute `worktreeDir` setting, which had the same gap.

The guide's flag surface line and its contract test both name `--dir`. The skill is untouched: it shows the minimal loop, and a location is an advanced choice.

## Test plan

- `pnpm test` — 2896 pass, including five new cases: a relative `--dir` run from a *subdirectory* lands under the cwd (run from the repo root, cwd-relative and repo-relative agree, so that would prove nothing); `--dir` beats a `.stim.json` `worktreeDir`; a `--dir` through a symlink prints the real path; `--carry-ignored` into a nested `--dir` does not copy the worktree into itself; a blank `--dir` is rejected
- `format:check`, `lint`, `typecheck` — clean
- Built CLI in a scratch repo: `worktree create feat --dir .worktrees` printed `<repo>/.worktrees/feat` and created it there; `--help` lists the flag
- `--dir a/b/c` with no existing parent creates the chain, since `git worktree add` does; `--dir ''` and `--dir '  '` are rejected at the parser rather than falling through to the default directory (a test covers both)

A worktree nested inside the repository shows up as an untracked directory in the main checkout's `git status` until its parent is gitignored. That is git, not Stim, but it is the one thing a user of `--dir <inside-the-repo>` has to do themselves.


