### PR TITLE
fix: roll back a stranded branch and refuse --base on an existing one

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -404,7 +404,21 @@ test('the errors topic documents every code worktree create can emit, and the ru
   expect(section).toMatch(/INCLUDING the case where the branch happens to sit on the requested base/i);
   expect(section).toMatch(/Stim deletes the branch it just made/i);
   expect(section).toMatch(/only a branch that create made/i);
+  expect(section).toMatch(/decides that from whether THIS run passed -b/);
+  expect(section).toMatch(/a branch named \.\.\. already exists.{0,80}did not make it/i);
+  expect(section).toMatch(/base sha captured before the add/i);
   expect(src).not.toMatch(/--base does not apply/);
+
+  const settings = renderTopic('settings');
+  assert(settings);
+  const website = readFileSync(new URL('../../../../website/docs/settings.md', import.meta.url), 'utf-8');
+  for (const guidance of [settings, website]) {
+    const flat = guidance.replace(/\s+/g, ' ');
+    const entry = flat.slice(flat.lastIndexOf('worktree.baseRef'));
+    expect(entry).toMatch(/only the .{0,2}--base.{0,2} (FLAG|flag) triggers/i);
+    expect(entry).toMatch(/STIM_WORKTREE_BRANCH_EXISTS/);
+    expect(entry).toMatch(/still attaches/i);
+  }
 });
 
 test('the errors topic documents every code the engine can emit under a command', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -391,6 +391,22 @@ test('the errors topic documents every code the build commands and the iOS signi
   }
 });
 
+test('the errors topic documents every code worktree create can emit, and the rules behind it', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  const src = readFileSync(new URL('../commands/worktree.ts', import.meta.url), 'utf-8');
+  const codes = new Set([...src.matchAll(/STIM_[A-Z_]+/g)].map((m) => m[0]));
+  expect(codes.has('STIM_WORKTREE_BRANCH_EXISTS')).toBeTruthy();
+  for (const code of codes) expect(body.includes(code)).toBeTruthy();
+
+  const section = body.slice(body.indexOf('STIM_WORKTREE_BRANCH_EXISTS')).replace(/\s+/g, ' ');
+  expect(section).toMatch(/refuses whenever it is passed and the branch already exists/i);
+  expect(section).toMatch(/INCLUDING the case where the branch happens to sit on the requested base/i);
+  expect(section).toMatch(/Stim deletes the branch it just made/i);
+  expect(section).toMatch(/only a branch that create made/i);
+  expect(src).not.toMatch(/--base does not apply/);
+});
+
 test('the errors topic documents every code the engine can emit under a command', () => {
   const body = renderTopic('errors');
   assert(body);

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -1,5 +1,15 @@
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync, rmSync, symlinkSync } from 'fs';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { Command } from 'commander';
@@ -505,7 +515,7 @@ test('create action: refuses when a leftover branch would void an explicit --bas
   }
 });
 
-test('create action: a leftover branch already AT the base is attached to, not refused', async () => {
+test('create action: a leftover branch already AT the base is refused too, since --base would guarantee nothing', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-samesha-')));
   const repo = join(base, 'repo');
@@ -516,9 +526,14 @@ test('create action: a leftover branch already AT the base is attached to, not r
 
     const { logs, errs } = await runCreateInRepo(repo, 'feat-same', { base: headSha });
 
-    expect(logs).toEqual([join(defaultWorktreeDir(repo), 'feat-same')]);
-    expect(process.exitCode).not.toBe(1);
-    expect(errs.some((e) => /Attached to the existing branch worktree-feat-same/.test(String(e)))).toBeTruthy();
+    expect(logs).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(defaultWorktreeDir(repo), 'feat-same'))).toBe(false);
+    const text = errs.join('\n');
+    expect(text).toContain('STIM_WORKTREE_BRANCH_EXISTS');
+    expect(text).toMatch(/coincidence, not the guarantee/);
+    expect(text).toMatch(/branch -D worktree-feat-same/);
+    expect(text).not.toMatch(/Attached to the existing branch/);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
@@ -542,6 +557,55 @@ test('create action: with no --base a leftover branch is still attached to', asy
     expect(process.exitCode).not.toBe(1);
   } finally {
     process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a failed git worktree add rolls back the branch it just created', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-')));
