### PR TITLE
fix: type-check every known setting and refuse a wrong-typed value by name

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -505,6 +505,29 @@ describe('explicit remote backend behavior', () => {
     expect(selected).toEqual(['proxy']);
   });
 
+  test('a wrong-typed known setting is refused before device work, with nothing on stdout', async () => {
+    const h = harness({
+      resolveSettingsFor: () => ({ android: { variant: {} } }),
+      ensureDevice: never('the device'),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_BAD_ARG');
+    expect(result.error?.message).toBe('Invalid android.variant setting {}. Expected a string.');
+    expect(result.error?.remedy).toMatch(/guide settings/);
+    expect(h.calls.ensureDevice).toEqual([]);
+    expect(h.stdout).toEqual([]);
+    expect(h.stderr.join('\n')).not.toContain('not read by Stim');
+  });
+
+  test('stim android warns about an unknown setting key', async () => {
+    const h = harness({ resolveSettingsFor: () => ({ packageManager: 'pnpm' }) });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(h.stderr.join('\n')).toContain('setting "packageManager" is not read by Stim');
+    expect(h.stdout.join('\n')).not.toContain('packageManager');
+  });
+
   test('an invalid android.remote setting is a structured refusal', async () => {
     let resolved = false;
     const h = harness({

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -612,6 +612,30 @@ test('runDoctor reports a configured SimSlim profile when the binary is missing'
   }
 });
 
+test('runDoctor reports a wrong-typed setting as a finding rather than refusing', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-setting-shape-'));
+  const home = mkdtempSync(join(tmpdir(), 'stim-doctor-setting-home-'));
+  process.env.STIM_HOME = home;
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    writeFileSync(join(project, '.stim.json'), JSON.stringify({ ios: { configuration: {} }, caches: 42 }));
+    const findings = runDoctor(project, { concurrency: { maxBuilds: 0, maxDevices: 0 } });
+    const shapeFindings = findings.filter((finding) => /wrong type/i.test(finding.title));
+    expect(shapeFindings.map((finding) => finding.detail)).toEqual([
+      'Invalid ios.configuration setting {}. Expected a string.',
+      'Invalid caches setting 42. Expected an array of strings.',
+    ]);
+    for (const finding of shapeFindings) {
+      expect(finding.level).toBe('cost');
+      expect(finding.fix).toMatch(/guide settings/);
+    }
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('a project with no provider configured at all is reported as nothing', () => {
   expect(checkBuildCacheProvider({ expo: {} }, 57)).toBe(null);
   expect(checkBuildCacheProvider({ expo: {} }, 53)).toBe(null);

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -104,6 +104,23 @@ describe('a cache-scoped report', () => {
   });
 });
 
+test('a wrong-typed setting refuses gc with nothing on stdout', async () => {
+  const errs: string[] = [];
+  const originalError = console.error;
+  console.error = (...args) => errs.push(args.join(' '));
+  try {
+    const output = await captureLog(() =>
+      runGc({}, { settingShapeErrors: () => ['Invalid caches setting {}. Expected an array of strings.'] }),
+    );
+    expect(output).toBe('');
+    expect(errs.join('\n')).toContain('Invalid caches setting {}. Expected an array of strings.');
+    expect(process.exitCode).toBe(1);
+  } finally {
+    console.error = originalError;
+    process.exitCode = 0;
+  }
+});
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 test('names skipped entries and why they were skipped', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -567,15 +567,37 @@ test('the settings topic lists exactly the keys settings.js honours', () => {
   const body = renderTopic('settings');
   assert(body);
   const src = readFileSync(new URL('../settings.ts', import.meta.url), 'utf-8');
-  const knownStart = src.indexOf('const KNOWN_SETTINGS');
-  const knownEnd = src.indexOf(']);', knownStart);
-  const knownSource = src.slice(knownStart, knownEnd);
-  const known = [...knownSource.matchAll(/^\s*'([a-zA-Z.]+)',$/gm)]
-    .map((m) => m[1])
-    .filter((k): k is string => k !== undefined);
+  const table = src.slice(src.indexOf('const SETTING_SHAPES'), src.indexOf('};', src.indexOf('const SETTING_SHAPES')));
+  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z]+',$/gm)]
+    .map((match) => match[1])
+    .filter((key): key is string => key !== undefined);
   expect(known.length > 0).toBeTruthy();
   for (const key of known) {
     expect(body.includes(key)).toBeTruthy();
+  }
+});
+
+test('the errors topic names a wrong-typed setting as a STIM_BAD_ARG cause', () => {
+  const errors = renderTopic('errors');
+  assert(errors);
+  const section = errors.slice(errors.indexOf('STIM_BAD_ARG')).replace(/\s+/g, ' ');
+  expect(section).toMatch(/a known setting with the wrong type/);
+  expect(section).toMatch(/Invalid <key> setting <value>\. Expected <shape>\./);
+  expect(section).toMatch(/guide settings.{0,4} names the type each key takes/);
+});
+
+test('the setting type rule is stated once and is consistent across user guidance', () => {
+  const guide = renderTopic('settings');
+  assert(guide);
+  const website = readFileSync(new URL('../../../../website/docs/settings.md', import.meta.url), 'utf-8');
+  for (const guidance of [guide, website]) {
+    const flat = guidance.replace(/\s+/g, ' ');
+    expect(flat.match(/wrong type is refused by name/gi)).toHaveLength(1);
+    expect(flat).toMatch(/takes ONE type: a string, an array of strings, a number/i);
+    expect(flat).toMatch(/android\.avdConfig.? and .?cache\.options.?, an object/i);
+    expect(flat).toMatch(/refused by name on every command that resolves settings/i);
+    expect(flat).toMatch(/never falls back to a default silently/i);
+    expect(flat).toMatch(/doctor.{0,3} reports it as a finding instead of refusing/i);
   }
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -2393,6 +2393,26 @@ describe('--remote', () => {
     expect(remote.backends).toEqual(['proxy']);
   });
 
+  test('a wrong-typed known setting is refused before any device work, with nothing on stdout', async () => {
+    let asked = false;
+    const { exitCode, stderr, logs } = await run(
+      {},
+      {
+        resolveSettings: () => ({ ios: { configuration: {} } }),
+        resolveRemoteContext: () => {
+          asked = true;
+          return { failed: 'x', remedy: '' };
+        },
+      },
+    );
+    expect(asked).toBe(false);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('STIM_BAD_ARG');
+    expect(stderr).toContain('Invalid ios.configuration setting {}. Expected a string.');
+    expect(stderr).not.toContain('not read by Stim');
+    expect(logs).toEqual([]);
+  });
+
   test('an invalid ios.remote value is a structured refusal', async () => {
     let asked = false;
     const { exitCode, stderr } = await run(
@@ -3196,9 +3216,9 @@ describe('the project cache provider', () => {
   });
 });
 
-test('an invalid cache.provider setting is reported once and the run continues', async () => {
+test('an unusable cache.provider value is reported once and the run continues', async () => {
   reserve();
-  writeFileSync(join(root, '.stim.json'), JSON.stringify({ cache: { provider: 42 } }));
+  writeFileSync(join(root, '.stim.json'), JSON.stringify({ cache: { provider: '  ' } }));
   const { exitCode, errs, calls } = await run(
     {},
     {
@@ -3214,6 +3234,24 @@ test('an invalid cache.provider setting is reported once and the run continues',
   const notices = errs.filter((line) => line.includes('Invalid cache.provider setting'));
   expect(notices.length).toBe(1);
   expect(notices[0]).toMatch(/Using the local cache\./);
+});
+
+test('a wrong-typed cache.provider setting is refused before the build', async () => {
+  reserve();
+  writeFileSync(join(root, '.stim.json'), JSON.stringify({ cache: { provider: 42 } }));
+  const { exitCode, errs, calls } = await run(
+    {},
+    {
+      repoRoot: () => root,
+      loadCacheProvider: async () => {
+        throw new Error('an invalid setting must not reach the loader');
+      },
+    },
+  );
+
+  expect(exitCode).toBe(1);
+  expect(calls.order.includes('buildIos')).toBe(false);
+  expect(errs.join('\n')).toContain('Invalid cache.provider setting 42. Expected a string.');
 });
 
 test('a local hit leaves no provider download directory behind', async () => {

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -27,9 +27,9 @@ import {
   remoteIosSetting,
   resolveCacheProviderConfig,
   resolveSettings,
+  settingShapeErrors,
   tunnelModeSetting,
   unknownSettingKeys,
-  worktreeDirSettingError,
 } from '../settings.ts';
 import { setProjectSetting, setRepoSetting, upsertProject } from '../config.ts';
 
@@ -301,44 +301,93 @@ test('unknownSettingKeys reports a nested unknown without flagging its parent', 
   expect(unknownSettingKeys({ ios: { deviceType: 'x', bogus: 1 } })).toEqual(['ios.bogus']);
 });
 
-test('unknownSettingKeys treats a known scalar key with an object value as known, leaving refusal to its validator', () => {
+test('unknownSettingKeys treats a known scalar key with an object value as known, leaving refusal to the shape check', () => {
   expect(unknownSettingKeys({ worktreeDir: {} })).toEqual([]);
-  expect(worktreeDirSettingError({ worktreeDir: {} })).toMatch(/Invalid worktreeDir setting/);
+  expect(settingShapeErrors({ worktreeDir: {} })).toEqual(['Invalid worktreeDir setting {}. Expected a string path.']);
 
   expect(unknownSettingKeys({ ios: { lanHost: {} } })).toEqual([]);
-  expect(iosLanHostSettingError({ ios: { lanHost: {} } })).toMatch(/Invalid ios\.lanHost setting/);
+  expect(settingShapeErrors({ ios: { lanHost: {} } })).toEqual(['Invalid ios.lanHost setting {}. Expected a string.']);
 });
 
 test('unknownSettingKeys still reports a genuinely unknown nested key under ios', () => {
   expect(unknownSettingKeys({ ios: { bogus: {} } })).toEqual(['ios.bogus']);
 });
 
-test('unknownSettingKeys still reports an object value for a known scalar with no validator (transitional, see #210)', () => {
-  expect(unknownSettingKeys({ ios: { configuration: {} } })).toEqual(['ios.configuration']);
+test('a known key is never an unknown-key warning, whatever its value', () => {
+  for (const value of [{}, 42, true, [], null, 'x']) {
+    expect(unknownSettingKeys({ ios: { configuration: value } })).toEqual([]);
+    expect(unknownSettingKeys({ caches: value })).toEqual([]);
+  }
+  expect(settingShapeErrors({ ios: { configuration: {} } })).toEqual([
+    'Invalid ios.configuration setting {}. Expected a string.',
+  ]);
 });
 
-test('every validated scalar key is a known setting, as a string and as an object', () => {
-  const validated = [
-    'worktreeDir',
-    'ios.lanHost',
-    'ios.signingIdentity',
-    'ios.signingIdentitySha1',
-    'ios.remote',
-    'ios.simslimProfile',
-    'android.remote',
-    'android.dataPartitionSizeGb',
-    'android.avdConfigFile',
-    'cache.provider',
-  ];
-  const nested = (path: string, value: unknown): Record<string, unknown> =>
-    path
-      .split('.')
-      .toReversed()
-      .reduce<Record<string, unknown>>((inner, key) => ({ [key]: inner }), value as Record<string, unknown>);
-  for (const path of validated) {
-    expect(unknownSettingKeys(nested(path, 'x'))).toEqual([]);
-    expect(unknownSettingKeys(nested(path, {}))).toEqual([]);
+function nestedSetting(path: string, value: unknown): Record<string, unknown> {
+  return path
+    .split('.')
+    .toReversed()
+    .reduce<Record<string, unknown>>((inner, key) => ({ [key]: inner }), value as Record<string, unknown>);
+}
+
+const SHAPE_CASES: Record<string, { valid: unknown; invalid: unknown; expected: string }> = {
+  'ios.deviceType': { valid: 'iPhone 17 Pro', invalid: {}, expected: 'a string' },
+  'ios.runtime': { valid: '26.2', invalid: 26.2, expected: 'a string' },
+  'ios.configuration': { valid: 'Release', invalid: { name: 'Release' }, expected: 'a string' },
+  'ios.remote': { valid: 'proxy', invalid: true, expected: 'a string' },
+  'ios.simslimProfile': { valid: '.simslim/dev.json', invalid: {}, expected: 'a string path' },
+  'ios.signingIdentity': { valid: 'Apple Development: Jane', invalid: [], expected: 'a string' },
+  'ios.signingIdentitySha1': { valid: 'A'.repeat(40), invalid: 42, expected: 'a string' },
+  'ios.lanHost': { valid: '192.168.1.42', invalid: {}, expected: 'a string' },
+  'android.systemImage': { valid: 'system-images;android-36;google_apis;arm64-v8a', invalid: {}, expected: 'a string' },
+  'android.dataPartitionSizeGb': { valid: 8, invalid: '8', expected: 'a number' },
+  'android.avdConfigFile': { valid: 'avd/config.ini', invalid: {}, expected: 'a string path' },
+  'android.avdConfig': { valid: { 'hw.ramSize': 4096 }, invalid: 'hw.ramSize=4096', expected: 'an object' },
+  'android.variant': { valid: 'productionDebug', invalid: {}, expected: 'a string' },
+  'android.keystore': { valid: 'android/app/release.keystore', invalid: {}, expected: 'a string path' },
+  'android.keystorePassword': { valid: 'env:MY_KS_PASS', invalid: 1234, expected: 'a string' },
+  'android.remote': { valid: 'eas', invalid: true, expected: 'a string' },
+  'metro.tunnel': { valid: 'ngrok', invalid: {}, expected: 'a string' },
+  'metro.ngrokUrl': { valid: 'https://a.ngrok.app', invalid: {}, expected: 'a string' },
+  'metro.publicUrl': { valid: 'https://metro.example', invalid: false, expected: 'a string' },
+  worktreeDir: { valid: '.stim-worktrees', invalid: {}, expected: 'a string path' },
+  'worktree.baseRef': { valid: 'head', invalid: {}, expected: 'a string' },
+  'worktree.include': { valid: ['.env'], invalid: {}, expected: 'an array of strings' },
+  'worktree.exclude': { valid: ['node_modules'], invalid: ['ok', 7], expected: 'an array of strings' },
+  'cache.provider': { valid: './cache.cjs', invalid: {}, expected: 'a string' },
+  'cache.options': { valid: { bucket: 'a' }, invalid: 'nope', expected: 'an object' },
+  caches: { valid: ['~/.myapp-metro-cache'], invalid: {}, expected: 'an array of strings' },
+};
+
+test('every known setting has a shape, and a wrong-typed value is one refusal naming the key and the shape', () => {
+  const src = readFileSync(new URL('../settings.ts', import.meta.url), 'utf-8');
+  const table = src.slice(src.indexOf('const SETTING_SHAPES'), src.indexOf('};', src.indexOf('const SETTING_SHAPES')));
+  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z]+',$/gm)]
+    .map((match) => match[1])
+    .filter((key): key is string => key !== undefined);
+  expect(known.length).toBeGreaterThan(0);
+  expect(Object.keys(SHAPE_CASES).toSorted()).toEqual(known.toSorted());
+
+  for (const key of known) {
+    const shapeCase = SHAPE_CASES[key];
+    assert(shapeCase);
+    expect(settingShapeErrors(nestedSetting(key, shapeCase.invalid))).toEqual([
+      `Invalid ${key} setting ${JSON.stringify(shapeCase.invalid)}. Expected ${shapeCase.expected}.`,
+    ]);
+    expect(settingShapeErrors(nestedSetting(key, shapeCase.valid))).toEqual([]);
+    expect(unknownSettingKeys(nestedSetting(key, shapeCase.invalid))).toEqual([]);
+    expect(unknownSettingKeys(nestedSetting(key, shapeCase.valid))).toEqual([]);
   }
+});
+
+test('settingShapeErrors reports one line per bad key and ignores absent keys', () => {
+  expect(settingShapeErrors({})).toEqual([]);
+  expect(settingShapeErrors(null)).toEqual([]);
+  expect(settingShapeErrors('nope')).toEqual([]);
+  expect(settingShapeErrors({ ios: { configuration: {} }, worktreeDir: 5, packageManager: 'pnpm' })).toEqual([
+    'Invalid ios.configuration setting {}. Expected a string.',
+    'Invalid worktreeDir setting 5. Expected a string path.',
+  ]);
 });
 
 test('unknownSettingKeys tolerates empty and malformed input', () => {
@@ -589,8 +638,8 @@ test('ios.lanHost takes a bare address and refuses everything that would break s
 });
 
 test('worktreeDir refuses a non-string value and accepts a valid path', () => {
-  expect(worktreeDirSettingError({ worktreeDir: 5 })).toMatch(/Invalid worktreeDir setting/);
-  expect(worktreeDirSettingError({ worktreeDir: '.stim-worktrees' })).toBe(null);
+  expect(settingShapeErrors({ worktreeDir: 5 })).toEqual(['Invalid worktreeDir setting 5. Expected a string path.']);
+  expect(settingShapeErrors({ worktreeDir: '.stim-worktrees' })).toEqual([]);
 });
 
 test('the three iOS device settings are known keys', () => {

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -386,6 +386,26 @@ test('create action: a non-string worktreeDir setting refuses cleanly instead of
   }
 });
 
+test('create action: an object worktreeDir is one refusal, never an unknown-key warning', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-object-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+    writeFileSync(join(repo, '.stim.json'), JSON.stringify({ worktreeDir: {} }));
+
+    const { logs, errs } = await runCreateInRepo(repo, 'feat-object-dir', { install: false });
+
+    expect(logs).toEqual([]);
+    expect(errs.filter((e) => /Invalid worktreeDir setting/.test(e))).toHaveLength(1);
+    expect(errs.some((e) => /Invalid worktreeDir setting \{\}\. Expected a string path\./.test(e))).toBeTruthy();
+    expect(errs.some((e) => /not read by Stim/.test(e))).toBe(false);
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: --dir takes precedence over the worktreeDir setting', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-dir-setting-')));

--- a/packages/stim-cli/src/caches.ts
+++ b/packages/stim-cli/src/caches.ts
@@ -5,7 +5,7 @@ import { METRO_NAMED_CACHE_LAYOUT } from '@stim-cli/core';
 import { directorySize } from './fs-util.ts';
 import { registeredCaches } from './cache-manifest.ts';
 import { findProjectRoot } from './project.ts';
-import { resolveSettings } from './settings.ts';
+import { resolveSettings, settingShapeErrors, type SettingsObject } from './settings.ts';
 import { gitCommonDir, repoRoot } from './worktree.ts';
 
 export interface CacheDescriptor {
@@ -80,15 +80,23 @@ function declaredCaches(paths: string[]): CacheDescriptor[] {
     .map((dir): CacheDescriptor => ({ name: 'declared', dir, prune: 'entries', note: 'from the `caches` setting' }));
 }
 
-export function declaredCachePaths(cwd: string = process.cwd()): string[] {
+function projectSettings(cwd: string): SettingsObject {
   const root = findProjectRoot(cwd);
-  if (!root) return [];
-  const settings = resolveSettings({
+  if (!root) return {};
+  return resolveSettings({
     projectPath: root,
     gitCommonDir: gitCommonDir(root),
     repoRoot: repoRoot(root),
   });
-  return Array.isArray(settings?.caches) ? (settings.caches as string[]) : [];
+}
+
+export function declaredCachePaths(cwd: string = process.cwd()): string[] {
+  const declared = projectSettings(cwd).caches;
+  return Array.isArray(declared) ? (declared as string[]) : [];
+}
+
+export function projectSettingShapeErrors(cwd: string = process.cwd()): string[] {
+  return settingShapeErrors(projectSettings(cwd));
 }
 
 export function discoverCaches({ declared = [] }: { declared?: string[] } = {}): CacheDescriptor[] {

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -60,6 +60,7 @@ import {
 } from './ios.ts';
 import {
   REMOTE_DEVICE_BACKENDS,
+  SETTING_SHAPE_REMEDY,
   androidAvdConfigSettingError,
   androidDataPartitionSizeGbSettingError,
   cacheProviderSettingError,
@@ -68,7 +69,9 @@ import {
   remoteDeviceSettingError,
   resolveCacheProviderConfig,
   resolveSettings,
+  settingShapeErrors,
   tunnelModeSetting,
+  unknownSettingKeys,
 } from '../settings.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
 import { readCollectors } from '../collector/state.ts';
@@ -1592,6 +1595,13 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     repoRoot: settingsRepoRoot,
   };
   const settings = resolveSettingsFor(settingsContext);
+  const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
+  if (shapeError) {
+    return fail('STIM_BAD_ARG', shapeError, SETTING_SHAPE_REMEDY, { lines: moreShapeErrors });
+  }
+  for (const key of unknownSettingKeys(settings)) {
+    out(phaseLine('setting', chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`)));
+  }
   const cacheProviderConfig = resolveCacheProvider(settingsContext);
   const cacheProviderError = cacheProviderSettingError(settings);
   if (cacheProviderError) out(phaseLine('cache', chalk.yellow(`${cacheProviderError} Using the local cache.`)));

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -106,7 +106,7 @@ export default function doctorCommand(program: Command): void {
         console.log(chalk.green('Nothing to flag.'));
         console.log(
           chalk.dim(
-            'Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile and, on a checkout without installed dependencies, fingerprint parity.',
+            'Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile, the type of every setting Stim reads and, on a checkout without installed dependencies, fingerprint parity.',
           ),
         );
         console.log(

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -23,10 +23,18 @@ import { getExecutor } from '../exec.ts';
 import { isPidAlive } from '../metro.ts';
 import { detectIsExpo, findProjectRoot } from '../project.ts';
 import { reclaimProject } from '../reclaim.ts';
+import { SETTING_SHAPE_REMEDY } from '../settings.ts';
 import { listAllIosSims, type IosSimRecord } from '../sim/ios.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 import { listAvds, ownedAvdDirectory } from '../sim/android.ts';
-import { declaredCachePaths, discoverCaches, pruneCache, sizeCaches, type CacheDescriptor } from '../caches.ts';
+import {
+  declaredCachePaths,
+  discoverCaches,
+  projectSettingShapeErrors,
+  pruneCache,
+  sizeCaches,
+  type CacheDescriptor,
+} from '../caches.ts';
 import { workspaceDir, workspaceStateFile } from '../paths.ts';
 import { withRemoteSessionLock } from '../engine/device-remote.ts';
 import { withEasProjectLock } from '../engine/eas-project-lock.ts';
@@ -128,6 +136,7 @@ interface GcDependencies {
   precollectedEasSessionSweep?: EasSessionSweep;
   avdDirectory?: typeof ownedAvdDirectory;
   directorySize?: typeof directorySize;
+  settingShapeErrors?: () => string[];
 }
 
 // simctl and emulator listings can exceed 10 seconds on loaded hosts; 30 seconds still bounds hangs.
@@ -1043,6 +1052,13 @@ export async function collectGcReport(
 }
 
 export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}): Promise<void> {
+  const shapeErrors = (deps.settingShapeErrors ?? projectSettingShapeErrors)();
+  if (shapeErrors.length) {
+    for (const message of shapeErrors) console.error(chalk.red(message));
+    console.error(chalk.dim(SETTING_SHAPE_REMEDY));
+    process.exitCode = 1;
+    return;
+  }
   if (opts.cache) {
     return runGcCore(opts, {
       ...deps,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1009,7 +1009,9 @@ STIM_SUPERVISOR_EXITED
   the full records. Fix that and run \`start\` again; nothing is left running.
 
 STIM_BAD_ARG / STIM_NO_PROJECT
-  The command refused before doing anything: an unusable --wait value, an invalid
+  The command refused before doing anything: an unusable --wait value, a known
+  setting with the wrong type ("Invalid <key> setting <value>. Expected <shape>."
+  -- \`guide settings\` names the type each key takes), an invalid
   Metro tunnel setting, an invalid android.dataPartitionSizeGb value, an unsafe
   android.avdConfig key or fragment, a malformed ios.signingIdentity,
   ios.signingIdentitySha1 or ios.lanHost value, \`--device\` with an empty
@@ -2104,6 +2106,12 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         environment or the machine layers.
   caches                extra shared-cache paths for \`gc\` to report. A JSON
                         array; every path is treated as a flat store.
+
+Every key above takes ONE type: a string, an array of strings, a number, or,
+for android.avdConfig and cache.options, an object. A value of the wrong type is
+refused by name on every command that resolves settings, so a wrong shape never
+falls back to a default silently. \`stim doctor\` reports it as a finding
+instead of refusing.
 
 Anything else is IGNORED, and Stim warns about it by name on every run that
 resolves settings. If you see such a warning, the key was either renamed or

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -123,6 +123,8 @@ import {
   remoteIosSetting,
   resolveCacheProviderConfig,
   resolveSettings,
+  SETTING_SHAPE_REMEDY,
+  settingShapeErrors,
   tunnelModeSetting,
   unknownSettingKeys,
   type SettingsObject,
@@ -1616,6 +1618,15 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     repoRoot: settingsRepoRoot,
   };
   const settings = d.resolveSettings(settingsContext);
+  const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
+  if (shapeError) {
+    return fail({
+      code: 'STIM_BAD_ARG',
+      message: shapeError,
+      lines: moreShapeErrors,
+      remedy: SETTING_SHAPE_REMEDY,
+    });
+  }
   const cacheProviderConfig = d.resolveCacheProviderConfig(settingsContext);
   for (const key of unknownSettingKeys(settings)) {
     note(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
@@ -1640,7 +1651,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       return fail({
         code: 'STIM_BAD_ARG',
         message: settingError,
-        remedy: 'Run `stim guide settings` for the shape each ios.* key takes.',
+        remedy: SETTING_SHAPE_REMEDY,
       });
     }
   }

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -30,6 +30,8 @@ import {
   remoteIosSetting,
   resolveCacheProviderConfig,
   resolveSettings,
+  SETTING_SHAPE_REMEDY,
+  settingShapeErrors,
   tunnelModeSetting,
   unknownSettingKeys,
 } from '../settings.ts';
@@ -330,6 +332,15 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
         repoRoot: worktreeRoot,
       };
       const settings = resolveSettings(settingsContext);
+      const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
+      if (shapeError) {
+        return fail({
+          code: 'STIM_BAD_ARG',
+          message: shapeError,
+          lines: moreShapeErrors,
+          remedy: SETTING_SHAPE_REMEDY,
+        });
+      }
       const cacheProvider = resolveCacheProviderConfig(settingsContext);
       for (const key of unknownSettingKeys(settings)) {
         note(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { resolveSettings, unknownSettingKeys, worktreeDirSettingError } from '../settings.ts';
+import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
 import { reclaimProject } from '../reclaim.ts';
@@ -213,14 +213,15 @@ export function registerCreate(worktree: Command): void {
       }
       const common = gitCommonDir(process.cwd());
       const settings = resolveSettings({ gitCommonDir: common, repoRoot: root }) as WorktreeSettings;
-      for (const key of unknownSettingKeys(settings)) {
-        console.error(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
-      }
-      const worktreeDirError = worktreeDirSettingError(settings);
-      if (worktreeDirError) {
-        console.error(chalk.red(worktreeDirError));
+      const shapeErrors = settingShapeErrors(settings);
+      if (shapeErrors.length) {
+        for (const message of shapeErrors) console.error(chalk.red(message));
+        console.error(chalk.dim(SETTING_SHAPE_REMEDY));
         process.exitCode = 1;
         return;
+      }
+      for (const key of unknownSettingKeys(settings)) {
+        console.error(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
       }
 
       const base = opts.base || settings?.worktree?.baseRef || 'head';

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -22,7 +22,14 @@ import {
   providerFromConfig,
   resolveEasCliBin,
 } from './engine/remote-cache.ts';
-import { iosSimSlimProfileSetting, remoteAndroidSetting, remoteIosSetting, resolveSettings } from './settings.ts';
+import {
+  iosSimSlimProfileSetting,
+  remoteAndroidSetting,
+  remoteIosSetting,
+  resolveSettings,
+  SETTING_SHAPE_REMEDY,
+  settingShapeErrors,
+} from './settings.ts';
 import type { RemoteDeviceBackend } from './types.ts';
 
 type AnyJson = Record<string, unknown>;
@@ -614,6 +621,9 @@ export function runDoctor(
     gitCommonDir: gitCommonDir(projectRoot),
     repoRoot: settingsRepoRoot,
   });
+  const settingShapeFindings = settingShapeErrors(projectSettings).map((error) =>
+    finding('cost', 'A setting has the wrong type', error, SETTING_SHAPE_REMEDY),
+  );
   let simslimProfile: string | null = null;
   let simslimProfileError: string | null = null;
   try {
@@ -664,6 +674,7 @@ export function runDoctor(
     concurrencyFinding,
     simslimFinding,
     ...remoteFindings,
+    ...settingShapeFindings,
   ].filter((f): f is Finding => Boolean(f));
 }
 

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -25,51 +25,77 @@ export function mergeSettingsLayers(layers: Array<SettingsObject | null | undefi
   return out;
 }
 
-const KNOWN_SETTINGS = new Set([
-  'ios.deviceType',
-  'ios.runtime',
-  'ios.configuration',
-  'ios.remote',
-  'ios.simslimProfile',
-  'ios.signingIdentity',
-  'ios.signingIdentitySha1',
-  'ios.lanHost',
-  'android.systemImage',
-  'android.dataPartitionSizeGb',
-  'android.avdConfigFile',
-  'android.avdConfig',
-  'android.variant',
-  'android.keystore',
-  'android.keystorePassword',
-  'android.remote',
-  'metro.tunnel',
-  'metro.ngrokUrl',
-  'metro.publicUrl',
-  'worktreeDir',
-  'worktree.baseRef',
-  'worktree.include',
-  'worktree.exclude',
-  'cache.provider',
-  'cache.options',
-  'caches',
-]);
+type SettingShape = 'string' | 'path' | 'strings' | 'number' | 'object';
 
-const OPEN_SETTINGS_OBJECTS = new Set(['android.avdConfig', 'cache.options']);
+interface SettingShapeRule {
+  expected: string;
+  accepts: (value: unknown) => boolean;
+}
 
-// Keys outside this set have no validator on every command that reads them,
-// so an object value keeps the unknown-key warning; see issue #210.
-const VALIDATED_SCALAR_SETTINGS = new Set([
-  'worktreeDir',
-  'ios.lanHost',
-  'ios.signingIdentity',
-  'ios.signingIdentitySha1',
-  'ios.remote',
-  'ios.simslimProfile',
-  'android.remote',
-  'android.dataPartitionSizeGb',
-  'android.avdConfigFile',
-  'cache.provider',
-]);
+const SETTING_SHAPE_RULES: Record<SettingShape, SettingShapeRule> = {
+  string: { expected: 'a string', accepts: (value) => typeof value === 'string' },
+  path: { expected: 'a string path', accepts: (value) => typeof value === 'string' },
+  strings: {
+    expected: 'an array of strings',
+    accepts: (value) => Array.isArray(value) && value.every((entry) => typeof entry === 'string'),
+  },
+  number: { expected: 'a number', accepts: (value) => typeof value === 'number' },
+  object: { expected: 'an object', accepts: isPlainObject },
+};
+
+const SETTING_SHAPES: Record<string, SettingShape> = {
+  'ios.deviceType': 'string',
+  'ios.runtime': 'string',
+  'ios.configuration': 'string',
+  'ios.remote': 'string',
+  'ios.simslimProfile': 'path',
+  'ios.signingIdentity': 'string',
+  'ios.signingIdentitySha1': 'string',
+  'ios.lanHost': 'string',
+  'android.systemImage': 'string',
+  'android.dataPartitionSizeGb': 'number',
+  'android.avdConfigFile': 'path',
+  'android.avdConfig': 'object',
+  'android.variant': 'string',
+  'android.keystore': 'path',
+  'android.keystorePassword': 'string',
+  'android.remote': 'string',
+  'metro.tunnel': 'string',
+  'metro.ngrokUrl': 'string',
+  'metro.publicUrl': 'string',
+  worktreeDir: 'path',
+  'worktree.baseRef': 'string',
+  'worktree.include': 'strings',
+  'worktree.exclude': 'strings',
+  'cache.provider': 'string',
+  'cache.options': 'object',
+  caches: 'strings',
+};
+
+const KNOWN_SETTINGS = new Set(Object.keys(SETTING_SHAPES));
+
+function settingValueAt(settings: unknown, path: string): unknown {
+  let node: unknown = settings;
+  for (const segment of path.split('.')) {
+    if (!isPlainObject(node)) return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+export function settingShapeErrors(settings: unknown): string[] {
+  const errors: string[] = [];
+  for (const [path, shape] of Object.entries(SETTING_SHAPES)) {
+    const value = settingValueAt(settings, path);
+    if (value === undefined) continue;
+    const rule = SETTING_SHAPE_RULES[shape];
+    if (rule.accepts(value)) continue;
+    errors.push(`Invalid ${path} setting ${JSON.stringify(value)}. Expected ${rule.expected}.`);
+  }
+  return errors;
+}
+
+export const SETTING_SHAPE_REMEDY = 'Run `stim guide settings` for the shape each setting takes.';
 
 export const MIN_ANDROID_DATA_PARTITION_SIZE_GB: number = 6;
 export const DEFAULT_ANDROID_DATA_PARTITION_SIZE_GB: number = 8;
@@ -403,29 +429,17 @@ export function iosLanHostSettingError(settings: unknown): string | null {
   return null;
 }
 
-export function worktreeDirSettingError(settings: unknown): string | null {
-  if (!isPlainObject(settings) || !('worktreeDir' in settings)) return null;
-  const raw = settings.worktreeDir;
-  if (typeof raw !== 'string') {
-    return `Invalid worktreeDir setting ${JSON.stringify(raw)}. Expected a string path.`;
-  }
-  return null;
-}
-
 export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {
   if (!isPlainObject(settings)) return [];
   const unknown: string[] = [];
   for (const [key, value] of Object.entries(settings)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    if (isPlainObject(value)) {
-      if (OPEN_SETTINGS_OBJECTS.has(path)) continue;
-      if (VALIDATED_SCALAR_SETTINGS.has(path)) continue;
-      const hasKnownChildren = [...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`));
-      if (hasKnownChildren) unknown.push(...unknownSettingKeys(value, path));
-      else unknown.push(path);
+    if (KNOWN_SETTINGS.has(path)) continue;
+    if (isPlainObject(value) && [...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`))) {
+      unknown.push(...unknownSettingKeys(value, path));
       continue;
     }
-    if (!KNOWN_SETTINGS.has(path)) unknown.push(path);
+    unknown.push(path);
   }
   return unknown;
 }

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -17,7 +17,11 @@ Stim reads the first value found in this order:
 4. The Stim default.
 
 Nested objects merge by key. Arrays replace lower-precedence arrays. Unknown
-keys produce a warning.
+keys produce a warning. Every key below takes one type: a string, an array of
+strings, a number, or, for `android.avdConfig` and `cache.options`, an object.
+A value of the wrong type is refused by name on every command that resolves
+settings, so a wrong shape never falls back to a default silently. `stim doctor`
+reports it as a finding instead of refusing.
 
 ## Committed settings
 


### PR DESCRIPTION
## Description

Only 12 of the 26 known settings had a validator, and two of those (`metro.tunnel`,
`metro.ngrokUrl`) ran under `start` alone. For the other 14 a wrong-typed value was
silently ignored or passed through: `{"ios": {"configuration": {"name": "Release"}}}`
built Debug, `{"caches": {}}` stopped `gc` pruning declared directories,
`{"android": {"keystore": {}}}` fell back to the debug keystore on a release swap.
Separately, `commands/android.ts` never called `unknownSettingKeys`, so `stim android`
has never warned about an unknown key. #208 made the object case visible for the
validated keys only, through a transitional `VALIDATED_SCALAR_SETTINGS` set that this
replaces.

## Solution

**A correctly typed settings file behaves exactly as before.** A wrong-typed one now
stops the command by name instead of quietly doing the wrong thing.

`SETTING_SHAPES` in `packages/stim-cli/src/settings.ts` gives all 26 keys one shape each and
is the single source of truth: `KNOWN_SETTINGS` is now `new Set(Object.keys(SETTING_SHAPES))`,
so a key in the table but missing from the set is unrepresentable. `settingShapeErrors(settings)`
is pure and returns one message per wrong-typed key, in table order, in the shape the per-key
validators already used: `Invalid ios.configuration setting {"name":"Release"}. Expected a string.`

| shape | keys |
| --- | --- |
| a string | `ios.deviceType`, `ios.runtime`, `ios.configuration`, `ios.remote`, `ios.signingIdentity`, `ios.signingIdentitySha1`, `ios.lanHost`, `android.systemImage`, `android.variant`, `android.keystorePassword`, `android.remote`, `metro.tunnel`, `metro.ngrokUrl`, `metro.publicUrl`, `worktree.baseRef`, `cache.provider` |
| a string path | `ios.simslimProfile`, `android.avdConfigFile`, `android.keystore`, `worktreeDir` |
| an array of strings | `worktree.include`, `worktree.exclude`, `caches` |
| a number | `android.dataPartitionSizeGb` |
| an object | `android.avdConfig`, `cache.options` |

`start`, `ios`, `android`, `worktree create`, and `gc` run the check right after
resolution and refuse: red on stderr, exit 1, nothing on stdout. Under `--json` the payload
carries the first error as its `message` and the remaining bad keys are stderr lines only, the
way every other multi-line refusal in these commands already behaves. **`doctor` is the
exception** and reports each error as a `costs time` finding, because refusing would
defeat the one command whose job is to name what is wrong. `status`, `stop`, and `logs`
resolve no settings at all. `gc` reaches settings through `declaredCachePaths`, so
`caches.ts` grew a sibling `projectSettingShapeErrors` over the same resolution rather
than a second one.

**One deliberate behavior change beyond the 14 silent keys:** `{"cache": {"provider": 42}}`
used to warn and keep building on the local cache; a wrong type is now a refusal like every
other key. What the shape check does not own is unchanged, so `{"cache": "nope"}` and
`{"cache": {"provider": "  "}}` still warn once and the build continues. Machine-level
`caches` in `~/.stim/config.json` is a different key that never enters `resolveSettings`,
so the array shape here does not touch it.

The semantic validators keep running on top, now only on values that already have the right
type: identity format, LAN host format, remote backend name, tunnel mode, the
`android.dataPartitionSizeGb` range, AVD key safety, and the profile / config-file path
checks. Only `worktreeDirSettingError` is gone; it was a type check and nothing else, and
the table reproduces its message verbatim.

`VALIDATED_SCALAR_SETTINGS` and `OPEN_SETTINGS_OBJECTS` are deleted. `unknownSettingKeys`
now skips any path in `KNOWN_SETTINGS` before it looks at the value, so a known key is never
an unknown-key warning whatever its value. A genuinely unknown key under a known parent
(`ios.bogus`) is still reported, and `stim android` runs that warning now too.

`guide errors` names a wrong-typed setting in the `STIM_BAD_ARG` cause list, with the message
shape and a pointer to `guide settings`.

## Test plan

Built CLI (`node packages/stim-cli/dist/cli.mjs`) against a scratch git project with a
temporary `STIM_HOME` and this `.stim.json` (invariant 9 does not strictly apply: no
external tool call changed):

```json
{
  "ios": { "configuration": { "name": "Release" } },
  "android": { "variant": {} },
  "worktreeDir": {},
  "caches": {},
  "packageManager": "pnpm"
}
```

`stim worktree create feat-x`, `stim start`, `stim ios`, `stim android`, and `stim gc` each
exit 1 with an empty stdout, no unknown-key warning, and the four refusals plus the remedy
on stderr, e.g. `stim ios`:

```
  error       Invalid ios.configuration setting {"name":"Release"}. Expected a string.
              Invalid android.variant setting {}. Expected a string.
              Invalid worktreeDir setting {}. Expected a string path.
              Invalid caches setting {}. Expected an array of strings.
  remedy      Run `stim guide settings` for the shape each setting takes.
  failed      STIM_BAD_ARG
```

`stim doctor` exits 0 and lists the same four as findings; `stim doctor --json` still prints
exactly one parseable payload. `stim ios --json` prints one payload whose `message` is the
first error:

```json
{"code":"STIM_BAD_ARG","message":"Invalid ios.configuration setting {\"name\":\"Release\"}. Expected a string.","remedy":"Run `stim guide settings` for the shape each setting takes."}
```
 With the file corrected and `packageManager` left in place,
`stim worktree create feat-ok` prints only the created path on stdout and the one real
warning (`setting "packageManager" is not read by Stim`) on stderr.

New tests: a table-driven `settings.test.ts` case reads `SETTING_SHAPES` out of the source,
asserts a hand-written expectation table covers exactly those keys, and for each feeds a
wrong-typed value (objects, `42`, `true`, `'8'`, a mixed array) expecting one message naming
the key and shape, plus the right-typed value expecting none and no unknown-key warning
either way. Command-level refusals for `ios`, `android`, `worktree create`, and `gc` assert
an empty stdout; `stim android` gains an unknown-key warning test; `doctor.test.ts` pins the
finding. The rule is stated once in `guide settings` and in `website/docs/settings.md`, and
pinned by a cross-guidance test.

Both source scrapes (`guide.test.ts`, `settings.test.ts`) read `SETTING_SHAPES` rather than
`KNOWN_SETTINGS`. Ablation, adding `'ios.bogusKey': 'string'` to the table:

```
FAIL guide.test.ts > the settings topic lists exactly the keys settings.js honours
  AssertionError: expected false to be truthy
FAIL settings.test.ts > every known setting has a shape, and a wrong-typed value is one refusal ...
  AssertionError: expected [ 'android.avdConfig', ...(25) ] to deeply equal [ ...(26) ]
  -   "ios.bogusKey",
```

`pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (78 files, 2971 tests),
and `pnpm run knip` all pass, rebased on `origin/main` @ 6640771.

Fixes #210.

