### PR TITLE
fix: stop flagging a known scalar setting as unknown when its value is an object

### DIFF
--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -313,6 +313,10 @@ test('unknownSettingKeys still reports a genuinely unknown nested key under ios'
   expect(unknownSettingKeys({ ios: { bogus: {} } })).toEqual(['ios.bogus']);
 });
 
+test('unknownSettingKeys still reports an object value for a known scalar with no validator (transitional, see #210)', () => {
+  expect(unknownSettingKeys({ ios: { configuration: {} } })).toEqual(['ios.configuration']);
+});
+
 test('unknownSettingKeys tolerates empty and malformed input', () => {
   expect(unknownSettingKeys({})).toEqual([]);
   expect(unknownSettingKeys(null)).toEqual([]);

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -301,6 +301,18 @@ test('unknownSettingKeys reports a nested unknown without flagging its parent', 
   expect(unknownSettingKeys({ ios: { deviceType: 'x', bogus: 1 } })).toEqual(['ios.bogus']);
 });
 
+test('unknownSettingKeys treats a known scalar key with an object value as known, leaving refusal to its validator', () => {
+  expect(unknownSettingKeys({ worktreeDir: {} })).toEqual([]);
+  expect(worktreeDirSettingError({ worktreeDir: {} })).toMatch(/Invalid worktreeDir setting/);
+
+  expect(unknownSettingKeys({ ios: { lanHost: {} } })).toEqual([]);
+  expect(iosLanHostSettingError({ ios: { lanHost: {} } })).toMatch(/Invalid ios\.lanHost setting/);
+});
+
+test('unknownSettingKeys still reports a genuinely unknown nested key under ios', () => {
+  expect(unknownSettingKeys({ ios: { bogus: {} } })).toEqual(['ios.bogus']);
+});
+
 test('unknownSettingKeys tolerates empty and malformed input', () => {
   expect(unknownSettingKeys({})).toEqual([]);
   expect(unknownSettingKeys(null)).toEqual([]);

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -317,6 +317,30 @@ test('unknownSettingKeys still reports an object value for a known scalar with n
   expect(unknownSettingKeys({ ios: { configuration: {} } })).toEqual(['ios.configuration']);
 });
 
+test('every validated scalar key is a known setting, as a string and as an object', () => {
+  const validated = [
+    'worktreeDir',
+    'ios.lanHost',
+    'ios.signingIdentity',
+    'ios.signingIdentitySha1',
+    'ios.remote',
+    'ios.simslimProfile',
+    'android.remote',
+    'android.dataPartitionSizeGb',
+    'android.avdConfigFile',
+    'cache.provider',
+  ];
+  const nested = (path: string, value: unknown): Record<string, unknown> =>
+    path
+      .split('.')
+      .reverse()
+      .reduce<Record<string, unknown>>((inner, key) => ({ [key]: inner }), value as Record<string, unknown>);
+  for (const path of validated) {
+    expect(unknownSettingKeys(nested(path, 'x'))).toEqual([]);
+    expect(unknownSettingKeys(nested(path, {}))).toEqual([]);
+  }
+});
+
 test('unknownSettingKeys tolerates empty and malformed input', () => {
   expect(unknownSettingKeys({})).toEqual([]);
   expect(unknownSettingKeys(null)).toEqual([]);

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -333,7 +333,7 @@ test('every validated scalar key is a known setting, as a string and as an objec
   const nested = (path: string, value: unknown): Record<string, unknown> =>
     path
       .split('.')
-      .reverse()
+      .toReversed()
       .reduce<Record<string, unknown>>((inner, key) => ({ [key]: inner }), value as Record<string, unknown>);
   for (const path of validated) {
     expect(unknownSettingKeys(nested(path, 'x'))).toEqual([]);

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -56,8 +56,8 @@ const KNOWN_SETTINGS = new Set([
 
 const OPEN_SETTINGS_OBJECTS = new Set(['android.avdConfig', 'cache.options']);
 
-// Transitional: every other known scalar setting accepts an object value
-// silently instead of being refused; see the follow-up in issue #210.
+// Keys outside this set have no validator on every command that reads them,
+// so an object value keeps the unknown-key warning; see issue #210.
 const VALIDATED_SCALAR_SETTINGS = new Set([
   'worktreeDir',
   'ios.lanHost',

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -404,6 +404,7 @@ export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {
     const path = prefix ? `${prefix}.${key}` : key;
     if (isPlainObject(value)) {
       if (OPEN_SETTINGS_OBJECTS.has(path)) continue;
+      if (KNOWN_SETTINGS.has(path)) continue;
       const hasKnownChildren = [...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`));
       if (hasKnownChildren) unknown.push(...unknownSettingKeys(value, path));
       else unknown.push(path);

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -56,6 +56,21 @@ const KNOWN_SETTINGS = new Set([
 
 const OPEN_SETTINGS_OBJECTS = new Set(['android.avdConfig', 'cache.options']);
 
+// Transitional: every other known scalar setting accepts an object value
+// silently instead of being refused; see the follow-up in issue #210.
+const VALIDATED_SCALAR_SETTINGS = new Set([
+  'worktreeDir',
+  'ios.lanHost',
+  'ios.signingIdentity',
+  'ios.signingIdentitySha1',
+  'ios.remote',
+  'ios.simslimProfile',
+  'android.remote',
+  'android.dataPartitionSizeGb',
+  'android.avdConfigFile',
+  'cache.provider',
+]);
+
 export const MIN_ANDROID_DATA_PARTITION_SIZE_GB: number = 6;
 export const DEFAULT_ANDROID_DATA_PARTITION_SIZE_GB: number = 8;
 export const MAX_ANDROID_DATA_PARTITION_SIZE_GB: number = 16 * 1024;
@@ -404,7 +419,7 @@ export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {
     const path = prefix ? `${prefix}.${key}` : key;
     if (isPlainObject(value)) {
       if (OPEN_SETTINGS_OBJECTS.has(path)) continue;
-      if (KNOWN_SETTINGS.has(path)) continue;
+      if (VALIDATED_SCALAR_SETTINGS.has(path)) continue;
       const hasKnownChildren = [...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`));
       if (hasKnownChildren) unknown.push(...unknownSettingKeys(value, path));
       else unknown.push(path);


### PR DESCRIPTION
## Description

A committed setting whose value is a plain object with no known children,
such as `{ "worktreeDir": {} }` or `{ "ios": { "lanHost": {} } }`, printed
two contradictory messages: first the yellow `Warning: setting "worktreeDir"
is not read by Stim and will be ignored.`, then the red
`Invalid worktreeDir setting {}. Expected a string path.` refusal from its
validator. The key is read; the warning was wrong.

`unknownSettingKeys` in `packages/stim-cli/src/settings.ts` recursed into an
object value without first checking whether the key itself was already a
known scalar setting, so it treated the key as unknown before its validator
got a chance to refuse it.

## Solution

The first version of this fix skipped every key in `KNOWN_SETTINGS`, but
review found that trades a visible (mis-worded) warning for silence: most
known scalars have no validator on the command path that reads them, so an
object value for e.g. `ios.configuration` or `caches` would now pass through
uncaught instead of being flagged either way.

`unknownSettingKeys` now skips an object-valued path only when it is in a
new `VALIDATED_SCALAR_SETTINGS` set -- keys whose validator refuses the
value on every command that reads them:
`worktreeDir`, `ios.lanHost`, `ios.signingIdentity`, `ios.signingIdentitySha1`,
`ios.remote`, `ios.simslimProfile`, `android.remote`,
`android.dataPartitionSizeGb`, `android.avdConfigFile`, `cache.provider`.

`metro.tunnel` and `metro.ngrokUrl` are known and have a validator
(`metroTunnelSettingError`), but it only runs in `start` -- `ios.ts` and
`android.ts` don't call it -- so they stay out of the set too.

The other 14 known scalars keep the old (mis-worded but at least visible)
"not read by Stim" warning for an object value until they each get a
validator: `ios.configuration`, `ios.deviceType`, `ios.runtime`,
`android.variant`, `android.systemImage`, `android.keystore`,
`android.keystorePassword`, `metro.publicUrl`, `worktree.baseRef`,
`worktree.include`, `worktree.exclude`, `caches`, `metro.tunnel`, and
`metro.ngrokUrl`. Tracked in #210, which also covers `stim android` never
calling `unknownSettingKeys` at all.

Known parent objects such as `ios`, `android`, `cache`, and `worktree` are
unaffected either way: their own path (e.g. `"ios"`) is never itself a
`VALIDATED_SCALAR_SETTINGS` or `KNOWN_SETTINGS` entry, so the function still
recurses into them and reports genuinely unknown children.

No validator changed.

## Test plan

- Reproduced the bug first with a scratch unit test: before the fix,
  `unknownSettingKeys({ worktreeDir: {} })` returned `['worktreeDir']` and
  `unknownSettingKeys({ ios: { lanHost: {} } })` returned `['ios.lanHost']`.
- Added `packages/stim-cli/src/__tests__/settings.test.ts` cases:
  - `unknownSettingKeys({ worktreeDir: {} })` and
    `unknownSettingKeys({ ios: { lanHost: {} } })` both return `[]`, while
    `worktreeDirSettingError` and `iosLanHostSettingError` still refuse the
    same input -- only the red refusal prints.
  - `unknownSettingKeys({ ios: { bogus: {} } })` still reports
    `['ios.bogus']`, confirming a genuinely unknown nested key under a
    known parent is still caught.
  - `unknownSettingKeys({ ios: { configuration: {} } })` still reports
    `['ios.configuration']`, confirming the transitional (unvalidated)
    behavior for the 14 keys above.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`,
  `pnpm run typecheck`, and `pnpm test` all pass (77 test files, 2909 tests).

Fixes #207. Follow-up: #210.