+  const repo = join(base, 'repo');
+  const unwritable = join(base, 'unwritable');
+  try {
+    const git = initScratchRepo(repo);
+    mkdirSync(unwritable);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: unwritable }));
+    chmodSync(unwritable, 0o500);
+
+    const { logs, errs } = await runCreateInRepo(repo, 'feat-roll', { install: false });
+
+    expect(logs).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    expect(git('git branch --list worktree-feat-roll').trim()).toBe('');
+    expect(errs.join('\n')).toMatch(/Deleted worktree-feat-roll/);
+  } finally {
+    process.exitCode = 0;
+    chmodSync(unwritable, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a failed git worktree add keeps a branch it did not create', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-keep-')));
+  const repo = join(base, 'repo');
+  const unwritable = join(base, 'unwritable');
+  try {
+    const git = initScratchRepo(repo);
+    git('git branch worktree-feat-keep');
+    mkdirSync(unwritable);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: unwritable }));
+    chmodSync(unwritable, 0o500);
+
+    const { logs, errs } = await runCreateInRepo(repo, 'feat-keep', { install: false });
+
+    expect(logs).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    expect(git('git branch --list worktree-feat-keep')).toMatch(/worktree-feat-keep/);
+    expect(errs.join('\n')).not.toMatch(/Deleted worktree-feat-keep/);
+  } finally {
+    process.exitCode = 0;
+    chmodSync(unwritable, 0o700);
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -21,7 +21,7 @@ import {
   warmCarryCategories,
   warmCarrySummary,
 } from '../commands/worktree.ts';
-import { resetExecutor } from '../exec.ts';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import { defaultWorktreeDir } from '../worktree.ts';
 import { findEnclosingWorktreeRoot, getProject, upsertProject } from '../config.ts';
 
@@ -561,7 +561,15 @@ test('create action: with no --base a leftover branch is still attached to', asy
   }
 });
 
