### PR TITLE
Say what a sandbox blocks before an agent finds out by failing

### DIFF
--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -122,6 +122,19 @@ Ask the user before these actions:
   delete it. An explicit `stop` shuts down a Stim-owned simulator even when
   another process uses it. It never shuts down an unowned simulator.
 
+## Under a sandbox
+
+An agent harness that sandboxes shell commands usually permits writes inside
+the project and little else. Three things Stim needs sit outside that
+boundary, and none of the failures names the sandbox: writes to `STIM_HOME`
+fail with `EPERM` on a directory the user can write, the iOS simulator service
+looks dead, and the adb server looks unreachable. They are not a broken
+machine.
+
+Decide at the start of a session, not after the third failure: either run Stim
+with the harness's sandbox disabled, or ask the user to allow those three.
+`stim guide errors` lists what to allow.
+
 ## Load advanced guidance only when needed
 
 The installed CLI is the source of truth for flags, payloads, settings, error

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -127,13 +127,16 @@ Ask the user before these actions:
 An agent harness that sandboxes shell commands usually permits writes inside
 the project and little else. Three things Stim needs sit outside that
 boundary, and none of the failures names the sandbox: writes to `STIM_HOME`
-fail with `EPERM` on a directory the user can write, the iOS simulator service
-looks dead, and the adb server looks unreachable. They are not a broken
-machine.
+(`~/.stim` unless set) fail with `EPERM` on a directory the user can write, the
+iOS simulator service looks dead, and the adb server looks unreachable. They
+are not a broken machine. Compare that path against the harness's own
+allowlist, and the conflict is visible before anything runs.
 
 Decide at the start of a session, not after the third failure: either run Stim
 with the harness's sandbox disabled, or ask the user to allow those three.
-`stim guide errors` lists what to allow.
+`stim guide errors` lists what to allow. The same boundary catches other
+commands: a git credential helper prints `failed to store` on a fetch that
+worked.
 
 ## Load advanced guidance only when needed
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -613,6 +613,34 @@ test('the guide names every path Stim ignores by default', () => {
   }
 });
 
