### PR TITLE
feat: physical device leases: engine, file protocol, status, stop, gc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ changes, and wait for the new checks.
   thin I/O wrappers. Unit-test the pure functions.
 - **Locked state.** Lock every read-modify-write to global config or workspace
   state. Use atomic writes. Long-lived build locks use PID liveness, not mtime.
+  Device leases use a declared expiry because the holder can be an agent with no
+  process.
 - **Cache contracts.** The cache packages must work without `Stim` installed.
   Keep their config path, cache root, cache key, and registration behavior
   aligned with the CLI. Resolution order is environment, machine config, then
@@ -144,11 +146,15 @@ Stim can create, boot, shut down, or delete only devices it created, named
 user-created emulator or simulator. Keep a device record when teardown fails so
 `gc` can find the device later.
 
-A physical Android device reached through `android --device` is the one device
-Stim uses but does not own. Hardware cannot be created or booted, so that path
-installs, launches, and reads logs, and nothing more. It records no device, so
-`stop`, `gc`, and `teardown.ts` never see it. Keep it that way: a physical
-serial must never enter the project registry.
+A physical device reached through `android --device` or `ios --device` is
+used but not owned. Hardware cannot be created or booted, so those paths
+install, launch, and read what logs they can, and nothing more. The only
+state a physical device leaves is its lease: the file under
+`$STIM_HOME/device-locks/` and the holder's token in that workspace's
+`state.json`. A serial or UDID never enters the project registry, and
+`teardown.ts` never sees a physical device. `stop` and `worktree remove`
+release the workspace's leases; `gc --delete` deletes only expired lease
+files.
 
 ### 3. Fixed invocations; never derive commands from project scripts
 

