### PR TITLE
docs: fix AGENTS.md invariant 3 claiming iOS has no --device equivalent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,14 +157,17 @@ Metro from the project's dependencies. Expo runs its fixed start command. iOS
 and Android use fixed `xcodebuild` and Gradle arguments.
 
 The supported build selectors are `ios --configuration <name>` and
-`android --variant <name>`. `android --device [serial]` selects a connected
-physical device; there is no iOS equivalent, because that needs code signing.
-Do not add install flows. Non-Debug iOS configurations and Android variants
-ending in `Release` skip Metro. A release cache hit must inject the current JS
-into a copy of the artifact. A swap failure must run a full build; it must never
-install stale JS. Android swaps require an emitted-asset manifest match, then
-`zipalign` before `apksigner`. Store signing and distribution remain out of
-scope.
+`android --variant <name>`. `ios --device [udid]` and `android --device
+[serial]` select a connected physical device; the iOS path requires a
+development signing identity and a matching embedded provisioning profile,
+and the signing gate refuses an expired profile or one that does not name
+the target device — including an Enterprise or App Store profile, which
+carries no device list to check. Do not add install flows. Non-Debug iOS
+configurations and Android variants ending in `Release` skip Metro. A
+release cache hit must inject the current JS into a copy of the artifact. A
+swap failure must run a full build; it must never install stale JS. Android
+swaps require an emitted-asset manifest match, then `zipalign` before
+`apksigner`. Store signing and distribution remain out of scope.
 
 ### 4. Centralize device teardown
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,17 +157,27 @@ Metro from the project's dependencies. Expo runs its fixed start command. iOS
 and Android use fixed `xcodebuild` and Gradle arguments.
 
 The supported build selectors are `ios --configuration <name>` and
-`android --variant <name>`. `ios --device [udid]` and `android --device
-[serial]` select a connected physical device; the iOS path requires a
-development signing identity and a matching embedded provisioning profile,
-and the signing gate refuses an expired profile or one that does not name
-the target device — including an Enterprise or App Store profile, which
-carries no device list to check. Do not add install flows. Non-Debug iOS
-configurations and Android variants ending in `Release` skip Metro. A
-release cache hit must inject the current JS into a copy of the artifact. A
-swap failure must run a full build; it must never install stale JS. Android
-swaps require an emitted-asset manifest match, then `zipalign` before
-`apksigner`. Store signing and distribution remain out of scope.
+`android --variant <name>`. `android --device [serial]` and
+`ios --device [udid]` select a connected physical device. Non-Debug iOS
+configurations and Android variants ending in `Release` skip Metro. A release
+cache hit must inject the current JS into a copy of the artifact. A swap
+failure must run a full build; it must never install stale JS. Android swaps
+require an emitted-asset manifest match, then `zipalign` before `apksigner`.
+
+An iOS device build is always signed, Debug included. Before Stim installs or
+re-seals a device app, the signing gate reads the bundle's own
+`embedded.mobileprovision` and refuses one that is missing, expired, carries
+no `ProvisionedDevices` list (App Store and enterprise profiles), or does not
+name the target UDID. Stim re-signs only copies it makes, with an identity
+present in the keychain: the one the profile's certificate names, or the one
+`ios.signingIdentity` pins. It never passes signing flags to `xcodebuild`, in
+particular never `-allowProvisioningUpdates`, because a build must not mutate
+an Apple Developer account. Stim installs only onto a device it drives in this
+run: an owned simulator or emulator, a physical device named by `--device`, or
+the remote device `--remote` targets. Do not add distribution flows: no store
+upload, no TestFlight, no over-the-air install page, no reconstruction of the
+project's own delivery pipeline. Archives, `.ipa` export, store signing, and
+distribution remain out of scope.
 
 ### 4. Centralize device teardown
 


### PR DESCRIPTION
## Description

Invariant 3 in `AGENTS.md` still read `android --device [serial] selects a connected physical device; there is no iOS equivalent, because that needs code signing.` `ios --device [udid]` has existed since #189, and `packages/stim-cli/src/commands/ios.ts` defines it. An agent reading invariant 3 as written would refuse or try to remove a shipped flag.

## Solution

Replaced the outdated sentence with the present rule, grounded in what `engine/ios-signing.ts` and `engine/ios-profile.ts` actually do: `ios --device` and `android --device` both select a connected physical device, and the iOS path additionally needs a signing identity in the keychain and a matching embedded provisioning profile. `profileGate()` in `ios-profile.ts` refuses an expired profile, one whose `ProvisionedDevices` list doesn't name the target UDID, and an Enterprise or App Store profile (no `ProvisionedDevices` key to check at all — both kinds fall through the same branch).

Kept this hunk isolated to invariant 3's paragraph — #226 is concurrently editing invariant 2 and the Locked-state rule in the same file.

Scoped to the one sentence the issue flags. `docs/specs/2026-09-01-ios-device-release-design.md`'s "Invariant deltas" section has a fuller rewrite of this invariant (narrowing "Do not add install flows", extending the store-signing sentence, adding an iOS swap-gate sentence); that's a separate, later change, and the issue itself scopes this as a "one-paragraph docs change."

- Also checked: the spec's other named item, the `--remote` enumeration fix (`guide.test.ts`'s flag-list assertion needing `--device` added to `ios.ts`'s entry). Already in place — `commands/guide.ts`'s option-surface listing already reads `ios --json --no-metro-check --no-build-cache --configuration <name> --device [udid] --remote <proxy|eas>` — so no change needed there.

## Test plan

- `pnpm run format:check` -- passes.

Fixes #228
