### PR TITLE
fix: run worktree add with LC_ALL=C so the branch-exists guard matches git's English text

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -605,6 +605,36 @@ test('addWorktree uses -b when the caller says the branch is new, whatever the r
   }
 });
 
+test('addWorktree forces LC_ALL=C so the branch-exists guard can match git English text', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'stim-test-add-locale-'));
+  try {
+    const path = join(tmp, 'repo4');
+    const opts: (Record<string, unknown> | undefined)[] = [];
+    setExecutor({
+      run: (cmd) => {
+        throw new Error(`unexpected shell run: ${cmd}`);
+      },
+      runFile: (_file, _args, options) => {
+        opts.push(options);
+        return '';
+      },
+      runQuiet: () => '',
+      spawn: () => {},
+    });
+
+    addWorktree({ path, branch: 'worktree-locale', baseRef: 'origin/main', createBranch: true });
+
+    expect(opts).toEqual([{ env: { LC_ALL: 'C' } }]);
+
+    opts.length = 0;
+    addWorktree({ path, branch: 'worktree-locale-attach', baseRef: 'origin/main', createBranch: false });
+
+    expect(opts).toEqual([{ env: { LC_ALL: 'C' } }]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('removeWorktree runs git via runFile (no shell) and includes --force only when asked', () => {
   const path = '/tmp/my worktree/repo';
   const calls: string[][] = [];

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -506,11 +506,11 @@ export function addWorktree({
   assertSafeWorktreePath(path);
   mkdirSync(dirname(path), { recursive: true });
   if (!createBranch) {
-    getExecutor().runFile('git', ['worktree', 'add', '--', path, branch]);
+    getExecutor().runFile('git', ['worktree', 'add', '--', path, branch], { env: { LC_ALL: 'C' } });
     return path;
   }
   assertSafeBaseRef(baseRef);
-  getExecutor().runFile('git', ['worktree', 'add', '-b', branch, '--', path, baseRef]);
+  getExecutor().runFile('git', ['worktree', 'add', '-b', branch, '--', path, baseRef], { env: { LC_ALL: 'C' } });
   return path;
 }
 


### PR DESCRIPTION
## Description

`rollBackCreatedBranch` (`packages/stim-cli/src/commands/worktree.ts`) keeps a branch when the failed `git worktree add -b` reports `a branch named ... already exists`, matched by `GIT_BRANCH_ALREADY_EXISTS` against git's English text. A git built with gettext catalogs (Homebrew, most Linux distributions) prints a translated message under a non-English `LANG`. Then the guard misses, and the rollback falls through to the sha compare -- where a branch someone else created at the same base, inside the window between Stim's `-b` and git's ref write, could still be deleted.

The two `git worktree add` calls in `addWorktree` (`packages/stim-cli/src/worktree.ts`) inherited the process locale, so this depended on the caller's environment.

## Solution

Pass `{ env: { LC_ALL: 'C' } }` on both `runFile('git', ['worktree', 'add', ...])` calls in `addWorktree` -- the `-b` form and the attach-to-existing-branch form, for consistency. `exec.ts`'s `runFile` merges `env` over `process.env`, so this forces git's untranslated English output regardless of the caller's `LANG`/`LC_ALL`, without touching anything else in the child environment.

## Test plan

- Added a unit test asserting both `addWorktree` calls pass `{ env: { LC_ALL: 'C' } }` as the third `runFile` argument. The existing `toEqual([['git', [...]]])` assertions in the other three `addWorktree` tests are untouched since they only record `[file, args]`.
- Real-tool check (invariant 9): in a scratch repo, `LC_ALL=C git worktree add -b existing-branch ...` against an already-existing branch prints `fatal: a branch named 'existing-branch' already exists`, matching `GIT_BRANCH_ALREADY_EXISTS`. Apple Git on this machine has no gettext catalogs, so `LANG=` and `LC_ALL=C` print identical text here. This only shows the flag is a no-op where it isn't needed; there's no catalog build on this machine to verify the actual translated-locale fix against.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm test` all pass from the repo root (77 test files, 2914 tests).

Fixes #209