--- a/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
@@ -1,0 +1,536 @@
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import {
+  DEFAULT_LEASE_MS,
+  deviceLeaseLockPath,
+  deviceLeasePath,
+  deviceLocksDir,
+  listLeaseFiles,
+  parseLease,
+  parseLeaseDuration,
+  raiseLease,
+  releaseRunLease,
+  releaseWorkspaceLeases,
+  removeExpiredLease,
+  selectPoolDevice,
+  takeLease,
+  type DeviceLease,
+  type LeaseIo,
+  type WorkspaceLeases,
+} from '../engine/device-lease.ts';
+import { writeWorkspaceState } from '../supervisor/state.ts';
+
+const ROOT_A = '/worktree/a';
+const ROOT_B = '/worktree/b';
+const UDID = '00008101-000A10913C89001E';
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-home-'));
+  process.env.STIM_HOME = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+interface Harness {
+  io: LeaseIo;
+  files: Map<string, string>;
+  holders: Map<string, WorkspaceLeases>;
+  locks: string[];
+  advance: (ms: number) => void;
+  read: (platform: string, id: string) => DeviceLease | null;
+}
+
+function harness(start = Date.parse('2026-09-02T12:00:00.000Z')): Harness {
+  const files = new Map<string, string>();
+  const holders = new Map<string, WorkspaceLeases>();
+  const locks: string[] = [];
+  let clock = start;
+  const io: LeaseIo = {
+    now: () => clock,
+    readLease: (path) => files.get(path) ?? null,
+    writeLease: (path, body) => {
+      files.set(path, body);
+    },
+    removeLease: (path) => {
+      files.delete(path);
+    },
+    listLeaseNames: () => [...files.keys()].map((path) => basename(path)),
+    withLeaseLock: (lockPath, fn) => {
+      locks.push(lockPath);
+      return fn();
+    },
+    readHolder: (root) => structuredClone(holders.get(root) ?? {}),
+    writeHolder: (root, leases) => {
+      holders.set(root, structuredClone(leases));
+    },
+  };
+  return {
+    io,
+    files,
+    holders,
+    locks,
+    advance: (ms) => {
+      clock += ms;
+    },
+    read: (platform, id) => parseLease(files.get(deviceLeasePath(platform, id)) ?? null),
+  };
+}
+
+describe('where a lease lives', () => {
+  test('is a file under the config dir, named by platform and sanitized id', () => {
+    expect(deviceLocksDir()).toBe(join(home, 'device-locks'));
+    expect(deviceLeasePath('ios', UDID)).toBe(join(home, 'device-locks', `ios-${UDID}.json`));
+  });
+
+  test("an adb TCP serial's colon cannot escape the lease directory", () => {
+    const path = deviceLeasePath('android', '192.168.1.5:5555');
+    expect(path).toBe(join(home, 'device-locks', 'android-192.168.1.5-5555.json'));
+    const escaped = deviceLeasePath('android', '../../etc/passwd');
+    expect(dirname(escaped)).toBe(join(home, 'device-locks'));
+    expect(basename(escaped).includes('/')).toBe(false);
+  });
+
+  test('the lock shares the stem with the lease it guards', () => {
+    expect(deviceLeaseLockPath('ios', UDID)).toBe(join(home, 'device-locks', `ios-${UDID}.lock`));
+  });
+});
+
+describe('taking a lease', () => {
+  test('a free device is taken, recorded in the file and in the workspace state', () => {
+    const h = harness();
+    const result = takeLease(
+      { root: ROOT_A, platform: 'ios', id: UDID, deviceName: 'Old iPhone', kind: 'declared' },
+      h.io,
+    );
+    assert(result.status === 'taken');
+    expect(result.lease.holder).toBe(ROOT_A);
+    expect(result.lease.deviceName).toBe('Old iPhone');
+    expect(result.lease.expiresAt).toBe(
+      new Date(Date.parse(result.lease.grantedAt as string) + DEFAULT_LEASE_MS).toISOString(),
+    );
+    expect(h.holders.get(ROOT_A)).toEqual({ ios: { id: UDID, token: result.lease.token, kind: 'declared' } });
+  });
+
+  test('a device another workspace holds is refused, and its lease is untouched', () => {
+    const h = harness();
+    const first = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    assert(first.status === 'taken');
+    const second = takeLease({ root: ROOT_B, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    assert(second.status === 'held');
+    expect(second.lease.holder).toBe(ROOT_A);
+    expect(h.read('ios', UDID)?.token).toBe(first.lease.token);
+    expect(h.holders.get(ROOT_B)).toBeUndefined();
+  });
+
+  test('an expired lease is free, and the device is taken under a fresh token', () => {
+    const h = harness();
+    const first = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    assert(first.status === 'taken');
+    h.advance(DEFAULT_LEASE_MS + 1);
+    const second = takeLease({ root: ROOT_B, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    assert(second.status === 'taken');
+    expect(second.lease.holder).toBe(ROOT_B);
+    expect(second.lease.token).not.toBe(first.lease.token);
+  });
+
+  test('this workspace taking the device again sets the expiry, and can shorten it', () => {
+    const h = harness();
+    const first = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    assert(first.status === 'taken');
+    const shorter = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared', durationMs: 10_000 }, h.io);
+    assert(shorter.status === 'set');
+    expect(shorter.lease.token).toBe(first.lease.token);
+    expect(Date.parse(shorter.lease.expiresAt)).toBeLessThan(Date.parse(first.lease.expiresAt));
+  });
+
+  test('a file that does not parse is never overwritten', () => {
+    const h = harness();
+    h.files.set(deviceLeasePath('ios', UDID), '{ this is not a lease');
+    const result = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    expect(result).toEqual({ status: 'unreadable', path: deviceLeasePath('ios', UDID) });
+    expect(h.files.get(deviceLeasePath('ios', UDID))).toBe('{ this is not a lease');
+  });
+
+  test('a workspace holds at most one lease per platform', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    const second = takeLease({ root: ROOT_A, platform: 'ios', id: 'OTHER-UDID', kind: 'declared' }, h.io);
+    assert(second.status === 'taken');
+    expect(h.read('ios', UDID)).toBe(null);
+    expect(h.holders.get(ROOT_A)).toEqual({ ios: { id: 'OTHER-UDID', token: second.lease.token, kind: 'declared' } });
+  });
+
+  test('a lease on the other platform survives', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    takeLease({ root: ROOT_A, platform: 'android', id: 'R5CT', kind: 'run' }, h.io);
+    expect(h.read('ios', UDID)?.holder).toBe(ROOT_A);
+    expect(Object.keys(h.holders.get(ROOT_A) ?? {}).toSorted()).toEqual(['android', 'ios']);
+  });
+
+  test('every mutation runs under the lease lock', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    raiseLease({ root: ROOT_A, platform: 'ios', minMs: 60_000 }, h.io);
+    releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io);
+    expect(h.locks).toEqual([
+      deviceLeaseLockPath('ios', UDID),
+      deviceLeaseLockPath('ios', UDID),
+      deviceLeaseLockPath('ios', UDID),
+    ]);
+  });
+});
+
+describe('raising a lease', () => {
+  test('raises to now plus the step bound and never lowers the expiry', () => {
+    const h = harness();
+    const taken = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run', durationMs: 60_000 }, h.io);
+    assert(taken.status === 'taken');
+    const short = raiseLease({ root: ROOT_A, platform: 'ios', minMs: 10_000 }, h.io);
+    assert(short.status === 'raised');
+    expect(short.lease.expiresAt).toBe(taken.lease.expiresAt);
+
+    const long = raiseLease({ root: ROOT_A, platform: 'ios', minMs: 300_000 }, h.io);
+    assert(long.status === 'raised');
+    expect(Date.parse(long.lease.expiresAt)).toBeGreaterThan(Date.parse(taken.lease.expiresAt));
+  });
+
+  test('an expired file that still carries this run token is revived', () => {
+    const h = harness();
+    const taken = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run', durationMs: 60_000 }, h.io);
+    assert(taken.status === 'taken');
+    h.advance(120_000);
+    const raised = raiseLease({ root: ROOT_A, platform: 'ios', minMs: 60_000 }, h.io);
+    assert(raised.status === 'raised');
+    expect(raised.lease.token).toBe(taken.lease.token);
+    expect(Date.parse(raised.lease.expiresAt)).toBeGreaterThan(h.io.now());
+  });
+
+  test('a lease taken by another workspace is lost, and that lease is left alone', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run', durationMs: 60_000 }, h.io);
+    h.advance(61_000);
+    const stolen = takeLease({ root: ROOT_B, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    assert(stolen.status === 'taken');
+    const lost = raiseLease({ root: ROOT_A, platform: 'ios', minMs: 60_000 }, h.io);
+    assert(lost.status === 'lost');
+    expect(lost.lease?.holder).toBe(ROOT_B);
+    expect(h.read('ios', UDID)?.token).toBe(stolen.lease.token);
+  });
+
+  test('a workspace with no lease for the platform raises nothing', () => {
+    const h = harness();
+    expect(raiseLease({ root: ROOT_A, platform: 'android', minMs: 60_000 }, h.io)).toEqual({ status: 'none' });
+  });
+});
+
+describe('releasing a lease', () => {
+  test('a run-scoped lease is released by token', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    const released = releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io);
+    expect(released?.id).toBe(UDID);
+    expect(h.read('ios', UDID)).toBe(null);
+    expect(h.holders.get(ROOT_A)).toEqual({});
+  });
+
+  test('a declared lease outlives the run that raised it', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    expect(releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io)).toBe(null);
+    expect(h.read('ios', UDID)?.holder).toBe(ROOT_A);
+  });
+
+  test('a stale release with an old token leaves the newer grant alone', () => {
+    const h = harness();
+    const first = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run', durationMs: 60_000 }, h.io);
+    assert(first.status === 'taken');
+    const stale = h.holders.get(ROOT_A);
+    h.advance(61_000);
+    const second = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    assert(second.status === 'taken');
+    h.holders.set(ROOT_A, stale as WorkspaceLeases);
+
+    expect(releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io)).toBe(null);
+    expect(h.read('ios', UDID)?.token).toBe(second.lease.token);
+  });
+
+  test('a lease whose token this workspace lost is released by holder root', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    h.holders.delete(ROOT_A);
+    const released = releaseWorkspaceLeases(ROOT_A, {}, h.io);
+    expect(released.map((r) => r.id)).toEqual([UDID]);
+    expect(h.read('ios', UDID)).toBe(null);
+  });
+
+  test('another workspace lease is never released', () => {
+    const h = harness();
+    takeLease({ root: ROOT_B, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    expect(releaseWorkspaceLeases(ROOT_A, {}, h.io)).toEqual([]);
+    expect(h.read('ios', UDID)?.holder).toBe(ROOT_B);
+  });
+
+  test('every lease this workspace holds is released', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    takeLease({ root: ROOT_A, platform: 'android', id: 'R5CT', kind: 'run' }, h.io);
+    const released = releaseWorkspaceLeases(ROOT_A, {}, h.io);
+    expect(released.map((r) => r.platform).toSorted()).toEqual(['android', 'ios']);
+    expect(h.files.size).toBe(0);
+    expect(h.holders.get(ROOT_A)).toEqual({});
+  });
+});
+
+describe('the lease duration', () => {
+  test('accepts whole seconds and minutes inside the range', () => {
+    expect(parseLeaseDuration('10s')).toEqual({ ms: 10_000 });
+    expect(parseLeaseDuration('90s')).toEqual({ ms: 90_000 });
+    expect(parseLeaseDuration('5m')).toEqual({ ms: DEFAULT_LEASE_MS });
+    expect(parseLeaseDuration('30m')).toEqual({ ms: 1_800_000 });
+  });
+
+  test('refuses anything outside 10s to 30m', () => {
+    expect(parseLeaseDuration('9s')).toHaveProperty('error');
+    expect(parseLeaseDuration('31m')).toHaveProperty('error');
+    expect(parseLeaseDuration('1801s')).toHaveProperty('error');
+  });
+
+  test('refuses a shape the pattern does not describe', () => {
+    for (const value of ['5', '0s', '01m', '5h', '5M', '-1m', '1.5m', '']) {
+      expect(parseLeaseDuration(value)).toHaveProperty('error');
+    }
+  });
+});
+
+describe('choosing a device from the pool', () => {
+  const now = Date.parse('2026-09-02T12:00:00.000Z');
+  const lease = (over: Partial<DeviceLease>): DeviceLease => ({
+    version: 1,
+    platform: 'ios',
+    id: 'x',
+    deviceName: null,
+    holder: ROOT_B,
+    token: 't',
+    grantedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + 60_000).toISOString(),
+    ...over,
+  });
+
+  test('the first free candidate wins, in case-folded id order', () => {
+    const selection = selectPoolDevice({
+      candidates: [{ id: 'ZZZ' }, { id: 'aaa' }, { id: 'MMM' }],
+      leases: [],
+      now,
+    });
+    expect(selection).toEqual({ status: 'selected', candidate: { id: 'aaa' } });
+  });
+
+  test('a candidate whose lease expired is free', () => {
+    const selection = selectPoolDevice({
+      candidates: [{ id: 'aaa' }, { id: 'bbb' }],
+      leases: [lease({ id: 'aaa', expiresAt: new Date(now - 1).toISOString() })],
+      now,
+    });
+    expect(selection).toEqual({ status: 'selected', candidate: { id: 'aaa' } });
+  });
+
+  test('a candidate another workspace holds is skipped', () => {
+    const selection = selectPoolDevice({
+      candidates: [{ id: 'aaa' }, { id: 'bbb' }],
+      leases: [lease({ id: 'aaa' })],
+      now,
+    });
+    expect(selection).toEqual({ status: 'selected', candidate: { id: 'bbb' } });
+  });
+
+  test("this workspace's leased device wins even when it sorts last", () => {
+    const selection = selectPoolDevice({
+      candidates: [{ id: 'aaa' }, { id: 'zzz', name: 'Old iPhone' }],
+      leases: [lease({ id: 'zzz', holder: ROOT_A })],
+      held: 'zzz',
+      now,
+    });
+    expect(selection).toEqual({ status: 'selected', candidate: { id: 'zzz', name: 'Old iPhone' } });
+  });
+
+  test('a leased device that is not connected refuses rather than picking another', () => {
+    const selection = selectPoolDevice({ candidates: [{ id: 'aaa' }], leases: [], held: 'zzz', now });
+    expect(selection).toEqual({ status: 'held-disconnected', id: 'zzz' });
+  });
+
+  test('candidates with none free name every holder', () => {
+    const selection = selectPoolDevice({
+      candidates: [{ id: 'bbb' }, { id: 'aaa' }],
+      leases: [lease({ id: 'aaa' }), lease({ id: 'bbb', holder: '/worktree/c' })],
+      now,
+    });
+    assert(selection.status === 'busy');
+    expect(selection.holders.map((h) => h.holder)).toEqual([ROOT_B, '/worktree/c']);
+  });
+
+  test('no candidate at all is its own answer', () => {
+    expect(selectPoolDevice({ candidates: [], leases: [], now })).toEqual({ status: 'none' });
+  });
+});
+
+describe('the real file protocol', () => {
+  const LEASE_URL = new URL('../engine/device-lease.ts', import.meta.url).href;
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'stim-lease-'));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  function script(name: string, body: string) {
+    const path = join(scratch, name);
+    writeFileSync(path, body);
+    return path;
+  }
+
+  function runNode(path: string, args: string[] = []) {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [path, ...args],
+        { env: { ...process.env, STIM_HOME: home }, timeout: 60000 },
+        (err, stdout, stderr) => {
+          if (err && err.code === undefined) return reject(err);
+          resolve({ stdout: String(stdout), stderr: String(stderr) });
+        },
+      );
+    });
+  }
+
+  const barrier = (name: string) => [
+    'const { existsSync } = await import("node:fs");',
+    `while (!existsSync(${JSON.stringify(join(scratch, name))})) await new Promise(r => setTimeout(r, 5));`,
+  ];
+
+  function release(name: string) {
+    writeFileSync(join(scratch, name), '');
+  }
+
+  test('two processes racing for one free device leave exactly one holder', async () => {
+    const racer = script(
+      'racer.mjs',
+      [
+        `const { takeLease } = await import(${JSON.stringify(LEASE_URL)});`,
+        ...barrier('go'),
+        'const result = takeLease({ root: process.argv[2], platform: "ios", id: "RACE-UDID", kind: "run" });',
+        'console.log(JSON.stringify(result));',
+      ].join('\n'),
+    );
+
+    const runs = [runNode(racer, [join(scratch, 'a')]), runNode(racer, [join(scratch, 'b')])];
+    release('go');
+    const answers = (await Promise.all(runs)).map((r) => JSON.parse(r.stdout.trim()));
+
+    const taken = answers.filter((a) => a.status === 'taken');
+    const held = answers.filter((a) => a.status === 'held');
+    expect(taken).toHaveLength(1);
+    expect(held).toHaveLength(1);
+    expect(held[0].lease.token).toBe(taken[0].lease.token);
+    const survivor = parseLease(readFileSync(deviceLeasePath('ios', 'RACE-UDID'), 'utf-8'));
+    expect(survivor?.token).toBe(taken[0].lease.token);
+  });
+
+  test('a holder renewing against a claimant taking its expired lease leaves one holder', async () => {
+    const rootA = join(scratch, 'a');
+    const rootB = join(scratch, 'b');
+    const token = 'token-a';
+    writeWorkspaceState(rootA, { deviceLeases: { ios: { id: UDID, token, kind: 'run' } } });
+    const expired: DeviceLease = {
+      version: 1,
+      platform: 'ios',
+      id: UDID,
+      deviceName: 'Old iPhone',
+      holder: rootA,
+      token,
+      grantedAt: new Date(Date.now() - 120_000).toISOString(),
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    };
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(deviceLocksDir(), { recursive: true });
+    writeFileSync(deviceLeasePath('ios', UDID), `${JSON.stringify(expired, null, 2)}\n`);
+
+    const renewer = script(
+      'renewer.mjs',
+      [
+        `const { raiseLease } = await import(${JSON.stringify(LEASE_URL)});`,
+        ...barrier('go2'),
+        `console.log(JSON.stringify(raiseLease({ root: ${JSON.stringify(rootA)}, platform: "ios", minMs: 60000 })));`,
+      ].join('\n'),
+    );
+    const claimant = script(
+      'claimant.mjs',
+      [
+        `const { takeLease } = await import(${JSON.stringify(LEASE_URL)});`,
+        ...barrier('go2'),
+        `console.log(JSON.stringify(takeLease({ root: ${JSON.stringify(rootB)}, platform: "ios", id: ${JSON.stringify(UDID)}, kind: "run" })));`,
+      ].join('\n'),
+    );
+
+    const runs = [runNode(renewer), runNode(claimant)];
+    release('go2');
+    const [raise, take] = (await Promise.all(runs)).map((r) => JSON.parse(r.stdout.trim()));
+    const survivor = parseLease(readFileSync(deviceLeasePath('ios', UDID), 'utf-8'));
+    assert(survivor);
+
+    const world = {
+      raise: raise.status,
+      take: take.status,
+      holder: survivor.holder,
+      keptTheOldToken: survivor.token === token,
+    };
+    expect([
+      { raise: 'raised', take: 'held', holder: rootA, keptTheOldToken: true },
+      { raise: 'lost', take: 'taken', holder: rootB, keptTheOldToken: false },
+    ]).toContainEqual(world);
+  });
+
+  test('a lease that stopped being expired survives the delete that reported it', () => {
+    const root = join(scratch, 'a');
+    const path = deviceLeasePath('ios', UDID);
+    const rewrite = (expiresAt: number) => {
+      const lease = parseLease(readFileSync(path, 'utf-8')) as DeviceLease;
+      writeFileSync(path, JSON.stringify({ ...lease, expiresAt: new Date(expiresAt).toISOString() }));
+    };
+    takeLease({ root, platform: 'ios', id: UDID, kind: 'run', durationMs: 10_000 });
+    rewrite(Date.now() - 1000);
+    const reported = listLeaseFiles()[0];
+    assert(reported);
+
+    rewrite(Date.now() + 600_000);
+    expect(removeExpiredLease(reported)).toBe(false);
+    expect(existsSync(path)).toBe(true);
+
+    rewrite(Date.now() - 1000);
+    expect(removeExpiredLease(reported)).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('a lease file is reported with what its own directory holds', () => {
+    const taken = takeLease({ root: join(scratch, 'a'), platform: 'ios', id: UDID, kind: 'declared' });
+    assert(taken.status === 'taken');
+    const entries = listLeaseFiles();
+    expect(entries.map((e) => e.name)).toEqual([`ios-${UDID}.json`]);
+    expect(entries[0]?.lease?.holder).toBe(join(scratch, 'a'));
+    expect(existsSync(deviceLeasePath('ios', UDID))).toBe(true);
+
+    expect(releaseWorkspaceLeases(join(scratch, 'a')).map((r) => r.id)).toEqual([UDID]);
+    expect(listLeaseFiles()).toEqual([]);
+  });
+});

