### PR TITLE
Name the sandbox allowance in doctor, and apply it with --fix

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -84,6 +84,12 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'gc.ts': ['--delete', '--older-than', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--dir', '--label', '--force'],
   };
+  const doctorFlags: Record<string, string[]> = { 'doctor.ts': ['--json', '--fix'] };
+  for (const [file, flags] of Object.entries(doctorFlags)) {
+    const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');
+    for (const flag of flags) expect(src.includes(flag)).toBeTruthy();
+  }
+
   const retired: Record<string, string[]> = { 'gc.ts': ['--all'] };
   for (const [file, flags] of Object.entries(retired)) {
     const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -83,12 +83,9 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
     'gc.ts': ['--delete', '--older-than', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--dir', '--label', '--force'],
+    'doctor.ts': ['--json', '--fix'],
   };
-  const doctorFlags: Record<string, string[]> = { 'doctor.ts': ['--json', '--fix'] };
-  for (const [file, flags] of Object.entries(doctorFlags)) {
-    const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');
-    for (const flag of flags) expect(src.includes(flag)).toBeTruthy();
-  }
+  expect(/doctor\s+--json --fix/.test(lifecycle)).toBeTruthy();
 
   const retired: Record<string, string[]> = { 'gc.ts': ['--all'] };
   for (const [file, flags] of Object.entries(retired)) {

--- a/packages/stim-cli/src/__tests__/sandbox.test.ts
+++ b/packages/stim-cli/src/__tests__/sandbox.test.ts
@@ -1,0 +1,181 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { expect, test } from 'vitest';
+import {
+  applyClaudeAllowance,
+  claudeLocalSettingsPath,
+  detectHarness,
+  missingAllowance,
+  sandboxAllowance,
+  sandboxFinding,
+  withAllowance,
+} from '../sandbox.ts';
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), 'stim-sandbox-'));
+}
+
+test('detectHarness reads the variable each harness exports, and a codex config as a fallback', () => {
+  const noHome = join(tmpdir(), 'stim-sandbox-absent');
+  expect(detectHarness({ CLAUDECODE: '1' }, noHome)).toBe('claude-code');
+  expect(detectHarness({ CLAUDE_CODE_ENTRYPOINT: 'cli' }, noHome)).toBe('claude-code');
+  expect(detectHarness({ CODEX_COMPANION_SESSION_ID: 'x' }, noHome)).toBe('codex');
+  expect(detectHarness({}, noHome)).toBe(null);
+
+  const home = scratch();
+  try {
+    mkdirSync(join(home, '.codex'));
+    writeFileSync(join(home, '.codex', 'config.toml'), 'sandbox_mode = "workspace-write"\n');
+    expect(detectHarness({}, home)).toBe('codex');
+    // A harness that announces itself wins over a config file left on disk.
+    expect(detectHarness({ CLAUDECODE: '1' }, home)).toBe('claude-code');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('missingAllowance names only the parts no settings file supplies', () => {
+  const dir = scratch();
+  try {
+    const path = join(dir, 'settings.local.json');
+    expect(missingAllowance([path])).toEqual([
+      'sandbox.filesystem.allowWrite',
+      'sandbox.network.allowMachLookup',
+      'sandbox.network.allowLocalBinding',
+    ]);
+
+    writeFileSync(
+      path,
+      JSON.stringify({ sandbox: { filesystem: { allowWrite: ['~/.stim'] }, network: { allowLocalBinding: true } } }),
+    );
+    expect(missingAllowance([path])).toEqual(['sandbox.network.allowMachLookup']);
+
+    // Any file in the list may supply any part.
+    const other = join(dir, 'settings.json');
+    writeFileSync(other, JSON.stringify({ sandbox: { network: { allowMachLookup: ['com.apple.coresimulator.*'] } } }));
+    expect(missingAllowance([path, other])).toEqual([]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('missingAllowance tolerates a settings file that is absent or unreadable', () => {
+  const dir = scratch();
+  try {
+    const broken = join(dir, 'broken.json');
+    writeFileSync(broken, '{ not json');
+    expect(missingAllowance([join(dir, 'absent.json'), broken]).length).toBe(3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('missingAllowance honours a STIM_HOME that is not the default', () => {
+  const dir = scratch();
+  try {
+    const path = join(dir, 'settings.local.json');
+    writeFileSync(path, JSON.stringify({ sandbox: { filesystem: { allowWrite: ['~/.stim'] } } }));
+    // The default is covered, a relocated home is not.
+    expect(missingAllowance([path], '~/.stim')).not.toContain('sandbox.filesystem.allowWrite');
+    expect(missingAllowance([path], '/opt/stim-home')).toContain('sandbox.filesystem.allowWrite');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('withAllowance keeps every setting it did not come for', () => {
+  const before = {
+    permissions: { allow: ['Bash(git *)'] },
+    sandbox: {
+      enabled: true,
+      filesystem: { allowWrite: ['/already/here'], denyWrite: ['/secret'] },
+      network: { allowedDomains: ['example.com'] },
+    },
+  };
+  const after = withAllowance(before, sandboxAllowance());
+
+  expect(after.permissions).toEqual({ allow: ['Bash(git *)'] });
+  const sandbox = after.sandbox as {
+    enabled: boolean;
+    filesystem: { allowWrite: string[]; denyWrite: string[] };
+    network: { allowedDomains: string[]; allowMachLookup: string[]; allowLocalBinding: boolean };
+  };
+  expect(sandbox.enabled).toBe(true);
+  expect(sandbox.filesystem.denyWrite).toEqual(['/secret']);
+  expect(sandbox.filesystem.allowWrite).toEqual(['/already/here', '~/.stim']);
+  expect(sandbox.network.allowedDomains).toEqual(['example.com']);
+  expect(sandbox.network.allowMachLookup).toEqual(['com.apple.coresimulator.*']);
+  expect(sandbox.network.allowLocalBinding).toBe(true);
+  // The input is not mutated.
+  expect((before.sandbox.filesystem as { allowWrite: string[] }).allowWrite).toEqual(['/already/here']);
+});
+
+test('withAllowance is idempotent', () => {
+  const once = withAllowance({}, sandboxAllowance());
+  expect(withAllowance(once, sandboxAllowance())).toEqual(once);
+});
+
+test('applyClaudeAllowance writes the local settings file and leaves it valid JSON', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    expect(path.endsWith(join('.claude', 'settings.local.json'))).toBeTruthy();
+
+    const first = applyClaudeAllowance(path, sandboxAllowance());
+    expect(first.created).toBeTruthy();
+    expect(missingAllowance([path])).toEqual([]);
+
+    // A second run changes nothing and does not report a creation.
+    const before = readFileSync(path, 'utf-8');
+    expect(applyClaudeAllowance(path, sandboxAllowance()).created).toBeFalsy();
+    expect(readFileSync(path, 'utf-8')).toBe(before);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('sandboxFinding says nothing when no harness is present', () => {
+  const dir = scratch();
+  try {
+    expect(sandboxFinding(dir, { env: {}, home: dir })).toBe(null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sandboxFinding points Claude Code at the one command that fixes it', () => {
+  const dir = scratch();
+  try {
+    const f = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir });
+    expect(f?.level).toBe('cost');
+    expect(f?.detail).toContain('sandbox.filesystem.allowWrite');
+    expect(f?.fix).toContain('stim doctor --fix');
+    expect(f?.fix).toContain(join('.claude', 'settings.local.json'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sandboxFinding goes quiet once the allowance is in place', () => {
+  const dir = scratch();
+  try {
+    applyClaudeAllowance(claudeLocalSettingsPath(dir), sandboxAllowance());
+    expect(sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir })).toBe(null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sandboxFinding offers Codex no patch, because it has no per-path allowance', () => {
+  const dir = scratch();
+  try {
+    const f = sandboxFinding(dir, { env: { CODEX_COMPANION_SESSION_ID: 'x' }, home: dir });
+    expect(f?.level).toBe('cost');
+    expect(f?.detail).toContain('no per-path allowance');
+    expect(f?.fix).not.toContain('doctor --fix');
+    expect(f?.fix).toContain('danger-full-access');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/stim-cli/src/__tests__/sandbox.test.ts
+++ b/packages/stim-cli/src/__tests__/sandbox.test.ts
@@ -1,37 +1,45 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { expect, test } from 'vitest';
 import {
+  allowanceSearchPaths,
   applyClaudeAllowance,
   claudeLocalSettingsPath,
   detectHarness,
   missingAllowance,
   sandboxAllowance,
+  sandboxBlocksStimHome,
   sandboxFinding,
+  unmergeableKey,
   withAllowance,
 } from '../sandbox.ts';
+import { applySandboxFix } from '../commands/doctor.ts';
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), 'stim-sandbox-'));
 }
 
-test('detectHarness reads the variable each harness exports, and a codex config as a fallback', () => {
-  const noHome = join(tmpdir(), 'stim-sandbox-absent');
-  expect(detectHarness({ CLAUDECODE: '1' }, noHome)).toBe('claude-code');
-  expect(detectHarness({ CLAUDE_CODE_ENTRYPOINT: 'cli' }, noHome)).toBe('claude-code');
-  expect(detectHarness({ CODEX_COMPANION_SESSION_ID: 'x' }, noHome)).toBe('codex');
-  expect(detectHarness({}, noHome)).toBe(null);
+test('detectHarness reads the variable each harness exports', () => {
+  expect(detectHarness({ CLAUDECODE: '1' })).toBe('claude-code');
+  expect(detectHarness({ CLAUDE_CODE_ENTRYPOINT: 'cli' })).toBe('claude-code');
+  expect(detectHarness({ CODEX_SANDBOX: 'seatbelt' })).toBe('codex');
+  expect(detectHarness({})).toBe(null);
+  expect(detectHarness({ CLAUDECODE: '1', CODEX_SANDBOX: 'seatbelt' })).toBe('claude-code');
+});
 
-  const home = scratch();
+test('sandboxBlocksStimHome reports a directory it cannot write, and only that', () => {
+  const dir = scratch();
   try {
-    mkdirSync(join(home, '.codex'));
-    writeFileSync(join(home, '.codex', 'config.toml'), 'sandbox_mode = "workspace-write"\n');
-    expect(detectHarness({}, home)).toBe('codex');
-    // A harness that announces itself wins over a config file left on disk.
-    expect(detectHarness({ CLAUDECODE: '1' }, home)).toBe('claude-code');
+    expect(sandboxBlocksStimHome(join(dir, 'stim-home'))).toBe(false);
+
+    const locked = join(dir, 'locked');
+    mkdirSync(locked);
+    chmodSync(locked, 0o500);
+    expect(sandboxBlocksStimHome(join(locked, 'stim-home'))).toBe(process.getuid?.() !== 0);
+    chmodSync(locked, 0o700);
   } finally {
-    rmSync(home, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 
@@ -51,10 +59,27 @@ test('missingAllowance names only the parts no settings file supplies', () => {
     );
     expect(missingAllowance([path])).toEqual(['sandbox.network.allowMachLookup']);
 
-    // Any file in the list may supply any part.
     const other = join(dir, 'settings.json');
-    writeFileSync(other, JSON.stringify({ sandbox: { network: { allowMachLookup: ['com.apple.coresimulator.*'] } } }));
+    writeFileSync(other, JSON.stringify({ sandbox: { network: { allowMachLookup: ['com.apple.CoreSimulator.*'] } } }));
     expect(missingAllowance([path, other])).toEqual([]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('missingAllowance accepts the ways a home path is written, including a parent', () => {
+  const dir = scratch();
+  const home = '/Users/example';
+  const write = (value: unknown): string[] => {
+    const path = join(dir, 'settings.local.json');
+    writeFileSync(path, JSON.stringify({ sandbox: { filesystem: { allowWrite: [value] } } }));
+    return missingAllowance([path], '~/.stim', home);
+  };
+  try {
+    for (const value of ['~/.stim', '~/.stim/', '~/.stim/**', '$HOME/.stim', '/Users/example/.stim', '~']) {
+      expect(write(value)).not.toContain('sandbox.filesystem.allowWrite');
+    }
+    expect(write('~/.stim-other')).toContain('sandbox.filesystem.allowWrite');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -76,12 +101,21 @@ test('missingAllowance honours a STIM_HOME that is not the default', () => {
   try {
     const path = join(dir, 'settings.local.json');
     writeFileSync(path, JSON.stringify({ sandbox: { filesystem: { allowWrite: ['~/.stim'] } } }));
-    // The default is covered, a relocated home is not.
     expect(missingAllowance([path], '~/.stim')).not.toContain('sandbox.filesystem.allowWrite');
     expect(missingAllowance([path], '/opt/stim-home')).toContain('sandbox.filesystem.allowWrite');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('unmergeableKey names a value the merge would have to discard', () => {
+  expect(unmergeableKey({})).toBe(null);
+  expect(unmergeableKey({ permissions: { allow: [] } })).toBe(null);
+  expect(unmergeableKey({ sandbox: { enabled: true } })).toBe(null);
+  expect(unmergeableKey({ sandbox: 'workspace-write' })).toBe('sandbox');
+  expect(unmergeableKey({ sandbox: ['a'] })).toBe('sandbox');
+  expect(unmergeableKey({ sandbox: { filesystem: 'all' } })).toBe('sandbox.filesystem');
+  expect(unmergeableKey({ sandbox: { network: true } })).toBe('sandbox.network');
 });
 
 test('withAllowance keeps every setting it did not come for', () => {
@@ -107,7 +141,6 @@ test('withAllowance keeps every setting it did not come for', () => {
   expect(sandbox.network.allowedDomains).toEqual(['example.com']);
   expect(sandbox.network.allowMachLookup).toEqual(['com.apple.coresimulator.*']);
   expect(sandbox.network.allowLocalBinding).toBe(true);
-  // The input is not mutated.
   expect((before.sandbox.filesystem as { allowWrite: string[] }).allowWrite).toEqual(['/already/here']);
 });
 
@@ -122,23 +155,109 @@ test('applyClaudeAllowance writes the local settings file and leaves it valid JS
     const path = claudeLocalSettingsPath(root);
     expect(path.endsWith(join('.claude', 'settings.local.json'))).toBeTruthy();
 
-    const first = applyClaudeAllowance(path, sandboxAllowance());
-    expect(first.created).toBeTruthy();
+    expect(applyClaudeAllowance(path, sandboxAllowance()).status).toBe('created');
     expect(missingAllowance([path])).toEqual([]);
 
-    // A second run changes nothing and does not report a creation.
     const before = readFileSync(path, 'utf-8');
-    expect(applyClaudeAllowance(path, sandboxAllowance()).created).toBeFalsy();
+    expect(applyClaudeAllowance(path, sandboxAllowance()).status).toBe('updated');
     expect(readFileSync(path, 'utf-8')).toBe(before);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
+test('applyClaudeAllowance preserves settings it did not come for', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    mkdirSync(join(root, '.claude'));
+    writeFileSync(path, JSON.stringify({ permissions: { allow: ['Bash(git *)'] }, sandbox: { enabled: true } }));
+
+    expect(applyClaudeAllowance(path, sandboxAllowance()).status).toBe('updated');
+    const after = JSON.parse(readFileSync(path, 'utf-8')) as {
+      permissions: { allow: string[] };
+      sandbox: { enabled: boolean };
+    };
+    expect(after.permissions.allow).toEqual(['Bash(git *)']);
+    expect(after.sandbox.enabled).toBe(true);
+    expect(missingAllowance([path])).toEqual([]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applyClaudeAllowance refuses a file it cannot read back, and writes nothing', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    mkdirSync(join(root, '.claude'));
+    for (const contents of [
+      '{ // a comment Claude Code accepts\n  "permissions": { "allow": ["Bash(git *)"] }\n}',
+      '{ "permissions": { "allow": [] }, ',
+      '["not an object"]',
+      '"a string"',
+    ]) {
+      writeFileSync(path, contents);
+      const result = applyClaudeAllowance(path, sandboxAllowance());
+      expect(result.status).toBe('refused');
+      expect(readFileSync(path, 'utf-8')).toBe(contents);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applyClaudeAllowance refuses a sandbox value it would have to discard', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    mkdirSync(join(root, '.claude'));
+    const contents = JSON.stringify({ sandbox: 'workspace-write' });
+    writeFileSync(path, contents);
+
+    const result = applyClaudeAllowance(path, sandboxAllowance());
+    expect(result.status).toBe('refused');
+    expect(result.status === 'refused' && result.reason).toContain('sandbox');
+    expect(readFileSync(path, 'utf-8')).toBe(contents);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applyClaudeAllowance leaves no temporary file behind', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    applyClaudeAllowance(path, sandboxAllowance());
+    expect(readdirSync(join(root, '.claude'))).toEqual(['settings.local.json']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('allowanceSearchPaths covers the project and the user, project first', () => {
+  const paths = allowanceSearchPaths('/repo', '/home/me');
+  expect(paths).toEqual([
+    join('/repo', '.claude', 'settings.local.json'),
+    join('/repo', '.claude', 'settings.json'),
+    join('/home/me', '.claude', 'settings.json'),
+  ]);
+});
+
 test('sandboxFinding says nothing when no harness is present', () => {
   const dir = scratch();
   try {
-    expect(sandboxFinding(dir, { env: {}, home: dir })).toBe(null);
+    expect(sandboxFinding(dir, { env: {}, home: dir, blocked: true })).toBe(null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sandboxFinding says nothing when the harness is present but writes go through', () => {
+  const dir = scratch();
+  try {
+    expect(sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir, blocked: false })).toBe(null);
+    expect(sandboxFinding(dir, { env: { CODEX_SANDBOX: 'seatbelt' }, home: dir, blocked: false })).toBe(null);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -147,7 +266,7 @@ test('sandboxFinding says nothing when no harness is present', () => {
 test('sandboxFinding points Claude Code at the one command that fixes it', () => {
   const dir = scratch();
   try {
-    const f = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir });
+    const f = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir, blocked: true });
     expect(f?.level).toBe('cost');
     expect(f?.detail).toContain('sandbox.filesystem.allowWrite');
     expect(f?.fix).toContain('stim doctor --fix');
@@ -157,11 +276,13 @@ test('sandboxFinding points Claude Code at the one command that fixes it', () =>
   }
 });
 
-test('sandboxFinding goes quiet once the allowance is in place', () => {
+test('sandboxFinding asks for a restart once the allowance is written but not yet read', () => {
   const dir = scratch();
   try {
     applyClaudeAllowance(claudeLocalSettingsPath(dir), sandboxAllowance());
-    expect(sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir })).toBe(null);
+    const f = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir, blocked: true });
+    expect(f?.fix).toContain('Restart the session');
+    expect(f?.title).toContain('has not picked it up');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -170,12 +291,91 @@ test('sandboxFinding goes quiet once the allowance is in place', () => {
 test('sandboxFinding offers Codex no patch, because it has no per-path allowance', () => {
   const dir = scratch();
   try {
-    const f = sandboxFinding(dir, { env: { CODEX_COMPANION_SESSION_ID: 'x' }, home: dir });
+    const f = sandboxFinding(dir, { env: { CODEX_SANDBOX: 'seatbelt' }, home: dir, blocked: true });
     expect(f?.level).toBe('cost');
     expect(f?.detail).toContain('no per-path allowance');
     expect(f?.fix).not.toContain('doctor --fix');
     expect(f?.fix).toContain('danger-full-access');
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function captureFix(root: string, env: NodeJS.ProcessEnv): { out: string; exitCode: number | undefined } {
+  const lines: string[] = [];
+  const realError = console.error;
+  const realLog = console.log;
+  const realExit = process.exitCode;
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]): void => void lines.push(args.map(String).join(' '));
+  console.log = (...args: unknown[]): void => void lines.push(`STDOUT:${args.map(String).join(' ')}`);
+  try {
+    applySandboxFix(root, env);
+    return { out: lines.join('\n'), exitCode: process.exitCode };
+  } finally {
+    console.error = realError;
+    console.log = realLog;
+    process.exitCode = realExit;
+  }
+}
+
+test('applySandboxFix writes the allowance, then reports it is already there', () => {
+  const root = scratch();
+  try {
+    const env = { CLAUDECODE: '1', STIM_HOME: join(root, 'home') };
+    const first = captureFix(root, env);
+    expect(first.out).toContain('Wrote');
+    expect(first.exitCode).toBe(undefined);
+    expect(missingAllowance([claudeLocalSettingsPath(root)], env.STIM_HOME)).toEqual([]);
+
+    const second = captureFix(root, env);
+    expect(second.out).toContain('Nothing to apply');
+    expect(second.exitCode).toBe(undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxFix refuses a settings file it cannot read back, and says nothing was written', () => {
+  const root = scratch();
+  try {
+    const path = claudeLocalSettingsPath(root);
+    mkdirSync(join(root, '.claude'));
+    const contents = '{ // hand written\n "permissions": { "allow": ["Bash(git *)"] } }';
+    writeFileSync(path, contents);
+
+    const { out, exitCode } = captureFix(root, { CLAUDECODE: '1', STIM_HOME: join(root, 'home') });
+    expect(out).toContain('Nothing was written');
+    expect(exitCode).toBe(1);
+    expect(readFileSync(path, 'utf-8')).toBe(contents);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxFix writes nothing under Codex, and nothing without a harness', () => {
+  const root = scratch();
+  try {
+    const codex = captureFix(root, { CODEX_SANDBOX: 'seatbelt', STIM_HOME: join(root, 'home') });
+    expect(codex.out).toContain('Nothing to apply under Codex');
+    expect(codex.exitCode).toBe(1);
+
+    const none = captureFix(root, { STIM_HOME: join(root, 'home') });
+    expect(none.out).toContain('No sandboxing harness detected');
+    expect(none.exitCode).toBe(undefined);
+
+    expect(existsSync(claudeLocalSettingsPath(root))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxFix keeps its status off stdout, so --json stays parseable', () => {
+  const root = scratch();
+  try {
+    const { out } = captureFix(root, { CLAUDECODE: '1', STIM_HOME: join(root, 'home') });
+    expect(out).not.toContain('STDOUT:');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -1,9 +1,9 @@
-import { join } from 'path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { findProjectRoot } from '../project.ts';
 import { repoRoot } from '../worktree.ts';
 import {
+  allowanceSearchPaths,
   applyClaudeAllowance,
   claudeLocalSettingsPath,
   detectHarness,
@@ -19,11 +19,56 @@ interface DoctorOptions {
   fix?: boolean;
 }
 
+/**
+ * Status goes to stderr so `--json --fix` still prints one parseable payload
+ * on stdout, and the report that follows shows what the write left.
+ */
+export function applySandboxFix(root: string, env: NodeJS.ProcessEnv = process.env): void {
+  const harness = detectHarness(env);
+  if (harness === 'codex') {
+    console.error(chalk.yellow('Nothing to apply under Codex.'));
+    console.error(
+      chalk.dim(
+        'Its sandbox is one setting, `sandbox_mode`, with no per-path allowance: the only value that clears Stim is `danger-full-access`, which turns the sandbox off rather than allowing these three. Run Stim with the sandbox off instead, or set it yourself.',
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (harness !== 'claude-code') {
+    console.error(chalk.dim('No sandboxing harness detected, so there is nothing to apply.'));
+    return;
+  }
+
+  const settingsRoot = repoRoot(root) ?? root;
+  const stimHome = env.STIM_HOME || '~/.stim';
+  const target = claudeLocalSettingsPath(settingsRoot);
+  const missing = missingAllowance(allowanceSearchPaths(settingsRoot), stimHome);
+  if (missing.length === 0) {
+    console.error(chalk.green('Stim is already allowed through this sandbox. Nothing to apply.'));
+    return;
+  }
+
+  const result = applyClaudeAllowance(target, sandboxAllowance(stimHome));
+  if (result.status === 'refused') {
+    console.error(chalk.red(result.reason));
+    console.error(chalk.dim(`Nothing was written. Add ${missing.join(', ')} by hand.`));
+    process.exitCode = 1;
+    return;
+  }
+  console.error(chalk.green(`${result.status === 'created' ? 'Wrote' : 'Updated'} ${target}`));
+  console.error(
+    chalk.dim(
+      "Added writes to Stim's state directory, the simulator XPC service, and local port binding. Claude Code reads project settings from the directory a session starts in, so this file only counts for sessions rooted there. Restart the session for it to take effect.",
+    ),
+  );
+}
+
 export default function doctorCommand(program: Command): void {
   program
     .command('doctor')
     .description(
-      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only; changes nothing.',
+      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed.',
     )
     .option('--json', 'print the findings as JSON')
     .option(
@@ -38,38 +83,7 @@ export default function doctorCommand(program: Command): void {
         return;
       }
 
-      if (opts.fix) {
-        const harness = detectHarness();
-        const settingsRoot = repoRoot(root) ?? root;
-        const home = process.env.STIM_HOME || '~/.stim';
-        if (harness === 'claude-code') {
-          const path = claudeLocalSettingsPath(settingsRoot);
-          if (missingAllowance([path, join(settingsRoot, '.claude', 'settings.json')], home).length === 0) {
-            console.log(chalk.green('Stim is already allowed through this sandbox. Nothing to apply.'));
-            return;
-          }
-          const { created } = applyClaudeAllowance(path, sandboxAllowance(home));
-          console.log(chalk.green(`${created ? 'Wrote' : 'Updated'} ${path}`));
-          console.log(
-            chalk.dim(
-              "Added writes to Stim's state directory, the simulator XPC service, and local port binding. Restart the session for it to take effect.",
-            ),
-          );
-          return;
-        }
-        if (harness === 'codex') {
-          console.error(chalk.yellow('Nothing to apply under Codex.'));
-          console.error(
-            chalk.dim(
-              'Its sandbox is one setting, `sandbox_mode`, with no per-path allowance: the only value that clears Stim is `danger-full-access`, which turns the sandbox off rather than allowing these three. Run Stim with the sandbox off instead, or set it yourself.',
-            ),
-          );
-          process.exitCode = 1;
-          return;
-        }
-        console.log(chalk.dim('No sandboxing harness detected, so there is nothing to apply.'));
-        return;
-      }
+      if (opts.fix) applySandboxFix(root);
 
       const findings: Finding[] = runDoctor(root, {
         xcodeMajor: detectXcodeMajor(),
@@ -78,8 +92,10 @@ export default function doctorCommand(program: Command): void {
       const parity = await detectFingerprintParity(root);
       if (parity) findings.push(parity);
 
-      const sandbox = sandboxFinding(repoRoot(root) ?? root);
-      if (sandbox) findings.push(sandbox);
+      if (detectHarness()) {
+        const sandbox = sandboxFinding(repoRoot(root) ?? root);
+        if (sandbox) findings.push(sandbox);
+      }
 
       if (opts.json) {
         console.log(JSON.stringify({ project: root, findings }, null, 2));

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -73,7 +73,7 @@ export default function doctorCommand(program: Command): void {
     .option('--json', 'print the findings as JSON')
     .option(
       '--fix',
-      "allow Stim through this session's sandbox by writing the three keys into .claude/settings.local.json, the per-user file. Applies nothing else, and refuses where the harness has no per-path allowance.",
+      'apply the findings Stim can repair itself and report the rest, which stay read-only. Every repair writes a per-user file, never a committed one, and refuses a file it cannot read back rather than replace it. Today one finding qualifies: the sandbox allowance.',
     )
     .action(async (opts: DoctorOptions) => {
       const root = findProjectRoot(process.cwd());

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -1,11 +1,22 @@
+import { join } from 'path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { findProjectRoot } from '../project.ts';
+import { repoRoot } from '../worktree.ts';
+import {
+  applyClaudeAllowance,
+  claudeLocalSettingsPath,
+  detectHarness,
+  missingAllowance,
+  sandboxAllowance,
+  sandboxFinding,
+} from '../sandbox.ts';
 import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.ts';
 import type { Finding } from '../doctor.ts';
 
 interface DoctorOptions {
   json?: boolean;
+  fix?: boolean;
 }
 
 export default function doctorCommand(program: Command): void {
@@ -15,11 +26,48 @@ export default function doctorCommand(program: Command): void {
       'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only; changes nothing.',
     )
     .option('--json', 'print the findings as JSON')
+    .option(
+      '--fix',
+      "allow Stim through this session's sandbox by writing the three keys into .claude/settings.local.json, the per-user file. Applies nothing else, and refuses where the harness has no per-path allowance.",
+    )
     .action(async (opts: DoctorOptions) => {
       const root = findProjectRoot(process.cwd());
       if (!root) {
         console.error(chalk.red('Not in a React Native project (no package.json found).'));
         process.exitCode = 1;
+        return;
+      }
+
+      if (opts.fix) {
+        const harness = detectHarness();
+        const settingsRoot = repoRoot(root) ?? root;
+        const home = process.env.STIM_HOME || '~/.stim';
+        if (harness === 'claude-code') {
+          const path = claudeLocalSettingsPath(settingsRoot);
+          if (missingAllowance([path, join(settingsRoot, '.claude', 'settings.json')], home).length === 0) {
+            console.log(chalk.green('Stim is already allowed through this sandbox. Nothing to apply.'));
+            return;
+          }
+          const { created } = applyClaudeAllowance(path, sandboxAllowance(home));
+          console.log(chalk.green(`${created ? 'Wrote' : 'Updated'} ${path}`));
+          console.log(
+            chalk.dim(
+              "Added writes to Stim's state directory, the simulator XPC service, and local port binding. Restart the session for it to take effect.",
+            ),
+          );
+          return;
+        }
+        if (harness === 'codex') {
+          console.error(chalk.yellow('Nothing to apply under Codex.'));
+          console.error(
+            chalk.dim(
+              'Its sandbox is one setting, `sandbox_mode`, with no per-path allowance: the only value that clears Stim is `danger-full-access`, which turns the sandbox off rather than allowing these three. Run Stim with the sandbox off instead, or set it yourself.',
+            ),
+          );
+          process.exitCode = 1;
+          return;
+        }
+        console.log(chalk.dim('No sandboxing harness detected, so there is nothing to apply.'));
         return;
       }
 
@@ -29,6 +77,9 @@ export default function doctorCommand(program: Command): void {
 
       const parity = await detectFingerprintParity(root);
       if (parity) findings.push(parity);
+
+      const sandbox = sandboxFinding(repoRoot(root) ?? root);
+      if (sandbox) findings.push(sandbox);
 
       if (opts.json) {
         console.log(JSON.stringify({ project: root, findings }, null, 2));

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1093,6 +1093,11 @@ RUNNING UNDER A SANDBOX
   so this is the shape of the problem, not one harness's quirk. Codex also
   blocks network egress by default, which breaks a cache lookup and a fetch.
 
+  \`stim doctor\` names this when it sees a sandboxing harness, and
+  \`stim doctor --fix\` writes the three keys into .claude/settings.local.json,
+  the per-user file, merging with what is there. It refuses under Codex, which
+  has no per-path allowance to add.
+
   Two ways out, and choosing at the start of a session beats discovering it
   three failures in. Either run Stim with the harness's sandbox disabled, or
   allow the three. In Claude Code that is settings.json:
@@ -1361,6 +1366,7 @@ THE OPTION SURFACE, IN FULL
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide)
+  doctor          --json --fix    (--fix writes only the sandbox allowance)
   gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1372,7 +1372,7 @@ THE OPTION SURFACE, IN FULL
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide)
-  doctor          --json --fix    (--fix writes only the sandbox allowance)
+  doctor          --json --fix    (--fix applies the findings Stim can repair)
   gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1093,10 +1093,16 @@ RUNNING UNDER A SANDBOX
   so this is the shape of the problem, not one harness's quirk. Codex also
   blocks network egress by default, which breaks a cache lookup and a fetch.
 
-  \`stim doctor\` names this when it sees a sandboxing harness, and
+  \`stim doctor\` names this when a write to STIM_HOME actually fails, not
+  merely when a harness that can sandbox is present, and
   \`stim doctor --fix\` writes the three keys into .claude/settings.local.json,
   the per-user file, merging with what is there. It refuses under Codex, which
-  has no per-path allowance to add.
+  has no per-path allowance to add, and refuses any settings file it cannot
+  parse rather than replace it: comments make one unparseable here even though
+  Claude Code accepts them. Claude Code reads project settings from the
+  directory a session starts in, so in a monorepo the file has to sit at that
+  root to count, and a file written inside a worktree goes when the worktree
+  does.
 
   Two ways out, and choosing at the start of a session beats discovering it
   three failures in. Either run Stim with the harness's sandbox disabled, or
@@ -1234,7 +1240,7 @@ lines Stim composes rather than on files the project owns:
            config also gets the \`cache.provider\` tier behind that store.
 
 Each says so in one dim line. There is nothing to install, wire or commit, and
-no setup skill to run. \`stim doctor\` is the read-only second opinion when
+no setup skill to run. \`stim doctor\` is the second opinion when
 something IS blocked or slow: it reports only what Stim cannot handle itself
 (a missing dev client, ccache, a fingerprint no fresh worktree reproduces, a
 provider on a key this SDK ignores) plus the project-side settings that matter

--- a/packages/stim-cli/src/sandbox.ts
+++ b/packages/stim-cli/src/sandbox.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 import type { Finding } from './doctor.ts';
@@ -23,11 +23,37 @@ export function sandboxAllowance(stimHome: string = '~/.stim'): SandboxAllowance
   };
 }
 
-export function detectHarness(env: NodeJS.ProcessEnv = process.env, home: string = homedir()): Harness {
+export function detectHarness(env: NodeJS.ProcessEnv = process.env): Harness {
   if (env.CLAUDECODE || env.CLAUDE_CODE_ENTRYPOINT) return 'claude-code';
   if (Object.keys(env).some((k) => k.startsWith('CODEX_'))) return 'codex';
-  if (existsSync(join(home, '.codex', 'config.toml'))) return 'codex';
   return null;
+}
+
+function expandHome(value: string, home: string): string {
+  const v = value.trim();
+  if (v === '~' || v === '$HOME') return home;
+  if (v.startsWith('~/')) return join(home, v.slice(2));
+  if (v.startsWith('$HOME/')) return join(home, v.slice(6));
+  return v;
+}
+
+/**
+ * Whether the sandbox actually stops Stim, rather than whether a harness that
+ * can sandbox is present: a session with its sandbox off exports the same
+ * variables as one with it on, so only a write says which this is.
+ */
+export function sandboxBlocksStimHome(stimHome: string, home: string = homedir()): boolean {
+  const dir = expandHome(stimHome, home);
+  const probe = join(dir, `.probe-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(probe, '');
+    rmSync(probe, { force: true });
+    return false;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === 'EPERM' || code === 'EACCES';
+  }
 }
 
 /** Where a per-user, gitignored Claude Code settings file belongs for this project. */
@@ -35,23 +61,56 @@ export function claudeLocalSettingsPath(root: string): string {
   return join(root, '.claude', 'settings.local.json');
 }
 
-function readJson(path: string): Record<string, unknown> | null {
-  if (!existsSync(path)) return null;
+/** Every settings file that may already carry the allowance, most local first. */
+export function allowanceSearchPaths(settingsRoot: string, home: string = homedir()): string[] {
+  return [
+    claudeLocalSettingsPath(settingsRoot),
+    join(settingsRoot, '.claude', 'settings.json'),
+    join(home, '.claude', 'settings.json'),
+  ];
+}
+
+type Settings = Record<string, unknown>;
+type ReadResult = { kind: 'absent' } | { kind: 'invalid' } | { kind: 'object'; value: Settings };
+
+function isPlainObject(value: unknown): value is Settings {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Absent, unreadable and present-but-not-an-object are three different states.
+ * Collapsing them loses the one distinction that matters before a write: a
+ * file whose contents did not parse still holds settings we must not destroy.
+ */
+function readSettings(path: string): ReadResult {
+  let raw: string;
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ENOENT' ? { kind: 'absent' } : { kind: 'invalid' };
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isPlainObject(parsed) ? { kind: 'object', value: parsed } : { kind: 'invalid' };
   } catch {
-    return null;
+    return { kind: 'invalid' };
   }
 }
 
-function nested(source: Record<string, unknown> | null, ...keys: string[]): unknown {
+function nested(source: Settings | null, ...keys: string[]): unknown {
   let cursor: unknown = source;
   for (const key of keys) {
-    if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor)) return undefined;
-    cursor = (cursor as Record<string, unknown>)[key];
+    if (!isPlainObject(cursor)) return undefined;
+    cursor = cursor[key];
   }
   return cursor;
+}
+
+/** Whether an allowWrite entry covers the Stim home, including as a parent. */
+function covers(entry: string, target: string, home: string): boolean {
+  const e = expandHome(entry.replace(/\/+\*+$/, '').replace(/\/+$/, ''), home);
+  const t = expandHome(target.replace(/\/+$/, ''), home);
+  return e === t || t.startsWith(`${e}/`);
 }
 
 /**
@@ -59,35 +118,52 @@ function nested(source: Record<string, unknown> | null, ...keys: string[]): unkn
  * supply any part, so a project that solved this in one place is not asked to
  * repeat it in another.
  */
-export function missingAllowance(paths: string[], stimHome: string = '~/.stim'): string[] {
-  const files = paths.map(readJson);
-  const writes = files.flatMap((f) => {
-    const value = nested(f, 'sandbox', 'filesystem', 'allowWrite');
-    return Array.isArray(value) ? value.map(String) : [];
+export function missingAllowance(paths: string[], stimHome: string = '~/.stim', home: string = homedir()): string[] {
+  const files = paths.map((p) => {
+    const read = readSettings(p);
+    return read.kind === 'object' ? read.value : null;
   });
-  const lookups = files.flatMap((f) => {
-    const value = nested(f, 'sandbox', 'network', 'allowMachLookup');
-    return Array.isArray(value) ? value.map(String) : [];
-  });
-  const binding = files.some((f) => nested(f, 'sandbox', 'network', 'allowLocalBinding') === true);
+  const list = (...keys: string[]): string[] =>
+    files.flatMap((f) => {
+      const value = nested(f, ...keys);
+      return Array.isArray(value) ? value.map(String) : [];
+    });
 
   const missing: string[] = [];
-  const home = stimHome.replace(/\/+$/, '');
-  const bare = home.replace(/^~\//, '');
-  if (!writes.some((w) => w.replace(/\/+$/, '').replace(/^~\//, '') === bare)) {
+  if (!list('sandbox', 'filesystem', 'allowWrite').some((w) => covers(w, stimHome, home))) {
     missing.push('sandbox.filesystem.allowWrite');
   }
-  if (!lookups.some((l) => l.startsWith('com.apple.coresimulator'))) missing.push('sandbox.network.allowMachLookup');
-  if (!binding) missing.push('sandbox.network.allowLocalBinding');
+  if (
+    !list('sandbox', 'network', 'allowMachLookup').some((l) => l.toLowerCase().startsWith('com.apple.coresimulator'))
+  ) {
+    missing.push('sandbox.network.allowMachLookup');
+  }
+  if (!files.some((f) => nested(f, 'sandbox', 'network', 'allowLocalBinding') === true)) {
+    missing.push('sandbox.network.allowLocalBinding');
+  }
   return missing;
 }
 
+/**
+ * The key that stops a merge, or null when the settings can take the
+ * allowance. A value of an unexpected shape is someone else's, and rewriting
+ * it would lose whatever it means.
+ */
+export function unmergeableKey(settings: Settings): string | null {
+  if (!('sandbox' in settings)) return null;
+  if (!isPlainObject(settings.sandbox)) return 'sandbox';
+  const sandbox = settings.sandbox;
+  if ('filesystem' in sandbox && !isPlainObject(sandbox.filesystem)) return 'sandbox.filesystem';
+  if ('network' in sandbox && !isPlainObject(sandbox.network)) return 'sandbox.network';
+  return null;
+}
+
 /** Merge the allowance into a settings object, leaving everything else as it is. */
-export function withAllowance(settings: Record<string, unknown>, allowance: SandboxAllowance): Record<string, unknown> {
+export function withAllowance(settings: Settings, allowance: SandboxAllowance): Settings {
   const next = { ...settings };
-  const sandbox = { ...(next.sandbox as Record<string, unknown> | undefined) };
-  const filesystem = { ...(sandbox.filesystem as Record<string, unknown> | undefined) };
-  const network = { ...(sandbox.network as Record<string, unknown> | undefined) };
+  const sandbox = isPlainObject(next.sandbox) ? { ...next.sandbox } : {};
+  const filesystem = isPlainObject(sandbox.filesystem) ? { ...sandbox.filesystem } : {};
+  const network = isPlainObject(sandbox.network) ? { ...sandbox.network } : {};
 
   const writes = Array.isArray(filesystem.allowWrite) ? filesystem.allowWrite.map(String) : [];
   const lookups = Array.isArray(network.allowMachLookup) ? network.allowMachLookup.map(String) : [];
@@ -102,13 +178,40 @@ export function withAllowance(settings: Record<string, unknown>, allowance: Sand
   return next;
 }
 
-/** Write the allowance into a Claude Code local settings file, creating it if needed. */
-export function applyClaudeAllowance(path: string, allowance: SandboxAllowance): { created: boolean } {
-  const existing = readJson(path);
-  const created = existing === null && !existsSync(path);
+export type ApplyResult = { status: 'created' | 'updated' } | { status: 'refused'; reason: string };
+
+/**
+ * Write the allowance into a Claude Code local settings file, creating it if
+ * needed. Refuses whenever the current contents cannot be read back, because
+ * the merge would replace settings rather than extend them.
+ */
+export function applyClaudeAllowance(path: string, allowance: SandboxAllowance): ApplyResult {
+  const read = readSettings(path);
+  if (read.kind === 'invalid') {
+    return {
+      status: 'refused',
+      reason: `${path} is not a plain JSON object, so Stim cannot merge into it without losing what is there. Comments make a settings file unparseable here even though Claude Code accepts them.`,
+    };
+  }
+  const existing = read.kind === 'object' ? read.value : {};
+  const blocker = unmergeableKey(existing);
+  if (blocker) {
+    return {
+      status: 'refused',
+      reason: `${path} holds a "${blocker}" that is not an object, so Stim cannot merge into it without discarding that value.`,
+    };
+  }
+
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(withAllowance(existing ?? {}, allowance), null, 2)}\n`);
-  return { created };
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(withAllowance(existing, allowance), null, 2)}\n`);
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+  return { status: read.kind === 'absent' ? 'created' : 'updated' };
 }
 
 /**
@@ -121,10 +224,12 @@ export function sandboxFinding(
     env = process.env,
     home = homedir(),
     stimHome = process.env.STIM_HOME || '~/.stim',
-  }: { env?: NodeJS.ProcessEnv; home?: string; stimHome?: string } = {},
+    blocked,
+  }: { env?: NodeJS.ProcessEnv; home?: string; stimHome?: string; blocked?: boolean } = {},
 ): Finding | null {
-  const harness = detectHarness(env, home);
+  const harness = detectHarness(env);
   if (!harness) return null;
+  if (!(blocked ?? sandboxBlocksStimHome(stimHome, home))) return null;
 
   const symptoms = `Writes to ${stimHome} raise EPERM on a directory you can write, the simulator service looks dead, and the adb server looks unreachable.`;
   const title = 'This session sandboxes shell commands, and Stim is not allowed through';
@@ -138,16 +243,20 @@ export function sandboxFinding(
     };
   }
 
-  const local = claudeLocalSettingsPath(settingsRoot);
-  const missing = missingAllowance(
-    [local, join(settingsRoot, '.claude', 'settings.json'), join(home, '.claude', 'settings.json')],
-    stimHome,
-  );
-  if (missing.length === 0) return null;
+  const paths = allowanceSearchPaths(settingsRoot, home);
+  const missing = missingAllowance(paths, stimHome, home);
+  if (missing.length === 0) {
+    return {
+      level: 'cost',
+      title: 'Stim is allowed through this sandbox, but the session has not picked it up',
+      detail: `${symptoms} ${paths[0]} already grants all three, so the settings were read before they were written.`,
+      fix: 'Restart the session for the allowance to take effect.',
+    };
+  }
   return {
     level: 'cost',
     title,
     detail: `${symptoms} Missing: ${missing.join(', ')}.`,
-    fix: `Run \`stim doctor --fix\` to add them to ${local}, or add them by hand. See \`stim guide errors\`.`,
+    fix: `Run \`stim doctor --fix\` to add them to ${paths[0]}, or add them by hand. See \`stim guide errors\`.`,
   };
 }

--- a/packages/stim-cli/src/sandbox.ts
+++ b/packages/stim-cli/src/sandbox.ts
@@ -1,0 +1,153 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import type { Finding } from './doctor.ts';
+
+export type Harness = 'claude-code' | 'codex' | null;
+
+export interface SandboxAllowance {
+  allowWrite: string[];
+  allowMachLookup: string[];
+  allowLocalBinding: boolean;
+}
+
+/**
+ * What a sandboxed harness has to permit for Stim to work: its state
+ * directory, the XPC service simctl talks to, and the port adb's server binds.
+ */
+export function sandboxAllowance(stimHome: string = '~/.stim'): SandboxAllowance {
+  return {
+    allowWrite: [stimHome],
+    allowMachLookup: ['com.apple.coresimulator.*'],
+    allowLocalBinding: true,
+  };
+}
+
+export function detectHarness(env: NodeJS.ProcessEnv = process.env, home: string = homedir()): Harness {
+  if (env.CLAUDECODE || env.CLAUDE_CODE_ENTRYPOINT) return 'claude-code';
+  if (Object.keys(env).some((k) => k.startsWith('CODEX_'))) return 'codex';
+  if (existsSync(join(home, '.codex', 'config.toml'))) return 'codex';
+  return null;
+}
+
+/** Where a per-user, gitignored Claude Code settings file belongs for this project. */
+export function claudeLocalSettingsPath(root: string): string {
+  return join(root, '.claude', 'settings.local.json');
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function nested(source: Record<string, unknown> | null, ...keys: string[]): unknown {
+  let cursor: unknown = source;
+  for (const key of keys) {
+    if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor)) return undefined;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return cursor;
+}
+
+/**
+ * Which parts of the allowance the settings files already carry. Any file may
+ * supply any part, so a project that solved this in one place is not asked to
+ * repeat it in another.
+ */
+export function missingAllowance(paths: string[], stimHome: string = '~/.stim'): string[] {
+  const files = paths.map(readJson);
+  const writes = files.flatMap((f) => {
+    const value = nested(f, 'sandbox', 'filesystem', 'allowWrite');
+    return Array.isArray(value) ? value.map(String) : [];
+  });
+  const lookups = files.flatMap((f) => {
+    const value = nested(f, 'sandbox', 'network', 'allowMachLookup');
+    return Array.isArray(value) ? value.map(String) : [];
+  });
+  const binding = files.some((f) => nested(f, 'sandbox', 'network', 'allowLocalBinding') === true);
+
+  const missing: string[] = [];
+  const home = stimHome.replace(/\/+$/, '');
+  const bare = home.replace(/^~\//, '');
+  if (!writes.some((w) => w.replace(/\/+$/, '').replace(/^~\//, '') === bare)) {
+    missing.push('sandbox.filesystem.allowWrite');
+  }
+  if (!lookups.some((l) => l.startsWith('com.apple.coresimulator'))) missing.push('sandbox.network.allowMachLookup');
+  if (!binding) missing.push('sandbox.network.allowLocalBinding');
+  return missing;
+}
+
+/** Merge the allowance into a settings object, leaving everything else as it is. */
+export function withAllowance(settings: Record<string, unknown>, allowance: SandboxAllowance): Record<string, unknown> {
+  const next = { ...settings };
+  const sandbox = { ...(next.sandbox as Record<string, unknown> | undefined) };
+  const filesystem = { ...(sandbox.filesystem as Record<string, unknown> | undefined) };
+  const network = { ...(sandbox.network as Record<string, unknown> | undefined) };
+
+  const writes = Array.isArray(filesystem.allowWrite) ? filesystem.allowWrite.map(String) : [];
+  const lookups = Array.isArray(network.allowMachLookup) ? network.allowMachLookup.map(String) : [];
+
+  filesystem.allowWrite = [...new Set([...writes, ...allowance.allowWrite])];
+  network.allowMachLookup = [...new Set([...lookups, ...allowance.allowMachLookup])];
+  network.allowLocalBinding = true;
+
+  sandbox.filesystem = filesystem;
+  sandbox.network = network;
+  next.sandbox = sandbox;
+  return next;
+}
+
+/** Write the allowance into a Claude Code local settings file, creating it if needed. */
+export function applyClaudeAllowance(path: string, allowance: SandboxAllowance): { created: boolean } {
+  const existing = readJson(path);
+  const created = existing === null && !existsSync(path);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(withAllowance(existing ?? {}, allowance), null, 2)}\n`);
+  return { created };
+}
+
+/**
+ * The finding a sandboxed session should see: what fails, and the one command
+ * that fixes it where the harness has a per-path allowance.
+ */
+export function sandboxFinding(
+  settingsRoot: string,
+  {
+    env = process.env,
+    home = homedir(),
+    stimHome = process.env.STIM_HOME || '~/.stim',
+  }: { env?: NodeJS.ProcessEnv; home?: string; stimHome?: string } = {},
+): Finding | null {
+  const harness = detectHarness(env, home);
+  if (!harness) return null;
+
+  const symptoms = `Writes to ${stimHome} raise EPERM on a directory you can write, the simulator service looks dead, and the adb server looks unreachable.`;
+  const title = 'This session sandboxes shell commands, and Stim is not allowed through';
+
+  if (harness === 'codex') {
+    return {
+      level: 'cost',
+      title,
+      detail: `${symptoms} Codex has one sandbox setting and no per-path allowance, so there is nothing to add.`,
+      fix: 'Run Stim with the sandbox off, or start Codex with `codex -s danger-full-access`, which turns the whole sandbox off rather than allowing these three. See `stim guide errors`.',
+    };
+  }
+
+  const local = claudeLocalSettingsPath(settingsRoot);
+  const missing = missingAllowance(
+    [local, join(settingsRoot, '.claude', 'settings.json'), join(home, '.claude', 'settings.json')],
+    stimHome,
+  );
+  if (missing.length === 0) return null;
+  return {
+    level: 'cost',
+    title,
+    detail: `${symptoms} Missing: ${missing.join(', ')}.`,
+    fix: `Run \`stim doctor --fix\` to add them to ${local}, or add them by hand. See \`stim guide errors\`.`,
+  };
+}


### PR DESCRIPTION
## Summary

`stim doctor` now reports when the session's sandbox blocks Stim, and `stim doctor --fix` writes the allowance for the one harness that has a per-path allowance to write.

Closes #199.

## Changes

`doctor` gains a finding that fires when a write to `STIM_HOME` actually fails and a sandboxing harness is present. The probe matters: `CLAUDECODE` is exported by every Claude Code session, including ones with the bash sandbox off, so detecting the harness alone would flag sessions that have no problem.

`doctor --fix` merges three keys into `.claude/settings.local.json`, the per-user, gitignored file:

    sandbox.filesystem.allowWrite     ["~/.stim"]
    sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]
    sandbox.network.allowLocalBinding true

It refuses under Codex. Codex has one setting, `sandbox_mode`, with no per-path allowance; the only value that clears Stim is `danger-full-access`, which turns the sandbox off wholesale. Turning someone's sandbox off is not a tool's decision, so Codex gets the explanation and no write.

The write is careful about a file it did not author:

- It refuses anything it cannot read back as a JSON object, and writes nothing. Claude Code accepts comments in settings files; `JSON.parse` does not. Replacing such a file would silently drop every key in it.
- It refuses a `sandbox` value that is not an object rather than spreading it.
- It writes to a temp file and renames, so a file is never left half-written.
- Everything it did not come for is preserved, and a second run is a no-op.

Status goes to stderr, so `--json --fix` still prints exactly one parseable payload on stdout. The finding and the fix share one search-path list, so an allowance already present in user-level settings is not duplicated into the project.

## How did I test?

24 unit tests over the module and the command layer, covering the merge, the refusals, harness detection, the probe, path spellings (`~/.stim`, `$HOME/.stim`, an absolute path, a trailing `/**`, a covering parent), and `--fix` for each harness. Mutation-checked the refusal guard: removing it fails two tests.

End to end with the built CLI. A settings file with comments came back byte-identical after a refusal that exited 1. A valid file with `permissions`, `sandbox.enabled` and `denyWrite` kept all three and gained the allowance. A second `--fix` reported nothing to apply. A Claude Code session with a writable `STIM_HOME` produced no finding; one with a permission-denied `STIM_HOME` produced the finding and the fix line.

Full gate green: 2921 tests, `format:check`, `lint`, `typecheck`, `knip`.

## Risks and impact

This writes a file another tool owns, which is the whole risk surface. The mitigation is that it only ever adds keys to a file it could parse, refuses otherwise, and targets the per-user file rather than the committed one.

Claude Code reads project settings from the directory a session starts in. In a monorepo whose Stim project is a subdirectory, `--fix` writes to the git root, which a session rooted deeper will not read. The command prints the absolute path it wrote, and the guide says the file has to sit at the session's root. A file written inside a worktree goes when the worktree does.

## Rollback plan

Revert the PR. The keys it writes are inert to Stim itself; a user who wants them gone deletes the `sandbox` block from `.claude/settings.local.json`.