### PR TITLE
Judge carried Pods against the Podfile.lock the new worktree ends up with

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -676,6 +676,61 @@ test('create action: a plain create reports the exact warm-worktree command when
   }
 });
 
+function podsRepo(repo: string, { branchLock, workingLock }: { branchLock: string; workingLock: string }) {
+  const git = initScratchRepo(repo);
+  writeFileSync(join(repo, '.gitignore'), 'ios/Pods/\n');
+  mkdirSync(join(repo, 'ios'), { recursive: true });
+  writeFileSync(join(repo, 'ios', 'Podfile'), "platform :ios, '15.1'\n");
+  writeFileSync(join(repo, 'ios', 'Podfile.lock'), branchLock);
+  git('git add .gitignore ios/Podfile ios/Podfile.lock');
+  git('git commit -q -m pods');
+  writeFileSync(join(repo, 'ios', 'Podfile.lock'), workingLock);
+  mkdirSync(join(repo, 'ios', 'Pods'), { recursive: true });
+  writeFileSync(join(repo, 'ios', 'Pods', 'Manifest.lock'), workingLock);
+}
+
+test('create action: pods installed against an uncommitted Podfile.lock carried along are not called stale', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-pods-carried-')));
+  const repo = join(base, 'repo');
+  const branchLock = 'PODS:\n  - fmt (11.0.2)\n';
+  const workingLock = 'PODS:\n  - fmt (11.0.2)\n  - RNScreens (4.0.0)\n';
+  try {
+    podsRepo(repo, { branchLock, workingLock });
+
+    const { errs } = await runCreateInRepo(repo, 'feat-pods-carried', { base: 'head', carryIgnored: true });
+
+    const wt = join(defaultWorktreeDir(repo), 'feat-pods-carried');
+    expect(readFileSync(join(wt, 'ios', 'Podfile.lock'), 'utf-8')).toBe(
+      readFileSync(join(wt, 'ios', 'Pods', 'Manifest.lock'), 'utf-8'),
+    );
+    expect(errs.some((e) => /Carried ios\/Pods does not match/.test(e))).toBe(false);
+    expect(errs.some((e) => /Carried 1 uncommitted change\(s\)/.test(e))).toBe(true);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: pods that disagree with the Podfile.lock on disk still get the pod install warning', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-pods-stale-')));
+  const repo = join(base, 'repo');
+  try {
+    podsRepo(repo, { branchLock: 'PODS:\n  - fmt (11.0.2)\n', workingLock: 'PODS:\n  - fmt (11.0.2)\n' });
+    writeFileSync(join(repo, 'ios', 'Pods', 'Manifest.lock'), 'PODS:\n  - fmt (10.0.0)\n');
+
+    const { errs } = await runCreateInRepo(repo, 'feat-pods-stale', { base: 'head', carryIgnored: true });
+
+    const warning = errs.find((e) => /Carried ios\/Pods does not match/.test(e));
+    expect(warning).toContain('the ios/Podfile.lock on disk here');
+    expect(warning).toContain('pod install');
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: --carry-ignored reports warm categories and the copy mode', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-warm-summary-')));

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -695,6 +695,19 @@ test('a Pods directory with no Manifest.lock is not reported', () => {
   rmSync(root, { recursive: true, force: true });
 });
 