--- a/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
@@ -168,6 +168,32 @@ describe('taking a lease', () => {
     expect(h.holders.get(ROOT_A)).toEqual({ ios: { id: 'OTHER-UDID', token: second.lease.token, kind: 'declared' } });
   });
 
+  test('a lease file this root left on another device goes even when the token is lost', () => {
+    const h = harness();
+    takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
+    h.holders.delete(ROOT_A);
+
+    const second = takeLease({ root: ROOT_A, platform: 'ios', id: 'OTHER-UDID', kind: 'run' }, h.io);
+    assert(second.status === 'taken');
+    expect(h.read('ios', UDID)).toBe(null);
+    expect(listLeaseFiles(h.io).map((entry) => entry.id)).toEqual(['OTHER-UDID']);
+  });
+
+  test('a run set on this workspace declared lease neither converts nor shortens it', () => {
+    const h = harness();
+    const declared = takeLease(
+      { root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared', durationMs: 600_000 },
+      h.io,
+    );
+    assert(declared.status === 'taken');
+
+    const run = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run', durationMs: 60_000 }, h.io);
+    assert(run.status === 'set');
+    expect(run.lease.expiresAt).toBe(declared.lease.expiresAt);
+    expect(h.holders.get(ROOT_A)?.ios?.kind).toBe('declared');
+    expect(releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io)).toBe(null);
+  });
+
   test('a lease on the other platform survives', () => {
     const h = harness();
     takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'declared' }, h.io);
