### PR TITLE
docs: drop the AGENTS.md project-setup rule that doctor --fix retired

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ flags without an explicit product decision. Projects can wrap Stim when they
 need custom behavior.
 
 Runtime state belongs under `$STIM_HOME/workspaces/`, not in the project
-tree. Stim has no init step and never mutates project setup; do not add
-either. `doctor` reports setup that requires project judgment.
+tree. Stim has no init step; do not add one. `doctor` reports setup that
+requires project judgment.
 
 ## Development
 


### PR DESCRIPTION
## Description

AGENTS.md said Stim never mutates project setup. `doctor --fix` (#202) writes the sandbox allowance into `.claude/settings.local.json`, so the sentence was false and would send an agent to revert that behavior.

## Solution

Remove the project-setup clause and keep the rest: runtime state stays under `$STIM_HOME/workspaces/`, Stim has no init step, and `doctor` reports setup that requires project judgment. Present tense, no history.

## Test plan

- [x] `pnpm run format:check` clean (AGENTS.md is covered by oxfmt)
- [x] `grep -n "project setup" AGENTS.md` returns nothing; `CLAUDE.md` is a symlink and carries the change

Fixes #215