-test('create action: a failed git worktree add rolls back the branch it just created', async () => {
+const UNWRITABLE_SKIP =
+  'runs as root, where a 0o500 directory does not block writes, so the git failure cannot be staged';
+
+function skipAsRoot(ctx: { skip: (note?: string) => void }): void {
+  if (process.getuid?.() === 0) ctx.skip(UNWRITABLE_SKIP);
+}
+
+test('create action: a failed git worktree add rolls back the branch it just created', async (ctx) => {
+  skipAsRoot(ctx);
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-')));
   const repo = join(base, 'repo');
@@ -585,7 +593,8 @@ test('create action: a failed git worktree add rolls back the branch it just cre
   }
 });
 
-test('create action: a failed git worktree add keeps a branch it did not create', async () => {
+test('create action: a failed git worktree add keeps a branch it did not create', async (ctx) => {
+  skipAsRoot(ctx);
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-keep-')));
   const repo = join(base, 'repo');
@@ -606,6 +615,152 @@ test('create action: a failed git worktree add keeps a branch it did not create'
   } finally {
     process.exitCode = 0;
     chmodSync(unwritable, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a branch that appears between the pre-check and the add is never rolled back', async (ctx) => {
+  skipAsRoot(ctx);
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-race-')));
+  const repo = join(base, 'repo');
+  const unwritable = join(base, 'unwritable');
+  try {
+    const git = initScratchRepo(repo);
+    mkdirSync(unwritable);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: unwritable }));
+    chmodSync(unwritable, 0o500);
+
+    const real = getExecutor();
+    let verified = 0;
+    setExecutor({
+      run: (cmd: string, opts: unknown) => real.run(cmd, opts as never),
+      runFile: (file: string, args: string[], opts: unknown) => real.runFile(file, args, opts as never),
+      spawn: (cmd: string, args: string[], opts: unknown) => real.spawn(cmd, args, opts as never),
+      runQuiet: (cmd: string, opts: unknown) => {
+        const out = real.runQuiet(cmd, opts as never);
+        if (cmd.includes('refs/heads/worktree-feat-race') && ++verified === 1) {
+          git('git branch worktree-feat-race');
+        }
+        return out;
+      },
+    });
+
+    const { logs, errs } = await runCreateInRepo(repo, 'feat-race', { install: false });
+
+    expect(logs).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    expect(git('git branch --list worktree-feat-race')).toMatch(/worktree-feat-race/);
+    const text = errs.join('\n');
+    expect(text).not.toMatch(/Deleted worktree-feat-race/);
+    expect(text).toMatch(/Kept the branch worktree-feat-race[\s\S]*already existed/);
+  } finally {
+    process.exitCode = 0;
+    resetExecutor();
+    chmodSync(unwritable, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: the rollback reads refs/heads, so a same-named tag does not shield the branch', async (ctx) => {
+  skipAsRoot(ctx);
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-tag-')));
+  const repo = join(base, 'repo');
+  const unwritable = join(base, 'unwritable');
+  try {
+    const git = initScratchRepo(repo);
+    const firstSha = git('git rev-parse HEAD').trim();
+    writeFileSync(join(repo, 'NEW'), 'new');
+    git('git add NEW');
+    git('git commit -q -m second');
+    git(`git tag worktree-feat-tag ${firstSha}`);
+    mkdirSync(unwritable);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: unwritable }));
+    chmodSync(unwritable, 0o500);
+
+    const { errs } = await runCreateInRepo(repo, 'feat-tag', { install: false });
+
+    expect(process.exitCode).toBe(1);
+    expect(git('git branch --list worktree-feat-tag').trim()).toBe('');
+    expect(git('git tag --list worktree-feat-tag').trim()).toBe('worktree-feat-tag');
+    expect(errs.join('\n')).toMatch(/Deleted worktree-feat-tag/);
+  } finally {
+    process.exitCode = 0;
+    chmodSync(unwritable, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: the rollback compares against the base captured before the add, not a moved one', async (ctx) => {
+  skipAsRoot(ctx);
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-rollback-moved-')));
+  const repo = join(base, 'repo');
+  const unwritable = join(base, 'unwritable');
+  try {
+    const git = initScratchRepo(repo);
+    mkdirSync(unwritable);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: unwritable }));
+    chmodSync(unwritable, 0o500);
+
+    const real = getExecutor();
+    setExecutor({
+      run: (cmd: string, opts: unknown) => real.run(cmd, opts as never),
+      runQuiet: (cmd: string, opts: unknown) => real.runQuiet(cmd, opts as never),
+      spawn: (cmd: string, args: string[], opts: unknown) => real.spawn(cmd, args, opts as never),
+      runFile: (file: string, args: string[], opts: unknown) => {
+        if (file === 'git' && args[0] === 'worktree' && args[1] === 'add') {
+          try {
+            return real.runFile(file, args, opts as never);
+          } catch (error) {
+            writeFileSync(join(repo, 'MOVED'), 'moved');
+            git('git add MOVED');
+            git('git commit -q -m moved');
+            throw error;
+          }
+        }
+        return real.runFile(file, args, opts as never);
+      },
+    });
+
+    const { errs } = await runCreateInRepo(repo, 'feat-moved', { install: false });
+
+    expect(process.exitCode).toBe(1);
+    expect(git('git branch --list worktree-feat-moved').trim()).toBe('');
+    expect(errs.join('\n')).toMatch(/Deleted worktree-feat-moved/);
+  } finally {
+    process.exitCode = 0;
+    resetExecutor();
+    chmodSync(unwritable, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: a same-named tag does not stand in for the branch in the --base refusal', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-tag-refusal-')));
+  const repo = join(base, 'repo');
+  try {
+    const git = initScratchRepo(repo);
+    const firstSha = git('git rev-parse --short HEAD').trim();
+    writeFileSync(join(repo, 'NEW'), 'new');
+    git('git add NEW');
+    git('git commit -q -m second');
+    const headSha = git('git rev-parse --short HEAD').trim();
+    git(`git tag worktree-feat-tagbase ${firstSha}`);
+    git('git branch worktree-feat-tagbase');
+
+    const { errs } = await runCreateInRepo(repo, 'feat-tagbase', { base: 'head' });
+
+    expect(process.exitCode).toBe(1);
+    const text = errs.join('\n');
+    expect(text).toContain('STIM_WORKTREE_BRANCH_EXISTS');
+    expect(text).toContain(`already exists at ${headSha}`);
+    expect(text).not.toContain(firstSha);
+    expect(text).toMatch(/which is where --base head resolves right now/);
+  } finally {
+    process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -542,7 +542,7 @@ test('addWorktree runs git via runFile (no shell) with a `--` terminator, path a
       spawn: () => {},
     });
 
-    const result = addWorktree({ path, branch: 'feat-x', baseRef: 'origin/main', cwd: tmp });
+    const result = addWorktree({ path, branch: 'feat-x', baseRef: 'origin/main', createBranch: true });
 
     expect(result).toBe(path);
     expect(calls).toEqual([['git', ['worktree', 'add', '-b', 'feat-x', '--', path, 'origin/main']]]);
@@ -552,7 +552,7 @@ test('addWorktree runs git via runFile (no shell) with a `--` terminator, path a
   }
 });
 
-test('addWorktree attaches to an existing branch instead of erroring on -b', () => {
+test('addWorktree runs the form the caller chose and never re-decides for itself', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'stim-test-add-reuse-'));
   try {
     const path = join(tmp, 'repo2');
@@ -565,11 +565,13 @@ test('addWorktree attaches to an existing branch instead of erroring on -b', () 
         calls.push([file, args]);
         return '';
       },
-      runQuiet: (cmd) => (/rev-parse --verify --quiet/.test(cmd) ? 'deadbeef' : ''),
+      runQuiet: (cmd) => {
+        throw new Error(`addWorktree must not re-resolve anything: ${cmd}`);
+      },
       spawn: () => {},
     });
 
-    const result = addWorktree({ path, branch: 'worktree-fix-login', baseRef: 'origin/main', cwd: tmp });
+    const result = addWorktree({ path, branch: 'worktree-fix-login', baseRef: 'origin/main', createBranch: false });
 
     expect(result).toBe(path);
     expect(calls).toEqual([['git', ['worktree', 'add', '--', path, 'worktree-fix-login']]]);
