### PR TITLE
feat: name the sandbox allowance in doctor, apply it with --fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,10 @@ need custom behavior.
 
 Runtime state belongs under `$STIM_HOME/workspaces/`, not in the project
 tree. Stim has no init step and never mutates project setup; do not add
-either. `doctor` reports setup that requires project judgment.
+either. `doctor` reports setup that requires project judgment. The single
+exception is `doctor --fix`, which writes the sandbox allowance into the
+personal, gitignored harness settings file (`.claude/settings.local.json`) and
+nothing else; it never writes a committed file.
 
 ## Development
 

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -19,9 +19,11 @@ import {
   detectXcodeMajor,
   parseXcodeMajor,
   checkConcurrency,
+  checkSandboxAllowance,
 } from '../doctor.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import type { EasAuthResult } from '../engine/remote-cache.ts';
+import { sandboxAllowanceLines } from '../sandbox.ts';
 import assert from 'node:assert';
 
 test('checkMainCheckout reports missing dependencies, Pods, and native output', () => {
@@ -916,6 +918,67 @@ test.each([
 
     expect(findings.some((finding) => finding.title === 'The remote proxy credentials are missing')).toBe(true);
     expect(findings.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(false);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('checkSandboxAllowance stays silent with no harness and with the allowance in place', () => {
+  expect(checkSandboxAllowance({ harness: null })).toBe(null);
+  expect(checkSandboxAllowance({ harness: 'claude', satisfied: true })).toBe(null);
+});
+
+test('the Claude Code finding carries the patch verbatim and points at --fix', () => {
+  const found = checkSandboxAllowance({ harness: 'claude', satisfied: false });
+  assert(found);
+  expect(found.level).toBe('cost');
+  for (const line of sandboxAllowanceLines()) expect(found.detail).toContain(line);
+  expect(found.detail).toContain('.claude/settings.local.json');
+  expect(found.fix).toMatch(/doctor --fix/);
+});
+
+test('the Codex finding explains the single enum and recommends nothing automatic', () => {
+  const found = checkSandboxAllowance({ harness: 'codex' });
+  assert(found);
+  expect(found.level).toBe('note');
+  expect(found.detail).toMatch(/sandbox_mode/);
+  expect(found.detail).toMatch(/danger-full-access is the only value/);
+  expect(found.detail).not.toContain('sandbox.filesystem.allowWrite');
+  expect(found.fix).toMatch(/refuses/);
+});
+
+test('runDoctor reports the sandbox allowance from the project settings files', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-sandbox-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    const missing = runDoctor(project, {
+      concurrency: () => ({ maxBuilds: 0, maxDevices: 0 }),
+      harness: () => 'claude',
+      claudeSettings: [],
+    });
+    expect(missing.some((f) => /sandbox allowance/i.test(f.title))).toBe(true);
+
+    mkdirSync(join(project, '.claude'), { recursive: true });
+    writeFileSync(
+      join(project, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        sandbox: {
+          filesystem: { allowWrite: ['~/.stim'] },
+          network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: true },
+        },
+      }),
+    );
+    const handled = runDoctor(project, {
+      concurrency: () => ({ maxBuilds: 0, maxDevices: 0 }),
+      harness: () => 'claude',
+    });
+    expect(handled.some((f) => /sandbox/i.test(f.title))).toBe(false);
+
+    const none = runDoctor(project, {
+      concurrency: () => ({ maxBuilds: 0, maxDevices: 0 }),
+      harness: () => null,
+    });
+    expect(none.some((f) => /sandbox/i.test(f.title))).toBe(false);
   } finally {
     rmSync(project, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -5,6 +5,8 @@ import { DEFAULT_FINGERPRINT_IGNORES } from '../build-cache.ts';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
+import { checkSandboxAllowance } from '../doctor.ts';
+import { sandboxAllowanceLines } from '../sandbox.ts';
 
 test('every advertised topic renders non-empty content', () => {
   for (const name of topicNames()) {
@@ -76,6 +78,7 @@ test('the flags the guide advertises are the flags the commands define', () => {
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);
   const advertised = {
+    'doctor.ts': ['--json', '--fix'],
     'start.ts': ['--json', '--wait', '--remote'],
     'ios.ts': ['--json', '--no-metro-check', '--no-build-cache', '--configuration', '--device', '--remote'],
     'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--device', '--remote'],
@@ -746,6 +749,39 @@ test('the sandbox failures are named in the guide, and the skill points at them'
   // The skill says a sandbox exists and sends the reader to the topic.
   expect(skill).toMatch(/sandbox/i);
   expect(skill).toContain('stim guide errors');
+});
+
+test('the guide documents the doctor finding and --fix with the patch doctor reports', () => {
+  const errors = renderTopic('errors') ?? '';
+  const lifecycle = renderTopic('lifecycle') ?? '';
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+
+  // One source for the patch: the finding and the topic print the same lines.
+  const claude = checkSandboxAllowance({ harness: 'claude', satisfied: false });
+  assert(claude);
+  for (const line of sandboxAllowanceLines()) {
+    expect(claude.detail).toContain(line);
+    expect(errors).toContain(line);
+  }
+
+  // The finding always runs, and the topic names what doctor reads to detect it.
+  for (const detail of ['CLAUDECODE', 'CODEX_', '~/.codex/config.toml', '.claude/settings.local.json']) {
+    expect(errors).toContain(detail);
+  }
+  expect(errors).toContain('stim doctor --fix');
+  expect(lifecycle).toContain('stim doctor --fix');
+  expect(errors).toMatch(/never touches the committed/i);
+
+  // Codex gets the explanation and no write.
+  const codex = checkSandboxAllowance({ harness: 'codex' });
+  assert(codex);
+  for (const topic of [errors, codex.detail]) {
+    expect(topic).toMatch(/sandbox_mode/);
+    expect(topic).toMatch(/danger-full-access/);
+  }
+
+  // The flag is advanced detail: the guide carries it, the skill does not.
+  expect(skill).not.toContain('--fix');
 });
 
 test('advanced contracts stay in guide topics instead of the skill', () => {

--- a/packages/stim-cli/src/__tests__/sandbox.test.ts
+++ b/packages/stim-cli/src/__tests__/sandbox.test.ts
@@ -1,0 +1,267 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import assert from 'node:assert';
+import {
+  SANDBOX_ALLOWANCE,
+  applySandboxAllowance,
+  claudeSettingsPaths,
+  detectHarness,
+  mergeSandboxAllowance,
+  readClaudeSettings,
+  sandboxAllowanceLines,
+  sandboxAllowanceSatisfied,
+} from '../sandbox.ts';
+
+const FULL = {
+  sandbox: {
+    filesystem: { allowWrite: ['~/.stim'] },
+    network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: true },
+  },
+};
+
+function project(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+test('the advertised patch is the three keys and values the guide prints', () => {
+  expect(Object.keys(SANDBOX_ALLOWANCE)).toEqual([
+    'sandbox.filesystem.allowWrite',
+    'sandbox.network.allowMachLookup',
+    'sandbox.network.allowLocalBinding',
+  ]);
+  expect(sandboxAllowanceLines()).toEqual([
+    'sandbox.filesystem.allowWrite     ["~/.stim"]',
+    'sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]',
+    'sandbox.network.allowLocalBinding true',
+  ]);
+});
+
+test('detectHarness reads Claude Code first, then Codex env, then the Codex config file', () => {
+  const noCodexConfig = () => false;
+  expect(detectHarness({ env: { CLAUDECODE: '1' }, home: '/home', exists: noCodexConfig })).toBe('claude');
+  expect(detectHarness({ env: { CLAUDE_CODE_ENTRYPOINT: 'cli' }, home: '/home', exists: noCodexConfig })).toBe(
+    'claude',
+  );
+  expect(detectHarness({ env: { CODEX_SANDBOX: 'seatbelt' }, home: '/home', exists: noCodexConfig })).toBe('codex');
+  expect(detectHarness({ env: {}, home: '/home', exists: (p) => p === '/home/.codex/config.toml' })).toBe('codex');
+  expect(detectHarness({ env: {}, home: '/home', exists: noCodexConfig })).toBe(null);
+});
+
+test('detectHarness ignores empty harness variables', () => {
+  expect(detectHarness({ env: { CLAUDECODE: '  ', CODEX_HOME: '' }, home: '/home', exists: () => false })).toBe(null);
+});
+
+test('detectHarness prefers Claude Code when a Codex config file also exists', () => {
+  expect(detectHarness({ env: { CLAUDECODE: '1' }, home: '/home', exists: () => true })).toBe('claude');
+});
+
+test('the allowance is satisfied by any of the settings files, and by value not by key', () => {
+  expect(sandboxAllowanceSatisfied([FULL])).toBe(true);
+  expect(sandboxAllowanceSatisfied([])).toBe(false);
+  expect(
+    sandboxAllowanceSatisfied([
+      { sandbox: { filesystem: { allowWrite: ['~/.stim'] } } },
+      { sandbox: { network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: true } } },
+    ]),
+  ).toBe(true);
+
+  // An array that exists without the entry Stim needs is not an allowance.
+  expect(
+    sandboxAllowanceSatisfied([
+      {
+        sandbox: {
+          filesystem: { allowWrite: ['~/.other'] },
+          network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: true },
+        },
+      },
+    ]),
+  ).toBe(false);
+  expect(
+    sandboxAllowanceSatisfied([
+      {
+        ...FULL,
+        sandbox: {
+          ...FULL.sandbox,
+          network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: false },
+        },
+      },
+    ]),
+  ).toBe(false);
+});
+
+test('claudeSettingsPaths checks the local file, the committed file, and the user file', () => {
+  expect(claudeSettingsPaths('/repo', '/home')).toEqual([
+    '/repo/.claude/settings.local.json',
+    '/repo/.claude/settings.json',
+    '/home/.claude/settings.json',
+  ]);
+});
+
+test('mergeSandboxAllowance creates the whole patch when the file is absent', () => {
+  const merged = mergeSandboxAllowance(null);
+  assert(merged.ok);
+  expect(merged.changed).toBe(true);
+  expect(JSON.parse(merged.content)).toEqual(FULL);
+  expect(merged.content.endsWith('\n')).toBe(true);
+  expect(merged.added).toHaveLength(3);
+});
+
+test('mergeSandboxAllowance treats an empty file as absent', () => {
+  const merged = mergeSandboxAllowance('   \n');
+  assert(merged.ok);
+  expect(JSON.parse(merged.content)).toEqual(FULL);
+});
+
+test('mergeSandboxAllowance keeps unrelated keys, including a sibling sandbox key', () => {
+  const merged = mergeSandboxAllowance(
+    JSON.stringify({
+      permissions: { allow: ['Bash(ls:*)'] },
+      sandbox: { enabled: true, network: { allowUnixSockets: ['/tmp/x.sock'] } },
+    }),
+  );
+  assert(merged.ok);
+  const out = JSON.parse(merged.content);
+  expect(out.permissions).toEqual({ allow: ['Bash(ls:*)'] });
+  expect(out.sandbox.enabled).toBe(true);
+  expect(out.sandbox.network.allowUnixSockets).toEqual(['/tmp/x.sock']);
+  expect(out.sandbox.network.allowMachLookup).toEqual(['com.apple.coresimulator.*']);
+  expect(out.sandbox.network.allowLocalBinding).toBe(true);
+  expect(out.sandbox.filesystem.allowWrite).toEqual(['~/.stim']);
+});
+
+test('mergeSandboxAllowance appends to a partial allowance without duplicating', () => {
+  const merged = mergeSandboxAllowance(
+    JSON.stringify({
+      sandbox: {
+        filesystem: { allowWrite: ['~/.cache/other', '~/.stim'] },
+        network: { allowMachLookup: ['com.example.other'] },
+      },
+    }),
+  );
+  assert(merged.ok);
+  const out = JSON.parse(merged.content);
+  expect(out.sandbox.filesystem.allowWrite).toEqual(['~/.cache/other', '~/.stim']);
+  expect(out.sandbox.network.allowMachLookup).toEqual(['com.example.other', 'com.apple.coresimulator.*']);
+  expect(out.sandbox.network.allowLocalBinding).toBe(true);
+  expect(merged.added).toEqual(['sandbox.network.allowMachLookup', 'sandbox.network.allowLocalBinding']);
+});
+
+test('mergeSandboxAllowance is a no-op on a file that already carries the allowance', () => {
+  const source = JSON.stringify(FULL, null, 2);
+  const merged = mergeSandboxAllowance(source);
+  assert(merged.ok);
+  expect(merged.changed).toBe(false);
+  expect(merged.added).toEqual([]);
+  expect(JSON.parse(merged.content)).toEqual(FULL);
+});
+
+test('mergeSandboxAllowance refuses malformed JSON instead of overwriting it', () => {
+  const merged = mergeSandboxAllowance('{ "sandbox": ');
+  expect(merged.ok).toBe(false);
+  assert(!merged.ok);
+  expect(merged.reason).toMatch(/not valid JSON/);
+});
+
+test('mergeSandboxAllowance refuses a shape it would have to clobber', () => {
+  for (const [source, pattern] of [
+    ['[]', /not a JSON object/],
+    ['"settings"', /not a JSON object/],
+    [JSON.stringify({ sandbox: 'off' }), /sandbox is not an object/],
+    [JSON.stringify({ sandbox: { filesystem: { allowWrite: '~/.stim' } } }), /allowWrite is not an array/],
+    [JSON.stringify({ sandbox: { network: { allowLocalBinding: 'yes' } } }), /allowLocalBinding is not a boolean/],
+  ] as const) {
+    const merged = mergeSandboxAllowance(source);
+    assert(!merged.ok);
+    expect(merged.reason).toMatch(pattern);
+  }
+});
+
+test('applySandboxAllowance writes only the personal file and leaves the committed one alone', () => {
+  const root = project('stim-sandbox-apply-');
+  try {
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const committed = join(root, '.claude', 'settings.json');
+    writeFileSync(committed, JSON.stringify({ permissions: { allow: [] } }, null, 2));
+
+    const fix = applySandboxAllowance({ projectRoot: root, harness: 'claude' });
+    expect(fix.applied).toBe(true);
+    expect(fix.path).toBe(join(root, '.claude', 'settings.local.json'));
+    expect(fix.message).toMatch(/settings\.local\.json/);
+    expect(JSON.parse(readFileSync(fix.path as string, 'utf-8'))).toEqual(FULL);
+    expect(JSON.parse(readFileSync(committed, 'utf-8'))).toEqual({ permissions: { allow: [] } });
+
+    const again = applySandboxAllowance({ projectRoot: root, harness: 'claude' });
+    expect(again.applied).toBe(false);
+    expect(again.message).toMatch(/already carries/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxAllowance creates the .claude directory when the project has none', () => {
+  const root = project('stim-sandbox-create-');
+  try {
+    expect(existsSync(join(root, '.claude'))).toBe(false);
+    const fix = applySandboxAllowance({ projectRoot: root, harness: 'claude' });
+    expect(fix.applied).toBe(true);
+    expect(JSON.parse(readFileSync(join(root, '.claude', 'settings.local.json'), 'utf-8'))).toEqual(FULL);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxAllowance leaves a malformed personal file untouched', () => {
+  const root = project('stim-sandbox-bad-');
+  try {
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const local = join(root, '.claude', 'settings.local.json');
+    writeFileSync(local, '{ oops');
+    const fix = applySandboxAllowance({ projectRoot: root, harness: 'claude' });
+    expect(fix.applied).toBe(false);
+    expect(fix.message).toMatch(/Refusing to write/);
+    expect(readFileSync(local, 'utf-8')).toBe('{ oops');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxAllowance refuses under Codex and explains the single enum', () => {
+  const root = project('stim-sandbox-codex-');
+  try {
+    const fix = applySandboxAllowance({ projectRoot: root, harness: 'codex' });
+    expect(fix.applied).toBe(false);
+    expect(fix.path).toBe(null);
+    expect(fix.message).toMatch(/sandbox_mode/);
+    expect(fix.message).toMatch(/danger-full-access/);
+    expect(existsSync(join(root, '.claude'))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('applySandboxAllowance reports nothing to apply with no harness', () => {
+  const root = project('stim-sandbox-none-');
+  try {
+    const fix = applySandboxAllowance({ projectRoot: root, harness: null });
+    expect(fix.applied).toBe(false);
+    expect(fix.message).toMatch(/nothing to apply/);
+    expect(existsSync(join(root, '.claude'))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readClaudeSettings skips absent and unparseable files', () => {
+  const root = project('stim-sandbox-read-');
+  try {
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'settings.local.json'), '{ broken');
+    writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify(FULL));
+    const parsed = readClaudeSettings(claudeSettingsPaths(root, join(root, 'nowhere')));
+    expect(parsed).toEqual([FULL]);
+    expect(sandboxAllowanceSatisfied(parsed)).toBe(true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -3,18 +3,24 @@ import type { Command } from 'commander';
 import { findProjectRoot } from '../project.ts';
 import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.ts';
 import type { Finding } from '../doctor.ts';
+import { type SandboxFix, applySandboxAllowance, detectHarness } from '../sandbox.ts';
 
 interface DoctorOptions {
   json?: boolean;
+  fix?: boolean;
 }
 
 export default function doctorCommand(program: Command): void {
   program
     .command('doctor')
     .description(
-      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only; changes nothing.',
+      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed.',
     )
     .option('--json', 'print the findings as JSON')
+    .option(
+      '--fix',
+      'write the sandbox allowance into .claude/settings.local.json under Claude Code; the only thing doctor ever writes',
+    )
     .action(async (opts: DoctorOptions) => {
       const root = findProjectRoot(process.cwd());
       if (!root) {
@@ -23,15 +29,24 @@ export default function doctorCommand(program: Command): void {
         return;
       }
 
+      const harness = detectHarness();
+
+      let fix: SandboxFix | null = null;
+      if (opts.fix) {
+        fix = applySandboxAllowance({ projectRoot: root, harness });
+        console.error(fix.applied ? chalk.green(fix.message) : chalk.yellow(fix.message));
+      }
+
       const findings: Finding[] = runDoctor(root, {
         xcodeMajor: detectXcodeMajor(),
+        harness: () => harness,
       });
 
       const parity = await detectFingerprintParity(root);
       if (parity) findings.push(parity);
 
       if (opts.json) {
-        console.log(JSON.stringify({ project: root, findings }, null, 2));
+        console.log(JSON.stringify({ project: root, findings, ...(fix ? { fix } : {}) }, null, 2));
         return;
       }
 
@@ -39,7 +54,7 @@ export default function doctorCommand(program: Command): void {
         console.log(chalk.green('Nothing to flag.'));
         console.log(
           chalk.dim(
-            'Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile and, on a checkout without installed dependencies, fingerprint parity.',
+            'Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile, the sandbox allowance of a detected agent harness and, on a checkout without installed dependencies, fingerprint parity.',
           ),
         );
         console.log(

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1226,14 +1226,37 @@ RUNNING UNDER A SANDBOX
 
   Two ways out, and choosing at the start of a session beats discovering it
   three failures in. Either run Stim with the harness's sandbox disabled, or
-  allow the three. In Claude Code that is settings.json:
+  allow the three. In Claude Code that is a settings file:
 
     sandbox.filesystem.allowWrite     ["~/.stim"]
     sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]
     sandbox.network.allowLocalBinding true
 
-  In Codex the sandbox is one flag, \`codex -s\`, with no per-path allowance:
-  workspace-write still refuses STIM_HOME.
+  \`stim doctor\` does not wait for you to remember this. It reads CLAUDECODE /
+  CLAUDE_CODE_ENTRYPOINT and the CODEX_* variables plus ~/.codex/config.toml,
+  and when a sandboxing harness is present it reports a finding carrying those
+  three lines verbatim. Under Claude Code the finding is suppressed once the
+  three keys are satisfied in .claude/settings.local.json, .claude/settings.json
+  or ~/.claude/settings.json -- satisfied, not merely present: an allowWrite
+  array without "~/.stim" is still a missing allowance. The finding always
+  runs and needs no flag.
+
+  \`stim doctor --fix\` applies it, and it is the ONE thing any Stim command
+  writes into a project. It merges exactly those three keys into
+  .claude/settings.local.json -- the personal, gitignored file, created when
+  absent -- appending to the arrays without duplicating, keeping every other
+  key, and writing atomically. It never touches the committed
+  .claude/settings.json, it changes nothing else in the repo, and a
+  settings.local.json that does not parse is refused rather than overwritten.
+  It prints what it wrote to stderr. Restart the harness session afterwards.
+
+  In Codex the sandbox is one enum, \`sandbox_mode\` (read-only,
+  workspace-write, danger-full-access) or \`codex -s\`, with no per-path
+  allowance: workspace-write still refuses STIM_HOME and danger-full-access is
+  the only value that clears it. Switching a sandbox off wholesale is the
+  user's call, so \`--fix\` refuses under Codex and explains why, and doctor's
+  Codex finding recommends nothing automatic. With no harness detected,
+  \`--fix\` reports that there is nothing to apply.
 
   A git credential helper is often blocked too. It prints \`failed to store\`
   on a fetch that otherwise succeeded, and is safe to ignore.
@@ -1367,6 +1390,14 @@ provider on a key this SDK ignores) plus the project-side settings that matter
 solely for builds you make OUTSIDE Stim. A clean doctor means there is
 nothing Stim needs from this repo.
 
+  The one exception to read-only is \`stim doctor --fix\`, which exists for a
+  file Stim does not own: under Claude Code it merges the three sandbox
+  allowance keys into .claude/settings.local.json, the personal gitignored
+  harness file, and writes nothing else anywhere. It refuses under Codex,
+  which has no per-path allowance, and reports nothing to apply when no
+  harness is detected. The finding it applies always prints without the flag;
+  see \`guide errors\` for both.
+
 THE BUILD CACHE HAS THREE LEVELS
   1. Stim's own, on this machine: a directory under ~/.stim shared by
      every worktree, keyed on the @expo/fingerprint hash of the native inputs.
@@ -1486,6 +1517,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   the two env vars (see \`guide settings\`).
 
 THE OPTION SURFACE, IN FULL
+  doctor          --json --fix
   start           --json --wait <seconds> --remote
   ios             --json --no-metro-check --no-build-cache --configuration <name> --device [udid] --remote <proxy|eas>
   android         --json --no-metro-check --no-build-cache --variant <name> --device [serial] --remote <proxy|eas>

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -23,6 +23,16 @@ import {
   resolveEasCliBin,
 } from './engine/remote-cache.ts';
 import { iosSimSlimProfileSetting, remoteAndroidSetting, remoteIosSetting, resolveSettings } from './settings.ts';
+import {
+  type Harness,
+  CLAUDE_LOCAL_SETTINGS,
+  CODEX_REFUSAL,
+  claudeSettingsPaths,
+  detectHarness,
+  readClaudeSettings,
+  sandboxAllowanceLines,
+  sandboxAllowanceSatisfied,
+} from './sandbox.ts';
 import type { RemoteDeviceBackend } from './types.ts';
 
 type AnyJson = Record<string, unknown>;
@@ -537,6 +547,37 @@ export function checkSimSlim({
   );
 }
 
+export function checkSandboxAllowance({
+  harness,
+  satisfied = false,
+}: {
+  harness: Harness | null;
+  satisfied?: boolean;
+}): Finding | null {
+  if (harness === null) return null;
+
+  if (harness === 'codex') {
+    return finding(
+      'note',
+      'This is a Codex session, whose sandbox has no per-path allowance',
+      `A sandboxed shell blocks three things Stim needs, and none of the failures names the sandbox: writes to STIM_HOME (~/.stim unless set), the CoreSimulator service simctl reaches over XPC, and the adb server socket on tcp:5037. ${CODEX_REFUSAL}`,
+      'Decide before the session starts whether this one runs Stim, and if it does, run Codex with danger-full-access. `stim doctor --fix` refuses here.',
+    );
+  }
+
+  if (satisfied) return null;
+
+  const patch = sandboxAllowanceLines()
+    .map((line) => `    ${line}`)
+    .join('\n');
+  return finding(
+    'cost',
+    'This Claude Code session has no sandbox allowance for Stim',
+    `A sandboxed shell blocks three things Stim needs, and none of the failures names the sandbox: writes to STIM_HOME (~/.stim unless set), the CoreSimulator service simctl reaches over XPC, and the adb server socket on tcp:5037. None of ${CLAUDE_LOCAL_SETTINGS}, .claude/settings.json, or ~/.claude/settings.json carries all three keys:\n\n${patch}\n\n  The allowance changes nothing when the sandbox is off, so applying it costs nothing and saves three failures that read as a broken machine.`,
+    `\`stim doctor --fix\` merges exactly those keys into ${CLAUDE_LOCAL_SETTINGS}, the personal gitignored file, leaving every other key alone. See \`stim guide errors\`.`,
+  );
+}
+
 export function runDoctor(
   projectRoot: string,
   {
@@ -550,6 +591,8 @@ export function runDoctor(
     lookupAgentDevice = null,
     lookupEasCli = null,
     lookupSimSlim = null,
+    harness = null,
+    claudeSettings = null,
   }: {
     readFile?: typeof readFileSync;
     xcodeMajor?: number | null;
@@ -561,6 +604,8 @@ export function runDoctor(
     lookupAgentDevice?: (() => boolean) | null;
     lookupEasCli?: (() => boolean) | null;
     lookupSimSlim?: (() => boolean) | null;
+    harness?: Harness | null | (() => Harness | null);
+    claudeSettings?: readonly unknown[] | null;
   } = {},
 ): Finding[] {
   const read = (rel: string): string | null => {
@@ -653,6 +698,15 @@ export function runDoctor(
     )
     .filter((remoteFinding): remoteFinding is Finding => remoteFinding !== null);
 
+  const activeHarness = typeof harness === 'function' ? harness() : (harness ?? detectHarness());
+  const sandboxFinding = checkSandboxAllowance({
+    harness: activeHarness,
+    satisfied:
+      activeHarness === 'claude'
+        ? sandboxAllowanceSatisfied(claudeSettings ?? readClaudeSettings(claudeSettingsPaths(projectRoot)))
+        : false,
+  });
+
   return [
     ...checkMainCheckout(projectRoot),
     checkDevClient(pkg, isExpo),
@@ -663,6 +717,7 @@ export function runDoctor(
     easFinding,
     concurrencyFinding,
     simslimFinding,
+    sandboxFinding,
     ...remoteFindings,
   ].filter((f): f is Finding => Boolean(f));
 }

--- a/packages/stim-cli/src/sandbox.ts
+++ b/packages/stim-cli/src/sandbox.ts
@@ -1,0 +1,236 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+
+export type Harness = 'claude' | 'codex';
+
+type AllowanceValue = readonly string[] | true;
+
+export const SANDBOX_ALLOWANCE: Readonly<Record<string, AllowanceValue>> = {
+  'sandbox.filesystem.allowWrite': ['~/.stim'],
+  'sandbox.network.allowMachLookup': ['com.apple.coresimulator.*'],
+  'sandbox.network.allowLocalBinding': true,
+};
+
+export const CLAUDE_LOCAL_SETTINGS: string = join('.claude', 'settings.local.json');
+
+export const CODEX_REFUSAL =
+  "Codex has one sandbox setting rather than a per-path allowance: sandbox_mode is read-only, workspace-write, or danger-full-access. workspace-write still refuses STIM_HOME, so danger-full-access is the only value that clears it. Turning a sandbox off wholesale is the user's call, not a tool's, so Stim writes nothing here.";
+
+function allowanceLine(key: string, width: number): string {
+  const value = SANDBOX_ALLOWANCE[key];
+  const rendered = value === true ? 'true' : JSON.stringify(value);
+  return `${key.padEnd(width)} ${rendered}`;
+}
+
+export function sandboxAllowanceLines(): string[] {
+  const keys = Object.keys(SANDBOX_ALLOWANCE);
+  const width = Math.max(...keys.map((k) => k.length));
+  return keys.map((key) => allowanceLine(key, width));
+}
+
+function nonEmpty(value: string | undefined): boolean {
+  return Boolean(value && value.trim());
+}
+
+export function detectHarness({
+  env = process.env,
+  home = homedir(),
+  exists = existsSync,
+}: {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  exists?: (path: string) => boolean;
+} = {}): Harness | null {
+  if (nonEmpty(env.CLAUDECODE) || nonEmpty(env.CLAUDE_CODE_ENTRYPOINT)) return 'claude';
+  if (Object.keys(env).some((key) => key.startsWith('CODEX_') && nonEmpty(env[key]))) return 'codex';
+  if (exists(join(home, '.codex', 'config.toml'))) return 'codex';
+  return null;
+}
+
+export function claudeSettingsPaths(projectRoot: string, home: string = homedir()): string[] {
+  return [
+    join(projectRoot, CLAUDE_LOCAL_SETTINGS),
+    join(projectRoot, '.claude', 'settings.json'),
+    join(home, '.claude', 'settings.json'),
+  ];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function valueAt(source: unknown, path: string[]): unknown {
+  let current: unknown = source;
+  for (const segment of path) {
+    if (!isPlainObject(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function carries(actual: unknown, wanted: AllowanceValue): boolean {
+  if (wanted === true) return actual === true;
+  return Array.isArray(actual) && wanted.every((entry) => actual.includes(entry));
+}
+
+export function sandboxAllowanceSatisfied(settings: readonly unknown[]): boolean {
+  return Object.entries(SANDBOX_ALLOWANCE).every(([key, wanted]) =>
+    settings.some((source) => carries(valueAt(source, key.split('.')), wanted)),
+  );
+}
+
+export function readClaudeSettings(paths: readonly string[], read: typeof readFileSync = readFileSync): unknown[] {
+  const parsed: unknown[] = [];
+  for (const path of paths) {
+    let raw: string;
+    try {
+      raw = read(path, 'utf-8') as string;
+    } catch {
+      continue;
+    }
+    try {
+      parsed.push(JSON.parse(raw));
+    } catch {}
+  }
+  return parsed;
+}
+
+export type SandboxMerge =
+  | { ok: true; changed: boolean; content: string; added: string[] }
+  | { ok: false; reason: string };
+
+export function mergeSandboxAllowance(source: string | null): SandboxMerge {
+  let root: Record<string, unknown> = {};
+  if (source !== null && source.trim() !== '') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(source);
+    } catch (error) {
+      return { ok: false, reason: `it is not valid JSON: ${(error as Error).message}` };
+    }
+    if (!isPlainObject(parsed)) return { ok: false, reason: 'its top level is not a JSON object' };
+    root = structuredClone(parsed);
+  }
+
+  const added: string[] = [];
+  for (const [key, wanted] of Object.entries(SANDBOX_ALLOWANCE)) {
+    const path = key.split('.');
+    const leaf = path[path.length - 1] as string;
+    let container = root;
+    for (let depth = 0; depth < path.length - 1; depth++) {
+      const segment = path[depth] as string;
+      const next = container[segment];
+      if (next === undefined) {
+        const created: Record<string, unknown> = {};
+        container[segment] = created;
+        container = created;
+        continue;
+      }
+      if (!isPlainObject(next)) {
+        return { ok: false, reason: `${path.slice(0, depth + 1).join('.')} is not an object` };
+      }
+      container = next;
+    }
+
+    const current = container[leaf];
+    if (wanted === true) {
+      if (current !== undefined && typeof current !== 'boolean') {
+        return { ok: false, reason: `${key} is not a boolean` };
+      }
+      if (current !== true) {
+        container[leaf] = true;
+        added.push(key);
+      }
+      continue;
+    }
+    if (current !== undefined && !Array.isArray(current)) {
+      return { ok: false, reason: `${key} is not an array` };
+    }
+    const list = (current as unknown[] | undefined) ?? [];
+    const missing = wanted.filter((entry) => !list.includes(entry));
+    if (missing.length === 0) continue;
+    container[leaf] = [...list, ...missing];
+    added.push(key);
+  }
+
+  return { ok: true, changed: added.length > 0, content: `${JSON.stringify(root, null, 2)}\n`, added };
+}
+
+export interface SandboxFix {
+  harness: Harness | null;
+  applied: boolean;
+  path: string | null;
+  message: string;
+}
+
+function writeAtomic(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  writeFileSync(tmp, content);
+  try {
+    renameSync(tmp, path);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+}
+
+export function applySandboxAllowance({
+  projectRoot,
+  harness,
+  write = writeAtomic,
+  read = readFileSync,
+}: {
+  projectRoot: string;
+  harness: Harness | null;
+  write?: (path: string, content: string) => void;
+  read?: typeof readFileSync;
+}): SandboxFix {
+  if (harness === null) {
+    return {
+      harness,
+      applied: false,
+      path: null,
+      message:
+        'No sandboxing harness is in this environment, so there is nothing to apply. The allowance only means something to a harness that sandboxes shell commands.',
+    };
+  }
+  if (harness === 'codex') {
+    return { harness, applied: false, path: null, message: CODEX_REFUSAL };
+  }
+
+  const path = join(projectRoot, CLAUDE_LOCAL_SETTINGS);
+  let source: string | null = null;
+  try {
+    source = read(path, 'utf-8') as string;
+  } catch {
+    source = null;
+  }
+
+  const merged = mergeSandboxAllowance(source);
+  if (!merged.ok) {
+    return {
+      harness,
+      applied: false,
+      path,
+      message: `Refusing to write ${path}: ${merged.reason}. Nothing was changed. Repair the file, or add the three keys by hand.`,
+    };
+  }
+  if (!merged.changed) {
+    return {
+      harness,
+      applied: false,
+      path,
+      message: `${path} already carries the sandbox allowance. Nothing to write.`,
+    };
+  }
+
+  write(path, merged.content);
+  return {
+    harness,
+    applied: true,
+    path,
+    message: `Wrote the sandbox allowance into ${path} (${merged.added.join(', ')}). Every other key in that file is untouched, and the committed .claude/settings.json is never written. Restart the harness session for it to take effect.`,
+  };
+}

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -28,13 +28,39 @@ builds embed the JavaScript bundle and skip that requirement.
 ## `doctor`
 
 ```text
-stim doctor [--json]
+stim doctor [--fix] [--json]
 ```
 
 Inspects the main checkout. It reports missing or stale dependencies, CocoaPods
 state, cache conflicts, device capacity, and remote session problems. On a
 checkout without installed dependencies, it also reports fingerprint
-differences against a fresh worktree. The check is read-only.
+differences against a fresh worktree. The report is read-only.
+
+`doctor` also detects an agent harness that sandboxes shell commands (Claude
+Code through `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT`, Codex through `CODEX_*`
+and `~/.codex/config.toml`). When one is present and the allowance Stim needs is
+missing, it reports the patch verbatim:
+
+```text
+sandbox.filesystem.allowWrite     ["~/.stim"]
+sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]
+sandbox.network.allowLocalBinding true
+```
+
+- `--fix` merges exactly those three keys into `.claude/settings.local.json`,
+  the personal file Git ignores. It creates the file when absent, keeps every
+  other key, appends to the arrays without duplicating, writes atomically, and
+  prints what it wrote to stderr. It never writes the committed
+  `.claude/settings.json`, and it refuses a `settings.local.json` that does not
+  parse rather than overwriting it. This is the only thing any Stim command
+  writes into a project.
+- `--fix` refuses under Codex and says why: `sandbox_mode` is a single enum with
+  no per-path allowance, `workspace-write` still refuses `STIM_HOME`, and only
+  `danger-full-access` clears it. Turning a sandbox off wholesale is the user's
+  decision. With no harness detected, `--fix` reports that there is nothing to
+  apply.
+- `--json` prints one payload on stdout, and carries a `fix` object when `--fix`
+  ran.
 
 ## `start`
 


### PR DESCRIPTION
## Description

`guide errors` already names what a sandbox blocks and the skill routes an
agent there, but both leave the reader to translate that into their harness's
config by hand. `doctor` -- the command whose job is "your machine is not set
up for fast builds" -- said nothing, even though it can see both the harness
and the setting.

Two things a sandboxed harness makes invisible are in scope here: the harness
identity (Claude Code exports `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT`; Codex
exports `CODEX_*` and keeps `~/.codex/config.toml`) and, under Claude Code,
whether the three allowance keys are already satisfied in a settings file.

Blast radius: `doctor.ts`, `commands/doctor.ts`, `commands/guide.ts`, a new
`src/sandbox.ts`, the guide contract tests, and the website command
reference. No other command changes, and no runtime path changes.

## Solution

Two clearly separated parts, matching #199.

**(a) The finding. Always runs, no flag.** `runDoctor` gains a sandbox check.
When a sandboxing harness is detected and the allowance is missing, it reports
a finding carrying the patch verbatim. Under Claude Code, "already handled" is
decided by a pure function (`sandboxAllowanceSatisfied`) from the parsed
contents of `.claude/settings.local.json`, `.claude/settings.json`, and
`~/.claude/settings.json`. Satisfied is by value, not by key presence: an
`allowWrite` array that exists without `~/.stim` is still a missing allowance,
which keeps the finding and `--fix` in agreement (the finding disappears
exactly when `--fix` would be a no-op). Under Codex the finding is a `note`
that explains the single-enum sandbox and recommends nothing automatic.

**(b) `--fix`. Opt-in.** Under Claude Code it merges exactly that patch into
`.claude/settings.local.json`, creating it when absent, and prints what it
wrote to stderr. It refuses under Codex with the explanation, and reports
there is nothing to apply when no harness is detected. It never touches the
committed `.claude/settings.json`.

The whole file computation is one pure function, `mergeSandboxAllowance(source)`,
that takes the file's text (or `null`) and returns either a refusal or the
merged JSON. It deep-merges, appends to arrays without duplicating, keeps every
other key, and refuses rather than clobbers when the file does not parse or
when a path it needs holds a non-object/non-array/non-boolean. The I/O wrapper
around it does an atomic write (tmp + rename), the pattern `config.ts` and
`paths.ts` already use.

Deliberate trade-offs:

- The patch has one source. `SANDBOX_ALLOWANCE` in `sandbox.ts` produces both
  the printed lines and the merge; a contract test asserts the guide topic and
  the finding print the same three lines.
- `--fix` stays opt-in because Stim is writing another tool's config file and
  encoding a schema it does not own, which will drift. The printed finding does
  not drift, so that is the part that always runs.
- The Codex refusal names `danger-full-access` as the only value that clears
  `STIM_HOME` but recommends nothing automatic: switching a user's sandbox off
  wholesale is the user's call.
- AGENTS.md's "never mutates project setup" sentence now states the one
  exception in the present tense, and keeps "do not add either" for init/setup.
- `SKILL.md` is unchanged. The normal workflow, the safety rules, and topic
  routing are all the same -- the skill already says a sandbox exists and sends
  the reader to `stim guide errors` -- so invariant 1 says leave it alone. It
  also has 6 words of headroom under the 1,200-word cap.

## Test plan

New unit tests for the pure merge, against exactly the cases #199 asks for:
absent file, existing unrelated keys, existing partial allowance, existing full
allowance (no-op), malformed JSON (refuse, do not overwrite), plus shapes it
would have to clobber. Plus detection precedence, value-not-key satisfaction,
the atomic write leaving the committed file alone, the Codex refusal, and the
no-harness report.

New contract tests pin the flag and the finding to the guide: `doctor.ts`'s
`--json` / `--fix` are added to the "flags the guide advertises are the flags
the commands define" map, and a new test asserts the `errors` topic carries the
same three lines the finding carries, names `CLAUDECODE`, `CODEX_`,
`~/.codex/config.toml` and `.claude/settings.local.json`, says it never touches
the committed file, and that the skill does not carry `--fix`.

```text
pnpm run format:check   All matched files use the correct format.
pnpm run lint           clean
pnpm run build          Build complete
pnpm run typecheck      clean
pnpm test               78 files, 2961 tests passed
pnpm run knip           exit 0
```

`test:e2e` was not run: no e2e case touches `doctor`, and no end-to-end
workflow changed.

### The built CLI, in a scratch project

Scratch project with a committed `.claude/settings.json` holding an unrelated
key, `HOME` pointed at an empty directory so no real user settings leak in.

**1. `doctor` under `CLAUDECODE=1` shows the finding**

```text
costs time  This Claude Code session has no sandbox allowance for Stim
  A sandboxed shell blocks three things Stim needs, and none of the failures names the sandbox: writes to STIM_HOME (~/.stim unless set), the CoreSimulator service simctl reaches over XPC, and the adb server socket on tcp:5037. None of .claude/settings.local.json, .claude/settings.json, or ~/.claude/settings.json carries all three keys:

    sandbox.filesystem.allowWrite     ["~/.stim"]
    sandbox.network.allowMachLookup   ["com.apple.coresimulator.*"]
    sandbox.network.allowLocalBinding true

  The allowance changes nothing when the sandbox is off, so applying it costs nothing and saves three failures that read as a broken machine.
  -> `stim doctor --fix` merges exactly those keys into .claude/settings.local.json, the personal gitignored file, leaving every other key alone. See `stim guide errors`.

1 finding(s). Fix relevant "costs time" findings before copying the main checkout into a native worktree.
```

**2. `doctor --fix` writes the file (stderr)**

```text
Wrote the sandbox allowance into /private/tmp/stim199-scratch-24p6/.claude/settings.local.json (sandbox.filesystem.allowWrite, sandbox.network.allowMachLookup, sandbox.network.allowLocalBinding). Every other key in that file is untouched, and the committed .claude/settings.json is never written. Restart the harness session for it to take effect.
```

```json
// .claude/settings.local.json, created
{
  "sandbox": {
    "filesystem": { "allowWrite": ["~/.stim"] },
    "network": { "allowMachLookup": ["com.apple.coresimulator.*"], "allowLocalBinding": true }
  }
}
// .claude/settings.json, unchanged
{ "permissions": { "allow": ["Bash(ls:*)"] } }
```

**3. A second `doctor` shows it handled**

```text
Nothing to flag.
Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile, the sandbox allowance of a detected agent harness and, on a checkout without installed dependencies, fingerprint parity.
```

**4. A Codex-env run refuses (`CODEX_SANDBOX=seatbelt`, Claude vars unset)**

```text
Codex has one sandbox setting rather than a per-path allowance: sandbox_mode is read-only, workspace-write, or danger-full-access. workspace-write still refuses STIM_HOME, so danger-full-access is the only value that clears it. Turning a sandbox off wholesale is the user's call, not a tool's, so Stim writes nothing here.

note  This is a Codex session, whose sandbox has no per-path allowance
  A sandboxed shell blocks three things Stim needs, and none of the failures names the sandbox: writes to STIM_HOME (~/.stim unless set), the CoreSimulator service simctl reaches over XPC, and the adb server socket on tcp:5037. Codex has one sandbox setting rather than a per-path allowance: sandbox_mode is read-only, workspace-write, or danger-full-access. workspace-write still refuses STIM_HOME, so danger-full-access is the only value that clears it. Turning a sandbox off wholesale is the user's call, not a tool's, so Stim writes nothing here.
  -> Decide before the session starts whether this one runs Stim, and if it does, run Codex with danger-full-access. `stim doctor --fix` refuses here.
```

No `.claude/` directory is created on that run.

**5. No harness detected**

```text
No sandboxing harness is in this environment, so there is nothing to apply. The allowance only means something to a harness that sandboxes shell commands.
```

**6. Deep merge into an existing personal file, and idempotence**

Starting file had `permissions.allow`, `sandbox.enabled`, an unrelated
`allowWrite` entry, and `sandbox.network.allowUnixSockets`:

```json
{
  "permissions": { "allow": ["Bash(git status:*)"] },
  "sandbox": {
    "enabled": true,
    "filesystem": { "allowWrite": ["~/.other", "~/.stim"] },
    "network": {
      "allowUnixSockets": ["/tmp/a.sock"],
      "allowMachLookup": ["com.apple.coresimulator.*"],
      "allowLocalBinding": true
    }
  }
}
```

A second `--fix`: `... already carries the sandbox allowance. Nothing to write.`

**7. A malformed personal file is refused, not overwritten**

```text
Refusing to write /private/tmp/stim199-merge-JQKU/.claude/settings.local.json: it is not valid JSON: Expected property name or '}' in JSON at position 2 (line 1 column 3). Nothing was changed. Repair the file, or add the three keys by hand.
```

The file still reads `{ oops` afterwards.

**8. `--fix --json` keeps the stdout contract (invariant 7)**

The message goes to stderr; stdout carries exactly one payload, which gains a
`fix` object only when `--fix` ran:

```json
{
  "project": "/private/tmp/stim199-merge-JQKU",
  "findings": [],
  "fix": { "harness": "claude", "applied": true, "path": "...", "message": "..." }
}
```

Invariant 9 does not apply: no `git`, `simctl`, `adb`, `avdmanager`,
`xcodebuild` or Gradle argument list changed.

Fixes #199
