### PR TITLE
docs: claim an issue before implementing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,16 @@ confirm that an existing issue still applies to current
 `origin/main`; close stale issues with the fixing commit and verification
 evidence instead of creating duplicate work.
 
+Claim an issue before you implement it. Every agent works as the same GitHub
+user, so an assignee means nothing; the signals are a comment and a branch.
+Before starting, check the issue for an open linked pull request, a `Claimed:`
+comment newer than one day with no later `Released:` comment, and a branch on
+`origin` named for the issue. When any is present the issue is taken; pick
+another. To claim, comment `Claimed: <branch>` on the issue, create the worktree
+and branch, and push the branch to `origin` before implementing anything. The
+pull request replaces the claim once it opens. If you stop without opening one,
+comment `Released:` and delete the branch.
+
 Implement each valid issue in its own git worktree and branch created from the
 refreshed `origin/main`. Independent issues may run in parallel worktrees. Keep
 the branch limited to that issue, run the required checks, and open a pull

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,14 +54,13 @@ confirm that an existing issue still applies to current
 evidence instead of creating duplicate work.
 
 Claim an issue before you implement it. Every agent works as the same GitHub
-user, so an assignee means nothing; the signals are a comment and a branch.
-Before starting, check the issue for an open linked pull request, a `Claimed:`
-comment newer than one day with no later `Released:` comment, and a branch on
-`origin` named for the issue. When any is present the issue is taken; pick
-another. To claim, comment `Claimed: <branch>` on the issue, create the worktree
-and branch, and push the branch to `origin` before implementing anything. The
-pull request replaces the claim once it opens. If you stop without opening one,
-comment `Released:` and delete the branch.
+user, so assignees mean nothing; the claim is a comment plus a branch. Before
+starting, check the issue for an open pull request or a `Claimed: <branch>`
+comment newer than one day (by its `createdAt`) with no later `Released:`
+comment and that branch on `origin`. When either is present the issue is taken;
+pick another. To claim, comment `Claimed: <branch>`, then push the branch to
+`origin` before implementing anything. The open pull request replaces the
+claim. If you stop without one, comment `Released:` and delete the branch.
 
 Implement each valid issue in its own git worktree and branch created from the
 refreshed `origin/main`. Independent issues may run in parallel worktrees. Keep


### PR DESCRIPTION
## Description

Two agents implemented #199 in parallel (#202 merged, #212 closed unmerged). The workflow had no step that marks an issue as taken, and assignees cannot serve as that mark because every agent runs as the same GitHub user.

## Solution

A claim step in the "Issue and pull request workflow" section, between confirming the issue and creating the worktree. Signals that work for one shared user: a `Claimed: <branch>` comment on the issue and the branch pushed to `origin` before implementation. Before starting, an agent checks for an open linked pull request, a `Claimed:` comment newer than one day without a later `Released:`, or a matching branch on `origin`, and picks another issue when any is present. The pull request replaces the claim; an agent that stops without one comments `Released:` and deletes the branch.

## Test plan

- [x] `pnpm run format:check` clean
- [x] Read the section end to end for present-tense rules and no history; `CLAUDE.md` symlink carries the change

Fixes #214