@@ -578,7 +580,7 @@ test('addWorktree attaches to an existing branch instead of erroring on -b', () 
   }
 });
 
-test('addWorktree uses -b for a genuinely new branch name', () => {
+test('addWorktree uses -b when the caller says the branch is new, whatever the refs say now', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'stim-test-add-fresh-'));
   try {
     const path = join(tmp, 'repo3');
@@ -591,11 +593,11 @@ test('addWorktree uses -b for a genuinely new branch name', () => {
         calls.push([file, args]);
         return '';
       },
-      runQuiet: () => null,
+      runQuiet: () => 'deadbeef',
       spawn: () => {},
     });
 
-    addWorktree({ path, branch: 'worktree-new-thing', baseRef: 'origin/main', cwd: tmp });
+    addWorktree({ path, branch: 'worktree-new-thing', baseRef: 'origin/main', createBranch: true });
 
     expect(calls).toEqual([['git', ['worktree', 'add', '-b', 'worktree-new-thing', '--', path, 'origin/main']]]);
   } finally {
@@ -1005,13 +1007,13 @@ test('C1: addWorktree never lets a $(...) baseRef reach a shell, and still creat
         path: join(base, 'wt-evil'),
         branch: 'worktree-evil',
         baseRef: '$(touch PWNED2)',
-        cwd: root,
+        createBranch: true,
       }),
     ).toThrow(/invalid reference/);
     expect(existsSync(join(root, 'PWNED2'))).toBe(false);
 
     const wt = join(base, 'wt-good');
-    addWorktree({ path: wt, branch: 'worktree-good', baseRef: 'HEAD', cwd: root });
+    addWorktree({ path: wt, branch: 'worktree-good', baseRef: 'HEAD', createBranch: true });
     expect(existsSync(join(wt, '.git'))).toBe(true);
     expect(git('git worktree list --porcelain')).toMatch(/worktree-good/);
   } finally {
@@ -1033,7 +1035,7 @@ test('C1: addWorktree rejects a leading-dash baseRef with a clear error (defense
     spawn: () => {},
   });
   expect(() =>
-    addWorktree({ path, branch: 'worktree-x', baseRef: '--upload-pack=touch EVIL', cwd: dirname(path) }),
+    addWorktree({ path, branch: 'worktree-x', baseRef: '--upload-pack=touch EVIL', createBranch: true }),
   ).toThrow(/Refusing base ref/);
 });
 
@@ -1048,11 +1050,11 @@ test('C1: addWorktree rejects a worktree path with a leading dash or shell metac
     runQuiet: () => null,
     spawn: () => {},
   });
