### PR TITLE
fix: resolve a relative worktreeDir against the settings root

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -480,6 +480,17 @@ test('the settings topic lists exactly the keys settings.js honours', () => {
   }
 });
 
+test('the worktreeDir resolution rule is consistent across user guidance', () => {
+  const guide = renderTopic('settings');
+  assert(guide);
+  const website = readFileSync(new URL('../../../../website/docs/settings.md', import.meta.url), 'utf-8');
+  for (const body of [guide, website]) {
+    const flat = body.replace(/\s+/g, ' ');
+    expect(flat).toMatch(/worktreeDir.*relative.*resolves against.{0,40}repository root/i);
+  }
+  expect(guide.replace(/\s+/g, ' ')).toMatch(/worktreeDir.*--dir.*current directory/i);
+});
+
 test('the safe Android AVD override contract is consistent across user guidance', () => {
   const guide = renderTopic('settings');
   assert(guide);

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -374,6 +374,64 @@ test('create action: --dir takes precedence over the worktreeDir setting', async
   }
 });
 
+test('create action: a relative worktreeDir resolves against the repository root, not the cwd', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-relative-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: '.stim-worktrees' }));
+    const cwd = join(repo, 'apps', 'mobile');
+    mkdirSync(cwd, { recursive: true });
+
+    const { logs } = await runCreateInRepo(cwd, 'feat-relative', { install: false });
+
+    expect(logs).toEqual([join(repo, '.stim-worktrees', 'feat-relative')]);
+    expect(existsSync(join(cwd, '.stim-worktrees'))).toBeFalsy();
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: an absolute worktreeDir is used as written', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-absolute-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    const configured = join(base, 'elsewhere');
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: configured }));
+    const cwd = join(repo, 'apps', 'mobile');
+    mkdirSync(cwd, { recursive: true });
+
+    const { logs } = await runCreateInRepo(cwd, 'feat-absolute', { install: false });
+
+    expect(logs).toEqual([join(configured, 'feat-absolute')]);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: no worktreeDir setting uses the sibling default from any cwd', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-default-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    const cwd = join(repo, 'apps', 'mobile');
+    mkdirSync(cwd, { recursive: true });
+
+    const { logs } = await runCreateInRepo(cwd, 'feat-fallback', { install: false });
+
+    expect(logs).toEqual([join(defaultWorktreeDir(repo), 'feat-fallback')]);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: an existing branch is reported as attached, not as branched from --base', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-reuse-')));

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1922,8 +1922,12 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         did not create it, so a Metro request through it is
                         still gated the same way a managed tunnel's is. Set it
                         before Expo start so the manifest advertises it.