+test('the Podfile.lock on disk decides, so a carried lockfile change clears the mismatch', () => {
+  const branchLock = 'PODS:\n  - fmt (11.0.2)\n';
+  const workingLock = 'PODS:\n  - fmt (11.0.2)\n  - RNScreens (4.0.0)\n';
+  const root = podsFixture({ manifest: workingLock, podfileLock: branchLock });
+  try {
+    expect(podsOutOfSync(root, ['ios/Pods'])).toEqual([{ dir: 'ios', reason: 'mismatch' }]);
+    writeFileSync(join(root, 'ios', 'Podfile.lock'), workingLock);
+    expect(podsOutOfSync(root, ['ios/Pods'])).toEqual([]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('pod-install churn is recognised so the restore advice only fires when it works', () => {
   expect(isPodInstallChurn([' M ios/Podfile.lock', ' M ios/PatientApp.xcodeproj/project.pbxproj'])).toBe(true);
   expect(isPodInstallChurn([' M ios/Podfile.lock', ' M config.json'])).toBe(false);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1010,7 +1010,7 @@ but --base <ref> resolves to <sha>"  (worktree create)
 "Carried <dir>/Pods does not match the <dir>/Podfile.lock on disk here"
 (worktree create)
   \`ios/Pods\` is gitignored, so --carry-ignored clones it; \`ios/Podfile.lock\`
-  is tracked, so it comes from the branch. The check compares the cloned
+  is tracked. The check compares the cloned
   \`Pods/Manifest.lock\` with the \`Podfile.lock\` that is on disk in the new
   worktree AFTER the uncommitted changes are carried -- the same file
   \`pod install\` and \`xcodebuild\` read -- so an uncommitted lockfile the

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1007,13 +1007,20 @@ but --base <ref> resolves to <sha>"  (worktree create)
   \`gc --delete --cache "compilation cache"\`, then build again. The next
   build is a cold one.
 
-"Carried <dir>/Pods does not match <dir>/Podfile.lock"  (worktree create)
+"Carried <dir>/Pods does not match the <dir>/Podfile.lock on disk here"
+(worktree create)
   \`ios/Pods\` is gitignored, so --carry-ignored clones it; \`ios/Podfile.lock\`
-  is tracked, so it comes from the branch. When the source worktree's two
-  disagree, the new worktree inherits the contradiction. \`stim ios\` detects
-  this and runs \`pod install\` for you; the note is there so a build you run
-  yourself does not fail in its LAST phase with
+  is tracked, so it comes from the branch. The check compares the cloned
+  \`Pods/Manifest.lock\` with the \`Podfile.lock\` that is on disk in the new
+  worktree AFTER the uncommitted changes are carried -- the same file
+  \`pod install\` and \`xcodebuild\` read -- so an uncommitted lockfile the
+  clone was installed against does not trigger it. \`stim ios\` detects a real
+  mismatch and runs \`pod install\` for you; the note is there so a build you
+  run yourself does not fail in its LAST phase with
     error: The sandbox is not in sync with the Podfile.lock
+  A patch that does not apply reports itself first ("Could not carry the
+  source's uncommitted changes"); the branch lockfile then stands, and this
+  note is about that lockfile.
 
 "Warm source not carried: ... For the next worktree, use: stim worktree create
 <name> --carry-ignored"  (worktree create)

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -281,6 +281,12 @@ export function registerCreate(worktree: Command): void {
         for (const f of res.failed) {
           console.error(chalk.yellow(`Failed to clone ${f.file}: ${f.error}`));
         }
+        const changes = carryUncommittedChanges({ root, target });
+        if (changes?.applied) {
+          console.error(chalk.dim(carriedChangesLine(changes.files)));
+        } else if (changes?.conflicted) {
+          console.error(chalk.yellow(carryConflictWarning(changes.files)));
+        }
         const staleDeps = depsOutOfSync(root, target, res.copied);
         if (staleDeps.length) {
           const manifests = staleDeps.map((d) => (d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`)).join(', ');
@@ -300,15 +306,9 @@ export function registerCreate(worktree: Command): void {
             chalk.yellow(
               p.reason === 'missing'
                 ? `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
-                : `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match ${where}. Pods are gitignored and cloned; Podfile.lock is tracked and comes from the branch, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
+                : `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match the ${where} on disk here. Pods are gitignored and cloned; Podfile.lock is tracked, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
             ),
           );
-        }
-        const changes = carryUncommittedChanges({ root, target });
-        if (changes?.applied) {
-          console.error(chalk.dim(carriedChangesLine(changes.files)));
-        } else if (changes?.conflicted) {
-          console.error(chalk.yellow(carryConflictWarning(changes.files)));
         }
       } else {
         const excluded = readWorktreeExclude(root);

--- a/test/e2e/worktree-warm.e2e.js
+++ b/test/e2e/worktree-warm.e2e.js
@@ -1,7 +1,7 @@
 import { after, before, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,6 +56,40 @@ test('cold and warm worktree creation report different guidance', () => {
   assert.ok(existsSync(join(carriedPath, 'node_modules', 'pkg', 'index.js')));
   assert.ok(existsSync(join(carriedPath, 'ios', 'Pods', 'Manifest.lock')));
   assert.ok(existsSync(join(carriedPath, 'ios', 'build', 'generated.cpp')));
+});
+
+test('carried pods are judged against the Podfile.lock the new worktree ends up with', () => {
+  const repo = join(ctx.tmp, 'pods-app');
+  const branchLock = 'PODS:\n  - fmt (11.0.2)\n';
+  const workingLock = 'PODS:\n  - fmt (11.0.2)\n  - RNScreens (4.0.0)\n';
+  mkdirSync(join(repo, 'ios'), { recursive: true });
+  writeFileSync(join(repo, '.gitignore'), 'ios/Pods/\n');
+  writeFileSync(join(repo, 'ios', 'Podfile'), "platform :ios, '15.1'\n");
+  writeFileSync(join(repo, 'ios', 'Podfile.lock'), branchLock);
+  for (const args of [
+    ['init', '-b', 'main'],
+    ['config', 'user.email', 'e2e@example.com'],
+    ['config', 'user.name', 'stim-cli e2e'],
+    ['config', 'commit.gpgsign', 'false'],
+    ['add', '-A'],
+    ['commit', '-m', 'pods fixture'],
+  ]) {
+    execFileSync('git', ['-C', repo, ...args], { encoding: 'utf-8' });
+  }
+  writeFileSync(join(repo, 'ios', 'Podfile.lock'), workingLock);
+  mkdirSync(join(repo, 'ios', 'Pods'), { recursive: true });
+  writeFileSync(join(repo, 'ios', 'Pods', 'Manifest.lock'), workingLock);
+
+  const carried = spawnSync(
+    process.execPath,
+    [CLI, 'worktree', 'create', 'pods-carried', '--base', 'head', '--carry-ignored'],
+    { cwd: repo, env: { ...process.env, STIM_HOME: ctx.home }, encoding: 'utf-8' },
+  );
+  assert.equal(carried.status, 0, carried.stderr);
+  const created = carried.stdout.trim();
+  assert.equal(readFileSync(join(created, 'ios', 'Podfile.lock'), 'utf-8'), workingLock);
+  assert.equal(readFileSync(join(created, 'ios', 'Pods', 'Manifest.lock'), 'utf-8'), workingLock);
+  assert.doesNotMatch(carried.stderr, /Carried ios\/Pods does not match/);
 });
 
 function create(name, extra = []) {


### PR DESCRIPTION
## Description

`worktree create --carry-ignored` told three agents on the same project that the carried Pods
disagreed with the lockfile while `diff ios/Pods/Manifest.lock ios/Podfile.lock` in the new worktree
came back empty. Obeying it costs a `pod install` of several minutes for nothing.

The comparison itself was already against the new worktree's files; the ordering was wrong.
`registerCreate` ran the pods check at `commands/worktree.ts:296` and only then carried the source's
uncommitted changes at `:307`, so it read the Podfile.lock the branch checkout put on disk a moment
before `git apply` replaced it. When the source has an uncommitted `ios/Podfile.lock` -- exactly the
state a `pod install` in the source leaves behind -- the carried `Manifest.lock` matches the file
the worktree ends up with, not the one the check looked at. The same window applies to
`depsOutOfSync`, which compares the source's lockfile with the target's.

## Solution

Carry the uncommitted changes before the two staleness checks run, so both compare against the files
`pod install` and `xcodebuild` will actually read. The check needed no logic change.

The mismatch sentence now says "does not match the ios/Podfile.lock on disk here" and drops "comes
from the branch", which is no longer the whole story once a carried change can rewrite it. No
separate "tracked file differs from the branch" warning is warranted: when the patch does not apply,
`carryConflictWarning` already says so first, the branch lockfile stands, and the mismatch warning is
then literally true of what is on disk.

Output ordering moves: the dim `Carried N uncommitted change(s)` line now prints before the stale
dependency and pods warnings rather than after. Nothing parses that stream (invariant 7 keeps stdout
to the created path alone).

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck` -- clean.
- `pnpm test` -- 2900 passed / 77 files. `pnpm run test:e2e` -- 20 passed.
- Reverting only the reorder (keeping the tests) fails
  `create action: pods installed against an uncommitted Podfile.lock carried along are not called stale`
  with the false warning present, which is the reported bug.
- New unit fixtures pin the pure comparison: mismatch while the branch lockfile is on disk, clean once
  the carried lockfile replaces it.
- Real `git` and the real CLI (invariant 9), against a throwaway repo with a committed
  `ios/Podfile.lock`, an uncommitted edit to it, and an `ios/Pods/Manifest.lock` matching the edit:

  ```
  Cloned 1 gitignored path(s).
  Carried warm state: dependencies=no, CocoaPods=yes, native build output=no.
  Carried 1 uncommitted change(s) from the source (ios/Podfile.lock) -- uncommitted here too; commit deliberately.
  Worktree ready. Install dependencies yourself before building.
  $ diff <wt>/ios/Pods/Manifest.lock <wt>/ios/Podfile.lock   # exit 0
  ```

  With the manifest genuinely stale instead, the same real run still prints
  `Carried ios/Pods does not match the ios/Podfile.lock on disk here. ... Run `pod install` before building...`.

Fixes #190