-  expect(() => addWorktree({ path: '-evil/repo', branch: 'worktree-x', baseRef: 'HEAD', cwd: '/tmp' })).toThrow(
+  expect(() => addWorktree({ path: '-evil/repo', branch: 'worktree-x', baseRef: 'HEAD', createBranch: true })).toThrow(
     /a path beginning with "-"/,
   );
   expect(() =>
-    addWorktree({ path: '/tmp/a$(touch X)/repo', branch: 'worktree-x', baseRef: 'HEAD', cwd: '/tmp' }),
+    addWorktree({ path: '/tmp/a$(touch X)/repo', branch: 'worktree-x', baseRef: 'HEAD', createBranch: true }),
   ).toThrow(/shell metacharacters/);
 });
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1004,9 +1004,13 @@ STIM_WORKTREE_BRANCH_EXISTS  (worktree create)
   A leftover branch is no longer the usual cause. When \`git worktree add -b\`
   fails AFTER git created the branch (a locked .git/config, a read-only
   parent), Stim deletes the branch it just made, so the retry branches from
-  --base instead of attaching. It rolls back only a branch that create made:
-  one that already existed, moved off the base, or is checked out somewhere is
-  KEPT, and the note names \`git branch -D\` for it.
+  --base instead of attaching. It rolls back only a branch that create made,
+  and it decides that from whether THIS run passed -b, not from re-reading the
+  refs afterwards. So a branch that appears between the check and the add is
+  KEPT: git answers "a branch named ... already exists", and that answer is
+  proof this create did not make it. A branch that no longer matches the base
+  sha captured before the add, or that is checked out anywhere, is KEPT too.
+  Every keep names \`git branch -D\`.
 
 "failed to scan dependencies for source ..." on pods you did not touch  (ios)
   The compilation cache holds a damaged object. Xcode reports it per source
@@ -1948,7 +1952,11 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         overrides it for one run and resolves against the
                         current directory instead.
   worktree.baseRef      "head" (current HEAD) or "fresh" (origin/HEAD).
-                        Unset means "head".
+                        Unset means "head". It is a default, not an assertion:
+                        only the --base FLAG triggers the
+                        STIM_WORKTREE_BRANCH_EXISTS refusal, so a create that
+                        finds an existing worktree-<name> still attaches to it
+                        and says which ref was not applied.
   worktree.include      carry-over patterns, same role as .worktreeinclude
   worktree.exclude      additional --carry-ignored skip list, same role as
                         .worktreeexclude. Registered nested Git worktrees are

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -988,13 +988,25 @@ not on any remote"  (worktree remove)
   Runtime state is outside the project tree, so Stim's own files never cause
   Other dirty paths still refuse as described above.
 
-"Refusing to create <name>: the branch worktree-<name> already exists at <sha>,
-but --base <ref> resolves to <sha>"  (worktree create)
+STIM_WORKTREE_BRANCH_EXISTS  (worktree create)
+  "Refusing to create <name>: the branch worktree-<name> already exists at
+  <sha>, but --base <ref> resolves to <sha>" -- or, when the two agree,
+  "which is where --base <ref> resolves right now".
   \`git worktree add\` attaches to an existing branch and ignores the base, so
-  the worktree would not be based on what you asked for. Stim keeps branches
-  it did not create and branches with unique commits. Either pick another
-  name, or \`git branch -D worktree-<name>\` and retry. Without --base,
-  attaching is still the behaviour: nothing was promised about the tip.
+  the worktree would not be based on what you asked for. --base IS THE
+  REFUSAL'S TRIGGER: it is a correctness flag, so Stim refuses whenever it is
+  passed and the branch already exists, INCLUDING the case where the branch
+  happens to sit on the requested base -- that agreement is luck, not the
+  guarantee asked for. Stim keeps branches it did not create and branches with
+  unique commits. Either pick another name, or \`git branch -D
+  worktree-<name>\` and retry. Without --base, attaching is still the
+  behaviour: nothing was promised about the tip.
+  A leftover branch is no longer the usual cause. When \`git worktree add -b\`
+  fails AFTER git created the branch (a locked .git/config, a read-only
+  parent), Stim deletes the branch it just made, so the retry branches from
+  --base instead of attaching. It rolls back only a branch that create made:
+  one that already existed, moved off the base, or is checked out somewhere is
+  KEPT, and the note names \`git branch -D\` for it.
 
 "failed to scan dependencies for source ..." on pods you did not touch  (ios)
   The compilation cache holds a damaged object. Xcode reports it per source

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -129,15 +129,37 @@ function dependencyInstallCommands(target: string): string[] {
 
 const BRANCH_EXISTS_CODE = 'STIM_WORKTREE_BRANCH_EXISTS';
 
-function rollBackCreatedBranch({ root, branch, baseRef }: { root: string; branch: string; baseRef: string }): void {
-  const stranded = resolveFullRef(root, branch);
-  if (!stranded) return;
+const GIT_BRANCH_ALREADY_EXISTS = /a branch named .* already exists/i;
+
+function gitFailureText(error: unknown): string {
+  return `${(error as Error)?.message || String(error)}\n${String((error as { stderr?: unknown })?.stderr ?? '')}`;
+}
+
+function rollBackCreatedBranch({
+  root,
+  branch,
+  baseRef,
+  baseSha,
+  error,
+}: {
+  root: string;
+  branch: string;
+  baseRef: string;
+  baseSha: string | null;
+  error: unknown;
+}): void {
   const keep = (reason: string) => {
     console.error(chalk.yellow(`Kept the branch ${branch}: ${reason}`));
     console.error(chalk.dim(`  Delete it before retrying: git -C ${root} branch -D -- ${branch}`));
   };
-  if (stranded !== resolveFullRef(root, baseRef)) {
-    keep(`it points at ${stranded}, not at ${baseRef}, so Stim cannot prove this create made it`);
+  if (GIT_BRANCH_ALREADY_EXISTS.test(gitFailureText(error))) {
+    keep('git refused to create it because it already existed, so this create did not make it');
+    return;
+  }
+  const stranded = resolveFullRef(root, `refs/heads/${branch}`);
+  if (!stranded) return;
+  if (!baseSha || stranded !== baseSha) {
+    keep(`it points at ${stranded}, not at the ${baseRef} this create asked for, so Stim cannot prove it made it`);
     return;
   }
   const checkedOutAt = listWorktrees(root).find((candidate) => candidate.branch === branch)?.path;
@@ -148,8 +170,8 @@ function rollBackCreatedBranch({ root, branch, baseRef }: { root: string; branch
   try {
     deleteBranch(root, branch, stranded);
     console.error(chalk.dim(`Deleted ${branch}, which git created before the failure, so a retry starts clean.`));
-  } catch (error) {
-    keep(String((error as Error)?.message || error));
+  } catch (deleteError) {
+    keep(String((deleteError as Error)?.message || deleteError));
   }
 }
 
@@ -223,7 +245,7 @@ export function registerCreate(worktree: Command): void {
 
       const branch = `worktree-${name}`;
       const reusedBranch = branchExists(root, branch);
-      const branchSha = reusedBranch ? resolveRef(root, branch) : null;
+      const branchSha = reusedBranch ? resolveRef(root, `refs/heads/${branch}`) : null;
 
       if (opts.base && reusedBranch) {
         const diverged = branchSha !== baseSha;
@@ -254,11 +276,13 @@ export function registerCreate(worktree: Command): void {
         return;
       }
 
+      const createBranch = !reusedBranch;
+      const baseFullSha = createBranch ? resolveFullRef(root, baseRef) : null;
       try {
-        addWorktree({ path: target, branch, baseRef, cwd: root });
+        addWorktree({ path: target, branch, baseRef, createBranch });
       } catch (e) {
         console.error(String((e as Error)?.message || e));
-        if (!reusedBranch) rollBackCreatedBranch({ root, branch, baseRef });
+        if (createBranch) rollBackCreatedBranch({ root, branch, baseRef, baseSha: baseFullSha, error: e });
         process.exitCode = 1;
         return;
       }

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -127,6 +127,32 @@ function dependencyInstallCommands(target: string): string[] {
   return [...dirs].map((dir) => dependencyInstallCommand(target, dir));
 }
 
+const BRANCH_EXISTS_CODE = 'STIM_WORKTREE_BRANCH_EXISTS';
+
+function rollBackCreatedBranch({ root, branch, baseRef }: { root: string; branch: string; baseRef: string }): void {
+  const stranded = resolveFullRef(root, branch);
+  if (!stranded) return;
+  const keep = (reason: string) => {
+    console.error(chalk.yellow(`Kept the branch ${branch}: ${reason}`));
+    console.error(chalk.dim(`  Delete it before retrying: git -C ${root} branch -D -- ${branch}`));
+  };
+  if (stranded !== resolveFullRef(root, baseRef)) {
+    keep(`it points at ${stranded}, not at ${baseRef}, so Stim cannot prove this create made it`);
+    return;
+  }
+  const checkedOutAt = listWorktrees(root).find((candidate) => candidate.branch === branch)?.path;
+  if (checkedOutAt) {
+    keep(`it is checked out at ${checkedOutAt}`);
+    return;
+  }
+  try {
+    deleteBranch(root, branch, stranded);
+    console.error(chalk.dim(`Deleted ${branch}, which git created before the failure, so a retry starts clean.`));
+  } catch (error) {
+    keep(String((error as Error)?.message || error));
+  }
+}
+
 export function registerCreate(worktree: Command): void {
   worktree
     .command('create <name>')
@@ -199,15 +225,21 @@ export function registerCreate(worktree: Command): void {
       const reusedBranch = branchExists(root, branch);
       const branchSha = reusedBranch ? resolveRef(root, branch) : null;
 
-      if (opts.base && reusedBranch && branchSha !== baseSha) {
+      if (opts.base && reusedBranch) {
+        const diverged = branchSha !== baseSha;
         console.error(
           chalk.red(
-            `Refusing to create ${name}: the branch ${branch} already exists at ${branchSha || 'an unresolvable commit'}, but --base ${base} resolves to ${baseSha}.`,
+            `${BRANCH_EXISTS_CODE}: Refusing to create ${name}: the branch ${branch} already exists at ${branchSha || 'an unresolvable commit'}, ` +
+              (diverged
+                ? `but --base ${base} resolves to ${baseSha}.`
+                : `which is where --base ${base} resolves right now.`),
           ),
         );
         console.error(
           chalk.dim(
-            '  `git worktree add` attaches to an existing branch and ignores the base, so this worktree would NOT be based on what you asked for.',
+            diverged
+              ? '  `git worktree add` attaches to an existing branch and ignores the base, so this worktree would NOT be based on what you asked for.'
+              : '  `git worktree add` attaches to an existing branch and ignores the base, so the two agreeing here is a coincidence, not the guarantee --base exists to give.',
           ),
         );
         console.error(chalk.dim('  Either create it under a different name:'));
@@ -226,6 +258,7 @@ export function registerCreate(worktree: Command): void {
         addWorktree({ path: target, branch, baseRef, cwd: root });
       } catch (e) {
         console.error(String((e as Error)?.message || e));
+        if (!reusedBranch) rollBackCreatedBranch({ root, branch, baseRef });
         process.exitCode = 1;
         return;
       }
@@ -233,7 +266,7 @@ export function registerCreate(worktree: Command): void {
       console.error(
         chalk.dim(
           reusedBranch
-            ? `Attached to the existing branch ${branch}${branchSha ? ` (${branchSha})` : ''}; --base does not apply.`
+            ? `Attached to the existing branch ${branch}${branchSha ? ` (${branchSha})` : ''}; its tip is the base, and ${baseRef} was not applied.`
             : `Branched ${branch} from ${baseRef} (${baseSha}).`,
         ),
       );

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -496,21 +496,21 @@ export function addWorktree({
   path,
   branch,
   baseRef,
-  cwd,
+  createBranch,
 }: {
   path: string;
   branch: string;
   baseRef: string;
-  cwd: string;
+  createBranch: boolean;
 }): string {
   assertSafeWorktreePath(path);
   mkdirSync(dirname(path), { recursive: true });
-  if (branchExists(cwd || dirname(path), branch)) {
+  if (!createBranch) {
     getExecutor().runFile('git', ['worktree', 'add', '--', path, branch]);
-  } else {
-    assertSafeBaseRef(baseRef);
-    getExecutor().runFile('git', ['worktree', 'add', '-b', branch, '--', path, baseRef]);
+    return path;
   }
+  assertSafeBaseRef(baseRef);
+  getExecutor().runFile('git', ['worktree', 'add', '-b', branch, '--', path, baseRef]);
   return path;
 }
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -56,6 +56,11 @@ A relative `worktreeDir` resolves against the settings root, the repository
 root, so a committed `.stim.json` can place worktrees inside the repository.
 A relative `worktree create --dir` resolves against the current directory.
 
+`worktree.baseRef` is a default, not an assertion: only the `--base` flag
+triggers the `STIM_WORKTREE_BRANCH_EXISTS` refusal, so a create that finds an
+existing `worktree-<name>` still attaches to it and says which ref was not
+applied.
+
 Do not put secrets in a committed `.stim.json`. Keep secrets in ignored files
 and carry those files into a worktree.
 

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -16,6 +16,18 @@ cd ../<repo>-worktrees/feature-x
 The default base is the current checkout's `HEAD`. Use `--base fresh` for
 `origin/HEAD`, or pass any branch, tag, or commit that git resolves.
 
+`git worktree add` attaches to a branch named `worktree-<name>` when one
+already exists, and ignores the base. So `--base` with an existing branch is
+refused as `STIM_WORKTREE_BRANCH_EXISTS`, even when that branch currently sits
+on the requested base: the agreement is luck, not the guarantee the flag is
+for. Pick another name, or delete the branch and retry. Without `--base`,
+attaching is still the behaviour, and the create says which branch it attached
+to.
+
+When `git worktree add` fails after git has created the branch, Stim deletes
+that branch, so a retry branches from the base instead of attaching to a
+leftover. It rolls back only a branch this create made.
+
 ## Carry a warm working state
 
 ```bash

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -26,7 +26,8 @@ to.
 
 When `git worktree add` fails after git has created the branch, Stim deletes
 that branch, so a retry branches from the base instead of attaching to a