+test('the sandbox failures are named in the guide, and the skill points at them', () => {
+  const errors = renderTopic('errors') ?? '';
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+
+  // The three failures an agent actually sees.
+  for (const detail of [
+    'RUNNING UNDER A SANDBOX',
+    'CoreSimulatorService connection became invalid',
+    "ADB server didn't ACK",
+  ]) {
+    expect(errors).toContain(detail);
+  }
+
+  // The allowlist keys are advanced detail: the guide carries them, not the skill.
+  for (const key of [
+    'sandbox.filesystem.allowWrite',
+    'sandbox.network.allowMachLookup',
+    'sandbox.network.allowLocalBinding',
+  ]) {
+    expect(errors).toContain(key);
+    expect(skill).not.toContain(key);
+  }
+
+  // The skill says a sandbox exists and sends the reader to the topic.
+  expect(skill).toMatch(/sandbox/i);
+  expect(skill).toContain('stim guide errors');
+});
+
 test('advanced contracts stay in guide topics instead of the skill', () => {
   const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
   const advanced = [

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1505,7 +1505,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   } catch (error) {
     const code = (error as Error & { code?: string })?.code || 'STIM_WORKSPACE_STATE';
     const message = `Could not prepare this workspace's Stim state: ${(error as Error)?.message || error}`;
-    const remedy = 'Check that STIM_HOME is writable and has free space.';
+    const remedy =
+      'Check that STIM_HOME is writable and has free space. An EPERM on a directory you can write is a sandbox: allow writes to STIM_HOME, or run Stim with the sandbox disabled (`stim guide errors`).';
     out(phaseLine('error', chalk.red(`${code}: ${message}`)));
     out(phaseLine('remedy', remedy));
     if (json) emit(JSON.stringify({ code, message, remedy }));

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -492,9 +492,11 @@ code, never on the message.
 STIM_WORKSPACE_STATE / STIM_WORKSPACE_COLLISION
   Stim could not prepare this project's global workspace directory under
   $STIM_HOME/workspaces. Check that STIM_HOME is writable and has free
-  space. COLLISION means the readable-name-plus-digest directory already has a
-  workspace.json for a different canonical project path; do not overwrite it
-  until you identify which workspace owns it.
+  space. An EPERM on a directory the user CAN write is a sandbox, not a
+  permission bit -- see RUNNING UNDER A SANDBOX below. COLLISION means the
+  readable-name-plus-digest directory already has a workspace.json for a
+  different canonical project path; do not overwrite it until you identify
+  which workspace owns it.
 
 STIM_NO_METRO
   Nothing that could be proven to be THIS workspace's dev server holds the
@@ -1069,6 +1071,41 @@ too; commit deliberately."  (worktree create --carry-ignored)
 "Could not reserve a Metro port after 5 attempts"
   Several commands raced for the same ports and each one lost. Nothing is
   wrong; retry.
+
+RUNNING UNDER A SANDBOX
+
+  An agent harness that sandboxes shell commands typically permits writes
+  inside the project and blocks the rest. Three things Stim needs sit outside
+  that boundary, and none of the failures names the sandbox:
+
+    EPERM: operation not permitted, mkdir '<STIM_HOME>/workspaces/...'
+      writes to STIM_HOME (~/.stim unless set)
+
+    CoreSimulatorService connection became invalid   (macOS)
+    Unable to locate device set: ... Code=61 "Connection refused"
+      the simulator service simctl talks to over XPC
+
+    ADB server didn't ACK
+    could not install *smartsocket* listener: Operation not permitted
+      the adb server socket on tcp:5037
+
+  Measured on Claude Code and on Codex: the three fail the same way in both,
+  so this is the shape of the problem, not one harness's quirk. Codex also
+  blocks network egress by default, which breaks a cache lookup and a fetch.
+
+  Two ways out, and choosing at the start of a session beats discovering it
+  three failures in. Either run Stim with the harness's sandbox disabled, or
+  allow the three. In Claude Code that is settings.json:
+
+    sandbox.filesystem.allowWrite     ["~/.stim"]
+    sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]
+    sandbox.network.allowLocalBinding true
+
+  In Codex the sandbox is one flag, \`codex -s\`, with no per-path allowance:
+  workspace-write still refuses STIM_HOME.
+
+  A git credential helper is often blocked too. It prints \`failed to store\`
+  on a fetch that otherwise succeeded, and is safe to ignore.
 
 STIM_CONFIG_CORRUPT  ("Stim config at <path> is not valid JSON")
   Any command can raise it: every command reads ~/.stim/config.json first.

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1541,7 +1541,11 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     const code = (error as Error & { code?: string })?.code || 'STIM_WORKSPACE_STATE';
     const message = `Could not prepare this workspace's Stim state: ${(error as Error)?.message || error}`;
     note(chalk.red(`${code}: ${message}`));
-    note(chalk.dim('Check that STIM_HOME is writable and has free space.'));
+    note(
+      chalk.dim(
+        'Check that STIM_HOME is writable and has free space. An EPERM on a directory you can write is a sandbox: allow writes to STIM_HOME, or run Stim with the sandbox disabled (`stim guide errors`).',
+      ),
+    );
     if (json)
       console.log(JSON.stringify({ code, message, remedy: 'Check that STIM_HOME is writable and has free space.' }));
     process.exitCode = 1;

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -317,7 +317,8 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
         return fail({
           code: (error as Error & { code?: string })?.code || 'STIM_WORKSPACE_STATE',
           message: `Could not prepare this workspace's Stim state: ${(error as Error)?.message || error}`,
-          remedy: 'Check that STIM_HOME is writable and has free space.',
+          remedy:
+            'Check that STIM_HOME is writable and has free space. An EPERM on a directory you can write is a sandbox: allow writes to STIM_HOME, or run Stim with the sandbox disabled (`stim guide errors`).',
         });
       }
 


### PR DESCRIPTION
Closes #194.

## Description

An agent harness that sandboxes shell commands typically permits writes inside the project and little else. Three things Stim needs sit outside that boundary, and **none of the failures names the sandbox**:

```
EPERM: operation not permitted, mkdir '<STIM_HOME>/workspaces/...'
CoreSimulatorService connection became invalid
ADB server didn't ACK
```

The first reads as a permission bug on a directory the user can write; the other two read as a dead simulator service and an unreachable adb server. Three agents running a documented loop in parallel each hit them, each stopped to investigate, and each ended up retrying every Stim command with its harness's sandbox override. The `EPERM` remedy pointed them at disk space and `STIM_HOME` permissions, both fine.

## Solution

The skill gains a short section: the three exist, they do not look like a sandbox, decide once at the start of a session rather than after the third failure, and `stim guide errors` lists what to allow. The allowlist keys stay out of the skill — `guide errors` carries them, matching how the repo already splits brief from advanced.

`guide errors` gains `RUNNING UNDER A SANDBOX`: the exact failure text for each of the three, the Claude Code settings keys (`sandbox.filesystem.allowWrite`, `sandbox.network.allowMachLookup`, `sandbox.network.allowLocalBinding`), the note that Codex has one coarse flag with no per-path allowance, and the harmless `failed to store` a blocked git credential helper prints.

The `STIM_WORKSPACE_STATE` remedy now says an `EPERM` on a directory you can write is a sandbox, at all three sites that print it.

## Why the guide names two harnesses

I measured the same probes under Claude Code and under Codex. The three failures are identical in both — Codex reports `Connection refused (Code=61)` for the simulator and `could not install *smartsocket* listener` for adb, and refuses `STIM_HOME` under `workspace-write`. Codex additionally blocks network egress by default, which breaks a cache lookup and a `git fetch`. Naming both is what makes the section a statement about sandboxes rather than about one vendor.

## Test plan

- `pnpm test` — 2897 pass, including a new contract test: `guide errors` carries the three failure strings and the three allowlist keys, and the skill carries the pointer but not the keys
- `format:check`, `lint`, `typecheck`, `knip` — clean
- The skill stays inside its 1200-word budget (1160), which the existing compactness test enforces
- `stim guide errors` renders the section
