### PR TITLE
docs: document doctor --fix and the sandbox finding on the website

### DIFF
--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -28,13 +28,24 @@ builds embed the JavaScript bundle and skip that requirement.
 ## `doctor`
 
 ```text
-stim doctor [--json]
+stim doctor [--json] [--fix]
 ```
 
 Inspects the main checkout. It reports missing or stale dependencies, CocoaPods
 state, cache conflicts, device capacity, and remote session problems. On a
 checkout without installed dependencies, it also reports fingerprint
-differences against a fresh worktree. The check is read-only.
+differences against a fresh worktree. The check is read-only unless `--fix` is
+passed.
+
+`doctor` also flags when an agent harness sandboxes shell commands and Stim is
+not allowed through it, which shows up as unrelated-looking failures against
+the simulator service, the adb server, and Stim's own state directory.
+`--fix` writes the missing allowance into `.claude/settings.local.json`, a
+per-user, gitignored file, merging it with whatever is already there and
+touching nothing else. It refuses to change anything under Codex, whose
+sandbox has no per-path allowance to add, and it does nothing when no
+sandboxing harness is present. See `stim guide errors` for the failure
+signatures and the manual settings.
 
 ## `start`
 

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -40,8 +40,8 @@ passed.
 `doctor` also flags when an agent harness sandboxes shell commands and Stim is
 not allowed through it, which shows up as unrelated-looking failures against
 the simulator service, the adb server, and Stim's own state directory.
-`--fix` writes the missing allowance into `.claude/settings.local.json`, a
-per-user, gitignored file, merging it with whatever is already there and
+`--fix` writes the missing allowance into `.claude/settings.local.json` at the repository root, the
+per-user file, merging it with whatever is already there and
 touching nothing else. It refuses to change anything under Codex, whose
 sandbox has no per-path allowance to add, and it does nothing when no
 sandboxing harness is present. See `stim guide errors` for the failure

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -40,9 +40,9 @@ passed.
 `doctor` also flags when an agent harness sandboxes shell commands and Stim is
 not allowed through it, which shows up as unrelated-looking failures against
 the simulator service, the adb server, and Stim's own state directory.
-`--fix` writes the missing allowance into `.claude/settings.local.json` at the repository root, the
-per-user file, merging it with whatever is already there and
-touching nothing else. It refuses to change anything under Codex, whose
+`--fix` writes the missing allowance into `.claude/settings.local.json` at the
+repository root, the per-user file, merging it with whatever is already there
+and touching nothing else. It refuses to change anything under Codex, whose
 sandbox has no per-path allowance to add, and it does nothing when no
 sandboxing harness is present. See `stim guide errors` for the failure
 signatures and the manual settings.


### PR DESCRIPTION
## Description

`doctor --fix` (#202) applies the sandbox allowance, and `stim guide errors`
documents it, but `website/docs/commands.md` and `packages/stim-cli/README.md`
never mentioned the flag or the finding it fixes. `packages/stim-cli/README.md`
doesn't list `doctor`'s flags at all (only `stim doctor` in the
normal-workflow snippet), so this only touches the website.

## Solution

Added `--fix` to the `doctor` usage line on the website and one paragraph
under it, mirroring the guide's facts without repeating its mechanics:

- the finding: a sandboxing harness is present without the Stim allowance
- what `--fix` writes: the missing allowance into `.claude/settings.local.json`,
  a per-user gitignored file, merged with what's already there
- it refuses under Codex (no per-path allowance to add) and does nothing
  without a detected harness
- a pointer to `stim guide errors` for the failure signatures and manual
  settings

## Test plan

- `pnpm run format:check` and `pnpm test` from the repo root: 78 test files,
  2961 tests pass. `packages/stim-cli/src/__tests__/guide.test.ts` has no
  contract test pinning `commands.md` text, so nothing pins the paragraph's
  wording.
- `website`: `pnpm run typecheck` and `pnpm run build` (Docusaurus) both
  succeed.

Fixes #218