-leftover. It rolls back only a branch this create made.
+leftover. It rolls back only a branch this create made, judged by whether the
+run passed `-b` rather than by re-reading the refs afterwards.
 
 ## Carry a warm working state
 


### PR DESCRIPTION
## Description

`git worktree add -b <branch>` creates the branch before it creates the worktree
directory, so a failure in between (a locked `.git/config`, an unwritable parent)
leaves the branch behind while `worktree create` reports failure. The next create
under the same name then found an existing branch and took the attach path, which
ignores the base and said so as a note: "Attached to the existing branch
worktree-X; --base does not apply."

That note is the wrong strength for `--base`. The flag exists to guarantee what the
work starts from. The agents in #191 got the right base only because the stranded
branch happened to point at the fetched tip; a branch that had fallen behind --
exactly the case `--base origin/develop` is written for -- would have produced work
built on the wrong commit, reported as fine.

Suggestion 3 in the issue (delete the Stim-created branch on remove) is already the
behavior and is already documented in `SKILL.md` and `guide lifecycle`. I verified
it rather than changing it, so this branch does not touch `worktree remove`.

## Solution

Two changes, both in `worktree create`.

**Roll the stranded branch back.** When `addWorktree` throws, delete the branch git
just created so a retry branches from `--base` instead of attaching.