@@ -261,6 +287,17 @@ describe('releasing a lease', () => {
 
     expect(releaseRunLease({ root: ROOT_A, platform: 'ios' }, h.io)).toBe(null);
     expect(h.read('ios', UDID)?.token).toBe(second.lease.token);
+  });
+
+  test('a stale state token does not strand this root own unexpired lease', () => {
+    const h = harness();
+    const taken = takeLease({ root: ROOT_A, platform: 'ios', id: UDID, kind: 'run' }, h.io);
+    assert(taken.status === 'taken');
+    h.holders.set(ROOT_A, { ios: { id: UDID, token: 'a-token-from-a-dead-run', kind: 'run' } });
+
+    const released = releaseWorkspaceLeases(ROOT_A, {}, h.io);
+    expect(released.map((r) => r.id)).toEqual([UDID]);
+    expect(h.read('ios', UDID)).toBe(null);
   });
 
   test('a lease whose token this workspace lost is released by holder root', () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -19,6 +19,7 @@ import { setExecutor, resetExecutor } from '../exec.ts';
 import { saveConfig, loadConfig } from '../config.ts';
 import { register } from '../cache-manifest.ts';
 import { ensureRemoteBootOwned, withRemoteSessionLock } from '../engine/device-remote.ts';
+import { deviceLeasePath, deviceLocksDir } from '../engine/device-lease.ts';
 import { withEasProjectLock } from '../engine/eas-project-lock.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceStateFile } from '../paths.ts';
 import gcCommand, {
@@ -2515,4 +2516,135 @@ test('--delete removes the stale build slot and leaves a live one alone', async 
   expect(existsSync(stale)).toBe(false);
   expect(existsSync(live)).toBe(true);
   expect(output).toMatch(/build slot/i);
+});
+
+function writeLeaseFile({
+  platform = 'ios',
+  id = 'UDID-LEASE',
+  holder = '/w/holder',
+  expiresInMs = 60_000,
+  body = null,
+}: {
+  platform?: string;
+  id?: string;
+  holder?: string;
+  expiresInMs?: number;
+  body?: string | null;
+}) {
+  mkdirSync(deviceLocksDir(), { recursive: true });
+  const path = deviceLeasePath(platform, id);
+  const now = Date.now();
+  writeFileSync(
+    path,
+    body ??
+      JSON.stringify({
+        version: 1,
+        platform,
+        id,
+        deviceName: 'Old iPhone',
+        holder,
+        token: 'token-1',
+        grantedAt: new Date(now - 60_000).toISOString(),
+        expiresAt: new Date(now + expiresInMs).toISOString(),
+      }),
+  );
+  return path;
+}
+
+describe('expired device leases', () => {
+  test('a bare gc reports an expired lease and removes nothing', async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    const path = writeLeaseFile({ expiresInMs: -1000 });
+
+    const output = await captureLog(() => sweepingGc({}));
+    expect(output).toMatch(/Expired device leases \(1\)/);
+    expect(output).toMatch(/UDID-LEASE/);
+    expect(output).toMatch(/\/w\/holder/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test('--delete removes the expired lease and leaves a live one alone', async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    const expired = writeLeaseFile({ id: 'UDID-OLD', expiresInMs: -1000 });
+    const live = writeLeaseFile({ id: 'UDID-LIVE', holder: tmpHome, expiresInMs: 600_000 });
+
+    const output = await captureLog(() => sweepingGc({ delete: true }));
+    expect(existsSync(expired)).toBe(false);
+    expect(existsSync(live)).toBe(true);
+    expect(output).toMatch(/Cleared the expired ios device lease on UDID-OLD/);
+  });
+
+  test('a file that does not parse is reported and kept', async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    const path = writeLeaseFile({ id: 'UDID-BROKEN', body: '{ not a lease' });
+
+    const output = await captureLog(() => sweepingGc({ delete: true }));
+    expect(output).toMatch(/Device lease files kept \(1\)/);
+    expect(output).toMatch(/does not parse as a lease/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test('an unexpired lease whose holder is gone is reported and kept', async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    const path = writeLeaseFile({ id: 'UDID-ABSENT', holder: join(fakeHome, 'unmounted'), expiresInMs: 600_000 });
+
+    const output = await captureLog(() => sweepingGc({ delete: true }));
+    expect(output).toMatch(/Device lease files kept \(1\)/);
+    expect(output).toMatch(/is not on this machine, but the lease runs until/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test('a lease of a live workspace is not reported at all', async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    writeLeaseFile({ holder: tmpHome, expiresInMs: 600_000 });
+
+    const output = await captureLog(() => sweepingGc({}));
+    expect(output).not.toMatch(/device lease/i);
+  });
+});
+
+test('an expired lease counts as something to reclaim', () => {
+  const lines = formatGcReport({
+    deviceLeases: {
+      expired: [
+        {
+          path: '/h/device-locks/ios-U.json',
+          name: 'ios-U.json',
+          platform: 'ios',
+          id: 'U',
+          lease: {
+            version: 1,
+            platform: 'ios',
+            id: 'U',
+            deviceName: 'Old iPhone',
+            holder: '/w/dead',
+            token: 't',
+            grantedAt: null,
+            expiresAt: '2026-09-02T12:00:00.000Z',
+          },
+        },
+      ],
+      kept: [],
+    },
+  }).join('\n');
+  expect(lines.split('\n')[0]).not.toMatch(/^Nothing to reclaim\.$/);
+  expect(lines).toMatch(/Expired device leases \(1\)/);
+  expect(lines).toMatch(/Old iPhone/);
+  expect(lines).toMatch(/\/w\/dead/);
+});
+
+test('a kept lease file alone is not something to reclaim', () => {
+  const lines = formatGcReport({
+    deviceLeases: {
+      expired: [],
+      kept: [{ name: 'ios-U.json', path: '/h/device-locks/ios-U.json', reason: 'it does not parse as a lease' }],
+    },
+  }).join('\n');
+  expect(lines).toMatch(/Nothing to reclaim/);
+  expect(lines).toMatch(/Device lease files kept \(1\)/);
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -891,3 +891,18 @@ test('the guide documents the flavor refusal that lands before the build', () =>
   expect(errors).toMatch(/STIM_BAD_ARG[\s\S]*declares product flavors with\s+no variant selected/);
   expect(errors).toMatch(/caught before\s+the build instead \(STIM_BAD_ARG\)/);
 });
+
+test('the cleanup guide documents what gc does with device lease files', () => {
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+  expect(cleanup).toMatch(/DEVICE LEASES/);
+  expect(cleanup).toMatch(/~\/\.stim\/device-locks/);
+  expect(cleanup).toMatch(/`gc` reports[\s\S]*expiry has\s+passed/);
+  expect(cleanup).toMatch(/`gc --delete` removes those\s+files/);
+  expect(cleanup).toMatch(/under its own lock/);
+  expect(cleanup).toMatch(/reported and KEPT[\s\S]*does\s+not parse/);
+  expect(cleanup).toMatch(/unexpired lease\s+whose holder directory is gone/);
+  expect(cleanup).toMatch(/`stim status` lists every lease file/);
+  expect(cleanup).toMatch(/`stop` and\s+`worktree remove` release the leases/);
+  expect(cleanup).toMatch(/never remove another workspace's/);
+});

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -7,6 +7,7 @@ import { upsertProject, setDevice, getProject } from '../config.ts';
 import { describeDereferenced, reclaimProject } from '../reclaim.ts';
 import { endRecordedSession } from '../engine/device-remote.ts';
 import { ensureWorkspaceStorage, workspaceStateFile } from '../paths.ts';
+import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
 
 let tmpHome: string;
 
@@ -720,4 +721,41 @@ describe('the unverified-collector start-time split (mocked verify and start tim
     expect(r.skippedDevices).toEqual([]);
     rmSync(root, { recursive: true, force: true });
   }, 20_000);
+});
+
+test('reclaimProject releases the leases the workspace holds', async () => {
+  setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+  const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+  try {
+    ensureWorkspaceStorage(root);
+    const taken = takeLease({ root, platform: 'ios', id: 'UDID-1', deviceName: 'Old iPhone', kind: 'declared' });
+    expect(taken.status).toBe('taken');
+    const other = takeLease({ root: '/w/other', platform: 'android', id: 'R5CT', kind: 'run' });
+    expect(other.status).toBe('taken');
+
+    const result = await reclaimProject(root, { deleteOwnedDevices: false });
+
+    expect(result.releasedLeases).toEqual([
+      { platform: 'ios', id: 'UDID-1', deviceName: 'Old iPhone', expiresAt: expect.any(String) },
+    ]);
+    expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('reclaimProject releases a lease whose token the recreated workspace lost', async () => {
+  setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+  const root = mkdtempSync(join(tmpdir(), 'stim-ws-'));
+  try {
+    takeLease({ root, platform: 'ios', id: 'UDID-1', kind: 'declared' });
+    rmSync(workspaceStateFile(root), { force: true });
+
+    const result = await reclaimProject(root, { deleteOwnedDevices: false });
+
+    expect(result.releasedLeases.map((lease) => lease.id)).toEqual(['UDID-1']);
+    expect(listLeaseFiles()).toEqual([]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/packages/stim-cli/src/__tests__/status-state.test.ts
+++ b/packages/stim-cli/src/__tests__/status-state.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert';
 import {
   capacity,
+  deviceLeaseLines,
+  deviceLeaseStates,
   diskIsTight,
   diskLine,
   environmentState,
@@ -8,7 +10,9 @@ import {
   parseDfFree,
   tightVolumes,
   unprovisionedWorktrees,
+  type DeviceLeaseState,
 } from '../status.ts';
+import type { LeaseFileEntry } from '../engine/device-lease.ts';
 import { makeEnvironmentState } from './_factories.ts';
 
 const BOOTED = { udid: 'U1', name: 'stim-app', state: 'Booted' };
@@ -219,4 +223,67 @@ test('tightVolumes names only the volumes that are actually tight', () => {
   ];
   expect(tightVolumes(volumes).map((v) => v.volume)).toEqual(['/']);
   expect(tightVolumes([])).toEqual([]);
+});
+
+describe('device lease state', () => {
+  const now = Date.parse('2026-09-02T12:00:00.000Z');
+  const entry = (over: Partial<LeaseFileEntry> = {}): LeaseFileEntry => ({
+    path: '/h/device-locks/ios-U.json',
+    name: 'ios-U.json',
+    platform: 'ios',
+    id: 'U',
+    lease: {
+      version: 1,
+      platform: 'ios',
+      id: 'U',
+      deviceName: 'Old iPhone',
+      holder: '/w/a',
+      token: 't',
+      grantedAt: new Date(now - 60_000).toISOString(),
+      expiresAt: new Date(now + 60_000).toISOString(),
+    },
+    ...over,
+  });
+
+  test('marks this workspace lease and an expired one', () => {
+    const states = deviceLeaseStates(
+      [
+        entry(),
+        entry({
+          name: 'android-R5.json',
+          platform: 'android',
+          id: 'R5',
+          lease: {
+            version: 1,
+            platform: 'android',
+            id: 'R5',
+            deviceName: null,
+            holder: '/w/b',
+            token: 't2',
+            grantedAt: null,
+            expiresAt: new Date(now - 1).toISOString(),
+          },
+        }),
+      ],
+      { root: '/w/a', now },
+    );
+    expect(states[0]).toMatchObject({ holder: '/w/a', mine: true, expired: false, parsed: true });
+    expect(states[1]).toMatchObject({ holder: '/w/b', mine: false, expired: true, parsed: true });
+  });
+
+  test('a file that does not parse keeps its name and claims nothing', () => {
+    const [state] = deviceLeaseStates([entry({ lease: null })], { root: '/w/a', now });
+    expect(state).toMatchObject({ platform: 'ios', id: 'U', holder: null, expiresAt: null, parsed: false });
+    expect(deviceLeaseLines([state as DeviceLeaseState], now).join('\n')).toMatch(/unreadable lease file/);
+  });
+
+  test('the lines name the device, the holder and the time left', () => {
+    const lines = deviceLeaseLines(deviceLeaseStates([entry()], { root: '/w/a', now }), now);
+    expect(lines[0]).toBe('Device leases (1):');
+    expect(lines[1]).toMatch(/ios U \(Old iPhone\) -- \/w\/a until \d\d:\d\d:\d\d \(1m00s left\) \[this workspace\]/);
+  });
+
+  test('no lease file prints no section', () => {
+    expect(deviceLeaseLines([], now)).toEqual([]);
+  });
 });

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -11,6 +11,8 @@ import { makeConfig } from './_factories.ts';
 import statusCommand, { readVolumes } from '../commands/status.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
 import { ensureWorkspaceStorage, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
+import { deviceLeasePath, deviceLocksDir } from '../engine/device-lease.ts';
+import { findProjectRoot } from '../project.ts';
 
 let tmpHome: string;
 
@@ -436,4 +438,73 @@ test('a volume df cannot answer for is dropped, not reported as empty', async ()
   dfExecutor({ '/': dfOutput({ totalKb: 926 * 1024 * 1024, availableKb: 38 * 1024 * 1024 }) });
   const volumes = readVolumes('/Volumes/Unplugged/app');
   expect(volumes.map((v) => v.volume)).toEqual(['/']);
+});
+
+function writeLease({
+  platform = 'ios',
+  id,
+  holder,
+  expiresInMs,
+  body = null,
+}: {
+  platform?: string;
+  id: string;
+  holder?: string;
+  expiresInMs?: number;
+  body?: string | null;
+}) {
+  mkdirSync(deviceLocksDir(), { recursive: true });
+  writeFileSync(
+    deviceLeasePath(platform, id),
+    body ??
+      JSON.stringify({
+        version: 1,
+        platform,
+        id,
+        deviceName: 'Old iPhone',
+        holder,
+        token: `token-${id}`,
+        grantedAt: new Date(Date.now() - 1000).toISOString(),
+        expiresAt: new Date(Date.now() + (expiresInMs ?? 60_000)).toISOString(),
+      }),
+  );
+}
+
+describe('the device lease section', () => {
+  test('lists every lease file, whose it is and whether it expired', async () => {
+    saveConfig(makeConfig({ version: 2, projects: {} }));
+    const mine = findProjectRoot(process.cwd());
+    assert(mine);
+    writeLease({ id: 'UDID-MINE', holder: mine, expiresInMs: 60_000 });
+    writeLease({ platform: 'android', id: 'R5CT', holder: '/gone/workspace', expiresInMs: -5000 });
+
+    const logs = await runStatus();
+    const text = logs.join('\n');
+    expect(text).toMatch(/Device leases \(2\)/);
+    expect(text).toMatch(/ios UDID-MINE \(Old iPhone\)[^\n]*\[this workspace\]/);
+    expect(text).toMatch(/android R5CT[^\n]*\/gone\/workspace expired at/);
+
+    const payload = await runStatusJson();
+    expect(payload.deviceLeases).toHaveLength(2);
+    const [android, ios] = payload.deviceLeases;
+    expect(ios).toMatchObject({ platform: 'ios', id: 'UDID-MINE', holder: mine, mine: true, expired: false });
+    expect(android).toMatchObject({
+      platform: 'android',
+      id: 'R5CT',
+      holder: '/gone/workspace',
+      mine: false,
+      expired: true,
+    });
+    expect(typeof ios.expiresAt).toBe('string');
+  });
+
+  test('an unreadable lease file still shows, so nothing looks free that is not', async () => {
+    saveConfig(makeConfig({ version: 2, projects: {} }));
+    writeLease({ id: 'UDID-BROKEN', body: '{ not a lease' });
+
+    const logs = await runStatus();
+    expect(logs.join('\n')).toMatch(/unreadable lease file/);
+    const payload = await runStatusJson();
+    expect(payload.deviceLeases[0]).toMatchObject({ parsed: false, holder: null, mine: false, expired: false });
+  });
 });

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -18,6 +18,7 @@ import {
 import { makeConfig, makeError, makeMetroResolution } from './_factories.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { endRecordedSession } from '../engine/device-remote.ts';
+import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
 
 test('no supervisor recorded anywhere is "none", not an error', () => {
   const r = resolveSupervisorTarget({ state: null, record: null, reservedPort: 8083, isAlive: () => true });
@@ -1119,4 +1120,35 @@ test('an operator-supplied tunnel (metro.publicUrl) is never recorded, so `stop`
   });
   expect(called).toBe(false);
   expect(r.outcomes.metroTunnel.status).toBe('none');
+});
+
+test('stop releases the leases this workspace holds and lists them', async () => {
+  const taken = takeLease({ root: tmpRoot, platform: 'ios', id: 'UDID-1', deviceName: 'Old iPhone', kind: 'declared' });
+  assert(taken.status === 'taken');
+  takeLease({ root: '/w/other', platform: 'android', id: 'R5CT', kind: 'run' });
+
+  const reported: string[] = [];
+  const r = await runStop({
+    root: tmpRoot,
+    project: null,
+    state: null,
+    collectors: {},
+    report: (line: string) => reported.push(line),
+  });
+
+  expect(r.outcomes.releasedLeases).toEqual([
+    { platform: 'ios', id: 'UDID-1', deviceName: 'Old iPhone', expiresAt: taken.lease.expiresAt },
+  ]);
+  expect(r.summary).toMatch(/ios lease on UDID-1 released/);
+  expect(reported.join('\n')).toMatch(/released the ios lease on UDID-1/);
+  expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
+
+  const payload = JSON.parse(JSON.stringify({ root: tmpRoot, ok: r.ok, ...r.outcomes }));
+  expect(payload.releasedLeases).toHaveLength(1);
+});
+
+test('stop says nothing about leases when this workspace holds none', async () => {
+  const r = await runStop({ root: tmpRoot, project: null, state: null, collectors: {}, report: () => {} });
+  expect(r.outcomes.releasedLeases).toEqual([]);
+  expect(r.summary).not.toMatch(/lease/);
 });

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -1140,7 +1140,9 @@ test('stop releases the leases this workspace holds and lists them', async () =>
     { platform: 'ios', id: 'UDID-1', deviceName: 'Old iPhone', expiresAt: taken.lease.expiresAt },
   ]);
   expect(r.summary).toMatch(/ios lease on UDID-1 released/);
-  expect(reported.join('\n')).toMatch(/released the ios lease on UDID-1/);
+  expect(reported.join('\n')).toMatch(
+    new RegExp(`released the ios lease on UDID-1 \\(it ran until ${taken.lease.expiresAt}\\)`),
+  );
   expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
 
   const payload = JSON.parse(JSON.stringify({ root: tmpRoot, ok: r.ok, ...r.outcomes }));

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -19,6 +19,7 @@ import { asProcessExit } from './_factories.ts';
 import { setExecutor, resetExecutor } from '../exec.ts';
 import { upsertProject, getProject } from '../config.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceStateFile } from '../paths.ts';
+import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
 
 type ActionFn = (target: string | undefined, opts: Record<string, unknown>) => void | Promise<void>;
 
@@ -1471,4 +1472,29 @@ test('against a real repo: pod churn PLUS a modified source file is refused exac
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test('action: removal releases this workspace lease and leaves another workspace lease alone', async () => {
+  upsertProject(mainDir, { metroPort: 8086 });
+  ensureWorkspaceStorage(mainDir);
+  expect(takeLease({ root: mainDir, platform: 'ios', id: 'UDID-MINE', kind: 'declared' }).status).toBe('taken');
+  expect(takeLease({ root: wtDir, platform: 'android', id: 'R5CT', kind: 'run' }).status).toBe('taken');
+  const exec = makeExecutor({
+    worktrees: porcelain([{ path: mainDir, branch: 'main' }]),
+    mainTrees: [mainDir],
+  });
+  setExecutor(exec);
+
+  const errs: string[] = [];
+  const original = console.error;
+  console.error = (m) => errs.push(String(m));
+  try {
+    const run = captureAction(registerRemove);
+    await run(mainDir, {});
+  } finally {
+    console.error = original;
+  }
+
+  expect(process.exitCode).not.toBe(1);
+  expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
 });

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -7,6 +7,7 @@ import { clearDevice, getConfigDir, loadConfig } from '../config.ts';
 import { directorySize, formatBytes, isOnMountedVolume, listMountedVolumes, volumeRootFor } from '../fs-util.ts';
 import { listBuildLocks, readBuildLock } from '../engine/build-lock.ts';
 import { listBuildSlots, readBuildSlot } from '../engine/build-slots.ts';
+import { leaseIsExpired, listLeaseFiles, removeExpiredLease, type LeaseFileEntry } from '../engine/device-lease.ts';
 import {
   findOrphanedOwnedSessions,
   getSessionArgs,
@@ -82,6 +83,17 @@ interface EasSessionSweep {
   deletionSafe: boolean;
 }
 
+interface KeptLeaseFile {
+  name: string;
+  path: string;
+  reason: string;
+}
+
+interface DeviceLeaseGarbage {
+  expired: LeaseFileEntry[];
+  kept: KeptLeaseFile[];
+}
+
 interface GcReport {
   skipped: GcSkip[];
   deadProjects: string[];
@@ -90,6 +102,7 @@ interface GcReport {
   staleDeviceRecords: StaleDeviceRecord[];
   buildLocks: { stale: BuildLockInfo[]; live: BuildLockInfo[] };
   buildSlots: { stale: BuildSlotInfo[]; live: BuildSlotInfo[] };
+  deviceLeases: DeviceLeaseGarbage;
   deviceSweepNotices: string[];
   easSessionSweep: EasSessionSweep;
   caches: GcCache[];
@@ -611,6 +624,7 @@ export function formatGcReport({
   staleDeviceRecords = [],
   buildLocks = { stale: [], live: [] },
   buildSlots = { stale: [], live: [] },
+  deviceLeases = { expired: [], kept: [] },
   deviceSweepNotices = [],
   easSessionSweep = { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
   caches = [],
@@ -621,6 +635,7 @@ export function formatGcReport({
   const staleLocks = buildLocks?.stale ?? [];
   const liveLocks = buildLocks?.live ?? [];
   const staleSlots = buildSlots?.stale ?? [];
+  const expiredLeases = deviceLeases?.expired ?? [];
 
   if (cacheScope) {
     lines.push(`Cache scope: "${cacheScope}". Devices, project entries and locks were not inspected.`);
@@ -631,6 +646,7 @@ export function formatGcReport({
     staleDeviceRecords.length === 0 &&
     staleLocks.length === 0 &&
     staleSlots.length === 0 &&
+    expiredLeases.length === 0 &&
     easSessionSweep.orphaned.length === 0
   ) {
     const reasons = [];
@@ -711,6 +727,8 @@ export function formatGcReport({
     }
   }
 
+  lines.push(...leaseGarbageLines(deviceLeases));
+
   if (deviceSweepNotices.length) {
     lines.push(`Device sweep notices (${deviceSweepNotices.length}):`);
     for (const notice of deviceSweepNotices) lines.push(`  ${notice}`);
@@ -745,6 +763,26 @@ export function formatGcReport({
     }
   }
 
+  return lines;
+}
+
+function leaseGarbageLines({ expired, kept }: DeviceLeaseGarbage): string[] {
+  const lines: string[] = [];
+  if (expired.length) {
+    lines.push(`Expired device leases (${expired.length}) - the device is already free:`);
+    for (const entry of expired) {
+      const name = entry.lease?.deviceName ? ` (${entry.lease.deviceName})` : '';
+      lines.push(`  ${entry.platform} ${entry.id ?? entry.name}${name}`);
+      lines.push(
+        `              held by ${entry.lease?.holder ?? 'an unrecorded workspace'} until ${entry.lease?.expiresAt}`,
+      );
+    }
+    lines.push('              --delete removes the FILE only; an expired lease already holds nothing.');
+  }
+  if (kept.length) {
+    lines.push(`Device lease files kept (${kept.length}) - reported, never deleted:`);
+    for (const entry of kept) lines.push(`  ${entry.name}: ${entry.reason}`);
+  }
   return lines;
 }
 
@@ -886,6 +924,34 @@ function emptyCache(cache: CacheDescriptor): {
   return { removed, bytes: failed ? 0 : (cache.bytes ?? 0), failed, skipped: null };
 }
 
+function collectDeviceLeases(now: number): DeviceLeaseGarbage {
+  const expired: LeaseFileEntry[] = [];
+  const kept: KeptLeaseFile[] = [];
+  for (const entry of listLeaseFiles()) {
+    const lease = entry.lease;
+    if (!lease) {
+      kept.push({
+        name: entry.name,
+        path: entry.path,
+        reason: 'it does not parse as a lease, so no run may take that device',
+      });
+      continue;
+    }
+    if (leaseIsExpired(lease, now)) {
+      expired.push(entry);
+      continue;
+    }
+    if (!existsSync(lease.holder)) {
+      kept.push({
+        name: entry.name,
+        path: entry.path,
+        reason: `${lease.holder} is not on this machine, but the lease runs until ${lease.expiresAt}`,
+      });
+    }
+  }
+  return { expired, kept };
+}
+
 export async function collectGcReport(
   {
     olderThan = null,
@@ -910,6 +976,7 @@ export async function collectGcReport(
       staleDeviceRecords: [],
       buildLocks: { stale: [], live: [] },
       buildSlots: { stale: [], live: [] },
+      deviceLeases: { expired: [], kept: [] },
       deviceSweepNotices: [],
       easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
       caches,
@@ -1027,6 +1094,7 @@ export async function collectGcReport(
 
   const locks = listBuildLocks();
   const slots = listBuildSlots();
+  const deviceLeases = collectDeviceLeases(now);
 
   return {
     skipped,
@@ -1042,6 +1110,7 @@ export async function collectGcReport(
       stale: slots.filter((s) => !s.alive),
       live: slots.filter((s) => s.alive),
     },
+    deviceLeases,
     deviceSweepNotices,
     easSessionSweep,
     caches,
@@ -1158,6 +1227,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     staleDeviceRecords,
     buildLocks,
     buildSlots,
+    deviceLeases,
     easSessionSweep,
     caches,
   } = report;
@@ -1168,6 +1238,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     staleDeviceRecords.length > 0 ||
     buildLocks.stale.length > 0 ||
     buildSlots.stale.length > 0 ||
+    deviceLeases.expired.length > 0 ||
     easSessionSweep.orphaned.length > 0 ||
     ((olderThan !== null || all) && caches.length > 0);
 
@@ -1271,6 +1342,23 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     } catch (err) {
       deleteFailures++;
       console.log(chalk.red(`Failed to clear the build slot at ${slot.path}: ${(err as Error)?.message || err}`));
+    }
+  }
+
+  for (const entry of deviceLeases.expired) {
+    try {
+      if (removeExpiredLease(entry)) {
+        console.log(
+          chalk.green(
+            `Cleared the expired ${entry.platform} device lease on ${entry.id ?? entry.name} (held by ${entry.lease?.holder ?? 'an unrecorded workspace'})`,
+          ),
+        );
+      } else {
+        console.log(chalk.dim(`${entry.name} is no longer an expired lease; left alone.`));
+      }
+    } catch (err) {
+      deleteFailures++;
+      console.log(chalk.red(`Failed to clear the device lease at ${entry.path}: ${(err as Error)?.message || err}`));
     }
   }
 
@@ -1500,7 +1588,7 @@ export default function gcCommand(program: Command): void {
   program
     .command('gc')
     .description(
-      'Report what Stim has left behind: dead project entries, orphaned owned devices and EAS sessions, records of devices that no longer exist, build locks whose builder is gone, and the shared build caches. Reports by default; pass --delete to act.',
+      'Report what Stim has left behind: dead project entries, orphaned owned devices and EAS sessions, records of devices that no longer exist, build locks whose builder is gone, expired physical-device leases, and the shared build caches. Reports by default; pass --delete to act.',
     )
     .option('--delete', 'actually prune the reported entries and reap the reported devices')
     .option(

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1859,6 +1859,18 @@ BUILD LOCKS
   progress -- it is named in the report and touched by nothing, because
   removing it would put a second workspace on the same compile.
 
+DEVICE LEASES
+  A workspace can hold a timed lease on a physical device. The lease is one
+  file under ~/.stim/device-locks, and it expires on its own. \`gc\` reports
+  the lease files whose expiry has passed; \`gc --delete\` removes those
+  files, re-reading each one under its own lock first, so a lease renewed in
+  the meantime survives. Two kinds are reported and KEPT: a file that does
+  not parse, which no run may take the device around, and an unexpired lease
+  whose holder directory is gone. \`stim status\` lists every lease file with
+  its holder and expiry, including holders no config knows. \`stop\` and
+  \`worktree remove\` release the leases of the workspace they act on, and
+  nothing else deletes a lease file: never remove another workspace's.
+
 A device leaks when a project is abandoned WITHOUT either delete path -- the
 sim survives with nothing pointing at it. \`stim gc\` (no flag, writes
 nothing, always safe) reports those; \`gc --delete\` reaps them, and in the same

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -17,7 +17,17 @@ import type { IosSimRecord } from '../sim/ios.ts';
 import { listWorktrees } from '../worktree.ts';
 import type { WorktreeEntry } from '../worktree.ts';
 import { volumeRootFor } from '../fs-util.ts';
-import { capacity, diskLine, environmentState, parseDfFree, tightVolumes, unprovisionedWorktrees } from '../status.ts';
+import { listLeaseFiles } from '../engine/device-lease.ts';
+import {
+  capacity,
+  deviceLeaseLines,
+  deviceLeaseStates,
+  diskLine,
+  environmentState,
+  parseDfFree,
+  tightVolumes,
+  unprovisionedWorktrees,
+} from '../status.ts';
 import type { EnvironmentState, VolumeInfo, SimFacts, MetroFacts, WorktreeFacts } from '../status.ts';
 
 type SupervisorRecordExt = SupervisorRecord & { mode?: string | null };
@@ -81,6 +91,9 @@ export default function statusCommand(program: Command): void {
         );
       }
 
+      const leaseNow = Date.now();
+      const leases = deviceLeaseStates(listLeaseFiles(), { root: cwdRoot, now: leaseNow });
+
       const totalMemoryMb = Math.round(totalmem() / (1024 * 1024));
       const cap = capacity(states, totalMemoryMb);
       const orphanWorktrees = unprovisionedWorktrees(
@@ -94,6 +107,7 @@ export default function statusCommand(program: Command): void {
             {
               environments: states.map((state, i) => (labelOnlyRoots[i] ? { ...state, labelOnly: true } : state)),
               capacity: cap,
+              deviceLeases: leases,
               unprovisionedWorktrees: orphanWorktrees,
               simctlAvailable: simsAvailable,
             },
@@ -106,6 +120,7 @@ export default function statusCommand(program: Command): void {
 
       if (projects.length === 0 && orphanWorktrees.length === 0) {
         console.log(chalk.dim('No projects registered.'));
+        for (const line of deviceLeaseLines(leases, leaseNow)) console.log(line);
         return;
       }
 
@@ -155,6 +170,12 @@ export default function statusCommand(program: Command): void {
           );
         }
         for (const w of state.warnings) console.log(chalk.yellow(`  ! ${w}`));
+      }
+
+      const leaseLines = deviceLeaseLines(leases, leaseNow);
+      if (leaseLines.length) {
+        console.log('');
+        for (const line of leaseLines) console.log(line);
       }
 
       if (orphanWorktrees.length) {

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -18,6 +18,7 @@ import {
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 import { endRecordedSession } from '../engine/device-remote.ts';
+import { releaseWorkspaceLeases, type ReleasedLease } from '../engine/device-lease.ts';
 import { resolveEasCliBin } from '../engine/remote-cache.ts';
 import { stopTunnel } from '../engine/tunnel.ts';
 
@@ -267,6 +268,7 @@ interface StopOutcomes {
   device: DeviceOutcome;
   port: PortOutcome;
   metroTunnel: TunnelOutcome;
+  releasedLeases: ReleasedLease[];
 }
 
 interface TunnelOutcome {
@@ -304,6 +306,7 @@ export async function runStop({
   teardownRemoteSession = defaultTeardownRemoteSession,
   metroTunnel = undefined,
   stopMetroTunnel = stopTunnel,
+  releaseLeases = releaseWorkspaceLeases,
   freePort = defaultFreePort,
   clearRegistration = defaultClearRegistration,
   clearState = clearSupervisorState,
@@ -329,6 +332,7 @@ export async function runStop({
   remoteDevice?: RemoteDeviceRecord | null;
   metroTunnel?: ReturnType<typeof readMetroTunnel> | undefined;
   stopMetroTunnel?: typeof stopTunnel;
+  releaseLeases?: (root: string) => ReleasedLease[];
   teardownRemoteSession?: (root: string, sessionId: string) => { status: 'torn-down' | 'failed'; reason?: string };
   freePort?: (root: string, port: number) => void;
   clearRegistration?: (root: string) => Promise<void>;
@@ -348,6 +352,7 @@ export async function runStop({
     device: { ios: null, android: null },
     port: { status: 'none', port: reservedPort },
     metroTunnel: { status: 'none' },
+    releasedLeases: [],
   };
   let ok = true;
   let stillHolding: string | null | undefined = null;
@@ -460,6 +465,11 @@ export async function runStop({
     }
   } else if (tunnel?.kind === 'expo') {
     outcomes.metroTunnel = { status: 'not-managed' };
+  }
+
+  outcomes.releasedLeases = releaseLeases(root);
+  for (const lease of outcomes.releasedLeases) {
+    report(chalk.dim(`leases: released the ${lease.platform} lease on ${lease.id}`));
   }
 
   if (stillHolding) {
@@ -729,6 +739,7 @@ function summarize(root: string, outcomes: StopOutcomes, ok: boolean): string {
   if (outcomes.metroTunnel.status === 'stopped') parts.push(`${outcomes.metroTunnel.provider} tunnel stopped`);
   if (outcomes.metroTunnel.status === 'failed')
     parts.push(`${outcomes.metroTunnel.provider} tunnel could not be stopped`);
+  for (const lease of outcomes.releasedLeases) parts.push(`${lease.platform} lease on ${lease.id} released`);
   const what = parts.length ? parts.join(', ') : 'nothing was running';
   return `${ok ? 'Stopped' : 'Stopped with problems'}: ${what} (${root})`;
 }

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -469,7 +469,7 @@ export async function runStop({
 
   outcomes.releasedLeases = releaseLeases(root);
   for (const lease of outcomes.releasedLeases) {
-    report(chalk.dim(`leases: released the ${lease.platform} lease on ${lease.id}`));
+    report(chalk.dim(`leases: released the ${lease.platform} lease on ${lease.id} (it ran until ${lease.expiresAt})`));
   }
 
   if (stillHolding) {

--- a/packages/stim-cli/src/engine/build-lock.ts
+++ b/packages/stim-cli/src/engine/build-lock.ts
@@ -98,7 +98,7 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function segment(value: string): string {
+export function segment(value: string): string {
   return (
     String(value)
       .replace(/[^A-Za-z0-9._-]+/g, '-')

--- a/packages/stim-cli/src/engine/device-lease.ts
+++ b/packages/stim-cli/src/engine/device-lease.ts
@@ -232,19 +232,31 @@ export function takeLease(
 ): TakeLeaseResult {
   const previous = io.readHolder(root)[platform];
   if (previous && previous.id !== id) releaseHeld(root, platform, previous, io);
+  for (const entry of listLeaseFiles(io)) {
+    const other = entry.lease;
+    if (!other || other.platform !== platform || other.holder !== root || other.id === id) continue;
+    releaseByRoot(root, platform, other.id, io);
+  }
 
+  const declared = previous?.kind === 'declared' && previous.id === id;
   const path = deviceLeasePath(platform, id);
   const result = io.withLeaseLock(deviceLeaseLockPath(platform, id), (): TakeLeaseResult => {
     const now = io.now();
     const raw = io.readLease(path);
     const current = parseLease(raw);
     if (raw !== null && !current) return { status: 'unreadable', path };
-    const expiresAt = new Date(now + durationMs).toISOString();
+    const asked = now + durationMs;
     if (current && !leaseIsExpired(current, now)) {
       if (current.holder !== root) return { status: 'held', lease: current };
-      const kept = { ...current, deviceName: deviceName ?? current.deviceName, expiresAt };
+      const floor = declared && kind === 'run' ? Math.max(asked, Date.parse(current.expiresAt)) : asked;
+      const kept = {
+        ...current,
+        deviceName: deviceName ?? current.deviceName,
+        expiresAt: new Date(floor).toISOString(),
+      };
       return { status: 'set', lease: writeLease(kept, io) };
     }
+    const expiresAt = new Date(asked).toISOString();
     const granted: DeviceLease = {
       version: LEASE_VERSION,
       platform,
@@ -259,7 +271,8 @@ export function takeLease(
   });
 
   if (result.status === 'taken' || result.status === 'set') {
-    io.writeHolder(root, { ...io.readHolder(root), [platform]: { id, token: result.lease.token, kind } });
+    const recorded = result.status === 'set' && declared ? 'declared' : kind;
+    io.writeHolder(root, { ...io.readHolder(root), [platform]: { id, token: result.lease.token, kind: recorded } });
   }
   return result;
 }
@@ -318,6 +331,16 @@ function releaseHeld(
   return released;
 }
 
+function releaseByRoot(root: string, platform: LeasePlatform, id: string, io: LeaseIo): DeviceLease | null {
+  const path = deviceLeasePath(platform, id);
+  return io.withLeaseLock(deviceLeaseLockPath(platform, id), (): DeviceLease | null => {
+    const current = parseLease(io.readLease(path));
+    if (!current || current.holder !== root) return null;
+    io.removeLease(path);
+    return current;
+  });
+}
+
 export function releaseRunLease(
   { root, platform }: { root: string; platform: LeasePlatform },
   io: LeaseIo = fileLeaseIo,
@@ -334,10 +357,8 @@ export function releaseWorkspaceLeases(
   io: LeaseIo = fileLeaseIo,
 ): ReleasedLease[] {
   const released: ReleasedLease[] = [];
-  const seen = new Set<string>();
   for (const [name, record] of Object.entries(io.readHolder(root))) {
     if (!isPlatform(name) || (platform && name !== platform)) continue;
-    seen.add(`${name} ${record.id}`);
     const lease = releaseHeld(root, name, record, io);
     if (lease) released.push(summarize(lease));
   }
@@ -345,13 +366,7 @@ export function releaseWorkspaceLeases(
     const lease = entry.lease;
     if (!lease || lease.holder !== root) continue;
     if (platform && lease.platform !== platform) continue;
-    if (seen.has(`${lease.platform} ${lease.id}`)) continue;
-    const byRoot = io.withLeaseLock(deviceLeaseLockPath(lease.platform, lease.id), (): DeviceLease | null => {
-      const current = parseLease(io.readLease(entry.path));
-      if (!current || current.holder !== root) return null;
-      io.removeLease(entry.path);
-      return current;
-    });
+    const byRoot = releaseByRoot(root, lease.platform, lease.id, io);
     if (byRoot) released.push(summarize(byRoot));
   }
   return released;

--- a/packages/stim-cli/src/engine/device-lease.ts
+++ b/packages/stim-cli/src/engine/device-lease.ts
@@ -1,0 +1,417 @@
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getConfigDir } from '../config.ts';
+import { withDirLock } from '../dir-lock.ts';
+import { clearWorkspaceStateKeys, readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
+import { segment } from './build-lock.ts';
+
+export const LEASE_VERSION = 1;
+export const DEFAULT_LEASE_MS: number = 5 * 60 * 1000;
+export const MIN_LEASE_MS: number = 10 * 1000;
+export const MAX_LEASE_MS: number = 30 * 60 * 1000;
+
+const LEASE_SUFFIX = '.json';
+const LOCK_SUFFIX = '.lock';
+const DURATION = /^[1-9][0-9]*(s|m)$/;
+
+export type LeasePlatform = 'ios' | 'android';
+export type LeaseKind = 'declared' | 'run';
+
+export interface DeviceLease {
+  version: number;
+  platform: LeasePlatform;
+  id: string;
+  deviceName: string | null;
+  holder: string;
+  token: string;
+  grantedAt: string | null;
+  expiresAt: string;
+}
+
+export interface WorkspaceLeaseRecord {
+  id: string;
+  token: string;
+  kind: LeaseKind;
+}
+
+export type WorkspaceLeases = Partial<Record<LeasePlatform, WorkspaceLeaseRecord>>;
+
+export interface LeaseIo {
+  now: () => number;
+  readLease: (path: string) => string | null;
+  writeLease: (path: string, text: string) => void;
+  removeLease: (path: string) => void;
+  listLeaseNames: () => string[];
+  withLeaseLock: <T>(lockPath: string, fn: () => T) => T;
+  readHolder: (root: string) => WorkspaceLeases;
+  writeHolder: (root: string, leases: WorkspaceLeases) => void;
+}
+
+export function deviceLocksDir(): string {
+  return join(getConfigDir(), 'device-locks');
+}
+
+function leaseStem(platform: string, id: string): string {
+  return `${segment(platform)}-${segment(id)}`;
+}
+
+export function deviceLeasePath(platform: string, id: string): string {
+  return join(deviceLocksDir(), `${leaseStem(platform, id)}${LEASE_SUFFIX}`);
+}
+
+export function deviceLeaseLockPath(platform: string, id: string): string {
+  return join(deviceLocksDir(), `${leaseStem(platform, id)}${LOCK_SUFFIX}`);
+}
+
+export const fileLeaseIo: LeaseIo = {
+  now: () => Date.now(),
+  readLease(path) {
+    try {
+      return readFileSync(path, 'utf-8');
+    } catch {
+      return null;
+    }
+  },
+  writeLease(path, body) {
+    mkdirSync(deviceLocksDir(), { recursive: true });
+    const tmp = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`;
+    writeFileSync(tmp, body);
+    try {
+      renameSync(tmp, path);
+    } catch (error) {
+      rmSync(tmp, { force: true });
+      throw error;
+    }
+  },
+  removeLease(path) {
+    rmSync(path, { force: true });
+  },
+  listLeaseNames() {
+    try {
+      return readdirSync(deviceLocksDir());
+    } catch {
+      return [];
+    }
+  },
+  withLeaseLock(lockPath, fn) {
+    return withDirLock(lockPath, fn, { ensureParent: () => mkdirSync(deviceLocksDir(), { recursive: true }) });
+  },
+  readHolder(root) {
+    return parseWorkspaceLeases(readWorkspaceState(root)?.deviceLeases);
+  },
+  writeHolder(root, leases) {
+    if (Object.keys(leases).length === 0) clearWorkspaceStateKeys(root, ['deviceLeases']);
+    else writeWorkspaceState(root, { deviceLeases: leases });
+  },
+};
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function isPlatform(value: unknown): value is LeasePlatform {
+  return value === 'ios' || value === 'android';
+}
+
+export function parseLease(raw: string | null): DeviceLease | null {
+  if (typeof raw !== 'string') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const entry = parsed as Record<string, unknown>;
+  if (entry.version !== LEASE_VERSION || !isPlatform(entry.platform)) return null;
+  const id = text(entry.id);
+  const holder = text(entry.holder);
+  const token = text(entry.token);
+  const expiresAt = text(entry.expiresAt);
+  if (!id || !holder || !token || !expiresAt || !Number.isFinite(Date.parse(expiresAt))) return null;
+  return {
+    version: LEASE_VERSION,
+    platform: entry.platform,
+    id,
+    deviceName: text(entry.deviceName),
+    holder,
+    token,
+    grantedAt: text(entry.grantedAt),
+    expiresAt,
+  };
+}
+
+export function parseWorkspaceLeases(value: unknown): WorkspaceLeases {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const leases: WorkspaceLeases = {};
+  for (const [platform, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!isPlatform(platform) || !entry || typeof entry !== 'object') continue;
+    const record = entry as Record<string, unknown>;
+    const id = text(record.id);
+    const token = text(record.token);
+    if (!id || !token) continue;
+    leases[platform] = { id, token, kind: record.kind === 'run' ? 'run' : 'declared' };
+  }
+  return leases;
+}
+
+export function leaseIsExpired(lease: DeviceLease, now: number): boolean {
+  return Date.parse(lease.expiresAt) <= now;
+}
+
+export function parseLeaseDuration(value: string): { ms: number } | { error: string } {
+  const raw = String(value ?? '').trim();
+  const match = DURATION.exec(raw);
+  if (!match) {
+    return { error: `--for must be a whole number of seconds or minutes, such as 90s or 5m (got "${raw}").` };
+  }
+  const ms = Number(raw.slice(0, -1)) * (match[1] === 's' ? 1000 : 60 * 1000);
+  if (ms < MIN_LEASE_MS || ms > MAX_LEASE_MS) {
+    return { error: `--for must be between 10s and 30m (got "${raw}").` };
+  }
+  return { ms };
+}
+
+export interface LeaseFileEntry {
+  path: string;
+  name: string;
+  platform: string;
+  id: string | null;
+  lease: DeviceLease | null;
+}
+
+export function listLeaseFiles(io: LeaseIo = fileLeaseIo): LeaseFileEntry[] {
+  const dir = deviceLocksDir();
+  const entries: LeaseFileEntry[] = [];
+  for (const name of io.listLeaseNames().toSorted()) {
+    if (!name.endsWith(LEASE_SUFFIX)) continue;
+    const path = join(dir, name);
+    const lease = parseLease(io.readLease(path));
+    const stem = name.slice(0, -LEASE_SUFFIX.length);
+    const cut = stem.indexOf('-');
+    entries.push({
+      path,
+      name,
+      platform: lease?.platform ?? (cut > 0 ? stem.slice(0, cut) : stem),
+      id: lease?.id ?? (cut > 0 ? stem.slice(cut + 1) : null),
+      lease,
+    });
+  }
+  return entries;
+}
+
+function writeLease(lease: DeviceLease, io: LeaseIo): DeviceLease {
+  io.writeLease(deviceLeasePath(lease.platform, lease.id), `${JSON.stringify(lease, null, 2)}\n`);
+  return lease;
+}
+
+export type TakeLeaseResult =
+  | { status: 'taken'; lease: DeviceLease }
+  | { status: 'set'; lease: DeviceLease }
+  | { status: 'held'; lease: DeviceLease }
+  | { status: 'unreadable'; path: string };
+
+export function takeLease(
+  {
+    root,
+    platform,
+    id,
+    deviceName = null,
+    kind,
+    durationMs = DEFAULT_LEASE_MS,
+  }: {
+    root: string;
+    platform: LeasePlatform;
+    id: string;
+    deviceName?: string | null;
+    kind: LeaseKind;
+    durationMs?: number;
+  },
+  io: LeaseIo = fileLeaseIo,
+): TakeLeaseResult {
+  const previous = io.readHolder(root)[platform];
+  if (previous && previous.id !== id) releaseHeld(root, platform, previous, io);
+
+  const path = deviceLeasePath(platform, id);
+  const result = io.withLeaseLock(deviceLeaseLockPath(platform, id), (): TakeLeaseResult => {
+    const now = io.now();
+    const raw = io.readLease(path);
+    const current = parseLease(raw);
+    if (raw !== null && !current) return { status: 'unreadable', path };
+    const expiresAt = new Date(now + durationMs).toISOString();
+    if (current && !leaseIsExpired(current, now)) {
+      if (current.holder !== root) return { status: 'held', lease: current };
+      const kept = { ...current, deviceName: deviceName ?? current.deviceName, expiresAt };
+      return { status: 'set', lease: writeLease(kept, io) };
+    }
+    const granted: DeviceLease = {
+      version: LEASE_VERSION,
+      platform,
+      id,
+      deviceName,
+      holder: root,
+      token: randomBytes(12).toString('hex'),
+      grantedAt: new Date(now).toISOString(),
+      expiresAt,
+    };
+    return { status: 'taken', lease: writeLease(granted, io) };
+  });
+
+  if (result.status === 'taken' || result.status === 'set') {
+    io.writeHolder(root, { ...io.readHolder(root), [platform]: { id, token: result.lease.token, kind } });
+  }
+  return result;
+}
+
+export type RaiseLeaseResult =
+  | { status: 'raised'; lease: DeviceLease }
+  | { status: 'none' }
+  | { status: 'lost'; lease: DeviceLease | null };
+
+export function raiseLease(
+  { root, platform, minMs }: { root: string; platform: LeasePlatform; minMs: number },
+  io: LeaseIo = fileLeaseIo,
+): RaiseLeaseResult {
+  const record = io.readHolder(root)[platform];
+  if (!record) return { status: 'none' };
+  const path = deviceLeasePath(platform, record.id);
+  return io.withLeaseLock(deviceLeaseLockPath(platform, record.id), (): RaiseLeaseResult => {
+    const current = parseLease(io.readLease(path));
+    if (!current || current.token !== record.token) return { status: 'lost', lease: current };
+    const floor = io.now() + minMs;
+    if (Date.parse(current.expiresAt) >= floor) return { status: 'raised', lease: current };
+    const raised = { ...current, expiresAt: new Date(floor).toISOString() };
+    return { status: 'raised', lease: writeLease(raised, io) };
+  });
+}
+
+export interface ReleasedLease {
+  platform: LeasePlatform;
+  id: string;
+  deviceName: string | null;
+  expiresAt: string;
+}
+
+function summarize(lease: DeviceLease): ReleasedLease {
+  return { platform: lease.platform, id: lease.id, deviceName: lease.deviceName, expiresAt: lease.expiresAt };
+}
+
+function releaseHeld(
+  root: string,
+  platform: LeasePlatform,
+  record: WorkspaceLeaseRecord,
+  io: LeaseIo,
+): DeviceLease | null {
+  const path = deviceLeasePath(platform, record.id);
+  const released = io.withLeaseLock(deviceLeaseLockPath(platform, record.id), (): DeviceLease | null => {
+    const current = parseLease(io.readLease(path));
+    if (!current || current.token !== record.token) return null;
+    io.removeLease(path);
+    return current;
+  });
+  const held = io.readHolder(root);
+  if (held[platform]?.token === record.token) {
+    delete held[platform];
+    io.writeHolder(root, held);
+  }
+  return released;
+}
+
+export function releaseRunLease(
+  { root, platform }: { root: string; platform: LeasePlatform },
+  io: LeaseIo = fileLeaseIo,
+): ReleasedLease | null {
+  const record = io.readHolder(root)[platform];
+  if (!record || record.kind !== 'run') return null;
+  const released = releaseHeld(root, platform, record, io);
+  return released ? summarize(released) : null;
+}
+
+export function releaseWorkspaceLeases(
+  root: string,
+  { platform = null }: { platform?: LeasePlatform | null } = {},
+  io: LeaseIo = fileLeaseIo,
+): ReleasedLease[] {
+  const released: ReleasedLease[] = [];
+  const seen = new Set<string>();
+  for (const [name, record] of Object.entries(io.readHolder(root))) {
+    if (!isPlatform(name) || (platform && name !== platform)) continue;
+    seen.add(`${name} ${record.id}`);
+    const lease = releaseHeld(root, name, record, io);
+    if (lease) released.push(summarize(lease));
+  }
+  for (const entry of listLeaseFiles(io)) {
+    const lease = entry.lease;
+    if (!lease || lease.holder !== root) continue;
+    if (platform && lease.platform !== platform) continue;
+    if (seen.has(`${lease.platform} ${lease.id}`)) continue;
+    const byRoot = io.withLeaseLock(deviceLeaseLockPath(lease.platform, lease.id), (): DeviceLease | null => {
+      const current = parseLease(io.readLease(entry.path));
+      if (!current || current.holder !== root) return null;
+      io.removeLease(entry.path);
+      return current;
+    });
+    if (byRoot) released.push(summarize(byRoot));
+  }
+  return released;
+}
+
+export function removeExpiredLease(entry: LeaseFileEntry, io: LeaseIo = fileLeaseIo): boolean {
+  const lease = entry.lease;
+  if (!lease) return false;
+  return io.withLeaseLock(deviceLeaseLockPath(lease.platform, lease.id), (): boolean => {
+    const current = parseLease(io.readLease(entry.path));
+    if (!current || !leaseIsExpired(current, io.now())) return false;
+    io.removeLease(entry.path);
+    return true;
+  });
+}
+
+export interface PoolCandidate {
+  id: string;
+  name?: string | null;
+}
+
+export interface PoolHolder {
+  id: string;
+  holder: string;
+  expiresAt: string;
+}
+
+export type PoolSelection =
+  | { status: 'selected'; candidate: PoolCandidate }
+  | { status: 'held-disconnected'; id: string }
+  | { status: 'busy'; holders: PoolHolder[] }
+  | { status: 'none' };
+
+export function selectPoolDevice({
+  candidates,
+  leases,
+  held = null,
+  now,
+}: {
+  candidates: readonly PoolCandidate[];
+  leases: readonly DeviceLease[];
+  held?: string | null;
+  now: number;
+}): PoolSelection {
+  const ordered = candidates.toSorted((a, b) => {
+    const left = a.id.toLowerCase();
+    const right = b.id.toLowerCase();
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+  if (held) {
+    const mine = ordered.find((candidate) => candidate.id === held);
+    return mine ? { status: 'selected', candidate: mine } : { status: 'held-disconnected', id: held };
+  }
+  if (ordered.length === 0) return { status: 'none' };
+  const byId = new Map(leases.map((lease) => [lease.id, lease]));
+  const holders: PoolHolder[] = [];
+  for (const candidate of ordered) {
+    const lease = byId.get(candidate.id);
+    if (!lease || leaseIsExpired(lease, now)) return { status: 'selected', candidate };
+    holders.push({ id: lease.id, holder: lease.holder, expiresAt: lease.expiresAt });
+  }
+  return { status: 'busy', holders };
+}

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -13,6 +13,7 @@ import {
   type ManagedTunnelRecord,
 } from './supervisor/state.ts';
 import { endRecordedSession } from './engine/device-remote.ts';
+import { releaseWorkspaceLeases, type ReleasedLease } from './engine/device-lease.ts';
 import { resolveEasCliBin } from './engine/remote-cache.ts';
 import { stopTunnel, type StopTunnelResult } from './engine/tunnel.ts';
 import { workspaceDir } from './paths.ts';
@@ -267,6 +268,7 @@ export interface ReclaimResult {
   keptEntry: boolean;
   stoppedSession: string | null;
   stoppedTunnel: string | null;
+  releasedLeases: ReleasedLease[];
   removedWorkspaceDirs: string[];
   failedWorkspaceDirs: string[];
 }
@@ -278,6 +280,7 @@ export async function reclaimProject(
     preserveProjectRecord = false,
     stopSession = defaultStopSession,
     stopMetroTunnel = defaultStopMetroTunnel,
+    releaseLeases = releaseWorkspaceLeases,
     verifyCollector = verifyCollectorOwnership,
     readCollectorStartTime = readProcessStartTime,
   }: {
@@ -285,6 +288,7 @@ export async function reclaimProject(
     preserveProjectRecord?: boolean;
     stopSession?: StopSession;
     stopMetroTunnel?: StopMetroTunnelFn;
+    releaseLeases?: (root: string) => ReleasedLease[];
     verifyCollector?: typeof verifyCollectorOwnership;
     readCollectorStartTime?: (pid: number) => Date | null;
   } = {},
@@ -319,6 +323,13 @@ export async function reclaimProject(
   if (tunnel.failed) {
     skippedDevices.push(tunnel.failed);
     failedDevices.push(tunnel.failed);
+  }
+
+  let releasedLeases: ReleasedLease[] = [];
+  try {
+    releasedLeases = releaseLeases(path);
+  } catch {
+    releasedLeases = [];
   }
 
   let killedPid: number | null = null;
@@ -362,6 +373,7 @@ export async function reclaimProject(
     keptEntry,
     stoppedSession: remote.stopped,
     stoppedTunnel: tunnel.stopped,
+    releasedLeases,
     removedWorkspaceDirs,
     failedWorkspaceDirs,
   };

--- a/packages/stim-cli/src/status.ts
+++ b/packages/stim-cli/src/status.ts
@@ -1,4 +1,6 @@
+import { formatElapsed } from './command-output.ts';
 import type { ProjectRecord } from './config.ts';
+import type { LeaseFileEntry } from './engine/device-lease.ts';
 
 const IOS_SIM_MB = 1500;
 const ANDROID_EMULATOR_MB = 2500;
@@ -195,4 +197,61 @@ export function tightVolumes(volumes: VolumeInfo[] | null | undefined): VolumeIn
 export function unprovisionedWorktrees(worktrees: WorktreeFacts[], projectPaths: string[]): WorktreeFacts[] {
   const known = new Set(projectPaths);
   return worktrees.filter((w) => !known.has(w.path));
+}
+
+export interface DeviceLeaseState {
+  path: string;
+  platform: string;
+  id: string | null;
+  deviceName: string | null;
+  holder: string | null;
+  grantedAt: string | null;
+  expiresAt: string | null;
+  mine: boolean;
+  expired: boolean;
+  parsed: boolean;
+}
+
+export function deviceLeaseStates(
+  entries: readonly LeaseFileEntry[],
+  { root, now }: { root: string | null; now: number },
+): DeviceLeaseState[] {
+  return entries.map((entry) => {
+    const lease = entry.lease;
+    return {
+      path: entry.path,
+      platform: entry.platform,
+      id: entry.id,
+      deviceName: lease?.deviceName ?? null,
+      holder: lease?.holder ?? null,
+      grantedAt: lease?.grantedAt ?? null,
+      expiresAt: lease?.expiresAt ?? null,
+      mine: Boolean(lease && root && lease.holder === root),
+      expired: Boolean(lease && Date.parse(lease.expiresAt) <= now),
+      parsed: Boolean(lease),
+    };
+  });
+}
+
+function clockTime(iso: string): string {
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return iso;
+  return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
+}
+
+export function deviceLeaseLines(states: readonly DeviceLeaseState[], now: number): string[] {
+  if (states.length === 0) return [];
+  const lines = [`Device leases (${states.length}):`];
+  for (const state of states) {
+    const device = `${state.platform} ${state.id ?? state.path}${state.deviceName ? ` (${state.deviceName})` : ''}`;
+    if (!state.parsed || state.expiresAt === null) {
+      lines.push(`  ${device} -- unreadable lease file, so nothing may take the device: ${state.path}`);
+      continue;
+    }
+    const when = clockTime(state.expiresAt);
+    const remaining = Date.parse(state.expiresAt) - now;
+    const expiry = state.expired ? `expired at ${when}` : `until ${when} (${formatElapsed(remaining)} left)`;
+    lines.push(`  ${device} -- ${state.holder} ${expiry}${state.mine ? ' [this workspace]' : ''}`);
+  }
+  return lines;
 }


### PR DESCRIPTION
## Description

Two workspaces sharing one phone install over each other, and Stim has no
arbiter: `devicectl install` and `adb install -r` both terminate the running app
when the app ids match, and the second launch backgrounds the first when they
differ. `docs/specs/2026-09-02-device-lease-design.md` (merged in #222, from
#221) answers that with a timed lease a workspace holds on a physical device.

This is phase 1 of that spec's "Phases" list: the lease itself and the commands
that only observe or release one. Nothing calls it from `ios` or `android` yet
(phase 2), there is no `device lock` / `device unlock` command (phase 3), and
nothing selects among several connected devices (phase 4) beyond the pure
function that will. So on this branch a lease file appears only if a test writes
one -- which is why it lands first: from here on `status`, `stop`,
`worktree remove`, and `gc` all know what a lease is, so phase 2 cannot strand
one.

What changes:

- new `engine/device-lease.ts`, called by the four commands below and by nothing
  else;
- `status` gains a lease section and a `deviceLeases` JSON array;
- `stop` gains `releasedLeases` in its summary and JSON;
- `gc` reports expired lease files, and `--delete` removes them;
- `worktree remove` releases through `reclaimProject`, with no new output;
- `engine/build-lock.ts` exports its `segment` sanitizer, which the lease file
  name reuses;
- AGENTS.md and the `guide` cleanup topic take the spec's wording, except two
  guidance deltas that belong with the code they describe: the command-surface
  sentence (`device lock|unlock`, phase 3) and invariant 3's option-list line
  for `--wait` / `--no-wait`, which lands with those flags in phase 2.

No existing payload changes shape. `reclaimProject` swallows a failed release
rather than aborting a `worktree remove` over it: a lease expires on its own, so
the worst case is a device that looks busy for the rest of its declared
duration.

## Solution

A lease is one version-1 JSON file at
`$STIM_HOME/device-locks/<platform>-<segment(id)>.json` -- the build lock's
sanitizer, because an adb TCP serial carries a `:`. Its holder is the canonical
workspace root; the matching token lives in that workspace's `state.json` under
`deviceLeases`, written under the workspace state lock and creating the
workspace storage if needed, so a lease before `start` works.

Every mutation runs under the directory lock on the matching `.lock` path, the
primitive that already guards `state.json`, and inside it re-reads, applies one
rule, and writes through a temp file and a rename -- a plain rename on renew
would overwrite a claimant that just took the same file after it expired. The
token identifies a grant rather than a workspace, so a dead run's deferred
release is a no-op once someone else has been granted the device;
`releaseWorkspaceLeases` falls back to release by holder root for the case the
spec names, a recreated workspace directory whose token is gone, which is what
`stop` and `worktree remove` need.

The API phase 2 will call is here and tested but wired to nothing:
`raiseLease({ root, platform, minMs })` raises the expiry to now plus the step
bound and never lowers it (an expired file still carrying the run's own token is
revived -- nobody took it under the lock), and `releaseRunLease` releases only a
run-scoped lease, leaving a declared one where the run's raises left it.
`selectPoolDevice` is pure over candidates passed in, so phase 4 supplies the
resolver output.

`gc` treats leases as hygiene, not as what frees a device -- rule 1 already makes
an expired lease free. `--delete` re-reads each file under its lock, so a lease
renewed since the report survives. A file that does not parse, and an unexpired
lease whose holder path is absent, are reported and kept: invariant 8.

## Test plan

Per the spec's "Testing" section, for what phase 1 contains:

- `engine-device-lease.test.ts` runs every rule over an injected clock and file
  layer (take, renew, release, the stale-release ABA case, one lease per
  platform, the duration range, pool selection), and asserts each mutation went
  through the right lock path.
- Two child-process races cover the real protocol on real files: two processes
  taking one free device (exactly one wins, and the file is the winner's), and a
  holder renewing while a claimant takes its expired lease, which must land in
  one of exactly two consistent worlds -- revived and the claimant refused, or
  taken and the renewer lost.
- Command tests with `STIM_HOME` redirected cover `status` (text and JSON,
  including an unreadable file and a holder no config knows), `stop`,
  `worktree remove` through `registerRemove` (its own lease released, another
  workspace's untouched), and `gc` (report, `--delete`, both kept kinds, and the
  re-check that spares a renewed lease).

`pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (79 files,
3039 tests) and `pnpm run knip` pass on 95b3aae. No tool call changed here --
nothing in this phase installs, launches, or touches a device -- so invariant 9
has nothing new to exercise.

Fixes #225.

<details>
<summary>Which spec sentence each change implements</summary>

`docs/specs/2026-09-02-device-lease-design.md`, section -> change:

- "Lease state": the file shape and `$STIM_HOME/device-locks/<platform>-<segment(id)>.json` -> `deviceLeasePath` / the `DeviceLease` record; `segment` is exported from `engine/build-lock.ts` because the spec names that sanitizer. The holder's side, "written under the workspace state lock and created with the workspace storage if needed ... `deviceLeases: { ios?: { id, token, kind } }`" -> `fileLeaseIo.readHolder` / `writeHolder` over `withWorkspaceStateLock`. "The token identifies a grant, not a workspace" -> the token comparison in `releaseHeld` and `raiseLease`.
- "Lease protocol": "Every read-modify-write ... runs under the directory lock ... re-reads the file, applies one rule, and writes with a temp file and rename" -> `io.withLeaseLock` around every mutation, plus `fileLeaseIo.writeLease`. Rule 1 -> `leaseIsExpired` and the `unreadable` result. Rule 2 -> `takeLease`'s fresh token. Rule 3 -> token comparison, and `releaseWorkspaceLeases`'s by-holder-root pass. Rule 4 -> `takeLease`'s `set` (which can shorten) and `raiseLease`'s floor, which never lowers. Rule 5 -> the injected clock is this machine's.
- "ios and android": "before each device step the run raises the expiry to now plus the larger of 60 seconds and that step's upper bound" and "releases a run-scoped lease when the command exits" -> `raiseLease({ root, platform, minMs })` and `releaseRunLease`, exposed and tested, called by nothing yet. "A raise on an expired file that still carries the run's own token succeeds and revives the lease" -> the raise path ignores expiry when the token matches.
- "Pool", rules 1-5 -> `selectPoolDevice`: candidates passed in, id order case-folded, the held-device preference, the disconnected-held refusal, `busy` naming every holder, and `none`.
- "Commands": "`--for` matches `^[1-9][0-9]*(s|m)$` ... The default is `5m`, the minimum `10s`, the maximum `30m`" -> `parseLeaseDuration` and the three constants.
- "Other commands": the `status` bullet -> `deviceLeaseStates` / `deviceLeaseLines` in `status.ts` and the `deviceLeases` JSON key. The `stop` bullet -> `releaseLeases` in `runStop`, `releasedLeases` in the outcomes and the summary. The `worktree remove` bullet -> the release in `reclaimProject`, beside the remote session and the tunnel. The `gc` bullet -> `collectDeviceLeases`, the report section, and the `removeExpiredLease` loop under `--delete`.
- "Guidance deltas": the "Locked state" sentence and invariant 2's replacement paragraph, verbatim. Two deltas are deliberately not here: the command-surface sentence lands with `device lock` / `device unlock` in phase 3, and invariant 3's option list gains `--wait <seconds> --no-wait` in phase 2, with the flags themselves.
- "Phases", item 1 -> the scope of this PR.

</details>


