### PR TITLE
fix: refuse a non-string worktreeDir setting instead of crashing

### DIFF
--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -29,6 +29,7 @@ import {
   resolveSettings,
   tunnelModeSetting,
   unknownSettingKeys,
+  worktreeDirSettingError,
 } from '../settings.ts';
 import { setProjectSetting, setRepoSetting, upsertProject } from '../config.ts';
 
@@ -545,6 +546,11 @@ test('ios.lanHost takes a bare address and refuses everything that would break s
   ]) {
     expect(iosLanHostSettingError({ ios: { lanHost: bad } })).toMatch(/Invalid ios\.lanHost/);
   }
+});
+
+test('worktreeDir refuses a non-string value and accepts a valid path', () => {
+  expect(worktreeDirSettingError({ worktreeDir: 5 })).toMatch(/Invalid worktreeDir setting/);
+  expect(worktreeDirSettingError({ worktreeDir: '.stim-worktrees' })).toBe(null);
 });
 
 test('the three iOS device settings are known keys', () => {

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -358,6 +358,24 @@ test('create action: --carry-ignored into a nested --dir does not copy the workt
   }
 });
 
+test('create action: a non-string worktreeDir setting refuses cleanly instead of throwing', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-invalid-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: 5 }));
+
+    const { logs, errs } = await runCreateInRepo(repo, 'feat-invalid', { install: false });
+
+    expect(logs).toEqual([]);
+    expect(errs.some((e) => /Invalid worktreeDir setting/.test(e))).toBeTruthy();
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: --dir takes precedence over the worktreeDir setting', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-setting-')));

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { resolveSettings, unknownSettingKeys } from '../settings.ts';
+import { resolveSettings, unknownSettingKeys, worktreeDirSettingError } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
 import { reclaimProject } from '../reclaim.ts';
@@ -167,6 +167,12 @@ export function registerCreate(worktree: Command): void {
       const settings = resolveSettings({ gitCommonDir: common, repoRoot: root }) as WorktreeSettings;
       for (const key of unknownSettingKeys(settings)) {
         console.error(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
+      }
+      const worktreeDirError = worktreeDirSettingError(settings);
+      if (worktreeDirError) {
+        console.error(chalk.red(worktreeDirError));
+        process.exitCode = 1;
+        return;
       }
 
       const base = opts.base || settings?.worktree?.baseRef || 'head';

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -388,6 +388,15 @@ export function iosLanHostSettingError(settings: unknown): string | null {
   return null;
 }
 
+export function worktreeDirSettingError(settings: unknown): string | null {
+  if (!isPlainObject(settings) || !('worktreeDir' in settings)) return null;
+  const raw = settings.worktreeDir;
+  if (typeof raw !== 'string') {
+    return `Invalid worktreeDir setting ${JSON.stringify(raw)}. Expected a string path.`;
+  }
+  return null;
+}
+
 export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {
   if (!isPlainObject(settings)) return [];
   const unknown: string[] = [];


### PR DESCRIPTION
## Description

A committed `.stim.json` with a non-string `worktreeDir`, e.g. `{ "worktreeDir": 5 }`, made `stim worktree create` crash with a raw Node `TypeError` from `path.resolve` instead of the `Invalid <key> setting` refusal the other path settings (`ios.simslimProfile`, `android.avdConfigFile`, etc.) produce. `worktreeDir` was read straight off the merged settings object and cast to `string` at the type level only, with no runtime check.

## Solution

Added `worktreeDirSettingError` in `settings.ts`, following the shape of the other simple path-setting validators (`iosLanHostSettingError`, `iosSigningIdentitySettingError`): it returns `null` when the key is absent or already a string, and an `Invalid worktreeDir setting <value>. Expected a string path.` message otherwise. `commands/worktree.ts` calls it right after resolving settings and before computing the target directory, printing the message in red and exiting 1 on failure -- the same pattern `registerCreate` already uses for its other refusals.

This only adds a type check; it does not touch the resolution rule from #193/#200 (a relative value resolves against the repo root, `--dir` resolves against the cwd), so a valid string, whether relative or absolute, behaves exactly as before.

## Test plan

- `packages/stim-cli/src/__tests__/settings.test.ts`: `worktreeDirSettingError({ worktreeDir: 5 })` matches `/Invalid worktreeDir setting/`; `worktreeDirSettingError({ worktreeDir: '.stim-worktrees' })` is `null`.
- `packages/stim-cli/src/__tests__/worktree-create.test.ts`: a `.stim.json` with `{ "worktreeDir": 5 }` makes `worktree create` print the `Invalid worktreeDir setting` refusal on stderr and write nothing to stdout, instead of throwing.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm test` all pass (2906 tests, 77 files).

Fixes #205