The hard part is proving the branch is ours to delete, and the answer is not a
re-read of the refs. `addWorktree` used to re-run `branchExists` itself and silently
pick the attach form, so a branch appearing between the caller's pre-check and that
inner check meant the `-b` form never ran while the caller still believed it had
created the branch -- and the rollback then deleted someone else's branch. So
`addWorktree` no longer decides: the caller passes `createBranch`, `addWorktree` runs
exactly that form, and the rollback runs only when this process ran `-b`. Its `cwd`
parameter existed only for that inner check and is gone; `git worktree add` was
already relying on the process working directory.

Four guards then keep the branch instead of deleting it, each printing `git branch
-D`: git answering "a branch named ... already exists" (the remaining race window,
between our `-b` and git's own ref creation -- that answer is proof this create did
not make the branch); a tip that no longer matches the base sha **captured before the
add**, so a base that moves mid-flight cannot strand the branch; a ref checked out
anywhere; and any failure of the delete itself. The delete is the existing
`deleteBranch`, `update-ref -d <ref> <expected-sha>`, a compare-and-delete rather
than a blind `branch -D`, and both the rollback and the refusal now read
`refs/heads/<branch>` explicitly, because git resolves `refs/tags` first and a
same-named tag otherwise answers for the branch.

**Refuse `--base` against any existing branch.** The refusal used to fire only when
the branch and the base disagreed. It now fires whenever `--base` is passed and the
branch exists, including the agreeing case, whose second line says the agreement is a
coincidence rather than the guarantee `--base` is for. The refusal carries the code
`STIM_WORKTREE_BRANCH_EXISTS` and keeps its existing remedies (another name, or
`git branch -D` and retry) -- the issue called that refusal correct, so the wording
and structure are unchanged apart from the code and the second sentence.

