### PR TITLE
Make a run summary say what it proves

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2404,6 +2404,27 @@ describe('the pure parts', () => {
   });
 });
 
+describe('the device preparation step', () => {
+  test('a slow preparation gets its own timed line, so the elapsed total is accounted for', async () => {
+    let clock = 1_000_000;
+    const h = harness({
+      now: () => clock,
+      ensureDevice: async () => {
+        clock += 130_000;
+        return { avdName: 'stim-app-412', consolePort: 5584, owned: true };
+      },
+    });
+    await h.run();
+    expect(h.stderr.some((l) => /device\s+stim-app-412 prepared \(2m10s\)/.test(l))).toBeTruthy();
+  });
+
+  test('a preparation that costs nothing prints nothing of its own', async () => {
+    const h = harness();
+    await h.run();
+    expect(h.stderr.some((l) => /prepared \(/.test(l))).toBeFalsy();
+  });
+});
+
 describe('launch verification', () => {
   test("a verified launch reports launched: true and polls this workspace's timeline", async () => {
     const h = harness();
@@ -2413,7 +2434,9 @@ describe('launch verification', () => {
     expect(h.calls.verify[0]?.logsDir).toBe(workspaceLogsDir(root));
     expect(Number.isFinite(h.calls.verify[0]?.since)).toBeTruthy();
     expect(h.calls.verify[0]?.platform).toBe('android');
-    expect(h.stderr.some((l) => /verify.*bundle loaded, stable for 3s/.test(l))).toBeTruthy();
+    expect(
+      h.stderr.some((l) => /verify.*bundle loaded, stable for 3s -- the first screen may still be rendering/.test(l)),
+    ).toBeTruthy();
   });
 
   test('the picker: no bundle request makes it launched: "unverified", still exit ok', async () => {

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -1,4 +1,4 @@
-import { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+import { formatDuration, formatElapsed, phaseLine, shortHash } from '../command-output.ts';
 
 test('formatDuration uses one format for every command', () => {
   expect(formatDuration(0)).toBe('0ms');
@@ -11,6 +11,18 @@ test('formatDuration uses one format for every command', () => {
   expect(formatDuration(605000)).toBe('10m05s');
   expect(formatDuration(undefined)).toBe('unknown');
   expect(formatDuration(-1)).toBe('unknown');
+});
+
+test('formatElapsed keeps seconds at every scale, so a 30s progress line never repeats itself', () => {
+  expect(formatElapsed(0)).toBe('0s');
+  expect(formatElapsed(42_000)).toBe('42s');
+  expect(formatElapsed(60_000)).toBe('1m00s');
+  expect(formatElapsed(90_000)).toBe('1m30s');
+  expect(formatElapsed(119_600)).toBe('2m00s');
+  expect(formatElapsed(319_000)).toBe('5m19s');
+  expect(formatElapsed(605_000)).toBe('10m05s');
+  expect(formatElapsed(-5)).toBe('0s');
+  expect(formatElapsed(undefined)).toBe('0s');
 });
 
 test('phaseLine uses one indented column', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1548,7 +1548,7 @@ describe('verifyLaunch: still bundling', () => {
     expect(result.errors?.[0]?.msg).toBe('console.error during launch');
   });
 
-  test('a healthy iOS launch omits the transient TCP refusal but keeps application errors', async () => {
+  test('a healthy iOS launch omits the connection refusal but keeps application errors', async () => {
     const clock = fakeClock();
     const since = clock.at();
     const refusal = {
@@ -1585,8 +1585,8 @@ describe('verifyLaunch: still bundling', () => {
     expect(refusal.level).toBe('error');
   });
 
-  test.each([true, false, null])(
-    'the TCP refusal stays an error without a later pointer recovery when process health is %s',
+  test.each([true, null])(
+    'a verified launch omits the refusal with no matching pointer recovery when process health is %s',
     async (alive) => {
       const clock = fakeClock();
       const since = clock.at();
@@ -1605,12 +1605,13 @@ describe('verifyLaunch: still bundling', () => {
         readDeviceRecords: () => [refusal],
         processAlive: () => alive,
       });
+      expect(result.verified).toBe(true);
       expect(result.processAlive).toBe(alive);
-      expect(result.errors).toEqual([refusal]);
+      expect(result.errors).toEqual([]);
     },
   );
 
-  test('the TCP refusal stays an error when only an earlier or different pointer succeeds', async () => {
+  test('the refusal still prints when the process died instead of verifying', async () => {
     const clock = fakeClock();
     const since = clock.at();
     const refusal = {
@@ -1625,14 +1626,40 @@ describe('verifyLaunch: still bundling', () => {
       now: clock.now,
       sleep: clock.sleep,
       readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
-      readDeviceRecords: () => [
-        { ts: since + 15, src: 'device', level: 'info', msg: 'TCP Conn 0x11e8cb020 complete. fd: 24, err: 0' },
-        refusal,
-        { ts: since + 25, src: 'device', level: 'info', msg: 'TCP Conn 0x11e8cb160 complete. fd: 25, err: 0' },
-      ],
+      readDeviceRecords: () => [refusal],
+      processAlive: () => false,
+    });
+    expect(result).toMatchObject({ verified: false, fatal: true });
+    expect(result.errors).toEqual([refusal]);
+  });
+
+  test('a refusal-shaped message from another source or platform stays an error', async () => {
+    const clock = fakeClock();
+    const since = clock.at();
+    const clientRefusal = {
+      ts: since + 20,
+      src: 'client',
+      level: 'error',
+      msg: 'TCP Conn 0x11e8cb020 Failed : error 0:61 [61]',
+    };
+    const otherError = {
+      ts: since + 21,
+      src: 'device',
+      level: 'error',
+      msg: 'TCP Conn 0x11e8cb020 Failed : error 0:60 [60]',
+    };
+    const result = await verifyLaunch({
+      since,
+      platform: 'ios',
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: since + 10, event: 'bundle_build_done', platform: 'ios' }],
+      readDeviceRecords: () => [otherError],
+      readClientRecords: () => [clientRefusal],
       processAlive: () => true,
     });
-    expect(result.errors).toEqual([refusal]);
+    expect(result.verified).toBe(true);
+    expect(result.errors).toEqual([otherError, clientRefusal]);
   });
 
   test('errors before bundle completion are outside the stability window', async () => {

--- a/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
@@ -374,12 +374,18 @@ describe('waitingLine', () => {
       logFile: '/w/app-412/.stim/logs/build-ios.ndjson',
     });
     expect(line).toBe(
-      'build       waiting on /w/app-412 (pid 41233, 8m elapsed) -- tail /w/app-412/.stim/logs/build-ios.ndjson',
+      'build       waiting on /w/app-412 (pid 41233, 8m00s elapsed) -- tail /w/app-412/.stim/logs/build-ios.ndjson',
     );
   });
 
   test('reads in seconds before the first minute is up', () => {
     expect(waitingLine({ projectRoot: '/w', pid: 1, elapsedMs: 30000, logFile: '/l' })).toMatch(/30s elapsed/);
+  });
+
+  test('keeps seconds past the first minute, so two lines 30s apart never read the same', () => {
+    const args = { projectRoot: '/w', pid: 1, logFile: null };
+    expect(waitingLine({ ...args, elapsedMs: 60_000 })).toMatch(/1m00s elapsed/);
+    expect(waitingLine({ ...args, elapsedMs: 90_000 })).toMatch(/1m30s elapsed/);
   });
 
   test('says so when the holder recorded no log file', () => {
@@ -547,7 +553,7 @@ describe('takeoverLine', () => {
       now: () => 1_000_000 + 120_000,
     });
     expect(line).toMatch(/RETRY: \/w\/other's build of this fingerprint \(pid 4242\) FAILED without an artifact/);
-    expect(line).toMatch(/it started 2m ago/);
+    expect(line).toMatch(/it started 2m00s ago/);
     expect(line).toMatch(/SAME inputs/);
     expect(line).toMatch(/read \/w\/other\/\.stim\/logs\/build-android\.ndjson/);
   });

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -28,8 +28,8 @@ import {
   pickXcodeProject,
   productsDir,
   readBundleId,
-  formatHeartbeatElapsed,
   heartbeatLine,
+  startBuildHeartbeat,
   resolveScheme,
   tailLines,
   xcodebuildArgs,
@@ -628,13 +628,6 @@ describe('reading the bundle id', () => {
 });
 
 describe('the heartbeat line', () => {
-  test('formats elapsed time the way the completion line does', () => {
-    expect(formatHeartbeatElapsed(0)).toBe('0s');
-    expect(formatHeartbeatElapsed(42_000)).toBe('42s');
-    expect(formatHeartbeatElapsed(319_000)).toBe('5m19s');
-    expect(formatHeartbeatElapsed(605_000)).toBe('10m05s');
-  });
-
   test('carries the activity hint, truncated to one readable line', () => {
     expect(heartbeatLine(30_000, 'CompileC App.o')).toBe('build       still running (30s): CompileC App.o');
     const long = 'x'.repeat(200);
@@ -645,6 +638,107 @@ describe('the heartbeat line', () => {
 
   test('omits the hint before the child has printed anything', () => {
     expect(heartbeatLine(30_000, '')).toBe('build       still running (30s)');
+  });
+});
+
+describe('the heartbeat cadence', () => {
+  function fakeScheduler() {
+    let clock = 0;
+    let pending: { at: number; run: () => void } | null = null;
+    const fire = () => {
+      const due = pending;
+      pending = null;
+      due?.run();
+    };
+    return {
+      now: () => clock,
+      schedule: (run: () => void, delayMs: number) => {
+        pending = { at: clock + delayMs, run };
+        return () => {
+          pending = null;
+        };
+      },
+      advance(ms: number) {
+        clock += ms;
+        let due = pending;
+        while (due && due.at <= clock) {
+          pending = null;
+          due.run();
+          due = pending;
+        }
+      },
+      jump(ms: number) {
+        clock += ms;
+      },
+      fire,
+      idle: () => pending === null,
+    };
+  }
+
+  function heartbeat(scheduler: ReturnType<typeof fakeScheduler>, beats: string[], intervalMs = 30_000) {
+    return startBuildHeartbeat({
+      intervalMs,
+      elapsed: scheduler.now,
+      lastLine: () => '',
+      emit: (line) => beats.push(line),
+      schedule: scheduler.schedule,
+    });
+  }
+
+  test('lands on the interval grid, so no elapsed value is ever printed twice', () => {
+    const scheduler = fakeScheduler();
+    const beats: string[] = [];
+    const stop = heartbeat(scheduler, beats);
+    scheduler.advance(30_000);
+    scheduler.advance(30_000);
+    scheduler.advance(30_000);
+    stop();
+    expect(beats).toEqual([
+      'build       still running (30s)',
+      'build       still running (1m00s)',
+      'build       still running (1m30s)',
+    ]);
+    expect(scheduler.idle()).toBe(true);
+  });
+
+  test('a stalled loop reports the elapsed it woke up to, then resumes on the grid', () => {
+    const scheduler = fakeScheduler();
+    const beats: string[] = [];
+    const stop = heartbeat(scheduler, beats);
+    scheduler.advance(30_000);
+    scheduler.advance(300_000);
+    scheduler.advance(30_000);
+    scheduler.advance(30_000);
+    stop();
+    expect(beats).toEqual([
+      'build       still running (30s)',
+      'build       still running (5m30s)',
+      'build       still running (6m00s)',
+      'build       still running (6m30s)',
+    ]);
+  });
+
+  test('a timer that fires a millisecond early does not repeat the beat it just printed', () => {
+    const scheduler = fakeScheduler();
+    const beats: string[] = [];
+    const stop = heartbeat(scheduler, beats);
+    scheduler.advance(30_000);
+    scheduler.jump(29_999);
+    scheduler.fire();
+    expect(beats).toEqual(['build       still running (30s)']);
+    scheduler.advance(1);
+    stop();
+    expect(beats).toEqual(['build       still running (30s)', 'build       still running (1m00s)']);
+  });
+
+  test('a non-positive interval schedules nothing at all', () => {
+    const scheduler = fakeScheduler();
+    const beats: string[] = [];
+    const stop = heartbeat(scheduler, beats, 0);
+    scheduler.advance(120_000);
+    stop();
+    expect(beats).toEqual([]);
+    expect(scheduler.idle()).toBe(true);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_FINGERPRINT_IGNORES } from '../build-cache.ts';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
+import { HEARTBEAT_INTERVAL_MS } from '../engine/xcode.ts';
 
 test('every advertised topic renders non-empty content', () => {
   for (const name of topicNames()) {
@@ -129,6 +130,44 @@ test('the guide documents the identical-artifact skip and its fail-closed rule',
   expect(lifecycle).toMatch(/cannot determine[^.]*installs exactly as it always did/i);
   expect(lifecycle).toMatch(/release[\s\S]*COPY of the artifact[\s\S]*always installed/i);
   expect(lifecycle).toMatch(/installSkipped/);
+});
+
+test('the guide says what a verified launch does not prove, in the words the commands print', () => {
+  const facts = renderTopic('facts');
+  assert(facts);
+  expect(facts).toMatch(/IT IS NOT A PAINTED SCREEN/);
+  expect(facts).toMatch(/first screen may still be\s+rendering/);
+  expect(facts).toMatch(/Poll the UI before you trust a\s+screenshot/);
+  for (const command of ['ios', 'android']) {
+    const src = readFileSync(new URL(`../commands/${command}.ts`, import.meta.url), 'utf-8');
+    expect(src.includes('the first screen may still be rendering')).toBeTruthy();
+    expect(src.includes('ready: bundle loaded')).toBeFalsy();
+  }
+});
+
+test('the guide documents the one launch error a verified run drops', () => {
+  const logs = renderTopic('logs');
+  assert(logs);
+  expect(logs).toMatch(/TCP Conn \.\.\. Failed :\s+error 0:61 \[61\]/);
+  expect(logs).toMatch(/ECONNREFUSED/);
+  expect(logs).toMatch(/A refusal before the\s+launch verifies still prints/);
+  const src = readFileSync(new URL('../engine/app-install.ts', import.meta.url), 'utf-8');
+  expect(src.includes('error 0:61')).toBeTruthy();
+});
+
+test('the guide documents the progress cadence the heartbeat actually uses', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
+  expect(lifecycle).toMatch(/PROGRESS ON A LONG RUN/);
+  expect(lifecycle).toMatch(/every 30 seconds, on the 30-second\s+grid/);
+  expect(lifecycle).toMatch(/still running \(1m30s\)/);
+  expect(lifecycle).toMatch(/GAP BETWEEN HEARTBEATS IS NOT A HANG/);
+  expect(lifecycle).toMatch(/device\s+stim-app-412 \(BF2A\.\.\) created \(2m14s\)/);
+  for (const command of ['ios', 'android']) {
+    const src = readFileSync(new URL(`../commands/${command}.ts`, import.meta.url), 'utf-8');
+    expect(src.includes('SLOW_STEP_MS')).toBeTruthy();
+  }
 });
 
 test('the guide documents scoped iOS dev-client preapproval', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -519,16 +519,67 @@ describe('the Metro gate retries an indexing Metro', () => {
   });
 });
 
+describe('the device preparation step', () => {
+  test('a slow preparation gets its own timed line, so the elapsed total is accounted for', async () => {
+    reserve();
+    let clock = 1_000_000;
+    const { errs } = await run(
+      {},
+      {
+        now: () => clock,
+        ensureOwnedDevice: async () => {
+          clock += 130_000;
+          return { deviceUdid: UDID, deviceName: 'stim-fixture', owned: true };
+        },
+      },
+    );
+    expect(errs.join('\n')).toMatch(/device\s+stim-fixture \(BF2A\.\.\) prepared \(2m10s\)/);
+  });
+
+  test('a created simulator is named however fast it was', async () => {
+    reserve();
+    const { errs } = await run(
+      {},
+      {
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture',
+          owned: true,
+          created: true,
+        }),
+      },
+    );
+    expect(errs.join('\n')).toMatch(/device\s+stim-fixture \(BF2A\.\.\) created \(/);
+  });
+
+  test('a preparation that costs nothing prints nothing of its own', async () => {
+    reserve();
+    const { errs } = await run();
+    expect(errs.join('\n')).not.toMatch(/prepared \(/);
+  });
+});
+
 describe('launch verification', () => {
   test('a verified launch reports launched: true and says what it saw', async () => {
     reserve();
     const { logs, errs, exitCode, calls } = await run({ json: true });
     expect(exitCode).toBe(null);
     expect(parseFirst(logs).launched).toBe(true);
-    expect(errs.join('\n')).toMatch(/verify.*bundle loaded, stable for 3s/);
+    expect(errs.join('\n')).toMatch(/verify.*bundle loaded, stable for 3s -- the first screen may still be rendering/);
     expect(calls.args.verifyLaunch.logsDir).toBe(workspaceLogsDir(root));
     expect(Number.isFinite(calls.args.verifyLaunch.since)).toBeTruthy();
     expect(calls.args.verifyLaunch.platform).toBe('ios');
+  });
+
+  test('the ready line claims only what was proven, and says a paint is not part of it', async () => {
+    reserve();
+    const { errs } = await run(
+      {},
+      { verifyLaunch: async () => ({ verified: true, processAlive: true, waitedMs: 11_100 }) },
+    );
+    expect(errs.join('\n')).toMatch(
+      /verify\s+bundle loaded, process alive, stable for 3s -- the first screen may still be rendering \(11\.1s total\)/,
+    );
   });
 
   test('the picker: an unverified launch is launched: "unverified", exit 0, and a loud warning', async () => {

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -14,6 +14,13 @@ export function formatDuration(ms: unknown): string {
   return `${seconds}s`;
 }
 
+export function formatElapsed(ms: unknown): string {
+  const totalSeconds = Math.max(0, Math.round((Number(ms) || 0) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
+}
+
 export function phaseLine(label: unknown, text: string): string {
   return `  ${String(label).padEnd(LABEL_WIDTH)} ${text}`;
 }

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -56,6 +56,8 @@ import {
   noMetroRemedy,
   pickDevClientScheme,
   resolveMetroWithRetry,
+  SLOW_STEP_MS,
+  stepClock,
   stepTimer,
 } from './ios.ts';
 import {
@@ -822,8 +824,9 @@ async function verifyAndroidRun({
   if (verification?.verified) {
     phase(
       'verify',
-      `ready: bundle loaded, stable for 3s` +
+      `bundle loaded` +
         (verification.processAlive === true ? ', process alive' : '') +
+        `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
     for (const record of verification.errors ?? []) {
@@ -1768,6 +1771,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     });
     if (capacity) return fail(capacity.code, capacity.message, capacity.remedy);
 
+    const prepare = stepClock(now);
     try {
       device = await ensureDevice({
         platform: PLATFORM,
@@ -1792,6 +1796,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         lines: diag.lines,
         logPath: diag.logPath ? displayPath(root, diag.logPath) : null,
       });
+    }
+    const prepareMs = prepare();
+    if (prepareMs >= SLOW_STEP_MS) {
+      phase('device', `${device.avdName || device.deviceName || label} prepared (${formatDuration(prepareMs)})`);
     }
 
     const bootTimer = stepTimer(now);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -93,7 +93,15 @@ other line goes to stderr, so it is always safe to pipe.
                                  The command checks process liveness when the
                                  platform exposes it. Errors from that window
                                  are printed even when the app stays alive; the
-                                 agent decides whether a nonfatal error matters
+                                 agent decides whether a nonfatal error matters.
+                                 IT IS NOT A PAINTED SCREEN. Stim observes the
+                                 bundle and the process, never a frame, and a
+                                 cold app can keep rendering for a minute or
+                                 more after this, which is why the stderr line
+                                 reads \`bundle loaded, process alive, stable
+                                 for 3s -- the first screen may still be
+                                 rendering\`. Poll the UI before you trust a
+                                 screenshot
                     "bundling"   the request DID arrive and Metro was still
                                  building when the bundle timeout closed.
                                  The wiring is proven; the JS has simply not
@@ -453,7 +461,14 @@ WHAT WRITES WHAT
                        -- and, on iOS, where every Apple framework running in
                        the app's process also logs. The proven noise sources
                        are recorded at info rather than error; the rest is why
-                       --errors leaves this source out unless asked.
+                       --errors leaves this source out unless asked. A VERIFIED
+                       LAUNCH also drops one iOS device record from the RUN
+                       SUMMARY: the connection refusal \`TCP Conn ... Failed :
+                       error 0:61 [61]\` (61 is ECONNREFUSED). The app got its
+                       bundle over this workspace's Metro and outlived the
+                       stability window, so it recovered. A refusal before the
+                       launch verifies still prints, and the record stays an
+                       error in device.ndjson either way.
 
   ON A PHYSICAL IPHONE THE SAME FILE CARRIES LESS, and the difference is not
   cosmetic. \`simctl spawn\` is simulator-only and there is no devicectl
@@ -1312,6 +1327,25 @@ and produces an app that cannot load a bundle.
 
 Repeat step 3 whenever a NATIVE input changes. A JS-only edit needs nothing --
 that is what Fast Refresh over the running dev server is for.
+
+PROGRESS ON A LONG RUN
+  The whole summary is stderr; stdout carries only the \`--json\` payload. A
+  step that costs real time is named and timed, including the step that
+  creates or reconciles the owned device before anything is fingerprinted:
+
+    device      stim-app-412 (BF2A..) created (2m14s)
+
+  A step that is still running heartbeats every 30 seconds, on the 30-second
+  grid, so the values read 30s, 1m00s, 1m30s and never repeat:
+
+    build       still running (1m30s): > Task :app:compileDebugKotlin
+    build       waiting on /w/app-411 (pid 41233, 1m30s elapsed)
+
+  A GAP BETWEEN HEARTBEATS IS NOT A HANG. Stim runs device tools
+  synchronously, so a long \`simctl\`, \`adb\` or copy call holds the timer
+  until it returns; the next heartbeat then lands on the grid, which is why an
+  elapsed value can jump. Read the phase lines, not the wall clock, before
+  killing a run.
 
 AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
   Both platforms store the artifact verbatim, so its hash is its identity.

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -468,7 +468,8 @@ WHAT WRITES WHAT
                        bundle over this workspace's Metro and outlived the
                        stability window, so it recovered. A refusal before the
                        launch verifies still prints, and the record stays an
-                       error in device.ndjson either way.
+                       error in device.ndjson either way; read it with
+                       \`logs --errors --source device\`.
 
   ON A PHYSICAL IPHONE THE SAME FILE CARRIES LESS, and the difference is not
   cosmetic. \`simctl spawn\` is simulator-only and there is no devicectl

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -270,9 +270,16 @@ const COLLECTOR_POLL_MS = 25;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-export function stepTimer(now: () => number = Date.now): () => string {
+export const SLOW_STEP_MS = 2000;
+
+export function stepClock(now: () => number = Date.now): () => number {
   const t0 = now();
-  return () => `(${formatDuration(now() - t0)})`;
+  return () => now() - t0;
+}
+
+export function stepTimer(now: () => number = Date.now): () => string {
+  const elapsed = stepClock(now);
+  return () => `(${formatDuration(elapsed())})`;
 }
 
 export function shortUdid(udid: unknown): string {
@@ -997,8 +1004,9 @@ async function verifyIosRun({
   if (verification?.verified) {
     phase(
       'verify',
-      `ready: bundle loaded, stable for 3s` +
+      `bundle loaded` +
         (verification.processAlive === true ? ', process alive' : '') +
+        `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
     for (const record of verification.errors ?? []) {
@@ -1734,6 +1742,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       ReturnType<typeof ensureOwnedDevice>
     >;
   } else {
+    const prepare = stepClock(d.now);
     try {
       device = await d.ensureOwnedDevice({
         platform: PLATFORM,
@@ -1752,6 +1761,13 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         message: `Could not ensure an owned iOS simulator: ${(e as Error)?.message || e}`,
         remedy: 'Run `stim doctor` to check the simulator toolchain, then try again.',
       });
+    }
+    const prepareMs = prepare();
+    if (device.created || prepareMs >= SLOW_STEP_MS) {
+      phase(
+        'device',
+        `${deviceLabel(device, device.deviceUdid)} ${device.created ? 'created' : 'prepared'} (${formatDuration(prepareMs)})`,
+      );
     }
   }
 

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -802,9 +802,7 @@ export async function verifyLaunch({
           waitedMs,
         };
       }
-      const actionableErrors = errors.filter(
-        (record) => !isRecoveredIosConnectionRefusal(record, deviceRecords, platform),
-      );
+      const actionableErrors = errors.filter((record) => !isIosConnectionRefusal(record, platform));
       return { verified: true, record: proof, errors: actionableErrors, processAlive: alive, mode, waitedMs };
     }
 
@@ -838,32 +836,20 @@ function isLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null)
   return record.level === 'error' || record.level === 'fatal' || isFatalLaunchError(record, platform);
 }
 
-const TCP_REFUSAL = /^TCP Conn (0x[0-9a-f]+) Failed : error 0:61 \[61\]$/i;
-const TCP_SUCCESS = /^TCP Conn (0x[0-9a-f]+) complete\. fd: \d+, err: 0$/i;
+// Apple's Network framework logs a failed TCP connection at Error level with a
+// POSIX errno in the text, and 61 is ECONNREFUSED. A verified launch proves the
+// app recovered: it got its bundle over this workspace's Metro and outlived the
+// stability window. The record stays an error in device.ndjson.
+const TCP_REFUSAL = /^TCP Conn 0x[0-9a-f]+ Failed : error 0:61 \[61\]$/i;
 
-function isRecoveredIosConnectionRefusal(
-  record: NdjsonRecord,
-  deviceRecords: NdjsonRecord[],
-  platform: 'ios' | 'android' | null,
-): boolean {
-  if (platform !== 'ios' || record.src !== 'device' || record.level !== 'error' || typeof record.msg !== 'string') {
-    return false;
-  }
-  const refusal = TCP_REFUSAL.exec(record.msg);
-  const refusalTs = Number(record.ts);
-  if (!refusal?.[1] || !Number.isFinite(refusalTs)) return false;
-  const pointer = refusal[1].toLowerCase();
-  return deviceRecords.some((candidate) => {
-    const success = typeof candidate.msg === 'string' ? TCP_SUCCESS.exec(candidate.msg) : null;
-    return (
-      candidate.src === 'device' &&
-      candidate.proc === record.proc &&
-      candidate.level !== 'error' &&
-      candidate.level !== 'fatal' &&
-      Number(candidate.ts) > refusalTs &&
-      success?.[1]?.toLowerCase() === pointer
-    );
-  });
+function isIosConnectionRefusal(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {
+  return (
+    platform === 'ios' &&
+    record.src === 'device' &&
+    record.level === 'error' &&
+    typeof record.msg === 'string' &&
+    TCP_REFUSAL.test(record.msg)
+  );
 }
 
 function isFatalLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -837,9 +837,7 @@ function isLaunchError(record: NdjsonRecord, platform: 'ios' | 'android' | null)
 }
 
 // Apple's Network framework logs a failed TCP connection at Error level with a
-// POSIX errno in the text, and 61 is ECONNREFUSED. A verified launch proves the
-// app recovered: it got its bundle over this workspace's Metro and outlived the
-// stability window. The record stays an error in device.ndjson.
+// POSIX errno in the text, and 61 is ECONNREFUSED.
 const TCP_REFUSAL = /^TCP Conn 0x[0-9a-f]+ Failed : error 0:61 \[61\]$/i;
 
 function isIosConnectionRefusal(record: NdjsonRecord, platform: 'ios' | 'android' | null): boolean {

--- a/packages/stim-cli/src/engine/build-lock.ts
+++ b/packages/stim-cli/src/engine/build-lock.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { formatElapsed } from '../command-output.ts';
 import { getConfigDir } from '../config.ts';
 import { resolveBuild } from '../build-cache.ts';
 import { isPidAlive } from '../metro.ts';
@@ -249,16 +250,10 @@ export function listBuildLocks({ isAlive = isPidAlive }: ListBuildLocksOptions =
   return locks;
 }
 
-export function formatWaited(ms: number): string {
-  const total = Math.max(0, Math.round(Number(ms) || 0) / 1000);
-  if (total < 60) return `${Math.round(total)}s`;
-  return `${Math.floor(total / 60)}m`;
-}
-
 export function waitingLine({ projectRoot, pid, elapsedMs, logFile }: WaitingLineArgs): string {
   const where = projectRoot || 'another workspace';
   const tail = logFile ? ` -- tail ${logFile}` : '';
-  return `${'build'.padEnd(11)} waiting on ${where} (pid ${pid ?? '?'}, ${formatWaited(elapsedMs)} elapsed)${tail}`;
+  return `${'build'.padEnd(11)} waiting on ${where} (pid ${pid ?? '?'}, ${formatElapsed(elapsedMs)} elapsed)${tail}`;
 }
 
 export function takeoverLine({
@@ -276,7 +271,7 @@ export function takeoverLine({
 }): string {
   const where = projectRoot || 'another workspace';
   const started = startedAt ? Date.parse(startedAt) : Number.NaN;
-  const ago = Number.isFinite(started) ? ` (it started ${formatWaited(now() - started)} ago)` : '';
+  const ago = Number.isFinite(started) ? ` (it started ${formatElapsed(now() - started)} ago)` : '';
   const tail = logFile ? ` -- read ${logFile} before this one finishes` : '';
   return (
     `RETRY: ${where}'s build of this fingerprint (pid ${pid ?? '?'}) FAILED without an artifact${ago}, ` +
@@ -326,7 +321,7 @@ export async function waitForBuild({
     const elapsed = now() - started;
     if (elapsed >= ceilingMs) {
       const err = new Error(
-        `Waited ${formatWaited(elapsed)} for ${info.projectRoot || 'another workspace'}'s ${platform} build of ${key} ` +
+        `Waited ${formatElapsed(elapsed)} for ${info.projectRoot || 'another workspace'}'s ${platform} build of ${key} ` +
           `without an artifact, and pid ${info.pid} is still alive. The lock is ${path}; ` +
           'remove that directory if that process is not really building.',
       ) as Error & { code?: string; lockPath?: string; holder?: BuildLockRecord };

--- a/packages/stim-cli/src/engine/build-slots.ts
+++ b/packages/stim-cli/src/engine/build-slots.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, wri
 import { join } from 'node:path';
 import { getConfigDir } from '../config.ts';
 import { isPidAlive } from '../metro.ts';
-import { formatWaited } from './build-lock.ts';
+import { formatElapsed } from '../command-output.ts';
 
 const SLOT_FILE_NAME = 'slot.json';
 const SLOT_PREFIX = 'slot-';
@@ -149,7 +149,7 @@ export function tryAcquireBuildSlot({
 }
 
 export function slotWaitingLine({ max, elapsedMs }: { max: number; elapsedMs: number }): string {
-  return `${'build'.padEnd(11)} waiting for a build slot (all ${max} in use, ${formatWaited(elapsedMs)} elapsed)`;
+  return `${'build'.padEnd(11)} waiting for a build slot (all ${max} in use, ${formatElapsed(elapsedMs)} elapsed)`;
 }
 
 export async function acquireBuildSlot({
@@ -174,7 +174,7 @@ export async function acquireBuildSlot({
     const elapsed = now() - started;
     if (elapsed >= ceilingMs) {
       const err = new Error(
-        `Waited ${formatWaited(elapsed)} for one of ${max} build slots, and every slot is held by a ` +
+        `Waited ${formatElapsed(elapsed)} for one of ${max} build slots, and every slot is held by a ` +
           'process that is still alive. Slots live under ' +
           buildSlotsDir() +
           '; ' +

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -405,6 +405,7 @@ export function startBuildHeartbeat({
   if (!(intervalMs > 0)) return () => {};
   let stopped = false;
   let lastBeat = 0;
+  let cancel: (() => void) | null = null;
   function tick() {
     if (stopped) return;
     const ms = elapsed();
@@ -415,10 +416,10 @@ export function startBuildHeartbeat({
     }
     cancel = schedule(tick, intervalMs - (ms % intervalMs));
   }
-  let cancel = schedule(tick, intervalMs);
+  cancel = schedule(tick, intervalMs);
   return () => {
     stopped = true;
-    cancel();
+    cancel?.();
   };
 }
 

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -6,6 +6,7 @@ import { register } from '../cache-manifest.ts';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { sharedCompilationCache, workspaceDerivedData } from '../paths.ts';
+import { formatElapsed } from '../command-output.ts';
 import { createLineReader } from '../process-output.ts';
 import { capDiagnostics, describeDiagnostic, type Diagnostic, extractXcodeDiagnostics } from './errors-xcode.ts';
 import { cleanLine } from '../supervisor/server-expo.ts';
@@ -371,19 +372,20 @@ export const HEARTBEAT_INTERVAL_MS = 30_000;
 
 const HEARTBEAT_HINT_LENGTH = 80;
 
-export function formatHeartbeatElapsed(ms: number): string {
-  const totalSeconds = Math.max(0, Math.round(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return minutes > 0 ? `${minutes}m${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
-}
-
 export function heartbeatLine(elapsedMs: number, lastLine: string, label = 'build'): string {
   const hint =
     lastLine.length > HEARTBEAT_HINT_LENGTH ? `${lastLine.slice(0, HEARTBEAT_HINT_LENGTH - 3)}...` : lastLine;
   const activity = hint.trim() === '' ? '' : `: ${hint}`;
-  return `${label.padEnd(11)} still running (${formatHeartbeatElapsed(elapsedMs)})${activity}`;
+  return `${label.padEnd(11)} still running (${formatElapsed(elapsedMs)})${activity}`;
 }
+
+export type HeartbeatSchedule = (run: () => void, delayMs: number) => () => void;
+
+const defaultSchedule: HeartbeatSchedule = (run, delayMs) => {
+  const timer = setTimeout(run, delayMs);
+  timer.unref?.();
+  return () => clearTimeout(timer);
+};
 
 export function startBuildHeartbeat({
   intervalMs,
@@ -391,17 +393,33 @@ export function startBuildHeartbeat({
   lastLine,
   emit,
   label = 'build',
+  schedule = defaultSchedule,
 }: {
   intervalMs: number;
   elapsed: () => number;
   lastLine: () => string;
   emit: (line: string) => void;
   label?: string;
+  schedule?: HeartbeatSchedule;
 }): () => void {
   if (!(intervalMs > 0)) return () => {};
-  const timer = setInterval(() => emit(heartbeatLine(elapsed(), lastLine(), label)), intervalMs);
-  timer.unref?.();
-  return () => clearInterval(timer);
+  let stopped = false;
+  let lastBeat = 0;
+  function tick() {
+    if (stopped) return;
+    const ms = elapsed();
+    const beat = Math.floor(ms / intervalMs) * intervalMs;
+    if (beat > lastBeat) {
+      lastBeat = beat;
+      emit(heartbeatLine(beat, lastLine(), label));
+    }
+    cancel = schedule(tick, intervalMs - (ms % intervalMs));
+  }
+  let cancel = schedule(tick, intervalMs);
+  return () => {
+    stopped = true;
+    cancel();
+  };
 }
 
 function failedResult({


### PR DESCRIPTION
## Description

Three signals in the `ios` / `android` stderr summary read as something other than what they are (#192). All three were confirmed against `origin/main` at 4916eaf before changing anything; none of the three was already fixed.

1. **`launch err TCP Conn ... error 0:61` inside a passing run.** `verifyLaunch` drops a captured refusal only when a later device record shows *the same connection object* completing (`isRecoveredIosConnectionRefusal`, added by #123). Apple's Network framework logs `TCP Conn 0x... Failed : error 0:61 [61]` per connection attempt, and a probe that is refused is usually not retried on the same object, so the pairing rarely exists and the line survives into a passing summary. `packages/stim-cli/src/engine/app-install.ts:805` was the filter; `commands/ios.ts:1002` and `commands/android.ts:827` are what print it.

2. **`verify ready: bundle loaded, stable for 3s, process alive`.** Accurate about the process, read by every agent as "the app is on screen". Stim observes a bundle and a pid; nothing it can see reports a paint (`commands/ios.ts:997`, `commands/android.ts:822`).

3. **Progress heartbeats.** Two separate defects, one gap:
   - *Repeats.* `formatWaited` (`engine/build-lock.ts:252` on main) printed whole minutes past 60s (`1m`, `2m`), while `waitForBuild` prints progress every `WAIT_PROGRESS_MS = 30000` and `acquireBuildSlot` every `SLOT_PROGRESS_MS = 30000`. A waiter therefore printed `... 1m elapsed` at 60s and again at 90s: the same elapsed value twice per minute, exactly as reported.
   - *Cadence.* `startBuildHeartbeat` used `setInterval` (`engine/xcode.ts:402` on main). Stim's exec wrapper is synchronous (`execSync` / `execFileSync`), so any long tool call stalls the loop; Node then coalesces the missed ticks into one fire and **re-anchors the interval to the wake-up moment**, so the cadence drifts off the 30-second grid for the rest of the build. Measured on this machine (1s interval, 3.2s stall): old fires at t+1.00, 4.70, 5.70, 6.71, 7.71.
   - *Unnamed time.* On iOS, `ensureOwnedDevice` runs before any phase line and does the expensive work for a fresh workspace -- `simctl create`, first boot, and the SimSlim/dev-menu reconciliation (`engine/device.ts:216-236`) -- while the later `device ... booted 382ms` line only times `ensureBooted`, which finds the sim already booted. Android has the same shape (`commands/android.ts:1762`). That is where the four unaccounted minutes of a `4m22s` run go. I did not confirm the reporter's second guess (artifact restore): a local cache hit is already inside the timed `fingerprint` line, and the reported run's fingerprint line was 5s.

## Solution

One PR: the three parts are the same summary and overlap in `ios.ts`, `android.ts`, and `guide`.

1. A **verified** launch drops iOS device-log connection refusals, with no pointer pairing: the verification is the recovery proof. Errors before verification are untouched -- the fatal branch (process exited, bundle failed) still prints the refusal, and the record stays `error` in `device.ndjson` for `logs --source device`. This is the "suppress it once the launch verifies" option from the issue rather than a collector noise rule, because a collector demotion would also hide the refusal in the case where it is the explanation (an app that never reached Metro).

2. The ready line now reads `bundle loaded, process alive, stable for 3s -- the first screen may still be rendering (11.1s total)`. `launched` values and their meaning are unchanged (invariant 11); only the sentence changed. `guide facts` now says `IT IS NOT A PAINTED SCREEN ... Poll the UI before you trust a screenshot`. `SKILL.md` is unchanged: the workflow and the launch states did not change, and the file is 2 words under its 1,200-word cap.

3. - One `formatElapsed` in `command-output.ts` serves the heartbeat, the build-lock waiting line, the build-slot waiting line, and the takeover line: seconds at every scale (`1m00s`, `1m30s`), so two lines 30s apart can never read the same. `formatWaited` and `formatHeartbeatElapsed` are gone in its favour.
   - `startBuildHeartbeat` schedules the next beat off the elapsed clock (`intervalMs - elapsed % intervalMs`) and prints the grid value for the beat it lands in, with a `schedule` injection point for tests. After a stall it reports the elapsed it woke up to and returns to the grid; a beat is never printed twice.
   - A device-preparation step that costs real time gets its own line (`device stim-app-412 (BF2A..) created (2m14s)`), on both platforms, gated at `SLOW_STEP_MS = 2000` so a reused device stays silent. A created simulator is always named.
   - stdout is untouched: no JSON payload field was added, removed, or reshaped (invariant 7).

`guide lifecycle` gains `PROGRESS ON A LONG RUN`, documenting the 30-second grid, the new device line, and that a gap between heartbeats is a synchronous tool call rather than a hang.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip`: all clean.
- `pnpm test`: `Test Files 77 passed (77)`, `Tests 2911 passed (2911)`. (An earlier run of the same tree timed out three unrelated real-tool tests at 5s -- `engine-build-lock` process race, `worktree` 1MB `ls-files`, `engine-xcode` real `xcodebuild -list` -- under load from parallel agents on this machine; all three pass on their own and in the green full run.)
- New unit coverage:
  - `engine-app-install.test.ts`: a verified launch drops the refusal with and without a pointer recovery and with unknown process health, keeps application errors, keeps the refusal when the process died instead of verifying, and keeps refusal-shaped messages from another source or another errno.
  - `engine-xcode.test.ts` (`the heartbeat cadence`): a fake clock plus an injected scheduler proves the grid (30s, 1m00s, 1m30s), the stall case (30s then 5m30s, 6m00s, 6m30s), that a timer firing a millisecond early prints no beat twice, and that a non-positive interval schedules nothing.
  - `command-output.test.ts`: `formatElapsed` at every scale; `engine-build-lock.test.ts`: two waiting lines 30s apart no longer read the same.
  - `ios-command.test.ts` / `android-command.test.ts`: the exact ready line, and the device-preparation line appearing for a slow or created device and staying silent for a fast one (driven by an injected clock).
  - `guide.test.ts`: three contract tests tying `guide` to the source -- the ready wording (and that `ready: bundle loaded` is gone from both commands), the dropped refusal, and the heartbeat cadence (asserting `HEARTBEAT_INTERVAL_MS === 30_000` against the documented 30 seconds).
- Real-timer evidence for the cadence fix, same 1s interval and 3.2s event-loop stall, before and after:
  ```
  old  t+1.00s (1s)  t+4.70s (5s)  t+5.70s (6s)  t+6.71s (7s)  t+7.71s (8s)
  new  t+1.00s (1s)  t+4.70s (4s)  t+5.00s (5s)  t+6.00s (6s)  t+7.00s (7s)
  ```
- No changed tool call: this branch touches stderr text, a formatter, and a timer, and does not alter any `git`, `simctl`, `adb`, `xcodebuild`, or Gradle argument list, so invariant 9 has nothing new to exercise. No device was created or booted for it, and no `stim-*` device exists from this work.

Fixes #192