-  worktreeDir           where worktrees are created; worktree create --dir
-                        overrides it for one run
+  worktreeDir           where worktrees are created. A relative value resolves
+                        against the settings root (the repository root), not the
+                        current directory, so a committed .stim.json can place
+                        worktrees inside the repo. worktree create --dir
+                        overrides it for one run and resolves against the
+                        current directory instead.
   worktree.baseRef      "head" (current HEAD) or "fresh" (origin/HEAD).
                         Unset means "head".
   worktree.include      carry-over patterns, same role as .worktreeinclude

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -171,7 +171,9 @@ export function registerCreate(worktree: Command): void {
 
       const base = opts.base || settings?.worktree?.baseRef || 'head';
 
-      const dir = canonicalExistingPath(opts.dir || settings.worktreeDir || defaultWorktreeDir(root));
+      const dir = canonicalExistingPath(
+        opts.dir || (settings.worktreeDir ? resolve(root, settings.worktreeDir) : defaultWorktreeDir(root)),
+      );
       const target = worktreePath({ worktreeDir: dir, name });
 
       if (existsSync(target)) {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -171,7 +171,8 @@ Creates a git worktree and prints its absolute path.
 - `--base <ref>` accepts any branch, tag, or commit that git resolves.
 - `--dir <path>` creates the worktree under that directory instead of the
   `worktreeDir` setting or the default `<repo>-worktrees/` sibling. A relative
-  path resolves against the current directory. The worktree lands at
+  path resolves against the current directory, while a relative `worktreeDir`
+  setting resolves against the repository root. The worktree lands at
   `<dir>/<name>`.
 - `--label` sets the short Stim name used by the environment and device.
 - `--carry-ignored` copies safe ignored files and compatible uncommitted changes.

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -52,6 +52,10 @@ keys produce a warning.
 | `cache.options`               | Options passed to that provider                                                          |
 | `caches`                      | Additional cache paths reported by `gc`                                                  |
 
+A relative `worktreeDir` resolves against the settings root, the repository
+root, so a committed `.stim.json` can place worktrees inside the repository.
+A relative `worktree create --dir` resolves against the current directory.
+
 Do not put secrets in a committed `.stim.json`. Keep secrets in ignored files
 and carry those files into a worktree.
 


### PR DESCRIPTION
## Description

A relative `worktreeDir` in `.stim.json` resolved against the process's working
directory. `worktree create` computed `canonicalExistingPath(opts.dir ||
settings.worktreeDir || defaultWorktreeDir(root))`, and `canonicalExistingPath`
starts with `resolve(target)`, which anchors a relative value at `process.cwd()`.

`.stim.json` lives at the repository root and every other committed path setting
(`ios.simslimProfile`, `android.avdConfigFile`, `cache.provider`) resolves against
the settings root, so a relative `worktreeDir` reads as repo-relative. It was not.
Run from `apps/mobile` in a monorepo, `{"worktreeDir": ".claude/stim-worktrees"}`
created the worktree under `apps/mobile/.claude/`, and somewhere else again from a
different cwd. That made a committed, repo-relative `worktreeDir` unusable, which
is the only way to give every contributor the same worktree location without an
absolute path in a shared file.

Blast radius is the one expression. An absolute `worktreeDir` is unchanged
(`resolve` returns an absolute argument as written), the unset default is
unchanged, and `--dir` keeps resolving against the current directory, which is
right for a flag typed at a prompt.

## Solution

Resolve a configured `worktreeDir` against `root`, the repository root that
`worktree create` already resolved and already passes to `resolveSettings` as the
settings root. `--dir` still goes straight into `canonicalExistingPath`, so the
flag and the setting now have deliberately different anchors: the flag follows the
cwd, the committed setting follows the repository.

`guide settings`, `website/docs/settings.md`, and the `--dir` bullet in
`website/docs/commands.md` state both anchors, and a contract test holds the guide
and the website to that rule.

No containment check: unlike `ios.simslimProfile`, a worktree directory outside the
repository is the normal case, since the default is the `<repo>-worktrees/` sibling.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`
  all clean.
- `pnpm test`: 77 files, 2901 tests passed.
- `pnpm run test:e2e`: 19 passed, 0 failed. `worktree create` is covered there
  (`test/e2e/worktree-warm.e2e.js`), so the suite ran.
- Three new tests in `worktree-create.test.ts` drive the real action from
  `<repo>/apps/mobile` against a scratch repository built with real `git init` and
  real `git worktree add`, covering the relative setting (lands at
  `<repo>/.stim-worktrees/<name>`, and not under the cwd), an absolute setting
  (used as written), and no setting (the `<repo>-worktrees/` sibling default).
- New guide contract test: the `worktreeDir` rule is stated in both `guide
  settings` and `website/docs/settings.md`.
- Invariant 9, real tool call: ran the built CLI (`dist/cli.mjs`) from
  `apps/mobile` in a throwaway git repository whose committed `.stim.json` sets
  `"worktreeDir": ".claude/stim-worktrees"`. It printed
  `<repo>/.claude/stim-worktrees/nestrel`, and `git worktree list` reported the
  worktree at that path, under the repository root rather than under `apps/mobile`.

Fixes #193