Without `--base`, attaching is still the behavior; nothing was promised about the
tip. Its note no longer claims "--base does not apply" for a flag that was not
passed and now says which ref was not applied instead. The `worktree.baseRef`
setting is deliberately not a trigger -- this is about a flag typed to assert
correctness, not about a repo default -- and `guide settings` and
`website/docs/settings.md` now say so on that entry.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`
  all clean.
- `pnpm test`: 77 files, 2911 tests passed.
- `node --test test/e2e/worktree-warm.e2e.js`: 2 passed, 0 failed (the e2e file that
  covers `worktree create`).
- Unit tests, all driving real `git` against scratch repositories. Every one of the
  four below was confirmed to BITE: with only the source files reverted to the
  previous commit they fail with exactly the reported symptom (branch deleted /
  branch shielded / branch stranded / tag's sha quoted), and they pass on this
  commit.
  - a branch that appears between the pre-check and the add is never rolled back: a
    wrapped executor delegates to the real one and injects `git branch
    worktree-feat-race` after the first `rev-parse --verify` returns empty, so the
    `-b` form meets a branch it did not create; real git answers "a branch named
    'worktree-feat-race' already exists", and the branch survives with a "Kept the
    branch" note. Previously: "Deleted worktree-feat-race", branch gone;
  - a same-named tag does not shield the branch from the rollback (the tag survives,
    the branch is deleted). Previously the bare-name lookup returned the tag's sha
    and produced a false keep;
  - a base that moves between the add and the rollback (the wrapper commits after
    real git fails) does not strand the branch. Previously kept;
  - a same-named tag does not stand in for the branch in the `--base` refusal: the
    message quotes the branch's sha, not the tag's, and reads as the agreeing case.
- Unchanged-behaviour tests still pass: the plain rollback, keeping a branch that
  existed before the create, the diverging-branch refusal, the leftover-branch-at-
  the-base refusal (inverted in the first commit), and the no-`--base` attach path.
- `addWorktree`'s own tests now pin the new contract: it runs the form the caller
  chose and its `runQuiet` stub throws, so any re-resolution inside it fails the test.
- The three tests that stage the git failure with a `0o500` directory skip with an
  explanatory reason under `process.getuid?.() === 0`, since root writes through it.
- Guide contract test: every `STIM_*` code in `commands/worktree.ts` appears in
  `guide errors`; the section states the "including the agreeing case" rule, that the
  rollback decides from whether this run passed `-b`, that "already exists" keeps the
  branch, and that the base sha is the one captured before the add; the phrase
  `--base does not apply` is gone from the source; and the `worktree.baseRef` entry
  in both `guide settings` and `website/docs/settings.md` says only the flag triggers
  the refusal.
- Invariant 9, real tool calls, against throwaway git repositories using the built
  `dist/cli.mjs`:
  - create into a `0o500` directory printed the real git failure, then "Deleted
    worktree-rollme, which git created before the failure", and `git branch --list
    'worktree-*'` was empty;
  - the same create with the branch already present kept it (attach form, no
    rollback attempted);
  - the same create with a same-named tag deleted the branch and left the tag
    (`branch: [] tag: [worktree-taggy]`);
  - `--base head` against a branch sitting on HEAD printed
    `STIM_WORKTREE_BRANCH_EXISTS ... which is where --base head resolves right now`
    and exited 1; `--base HEAD` against a branch two commits behind printed the
    original diverging refusal, now code-prefixed; the same create without `--base`
    attached and printed the worktree path;
  - suggestion 3 check: `worktree create looptest3` then `worktree remove` reported
    "deleted branch worktree-looptest3", confirming remove already deletes a
    Stim-created branch with no unique commits. No change was made for it.

Rebased onto `origin/main` at `0a0603f` (after #200 and #201) so CI runs on the real
merge base.

Deliberately out of scope: `worktree remove` (already correct), the
`worktree.baseRef` setting as a refusal trigger, and any cleanup of a stale
`.git/worktrees/<name>` administrative entry, which git reports clearly on retry.

Fixes #191
