### PR TITLE
feat: pick a free device from the pool when --device names none

### DIFF
--- a/docs/specs/2026-09-02-device-lease-design.md
+++ b/docs/specs/2026-09-02-device-lease-design.md
@@ -182,7 +182,7 @@ With no id, on `lock` or on a `--device` run:
    state that are not emulators, TCP serials included.
 2. If this workspace leases a device of that platform, that device wins when
    it is a candidate. When it is not connected, an id-less run refuses with
-   `STIM_NO_DEVICE` naming it; an id selects another device.
+   `STIM_NO_DEVICE` naming it; `unlock` first, or use that device.
 3. Otherwise the first candidate not leased, or leased and expired, wins, in
    id order (case-folded). Names are printed, never sorted on: adb has none
    without one `getprop` per serial, and models repeat.
@@ -193,6 +193,12 @@ With no id, on `lock` or on a `--device` run:
 
 The chosen device is printed and returned in `--json` (`udid` or `serial`,
 `deviceName`) so the agent can hand the same id to its device tool.
+
+**Amendment, 2026-09-02 (#233).** Rule 2 said "an id selects another device",
+which contradicts "ios and android": a run whose id differs from this
+workspace's leased device of that platform refuses with `STIM_NO_DEVICE`
+naming the leased one. Naming an id does not escape a lease this workspace
+holds, so the remedy is `unlock` first, or use the device already leased.
 
 ## Other commands
 

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -4054,3 +4054,80 @@ describe('--device: the lease on the device', () => {
     expect(both.error?.message).toMatch(/--wait and --no-wait ask for opposite things/);
   });
 });
+
+describe('--device with no serial: the pool', () => {
+  const FIRST = 'RFCR7081Q9L';
+  const SECOND = 'ZY224T8XYZ';
+
+  function pool(serials: string[], overrides: Record<string, unknown> = {}) {
+    return harness({
+      device: true,
+      json: true,
+      listDevices: () => ({ emulators: [], physical: serials.map((serial) => ({ serial })), unhealthy: [] }),
+      deviceModel: (serial: string) => `model-${serial}`,
+      isEmulatorDevice: () => false,
+      checkCapacity: never('the device-capacity check'),
+      ensureDevice: never('the owned-device path'),
+      ...overrides,
+    });
+  }
+
+  test('the first free serial in case-folded id order is taken', async () => {
+    const h = pool([SECOND, FIRST]);
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe(FIRST);
+    expect(JSON.parse(h.stdout[0] as string).serial).toBe(FIRST);
+    expect(JSON.parse(h.stdout[0] as string).deviceName).toBe(`model-${FIRST}`);
+  });
+
+  test('a serial another workspace leases is skipped for the free one', async () => {
+    takeLease({ root: '/worktree/theirs', platform: 'android', id: FIRST, kind: 'declared' });
+    const h = pool([FIRST, SECOND]);
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe(SECOND);
+  });
+
+  test('a TCP serial is a candidate like any other', async () => {
+    const h = pool(['192.168.1.5:5555']);
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.install[0]?.serial).toBe('192.168.1.5:5555');
+    expect(listLeaseFiles().map((entry) => entry.id)).toEqual([]);
+  });
+
+  test('an emulator serial is never a candidate', async () => {
+    const h = pool([FIRST], { isEmulatorDevice: (serial: string) => serial === FIRST });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(NO_DEVICE);
+  });
+
+  test('a leased device that is not connected refuses, naming it and the way out', async () => {
+    takeLease({ root, platform: 'android', id: 'GONE-SERIAL', kind: 'declared' });
+    const h = pool([FIRST]);
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(NO_DEVICE);
+    expect(result.error?.message).toMatch(/This workspace leases GONE-SERIAL, and it is not connected/);
+    expect(result.error?.remedy).toMatch(/stim device unlock/);
+    expect(h.calls.install).toEqual([]);
+  });
+
+  test('every connected device leased elsewhere refuses with all of them named', async () => {
+    takeLease({ root: '/worktree/one', platform: 'android', id: FIRST, kind: 'declared' });
+    takeLease({ root: '/worktree/two', platform: 'android', id: SECOND, kind: 'declared' });
+    const h = pool([FIRST, SECOND], { wait: '0' });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_DEVICE_BUSY');
+    expect(result.error?.message).toMatch(/\/worktree\/one/);
+    expect(result.error?.message).toMatch(/\/worktree\/two/);
+    expect(JSON.parse(h.stdout[0] as string).lease).toMatchObject({ platform: 'android', id: FIRST });
+  });
+
+  test('a named serial still goes through the resolver, not the pool', async () => {
+    const h = pool([FIRST], { device: SECOND });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toMatch(/is not connected\. adb reports these physical devices/);
+  });
+});

--- a/packages/stim-cli/src/__tests__/device-command.test.ts
+++ b/packages/stim-cli/src/__tests__/device-command.test.ts
@@ -243,6 +243,74 @@ describe('stim device lock', () => {
     expect(h.out).toEqual([]);
   });
 
+  test('with no id, the first free device in id order is leased', async () => {
+    const h = harness({
+      listIosDevices: () =>
+        ['00008120-BBB', '00008030-AAA'].map((udid) => ({
+          udid,
+          name: `name-${udid}`,
+          bootState: 'booted',
+          developerModeStatus: 'enabled',
+          pairingState: 'paired',
+          transportType: 'wired',
+        })),
+    });
+    takeLease({ root: OTHER_ROOT, platform: 'ios', id: '00008030-AAA', kind: 'declared' }, h.io);
+
+    const facts = await runLock('ios', undefined, {}, h.deps);
+    assert(!('code' in facts));
+    expect(facts.id).toBe('00008120-BBB');
+    expect(facts.deviceName).toBe('name-00008120-BBB');
+  });
+
+  test('with no id and several android serials, the pool picks and adb names it', async () => {
+    const h = harness({
+      listAdbDevices: () => ({
+        emulators: [],
+        physical: [{ serial: 'ZY224' }, { serial: 'RFCR7081Q9L' }],
+        unhealthy: [],
+      }),
+    });
+    const facts = await runLock('android', undefined, {}, h.deps);
+    assert(!('code' in facts));
+    expect(facts.id).toBe('RFCR7081Q9L');
+    expect(facts.deviceName).toBe('SM-G996W');
+  });
+
+  test('a device this workspace leases but is not connected refuses, naming the way out', async () => {
+    const h = harness();
+    takeLease({ root, platform: 'ios', id: 'GONE-PHONE', kind: 'declared' }, h.io);
+    const failure = await runLock('ios', undefined, {}, h.deps);
+    assert('code' in failure);
+    expect(failure.code).toBe('STIM_NO_DEVICE');
+    expect(failure.message).toMatch(/This workspace leases GONE-PHONE, and it is not connected/);
+    expect(failure.remedy).toMatch(/stim device unlock/);
+  });
+
+  test('every connected device leased elsewhere refuses under --wait 0, naming all of them', async () => {
+    const h = harness({
+      listIosDevices: () =>
+        [PHONE, '00008120-BBB'].map((udid) => ({
+          udid,
+          name: 'Old iPhone',
+          bootState: 'booted',
+          developerModeStatus: 'enabled',
+          pairingState: 'paired',
+          transportType: 'wired',
+        })),
+    });
+    heldByAnother(h.io);
+    takeLease({ root: '/worktree/third', platform: 'ios', id: '00008120-BBB', kind: 'declared' }, h.io);
+
+    const failure = await runLock('ios', undefined, { wait: '0', json: true }, h.deps);
+    assert('code' in failure);
+    expect(failure.code).toBe('STIM_DEVICE_BUSY');
+    expect(failure.message).toMatch(/Every connected device is leased by another workspace/);
+    expect(failure.message).toMatch(new RegExp(`${OTHER_ROOT}`));
+    expect(failure.message).toMatch(/\/worktree\/third/);
+    expect(JSON.parse(h.out[0] as string).lease).toMatchObject({ platform: 'ios', id: PHONE, holder: OTHER_ROOT });
+  });
+
   test('a bad platform, --for and --wait are all STIM_BAD_ARG, before any device is listed', async () => {
     const listed: number[] = [];
     const h = harness({

--- a/packages/stim-cli/src/__tests__/engine-device-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-pool.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
-import { takeLease, type LeaseIo, type WorkspaceLeases } from '../engine/device-lease.ts';
+import { deviceLeasePath, takeLease, type LeaseIo, type WorkspaceLeases } from '../engine/device-lease.ts';
 import { DEVICE_WAIT_POLL_MS } from '../engine/device-lease-run.ts';
 import { heldPoolId, selectFromPool } from '../engine/device-pool.ts';
 import { iosPoolCandidates } from '../engine/ios-device.ts';
@@ -128,9 +128,9 @@ describe('which connected devices are candidates', () => {
 describe('choosing from the pool', () => {
   test('the first free candidate in case-folded id order wins', async () => {
     const h = harness();
-    const result = await pool(h, ['zzz', 'AAA', 'mmm']);
+    const result = await pool(h, ['Zzz', 'aaa']);
     assert(result.status === 'selected');
-    expect(result.candidate.id).toBe('AAA');
+    expect(result.candidate.id).toBe('aaa');
     expect(h.slept).toEqual([]);
   });
 
@@ -167,6 +167,44 @@ describe('choosing from the pool', () => {
     const result = await pool(h, [FIRST, SECOND]);
     assert(result.status === 'selected');
     expect(result.candidate.id).toBe(FIRST);
+  });
+
+  test('a candidate whose lease file does not parse is never treated as free', async () => {
+    const h = harness();
+    h.files.set(deviceLeasePath('ios', 'A-CORRUPT'), '{ not a lease');
+    const result = await pool(h, ['A-CORRUPT', 'B-FREE']);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe('B-FREE');
+  });
+
+  test('every candidate unreadable refuses, naming the files rather than the phones', async () => {
+    const h = harness();
+    h.files.set(deviceLeasePath('ios', 'A-CORRUPT'), '{ not a lease');
+    const result = await pool(h, ['A-CORRUPT']);
+    assert(result.status === 'refused');
+    expect(result.refusal.code).toBe('STIM_DEVICE_BUSY');
+    expect(result.refusal.message).toMatch(/Every connected device has an unreadable lease file/);
+    expect(result.refusal.message).toContain(deviceLeasePath('ios', 'A-CORRUPT'));
+    expect(result.refusal.remedy).toMatch(/`stim gc` reports them on every run/);
+    expect(result.refusal.lease).toEqual({
+      platform: null,
+      id: null,
+      deviceName: null,
+      holder: null,
+      expiresAt: null,
+    });
+    expect(h.slept).toEqual([]);
+  });
+
+  test('an unreadable file is named beside the holders when the rest are leased', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    h.files.set(deviceLeasePath('ios', 'A-CORRUPT'), '{ not a lease');
+    const result = await pool(h, ['A-CORRUPT', FIRST], { waitSeconds: 0 });
+    assert(result.status === 'refused');
+    expect(result.refusal.message).toMatch(/Every connected device is leased by another workspace/);
+    expect(result.refusal.message).toMatch(/Unreadable lease file/);
+    expect(result.refusal.message).toContain(deviceLeasePath('ios', 'A-CORRUPT'));
   });
 
   test('a leased device that is not connected refuses rather than picking another', async () => {

--- a/packages/stim-cli/src/__tests__/engine-device-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-pool.test.ts
@@ -1,0 +1,266 @@
+import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { takeLease, type LeaseIo, type WorkspaceLeases } from '../engine/device-lease.ts';
+import { DEVICE_WAIT_POLL_MS } from '../engine/device-lease-run.ts';
+import { heldPoolId, selectFromPool } from '../engine/device-pool.ts';
+import { iosPoolCandidates } from '../engine/ios-device.ts';
+import { androidPoolCandidates } from '../sim/android.ts';
+
+const ROOT = '/worktree/mine';
+const OTHER = '/worktree/theirs';
+const FIRST = '00008030-AAA';
+const SECOND = '00008120-BBB';
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-home-'));
+  process.env.STIM_HOME = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+function harness(start = Date.parse('2026-09-02T12:00:00.000Z')) {
+  const files = new Map<string, string>();
+  const holders = new Map<string, WorkspaceLeases>();
+  let clock = start;
+  const io: LeaseIo = {
+    now: () => clock,
+    readLease: (path) => files.get(path) ?? null,
+    writeLease: (path, body) => {
+      files.set(path, body);
+    },
+    removeLease: (path) => {
+      files.delete(path);
+    },
+    listLeaseNames: () => [...files.keys()].map((path) => basename(path)),
+    withLeaseLock: (_lock, fn) => fn(),
+    readHolder: (root) => structuredClone(holders.get(root) ?? {}),
+    writeHolder: (root, leases) => {
+      holders.set(root, structuredClone(leases));
+    },
+  };
+  const warnings: string[] = [];
+  const slept: number[] = [];
+  return {
+    io,
+    files,
+    holders,
+    warnings,
+    slept,
+    now: () => clock,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    sleep: async (ms: number) => {
+      slept.push(ms);
+      clock += ms;
+    },
+    warn: (line: string) => warnings.push(line),
+  };
+}
+
+type Harness = ReturnType<typeof harness>;
+
+const NONE = () => ({ message: 'No physical iOS device is connected.', remedy: 'Plug one in.' });
+
+function pool(h: Harness, ids: string[], over: Record<string, unknown> = {}) {
+  return selectFromPool({
+    root: ROOT,
+    platform: 'ios',
+    idLabel: 'udid',
+    list: () => ids.map((id) => ({ id, name: `name-${id}` })),
+    noCandidates: NONE,
+    waitSeconds: 60,
+    now: h.now,
+    sleep: h.sleep,
+    warn: h.warn,
+    io: h.io,
+    ...over,
+  });
+}
+
+function leasedBy(h: Harness, root: string, id: string, durationMs = 600_000) {
+  const taken = takeLease({ root, platform: 'ios', id, deviceName: `name-${id}`, kind: 'declared', durationMs }, h.io);
+  assert(taken.status === 'taken');
+  if (root !== ROOT) h.holders.delete(root);
+  return taken.lease;
+}
+
+describe('which connected devices are candidates', () => {
+  const device = (over: Record<string, unknown> = {}) => ({
+    udid: FIRST,
+    name: 'Old iPhone',
+    bootState: 'booted',
+    developerModeStatus: 'enabled',
+    pairingState: 'paired',
+    transportType: 'wired',
+    ...over,
+  });
+
+  test('an iOS device must be wired, paired, and have Developer Mode on', () => {
+    const accepted = iosPoolCandidates([
+      device(),
+      device({ udid: 'B', transportType: 'localNetwork' }),
+      device({ udid: 'C', pairingState: 'unpaired' }),
+      device({ udid: 'D', developerModeStatus: 'disabled' }),
+    ]);
+    expect(accepted.map((entry) => entry.udid)).toEqual([FIRST]);
+    expect(iosPoolCandidates([])).toEqual([]);
+  });
+
+  test('an Android candidate is any non-emulator adb reports in the device state, TCP included', () => {
+    const adb = {
+      emulators: [{ serial: 'emulator-5554', consolePort: 5554 }],
+      physical: [{ serial: 'RFCR7081Q9L' }, { serial: '192.168.1.5:5555' }, { serial: 'FAKE' }],
+      unhealthy: [{ serial: 'OFFLINE', kind: 'physical' as const, status: 'offline' }],
+    };
+    const accepted = androidPoolCandidates(adb, (serial) => serial === 'FAKE');
+    expect(accepted.map((entry) => entry.serial)).toEqual(['RFCR7081Q9L', '192.168.1.5:5555']);
+  });
+});
+
+describe('choosing from the pool', () => {
+  test('the first free candidate in case-folded id order wins', async () => {
+    const h = harness();
+    const result = await pool(h, ['zzz', 'AAA', 'mmm']);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe('AAA');
+    expect(h.slept).toEqual([]);
+  });
+
+  test('a candidate another workspace holds is skipped', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    const result = await pool(h, [FIRST, SECOND]);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(SECOND);
+  });
+
+  test('an expired lease makes its device free again', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST, 60_000);
+    h.advance(61_000);
+    const result = await pool(h, [FIRST, SECOND]);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(FIRST);
+  });
+
+  test("this workspace's own device wins even when it sorts last", async () => {
+    const h = harness();
+    leasedBy(h, ROOT, SECOND);
+    const result = await pool(h, [FIRST, SECOND]);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(SECOND);
+  });
+
+  test('a stale record does not pin this workspace to a device it no longer holds', async () => {
+    const h = harness();
+    leasedBy(h, ROOT, SECOND, 60_000);
+    h.advance(61_000);
+    expect(heldPoolId(ROOT, 'ios', h.now(), h.io)).toBe(null);
+    const result = await pool(h, [FIRST, SECOND]);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(FIRST);
+  });
+
+  test('a leased device that is not connected refuses rather than picking another', async () => {
+    const h = harness();
+    leasedBy(h, ROOT, 'GONE');
+    const result = await pool(h, [FIRST, SECOND]);
+    assert(result.status === 'refused');
+    expect(result.refusal.code).toBe('STIM_NO_DEVICE');
+    expect(result.refusal.message).toMatch(/This workspace leases GONE, and it is not connected/);
+    expect(result.refusal.remedy).toMatch(/stim device unlock/);
+    expect(result.refusal.remedy).toMatch(/Naming another `--device <udid>` refuses the same way/);
+  });
+
+  test('no candidate at all refuses with the resolver own words', async () => {
+    const h = harness();
+    const result = await pool(h, []);
+    assert(result.status === 'refused');
+    expect(result.refusal.code).toBe('STIM_NO_DEVICE');
+    expect(result.refusal.message).toBe('No physical iOS device is connected.');
+    expect(result.refusal.remedy).toBe('Plug one in.');
+  });
+});
+
+describe('waiting for a free device', () => {
+  test('the poll re-lists devices, so one plugged in mid-wait is taken', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    let connected = [FIRST];
+    const result = await pool(h, [], {
+      list: () => connected.map((id) => ({ id, name: `name-${id}` })),
+      sleep: async (ms: number) => {
+        h.slept.push(ms);
+        h.advance(ms);
+        if (h.slept.length === 2) connected = [FIRST, SECOND];
+      },
+    });
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(SECOND);
+    expect(h.slept).toEqual([DEVICE_WAIT_POLL_MS, DEVICE_WAIT_POLL_MS]);
+  });
+
+  test('a lease that frees mid-wait is taken without re-plugging anything', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST, 6_000);
+    const result = await pool(h, [FIRST]);
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(FIRST);
+    expect(h.slept).toHaveLength(3);
+  });
+
+  test('the wait running out names every holder, once with each expiry', async () => {
+    const h = harness();
+    const first = leasedBy(h, OTHER, FIRST);
+    leasedBy(h, '/worktree/third', SECOND);
+    const result = await pool(h, [FIRST, SECOND], { waitSeconds: 4 });
+    assert(result.status === 'refused');
+    expect(result.refusal.code).toBe('STIM_DEVICE_BUSY');
+    expect(result.refusal.message).toMatch(/Every connected device is leased by another workspace/);
+    expect(result.refusal.message).toMatch(/this run waited 4s for one/);
+    expect(result.refusal.message).toMatch(new RegExp(`${FIRST} \\(${OTHER}, until \\d\\d:`));
+    expect(result.refusal.message).toMatch(new RegExp(`${SECOND} \\(/worktree/third, until`));
+    expect(result.refusal.lease).toEqual({
+      platform: 'ios',
+      id: FIRST,
+      deviceName: `name-${FIRST}`,
+      holder: OTHER,
+      expiresAt: first.expiresAt,
+    });
+  });
+
+  test('--wait 0 refuses at once, without sleeping', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    const result = await pool(h, [FIRST], { waitSeconds: 0 });
+    assert(result.status === 'refused');
+    expect(h.slept).toEqual([]);
+    expect(result.refusal.message).not.toMatch(/waited/);
+  });
+
+  test('the waiting line names every holder, at once and then every 30 seconds', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    await pool(h, [FIRST], { waitSeconds: 61 });
+    expect(h.warnings).toHaveLength(3);
+    expect(h.warnings[0]).toMatch(/waiting for a free device; every connected one is leased/);
+    expect(h.warnings[0]).toMatch(new RegExp(`${FIRST} \\(${OTHER}, until`));
+  });
+
+  test('--no-wait takes the first candidate anyway, and leaves the lease to the run', async () => {
+    const h = harness();
+    leasedBy(h, OTHER, FIRST);
+    const result = await pool(h, [FIRST, SECOND], { noWait: true, list: () => [{ id: FIRST }] });
+    assert(result.status === 'selected');
+    expect(result.candidate.id).toBe(FIRST);
+    expect(h.slept).toEqual([]);
+  });
+});

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -952,9 +952,7 @@ test('the guide documents holding a device across runs with lock and unlock', ()
   expect(lifecycle).toMatch(/Nothing else moves an expiry[\s\S]*Only `lock` and a run's own steps do/);
   expect(lifecycle).toMatch(/Releasing nothing is not an error/);
   expect(lifecycle).toMatch(/releases by holder/);
-  expect(lifecycle).toMatch(
-    /With no id, `lock` takes the one connected device[\s\S]*pool rule, and it is not implemented yet/,
-  );
+  expect(lifecycle).toMatch(/With no id, `lock` and a `--device` run pick from the POOL/);
   expect(lifecycle).toMatch(/device\s+lock <ios\|android> \[id\] --for <duration> --wait <seconds> --json/);
   expect(lifecycle).toMatch(/unlock \[ios\|android\] --json/);
 });
@@ -971,4 +969,22 @@ test('the skill routes the lease to the guide and states the permanent lease rul
   expect(skill).toMatch(/stim device lock ios --for\s+10m` holds it across runs; `stim device unlock` gives it back/);
   expect(skill).toMatch(/Never delete another workspace's lease file under\s+`~\/\.stim\/device-locks`/);
   expect(skill).toMatch(/`gc --delete` removes the expired ones/);
+});
+
+test('the guide documents the pool an id-less --device picks from', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(lifecycle).toMatch(/THE POOL: WHICH DEVICE AN ID-LESS/);
+  expect(lifecycle).toMatch(/wired, paired, with Developer Mode on/);
+  expect(lifecycle).toMatch(/not an emulator, TCP serials included/);
+  expect(lifecycle).toMatch(/the device this workspace already leases, when it is among them/);
+  expect(lifecycle).toMatch(/first one not leased -- or leased and EXPIRED -- in\s+case-folded id order/);
+  expect(lifecycle).toMatch(/Ids are sorted on, never names/);
+  expect(lifecycle).toMatch(/NOT connected refuses with\s+STIM_NO_DEVICE naming it/);
+  expect(lifecycle).toMatch(/`stim device unlock` first/);
+  expect(lifecycle).toMatch(/the poll\s+re-LISTS devices/);
+  expect(lifecycle).toMatch(/STIM_DEVICE_BUSY names every\s+holder and its expiry/);
+  expect(lifecycle).toMatch(/No candidate at all is the existing STIM_NO_DEVICE/);
+  expect(lifecycle).toMatch(/`--no-wait` takes the first candidate\s+anyway/);
+  expect(lifecycle).toMatch(/in `--json` \(`udid` or\s+`serial`, plus `deviceName`\)/);
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -987,4 +987,9 @@ test('the guide documents the pool an id-less --device picks from', () => {
   expect(lifecycle).toMatch(/No candidate at all is the existing STIM_NO_DEVICE/);
   expect(lifecycle).toMatch(/`--no-wait` takes the first candidate\s+anyway/);
   expect(lifecycle).toMatch(/in `--json` \(`udid` or\s+`serial`, plus `deviceName`\)/);
+
+  expect(lifecycle).not.toMatch(/one connected device/);
+  expect(lifecycle).not.toMatch(/refuses with the candidate\s+list/);
+  expect(lifecycle).toMatch(/no serial it takes the first device it can lease/);
+  expect(lifecycle).toMatch(/with no UDID it takes the\s+first device it can lease/);
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3399,15 +3399,81 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(calls.order.includes('checkDeviceCapacity')).toBe(false);
   });
 
-  test('several connected phones refuse with the candidate list', async () => {
+  test('several connected phones no longer refuse: the first free one in id order is taken', async () => {
     reserve();
-    const { errs, exitCode } = await run(
-      { device: true },
+    const { errs, exitCode, logs } = await run(
+      { device: true, json: true },
+      connected([{ udid: '00008120-000A11223C44201E', name: 'Second' }, { udid: PHONE }]),
+    );
+    expect(exitCode).toBe(null);
+    expect(errs.join('\n')).not.toMatch(/STIM_NO_DEVICE/);
+    expect(parseFirst(logs).udid).toBe(PHONE);
+    expect(parseFirst(logs).deviceName).toBe('Test Phone');
+  });
+
+  test('a phone another workspace leases is skipped for the free one, whatever the order', async () => {
+    reserve();
+    takeLease({ root: '/worktree/theirs', platform: 'ios', id: PHONE, kind: 'declared' });
+    const { exitCode, logs } = await run(
+      { device: true, json: true },
+      connected([{ udid: PHONE }, { udid: '00008120-000A11223C44201E', name: 'Second' }]),
+    );
+    expect(exitCode).toBe(null);
+    expect(parseFirst(logs).udid).toBe('00008120-000A11223C44201E');
+  });
+
+  test('the phone this workspace leases wins even when another sorts first', async () => {
+    reserve();
+    const mine = takeLease({ root, platform: 'ios', id: '00008120-000A11223C44201E', kind: 'declared' });
+    assert(mine.status === 'taken');
+    const { exitCode, logs } = await run(
+      { device: true, json: true },
+      connected([{ udid: PHONE }, { udid: '00008120-000A11223C44201E', name: 'Second' }]),
+    );
+    expect(exitCode).toBe(null);
+    expect(parseFirst(logs).udid).toBe('00008120-000A11223C44201E');
+    expect(parseFirst(logs).lease).toEqual({ kind: 'declared', expiresAt: expect.any(String) });
+  });
+
+  test('a leased phone that is not connected refuses rather than silently using another', async () => {
+    reserve();
+    takeLease({ root, platform: 'ios', id: 'GONE-PHONE', kind: 'declared' });
+    const { errs, exitCode, calls } = await run({ device: true }, connected());
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
+    expect(errs.join('\n')).toMatch(/This workspace leases GONE-PHONE, and it is not connected/);
+    expect(errs.join('\n')).toMatch(/stim device unlock/);
+    expect(calls.order.includes('buildIos')).toBe(false);
+  });
+
+  test('every connected phone leased elsewhere refuses with all of them named', async () => {
+    reserve();
+    takeLease({ root: '/worktree/one', platform: 'ios', id: PHONE, deviceName: 'Test Phone', kind: 'declared' });
+    takeLease({ root: '/worktree/two', platform: 'ios', id: '00008120-000A11223C44201E', kind: 'declared' });
+    const { errs, exitCode, logs } = await run(
+      { device: true, json: true, wait: '0' },
       connected([{ udid: PHONE }, { udid: '00008120-000A11223C44201E', name: 'Second' }]),
     );
     expect(exitCode).toBe(1);
-    expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
-    expect(errs.join('\n')).toMatch(/stim ios --device <udid>/);
+    expect(errs.join('\n')).toMatch(/STIM_DEVICE_BUSY/);
+    expect(errs.join('\n')).toMatch(/\/worktree\/one/);
+    expect(errs.join('\n')).toMatch(/\/worktree\/two/);
+    expect(parseFirst(logs).lease).toMatchObject({ platform: 'ios', id: PHONE, holder: '/worktree/one' });
+  });
+
+  test('no connected phone at all still refuses with the resolver own message', async () => {
+    reserve();
+    const { errs, exitCode } = await run({ device: true }, { listIosDevices: () => [] });
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/No physical iOS device is connected/);
+    expect(errs.join('\n')).toMatch(/Developer Mode/);
+  });
+
+  test('a named udid still goes through the resolver, not the pool', async () => {
+    reserve();
+    const { errs, exitCode } = await run({ device: '00008120-000A11223C44201E' }, connected([{ udid: PHONE }]));
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/is not connected\. devicectl reports these cabled devices/);
   });
 
   test('the one connected phone is used, never owned, and never booted', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3461,6 +3461,23 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(parseFirst(logs).lease).toMatchObject({ platform: 'ios', id: PHONE, holder: '/worktree/one' });
   });
 
+  test('--no-wait with every connected phone leased installs on the first, without a lease', async () => {
+    reserve();
+    takeLease({ root: '/worktree/one', platform: 'ios', id: PHONE, deviceName: 'Test Phone', kind: 'declared' });
+    takeLease({ root: '/worktree/two', platform: 'ios', id: '00008120-000A11223C44201E', kind: 'declared' });
+    const { errs, exitCode, logs, calls } = await run(
+      { device: true, json: true, wait: false },
+      connected([{ udid: PHONE }, { udid: '00008120-000A11223C44201E', name: 'Second' }]),
+    );
+
+    expect(exitCode).toBe(null);
+    expect(calls.order.includes('installIosDeviceApp')).toBe(true);
+    expect(parseFirst(logs).udid).toBe(PHONE);
+    expect(parseFirst(logs).lease).toBe(null);
+    expect(errs.join('\n')).toMatch(/--no-wait: \/worktree\/one holds Test Phone/);
+    expect(listLeaseFiles()).toHaveLength(2);
+  });
+
   test('no connected phone at all still refuses with the resolver own message', async () => {
     reserve();
     const { errs, exitCode } = await run({ device: true }, { listIosDevices: () => [] });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -98,6 +98,7 @@ import {
 import {
   androidHome,
   androidPoolCandidates,
+  memoizeEmulatorProbe,
   emulatorDiskSpaceRemedy,
   emulatorFailureRemedy,
   extractEmulatorFailure,
@@ -1395,13 +1396,14 @@ async function pooledAndroidDevice({
   now: () => number;
   warn: (line: string) => void;
 }): Promise<{ device: OwnedDeviceRecord } | { code: string; message: string; remedy: string; extra: FailExtra }> {
+  const isEmulator = memoizeEmulatorProbe(isEmulatorDevice);
   const pooled = await selectPool({
     root,
     platform: PLATFORM,
     idLabel: 'serial',
-    list: () => androidPoolCandidates(listDevices(), isEmulatorDevice).map((entry) => ({ id: entry.serial })),
+    list: () => androidPoolCandidates(listDevices(), isEmulator).map((entry) => ({ id: entry.serial })),
     noCandidates: () => {
-      const resolved = resolvePhysicalDevice(null, listDevices(), isEmulatorDevice);
+      const resolved = resolvePhysicalDevice(null, listDevices(), isEmulator);
       return { message: resolved.error as string, remedy: resolved.remedy as string };
     },
     waitSeconds,
@@ -1777,7 +1779,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     return fail(
       'STIM_BAD_ARG',
       '--device was given an empty serial.',
-      'Pass `--device` on its own to use the one connected device, or `--device <serial>` to name one.',
+      'Pass `--device` on its own to take the first connected device this workspace can lease, or ' +
+        '`--device <serial>` to name one.',
     );
   }
   if (physical && commandRemoteBackend) {

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -97,6 +97,7 @@ import {
 } from '../engine/app-install.ts';
 import {
   androidHome,
+  androidPoolCandidates,
   emulatorDiskSpaceRemedy,
   emulatorFailureRemedy,
   extractEmulatorFailure,
@@ -116,6 +117,7 @@ import {
   resolveRemoteContext,
 } from '../engine/device-remote.ts';
 import { detectProviders } from '../engine/metro-reach.ts';
+import { selectFromPool } from '../engine/device-pool.ts';
 import {
   DEBUG_VERIFY_STEP_MS,
   acquireRunLease,
@@ -640,7 +642,7 @@ export function registerAndroid(program: Command): void {
     .option(
       '--device [serial]',
       "Install and launch on a connected physical device instead of this workspace's owned emulator. " +
-        'With no serial, the one connected device is used. Stim never creates, boots, or deletes a physical device.',
+        'With no serial, the first connected device this workspace can lease is used. Stim never creates, boots, or deletes a physical device.',
     )
     .option(
       '--remote <backend>',
@@ -691,6 +693,7 @@ interface RunAndroidOptions {
   waitConflict?: boolean;
   acquireLease?: typeof acquireRunLease;
   makeRunLease?: typeof runLease;
+  selectPool?: typeof selectFromPool;
   onLeaseSignal?: typeof releaseLeaseOnSignal;
   listDevices?: typeof listAdbDevices;
   deviceModel?: typeof physicalDeviceModel;
@@ -1371,6 +1374,54 @@ async function finishAndroidRun({
   return { ok: true, facts };
 }
 
+async function pooledAndroidDevice({
+  root,
+  selectPool,
+  listDevices,
+  isEmulatorDevice,
+  deviceModel,
+  waitSeconds,
+  noWait,
+  now,
+  warn,
+}: {
+  root: string;
+  selectPool: typeof selectFromPool;
+  listDevices: typeof listAdbDevices;
+  isEmulatorDevice: typeof probeEmulatorSerial;
+  deviceModel: typeof physicalDeviceModel;
+  waitSeconds: number;
+  noWait: boolean;
+  now: () => number;
+  warn: (line: string) => void;
+}): Promise<{ device: OwnedDeviceRecord } | { code: string; message: string; remedy: string; extra: FailExtra }> {
+  const pooled = await selectPool({
+    root,
+    platform: PLATFORM,
+    idLabel: 'serial',
+    list: () => androidPoolCandidates(listDevices(), isEmulatorDevice).map((entry) => ({ id: entry.serial })),
+    noCandidates: () => {
+      const resolved = resolvePhysicalDevice(null, listDevices(), isEmulatorDevice);
+      return { message: resolved.error as string, remedy: resolved.remedy as string };
+    },
+    waitSeconds,
+    noWait,
+    now,
+    warn,
+  });
+  if (pooled.status === 'refused') {
+    const { code, message, remedy, lease } = pooled.refusal;
+    return { code, message, remedy, extra: lease === null ? {} : { lease } };
+  }
+  return {
+    device: {
+      serial: pooled.candidate.id,
+      deviceName: deviceModel(pooled.candidate.id) ?? pooled.candidate.id,
+      owned: false,
+    },
+  };
+}
+
 function resolveRunAndroidOptions(
   {
     root,
@@ -1391,6 +1442,7 @@ function resolveRunAndroidOptions(
     waitConflict = false,
     acquireLease = acquireRunLease,
     makeRunLease = runLease,
+    selectPool = selectFromPool,
     onLeaseSignal = releaseLeaseOnSignal,
     listDevices = listAdbDevices,
     deviceModel = physicalDeviceModel,
@@ -1461,6 +1513,7 @@ function resolveRunAndroidOptions(
     waitConflict,
     acquireLease,
     makeRunLease,
+    selectPool,
     onLeaseSignal,
     listDevices,
     deviceModel,
@@ -1533,6 +1586,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     waitConflict,
     acquireLease,
     makeRunLease,
+    selectPool,
     onLeaseSignal,
     listDevices,
     deviceModel,
@@ -1861,7 +1915,22 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let bootDuration = '';
   let bootPromise: Promise<AndroidBootLike>;
 
-  if (physical) {
+  if (physical && !requestedSerial) {
+    const pooled = await pooledAndroidDevice({
+      root,
+      selectPool,
+      listDevices,
+      isEmulatorDevice,
+      deviceModel,
+      waitSeconds,
+      noWait,
+      now,
+      warn: (line: string) => out(phaseLine('lease', chalk.yellow(line))),
+    });
+    if ('code' in pooled) return fail(pooled.code, pooled.message, pooled.remedy, pooled.extra);
+    device = pooled.device;
+    bootPromise = Promise.resolve({ ok: true, serial: pooled.device.serial });
+  } else if (physical) {
     const resolved = resolvePhysicalDevice(requestedSerial, listDevices(), isEmulatorDevice);
     if (!resolved.serial) return fail(NO_DEVICE, resolved.error!, resolved.remedy!);
     device = {

--- a/packages/stim-cli/src/commands/device.ts
+++ b/packages/stim-cli/src/commands/device.ts
@@ -10,9 +10,16 @@ import {
   type ReleasedLease,
 } from '../engine/device-lease.ts';
 import { parseDeviceWait, waitForDevice } from '../engine/device-lease-run.ts';
-import { listIosDevices, resolveIosPhysicalDevice } from '../engine/ios-device.ts';
+import { selectFromPool } from '../engine/device-pool.ts';
+import { iosPoolCandidates, listIosDevices, resolveIosPhysicalDevice } from '../engine/ios-device.ts';
 import { findProjectRoot } from '../project.ts';
-import { listAdbDevices, physicalDeviceModel, probeEmulatorSerial, resolvePhysicalDevice } from '../sim/android.ts';
+import {
+  androidPoolCandidates,
+  listAdbDevices,
+  physicalDeviceModel,
+  probeEmulatorSerial,
+  resolvePhysicalDevice,
+} from '../sim/android.ts';
 
 const DEFAULT_FOR = '5m';
 
@@ -25,6 +32,7 @@ export interface DeviceDeps {
   takeLease: typeof takeLease;
   releaseLeases: typeof releaseWorkspaceLeases;
   waitForDevice: typeof waitForDevice;
+  selectFromPool: typeof selectFromPool;
   io: LeaseIo;
   now: () => number;
   sleep: (ms: number) => Promise<void>;
@@ -41,6 +49,7 @@ const DEFAULT_DEPS: DeviceDeps = {
   takeLease,
   releaseLeases: releaseWorkspaceLeases,
   waitForDevice,
+  selectFromPool,
   io: fileLeaseIo,
   now: () => Date.now(),
   sleep: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
@@ -127,6 +136,49 @@ function isFailure(value: object): value is DeviceFailure {
   return 'code' in value;
 }
 
+async function poolDevice(
+  platform: LeasePlatform,
+  idLabel: string,
+  waitSeconds: number,
+  deadline: number,
+  root: string,
+  d: DeviceDeps,
+): Promise<ResolvedDevice | DeviceFailure> {
+  const pooled = await d.selectFromPool({
+    root,
+    platform,
+    idLabel,
+    list: () =>
+      platform === 'ios'
+        ? iosPoolCandidates(d.listIosDevices()).map((entry) => ({ id: entry.udid, name: entry.name }))
+        : androidPoolCandidates(d.listAdbDevices(), d.probeEmulatorSerial).map((entry) => ({ id: entry.serial })),
+    noCandidates: () => {
+      const resolved =
+        platform === 'ios'
+          ? resolveIosPhysicalDevice(null, d.listIosDevices())
+          : resolvePhysicalDevice(null, d.listAdbDevices(), d.probeEmulatorSerial);
+      return { message: resolved.error as string, remedy: resolved.remedy as string };
+    },
+    waitSeconds,
+    deadline,
+    now: d.now,
+    sleep: d.sleep,
+    warn: (line: string) => d.note(chalk.yellow(line)),
+    io: d.io,
+  });
+  if (pooled.status === 'refused') {
+    return {
+      code: pooled.refusal.code,
+      message: pooled.refusal.message,
+      remedy: pooled.refusal.remedy,
+      ...(pooled.refusal.lease === null ? {} : { lease: pooled.refusal.lease }),
+    };
+  }
+  const name =
+    pooled.candidate.name ?? (platform === 'ios' ? pooled.candidate.id : d.physicalDeviceModel(pooled.candidate.id));
+  return { id: pooled.candidate.id, deviceName: name ?? pooled.candidate.id };
+}
+
 export async function runLock(
   platformArg: string,
   idArg: string | undefined,
@@ -188,12 +240,14 @@ export async function runLock(
     });
   }
 
-  const device = resolveDevice(platform, idArg ?? null, d);
-  if (isFailure(device)) return report(device);
-
   const idLabel = platform === 'ios' ? 'udid' : 'serial';
   const deadline = d.now() + wait.seconds * 1000;
   const lastLine: { at: number | null } = { at: null };
+
+  const device = idArg
+    ? resolveDevice(platform, idArg, d)
+    : await poolDevice(platform, idLabel, wait.seconds, deadline, root, d);
+  if (isFailure(device)) return report(device);
 
   for (;;) {
     const outcome = await d.waitForDevice({
@@ -304,7 +358,7 @@ export function registerDevice(program: Command, deps: Partial<DeviceDeps> = {})
   device
     .command('lock')
     .argument('<platform>', 'ios or android')
-    .argument('[id]', 'the UDID or serial to lease; without one, the connected device is used')
+    .argument('[id]', 'the UDID or serial to lease; without one, the first free connected device is used')
     .description(
       "Lease a connected physical device to this workspace for a declared time, so another workspace's " +
         '`--device` run waits instead of installing over it. Nothing but this command and a `--device` run moves the expiry.',

--- a/packages/stim-cli/src/commands/device.ts
+++ b/packages/stim-cli/src/commands/device.ts
@@ -16,6 +16,7 @@ import { findProjectRoot } from '../project.ts';
 import {
   androidPoolCandidates,
   listAdbDevices,
+  memoizeEmulatorProbe,
   physicalDeviceModel,
   probeEmulatorSerial,
   resolvePhysicalDevice,
@@ -144,6 +145,7 @@ async function poolDevice(
   root: string,
   d: DeviceDeps,
 ): Promise<ResolvedDevice | DeviceFailure> {
+  const isEmulator = memoizeEmulatorProbe(d.probeEmulatorSerial);
   const pooled = await d.selectFromPool({
     root,
     platform,
@@ -151,12 +153,12 @@ async function poolDevice(
     list: () =>
       platform === 'ios'
         ? iosPoolCandidates(d.listIosDevices()).map((entry) => ({ id: entry.udid, name: entry.name }))
-        : androidPoolCandidates(d.listAdbDevices(), d.probeEmulatorSerial).map((entry) => ({ id: entry.serial })),
+        : androidPoolCandidates(d.listAdbDevices(), isEmulator).map((entry) => ({ id: entry.serial })),
     noCandidates: () => {
       const resolved =
         platform === 'ios'
           ? resolveIosPhysicalDevice(null, d.listIosDevices())
-          : resolvePhysicalDevice(null, d.listAdbDevices(), d.probeEmulatorSerial);
+          : resolvePhysicalDevice(null, d.listAdbDevices(), isEmulator);
       return { message: resolved.error as string, remedy: resolved.remedy as string };
     },
     waitSeconds,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1591,8 +1591,8 @@ THE OPTION SURFACE, IN FULL
 
   \`android --device [serial]\` installs and launches on a physical device
   connected to this machine instead of this workspace's owned emulator. With
-  no serial it uses the one connected device, and refuses with the candidate
-  list when adb reports several. It cannot be combined with --remote.
+  no serial it takes the first device it can lease (THE POOL, below). It
+  cannot be combined with --remote.
 
   A \`--device\` run LEASES the device from just after the build until it
   exits, so a second workspace cannot install over it mid-run (see THE DEVICE
@@ -1606,8 +1606,8 @@ THE OPTION SURFACE, IN FULL
   10.0.2.2. Stim never creates, boots, shuts down, or deletes hardware.
 
   \`ios --device [udid]\` selects a connected iPhone, the same way
-  \`android --device\` selects a connected phone: with no UDID the one
-  connected device is used, several is a refusal listing them, and an iPhone
+  \`android --device\` selects a connected phone: with no UDID it takes the
+  first device it can lease (THE POOL, below), and an iPhone
   that is unpaired or has Developer Mode off is refused with the fix. It
   cannot be combined with --remote, and it never creates, boots, or deletes
   hardware -- there is no capacity check, no simulator creation, no boot wait,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1677,9 +1677,37 @@ HOLDING A DEVICE ACROSS RUNS
   and \`--json\` prints an empty list. It releases by holder, so it still
   works when the workspace directory was recreated and the token is gone.
 
-  With no id, \`lock\` takes the one connected device and refuses when several
-  are connected, exactly as \`--device\` does today. Picking the first FREE
-  device out of several is the pool rule, and it is not implemented yet.
+  With no id, \`lock\` and a \`--device\` run pick from the POOL of connected
+  devices, so two phones on one machine no longer refuse.
+
+THE POOL: WHICH DEVICE AN ID-LESS \`--device\` PICKS
+  Candidates are the connected devices the resolver already accepts: on iOS,
+  wired, paired, with Developer Mode on; on Android, every serial adb reports
+  in the \`device\` state that is not an emulator, TCP serials included. Then,
+  in order:
+
+    1. the device this workspace already leases, when it is among them;
+    2. otherwise the first one not leased -- or leased and EXPIRED -- in
+       case-folded id order.
+
+  Ids are sorted on, never names: adb has no name without one \`getprop\` per
+  serial, and models repeat.
+
+  A device this workspace leases that is NOT connected refuses with
+  STIM_NO_DEVICE naming it, rather than quietly moving to another phone. Naming
+  a different one with \`--device <id>\` refuses the same way, because a
+  workspace holds at most one lease per platform: \`stim device unlock\` first.
+
+  Candidates with none free is the wait: under \`--wait <seconds>\` the poll
+  re-LISTS devices, so a phone plugged in mid-wait is picked up as well as one
+  released mid-wait. When the wait runs out, STIM_DEVICE_BUSY names every
+  holder and its expiry. No candidate at all is the existing STIM_NO_DEVICE,
+  with the resolver's own message. \`--no-wait\` takes the first candidate
+  anyway and proceeds with no lease, as it does for one named device.
+
+  The chosen device is on the phase line and in \`--json\` (\`udid\` or
+  \`serial\`, plus \`deviceName\`), so an agent can hand the same id to its
+  device tool.
 
   A device build is LOCAL-TIER ONLY. Its cache key is
   \`<fingerprint>-<configuration>-device\`, so a device app can never collide

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -72,11 +72,13 @@ import {
   awaitIosDeviceLaunch,
   installIosDeviceApp,
   iosDeviceProcess,
+  iosPoolCandidates,
   listIosDevices,
   localNetworkPending,
   resolveIosPhysicalDevice,
   verifyIosDeviceReleaseLaunch,
 } from '../engine/ios-device.ts';
+import { selectFromPool } from '../engine/device-pool.ts';
 import {
   DEBUG_VERIFY_STEP_MS,
   acquireRunLease,
@@ -791,6 +793,7 @@ interface IosDeps {
   awaitIosDeviceLaunch: typeof awaitIosDeviceLaunch;
   acquireRunLease: typeof acquireRunLease;
   runLease: typeof runLease;
+  selectFromPool: typeof selectFromPool;
   releaseLeaseOnSignal: typeof releaseLeaseOnSignal;
   iosDeviceProcess: typeof iosDeviceProcess;
   verifyIosDeviceReleaseLaunch: typeof verifyIosDeviceReleaseLaunch;
@@ -863,6 +866,7 @@ const DEFAULT_DEPS: IosDeps = {
   awaitIosDeviceLaunch,
   acquireRunLease,
   runLease,
+  selectFromPool,
   releaseLeaseOnSignal,
   iosDeviceProcess,
   verifyIosDeviceReleaseLaunch,
@@ -904,7 +908,7 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     .option(
       '--device [udid]',
       "Build the iphoneos slice for a connected iPhone, install it, and launch it, instead of using this workspace's " +
-        'owned simulator. With no UDID, the one connected device is used. In Debug the app is wired to this ' +
+        'owned simulator. With no UDID, the first connected device this workspace can lease is used. In Debug the app is wired to this ' +
         "workspace's Metro over the LAN. Stim never creates, boots, or deletes a physical device.",
     )
     .option(
@@ -1831,13 +1835,38 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   const limits = d.getConcurrencyLimits();
 
   let physicalDevice: { udid: string; name: string } | null = null;
-  if (physical) {
+  if (physical && typeof deviceFlag !== 'string') {
+    const pooled = await d.selectFromPool({
+      root,
+      platform: PLATFORM,
+      idLabel: 'udid',
+      list: () => iosPoolCandidates(d.listIosDevices()).map((entry) => ({ id: entry.udid, name: entry.name })),
+      noCandidates: () => {
+        const resolved = resolveIosPhysicalDevice(null, d.listIosDevices());
+        return { message: resolved.error as string, remedy: resolved.remedy as string };
+      },
+      waitSeconds,
+      noWait,
+      now: d.now,
+      warn: (line: string) => note(chalk.yellow(phaseLine('lease', line))),
+    });
+    if (pooled.status === 'refused') {
+      return fail({
+        code: pooled.refusal.code,
+        message: pooled.refusal.message,
+        remedy: pooled.refusal.remedy,
+        ...(pooled.refusal.lease === null ? {} : { lease: pooled.refusal.lease }),
+      });
+    }
+    physicalDevice = { udid: pooled.candidate.id, name: pooled.candidate.name ?? pooled.candidate.id };
+  } else if (physical) {
     const resolved = resolveIosPhysicalDevice(typeof deviceFlag === 'string' ? deviceFlag : null, d.listIosDevices());
     if (!resolved.udid) {
       return fail({ code: 'STIM_NO_DEVICE', message: resolved.error!, remedy: resolved.remedy! });
     }
     physicalDevice = { udid: resolved.udid, name: resolved.name ?? resolved.udid };
-  } else {
+  }
+  if (!physical) {
     const capacity = d.checkDeviceCapacity({
       platform: PLATFORM,
       project: proj,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1766,7 +1766,9 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return fail({
       code: 'STIM_BAD_ARG',
       message: '--device was given an empty UDID.',
-      remedy: 'Pass `--device` on its own to use the one connected device, or `--device <udid>` to name one.',
+      remedy:
+        'Pass `--device` on its own to take the first connected device this workspace can lease, or ' +
+        '`--device <udid>` to name one.',
     });
   }
   if (physical && opts.remote) {

--- a/packages/stim-cli/src/engine/device-lease-run.ts
+++ b/packages/stim-cli/src/engine/device-lease-run.ts
@@ -18,9 +18,9 @@ export const LEASE_STEP_FLOOR_MS = 60_000;
 export const DEBUG_VERIFY_STEP_MS: number = VERIFY_TIMEOUT_MS + STABILITY_WINDOW_MS;
 export const DEFAULT_DEVICE_WAIT_SECONDS = 60;
 export const DEVICE_WAIT_POLL_MS = 2_000;
-const DEVICE_WAIT_LINE_MS = 30_000;
+export const DEVICE_WAIT_LINE_MS = 30_000;
 
-const DEVICE_BUSY = 'STIM_DEVICE_BUSY';
+export const DEVICE_BUSY = 'STIM_DEVICE_BUSY';
 const DEVICE_LOST = 'STIM_DEVICE_LOST';
 
 export function leaseStepMs(boundMs = 0): number {
@@ -62,7 +62,7 @@ function clockTime(iso: string): string {
   return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
 }
 
-function leaseExpiryText(expiresAt: string, now: number): string {
+export function leaseExpiryText(expiresAt: string, now: number): string {
   const remaining = Date.parse(expiresAt) - now;
   return `${clockTime(expiresAt)} (${formatElapsed(Math.max(0, remaining))} from now)`;
 }

--- a/packages/stim-cli/src/engine/device-pool.ts
+++ b/packages/stim-cli/src/engine/device-pool.ts
@@ -1,0 +1,156 @@
+import {
+  deviceLeasePath,
+  fileLeaseIo,
+  leaseIsExpired,
+  parseLease,
+  selectPoolDevice,
+  type DeviceLease,
+  type LeaseIo,
+  type LeasePlatform,
+  type PoolCandidate,
+  type PoolHolder,
+} from './device-lease.ts';
+import {
+  DEVICE_BUSY,
+  DEVICE_WAIT_LINE_MS,
+  DEVICE_WAIT_POLL_MS,
+  leaseExpiryText,
+  type RunLeaseRefusal,
+} from './device-lease-run.ts';
+
+export interface PoolRefusalText {
+  message: string;
+  remedy: string;
+}
+
+export type PoolResult =
+  | { status: 'selected'; candidate: PoolCandidate }
+  | { status: 'refused'; refusal: RunLeaseRefusal };
+
+export function heldPoolId(
+  root: string,
+  platform: LeasePlatform,
+  now: number,
+  io: LeaseIo = fileLeaseIo,
+): string | null {
+  const record = io.readHolder(root)[platform];
+  if (!record) return null;
+  const lease = parseLease(io.readLease(deviceLeasePath(platform, record.id)));
+  if (!lease || lease.token !== record.token || leaseIsExpired(lease, now)) return null;
+  return record.id;
+}
+
+function candidateLeases(platform: LeasePlatform, candidates: readonly PoolCandidate[], io: LeaseIo): DeviceLease[] {
+  const leases: DeviceLease[] = [];
+  for (const candidate of candidates) {
+    const lease = parseLease(io.readLease(deviceLeasePath(platform, candidate.id)));
+    if (lease) leases.push(lease);
+  }
+  return leases;
+}
+
+function disconnectedHeldRefusal(id: string, idLabel: string): RunLeaseRefusal {
+  return {
+    code: 'STIM_NO_DEVICE',
+    message: `This workspace leases ${id}, and it is not connected.`,
+    remedy:
+      'Run `stim device unlock` to give it up, then run this command again. Naming another ' +
+      `\`--device <${idLabel}>\` refuses the same way while this lease is held.`,
+    lease: null,
+  };
+}
+
+function poolBusyRefusal(
+  holders: readonly PoolHolder[],
+  leases: readonly DeviceLease[],
+  now: number,
+  waitSeconds: number,
+): RunLeaseRefusal {
+  const named = holders.map(
+    (holder) => `${holder.id} (${holder.holder}, until ${leaseExpiryText(holder.expiresAt, now)})`,
+  );
+  const first = holders[0];
+  const lease = first ? leases.find((entry) => entry.id === first.id) : undefined;
+  return {
+    code: DEVICE_BUSY,
+    message:
+      `Every connected device is leased by another workspace${waitSeconds > 0 ? `, and this run waited ${waitSeconds}s for one` : ''}: ` +
+      `${named.join('; ')}.`,
+    remedy:
+      'Wait longer with `--wait <seconds>`, connect another device, or pass `--no-wait` to install anyway -- ' +
+      "which takes no lease and, when both workspaces build the same app id, terminates the holder's running app.",
+    lease: first
+      ? {
+          platform: lease?.platform ?? null,
+          id: first.id,
+          deviceName: lease?.deviceName ?? null,
+          holder: first.holder,
+          expiresAt: first.expiresAt,
+        }
+      : null,
+  };
+}
+
+export async function selectFromPool({
+  root,
+  platform,
+  idLabel,
+  list,
+  noCandidates,
+  waitSeconds,
+  deadline,
+  noWait = false,
+  now = Date.now,
+  sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+  warn = () => {},
+  io = fileLeaseIo,
+}: {
+  root: string;
+  platform: LeasePlatform;
+  idLabel: string;
+  list: () => PoolCandidate[];
+  noCandidates: () => PoolRefusalText;
+  waitSeconds: number;
+  deadline?: number;
+  noWait?: boolean;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  warn?: (line: string) => void;
+  io?: LeaseIo;
+}): Promise<PoolResult> {
+  const held = heldPoolId(root, platform, now(), io);
+  const until = deadline ?? now() + waitSeconds * 1000;
+  let lastLine: number | null = null;
+
+  for (;;) {
+    const candidates = list();
+    const leases = candidateLeases(platform, candidates, io);
+    const selection = selectPoolDevice({ candidates, leases, held, now: now() });
+
+    if (selection.status === 'selected') return selection;
+    if (selection.status === 'held-disconnected') {
+      return { status: 'refused', refusal: disconnectedHeldRefusal(selection.id, idLabel) };
+    }
+    if (selection.status === 'none') {
+      const { message, remedy } = noCandidates();
+      return { status: 'refused', refusal: { code: 'STIM_NO_DEVICE', message, remedy, lease: null } };
+    }
+
+    const first = selection.holders[0];
+    if (noWait && first) {
+      const candidate = candidates.find((entry) => entry.id === first.id);
+      if (candidate) return { status: 'selected', candidate };
+    }
+    if (now() >= until) {
+      return { status: 'refused', refusal: poolBusyRefusal(selection.holders, leases, now(), waitSeconds) };
+    }
+    if (lastLine === null || now() - lastLine >= DEVICE_WAIT_LINE_MS) {
+      lastLine = now();
+      const holders = selection.holders
+        .map((holder) => `${holder.id} (${holder.holder}, until ${leaseExpiryText(holder.expiresAt, now())})`)
+        .join('; ');
+      warn(`waiting for a free device; every connected one is leased: ${holders}`);
+    }
+    await sleep(DEVICE_WAIT_POLL_MS);
+  }
+}

--- a/packages/stim-cli/src/engine/device-pool.ts
+++ b/packages/stim-cli/src/engine/device-pool.ts
@@ -40,13 +40,26 @@ export function heldPoolId(
   return record.id;
 }
 
-function candidateLeases(platform: LeasePlatform, candidates: readonly PoolCandidate[], io: LeaseIo): DeviceLease[] {
-  const leases: DeviceLease[] = [];
+interface PoolReading {
+  usable: PoolCandidate[];
+  leases: DeviceLease[];
+  unreadable: string[];
+}
+
+function readPool(platform: LeasePlatform, candidates: readonly PoolCandidate[], io: LeaseIo): PoolReading {
+  const reading: PoolReading = { usable: [], leases: [], unreadable: [] };
   for (const candidate of candidates) {
-    const lease = parseLease(io.readLease(deviceLeasePath(platform, candidate.id)));
-    if (lease) leases.push(lease);
+    const path = deviceLeasePath(platform, candidate.id);
+    const raw = io.readLease(path);
+    const lease = parseLease(raw);
+    if (raw !== null && !lease) {
+      reading.unreadable.push(path);
+      continue;
+    }
+    reading.usable.push(candidate);
+    if (lease) reading.leases.push(lease);
   }
-  return leases;
+  return reading;
 }
 
 function disconnectedHeldRefusal(id: string, idLabel: string): RunLeaseRefusal {
@@ -60,9 +73,18 @@ function disconnectedHeldRefusal(id: string, idLabel: string): RunLeaseRefusal {
   };
 }
 
+const NO_LEASE_FACTS = { platform: null, id: null, deviceName: null, holder: null, expiresAt: null };
+
+function unreadableSentence(unreadable: readonly string[]): string {
+  return unreadable.length
+    ? ` Unreadable lease file, so no run may take that device around it: ${unreadable.join('; ')}.`
+    : '';
+}
+
 function poolBusyRefusal(
   holders: readonly PoolHolder[],
   leases: readonly DeviceLease[],
+  unreadable: readonly string[],
   now: number,
   waitSeconds: number,
 ): RunLeaseRefusal {
@@ -71,23 +93,29 @@ function poolBusyRefusal(
   );
   const first = holders[0];
   const lease = first ? leases.find((entry) => entry.id === first.id) : undefined;
+  if (!first) {
+    return {
+      code: DEVICE_BUSY,
+      message: `Every connected device has an unreadable lease file, so Stim cannot tell who holds them: ${unreadable.join('; ')}.`,
+      remedy: 'Read each file and, once you know no run depends on it, delete it. `stim gc` reports them on every run.',
+      lease: NO_LEASE_FACTS,
+    };
+  }
   return {
     code: DEVICE_BUSY,
     message:
       `Every connected device is leased by another workspace${waitSeconds > 0 ? `, and this run waited ${waitSeconds}s for one` : ''}: ` +
-      `${named.join('; ')}.`,
+      `${named.join('; ')}.${unreadableSentence(unreadable)}`,
     remedy:
       'Wait longer with `--wait <seconds>`, connect another device, or pass `--no-wait` to install anyway -- ' +
       "which takes no lease and, when both workspaces build the same app id, terminates the holder's running app.",
-    lease: first
-      ? {
-          platform: lease?.platform ?? null,
-          id: first.id,
-          deviceName: lease?.deviceName ?? null,
-          holder: first.holder,
-          expiresAt: first.expiresAt,
-        }
-      : null,
+    lease: {
+      platform: lease?.platform ?? null,
+      id: first.id,
+      deviceName: lease?.deviceName ?? null,
+      holder: first.holder,
+      expiresAt: first.expiresAt,
+    },
   };
 }
 
@@ -124,25 +152,31 @@ export async function selectFromPool({
 
   for (;;) {
     const candidates = list();
-    const leases = candidateLeases(platform, candidates, io);
-    const selection = selectPoolDevice({ candidates, leases, held, now: now() });
+    const { usable, leases, unreadable } = readPool(platform, candidates, io);
+    const selection = selectPoolDevice({ candidates: usable, leases, held, now: now() });
 
     if (selection.status === 'selected') return selection;
     if (selection.status === 'held-disconnected') {
       return { status: 'refused', refusal: disconnectedHeldRefusal(selection.id, idLabel) };
     }
     if (selection.status === 'none') {
+      if (unreadable.length) {
+        return { status: 'refused', refusal: poolBusyRefusal([], leases, unreadable, now(), waitSeconds) };
+      }
       const { message, remedy } = noCandidates();
       return { status: 'refused', refusal: { code: 'STIM_NO_DEVICE', message, remedy, lease: null } };
     }
 
     const first = selection.holders[0];
     if (noWait && first) {
-      const candidate = candidates.find((entry) => entry.id === first.id);
+      const candidate = usable.find((entry) => entry.id === first.id);
       if (candidate) return { status: 'selected', candidate };
     }
     if (now() >= until) {
-      return { status: 'refused', refusal: poolBusyRefusal(selection.holders, leases, now(), waitSeconds) };
+      return {
+        status: 'refused',
+        refusal: poolBusyRefusal(selection.holders, leases, unreadable, now(), waitSeconds),
+      };
     }
     if (lastLine === null || now() - lastLine >= DEVICE_WAIT_LINE_MS) {
       lastLine = now();

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -117,6 +117,10 @@ function unhealthy(device: IosDeviceEntry): ResolvedIosDevice | null {
   return null;
 }
 
+export function iosPoolCandidates(devices: readonly IosDeviceEntry[]): IosDeviceEntry[] {
+  return (Array.isArray(devices) ? devices : []).filter((device) => isWired(device) && unhealthy(device) === null);
+}
+
 export function resolveIosPhysicalDevice(requested: string | null, devices: IosDeviceEntry[]): ResolvedIosDevice {
   const listed = Array.isArray(devices) ? devices : [];
   const cabled = listed.filter(isWired);

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -330,6 +330,19 @@ function emulatorRefusal(serial: string): ResolvedPhysicalDevice {
   };
 }
 
+export function memoizeEmulatorProbe(
+  probe: (serial: string) => boolean = probeEmulatorSerial,
+): (serial: string) => boolean {
+  const seen = new Map<string, boolean>();
+  return (serial: string) => {
+    const cached = seen.get(serial);
+    if (cached !== undefined) return cached;
+    const probed = probe(serial);
+    seen.set(serial, probed);
+    return probed;
+  };
+}
+
 export function androidPoolCandidates(
   adb: AdbDevices,
   isEmulator: (serial: string) => boolean = probeEmulatorSerial,

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -330,6 +330,13 @@ function emulatorRefusal(serial: string): ResolvedPhysicalDevice {
   };
 }
 
+export function androidPoolCandidates(
+  adb: AdbDevices,
+  isEmulator: (serial: string) => boolean = probeEmulatorSerial,
+): AdbPhysicalEntry[] {
+  return (adb?.physical ?? []).filter((entry) => !isEmulator(entry.serial));
+}
+
 export function resolvePhysicalDevice(
   requested: string | null,
   adb: AdbDevices,

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -182,6 +182,11 @@ number of seconds or minutes from `10s` to `30m` and defaults to `5m`;
 (default 60 seconds, `0` refuses at once). Locking a device this workspace
 already holds sets a new expiry, which can shorten it.
 
+With no id, `lock` picks from the connected devices the resolver accepts: the
+one this workspace already leases when it is connected, otherwise the first
+free one in id order. The same rule serves `ios --device` and
+`android --device` with no id, so two devices on one machine no longer refuse.
+
 `unlock` releases every lease this workspace holds, or only the platform
 named; releasing nothing is not an error. A `--device` run takes a lease of
 its own for the length of the run, so `lock` is for holding a device across

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -74,8 +74,8 @@ machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
 - `--device [udid]` builds, installs, and launches on a connected iPhone instead
-  of the owned simulator. With no UDID the one connected device is used. Stim
-  never creates, boots, or deletes hardware.
+  of the owned simulator. With no UDID it takes the first connected device it
+  can lease. Stim never creates, boots, or deletes hardware.
 - `--remote proxy` uses a configured Agent Device daemon.
 - `--remote eas` uses an EAS remote simulator.
 - `--no-metro-check` skips the Debug dev-server gate.


### PR DESCRIPTION
## Description

With two phones cabled to one machine, `stim ios --device` refuses: "Several
devices are connected". That refusal predates leases, when Stim had no way to
tell one device from another. Phases 1-3 gave every physical device a lease
file, so the question is no longer "which did you mean" but "which is free",
and Stim can answer it. This is phase 4 of
`docs/specs/2026-09-02-device-lease-design.md`: the "Pool" section, for
`ios --device`, `android --device`, and `stim device lock`.

Stacked on `feat/device-lease-commands` (#232); it retargets to `main` when
that merges. Its own diff is `cacd915`.

What changes, only on the id-less path:

- new `engine/device-pool.ts`: candidate leases in, one device out, with the
  wait and the refusals;
- `iosPoolCandidates` / `androidPoolCandidates` next to the resolvers they
  filter with;
- `ios`, `android` and `device lock` use the pool when no id is given, and the
  existing resolver unchanged when one is;
- the guide's interim paragraph ("the pool rule is not implemented yet") is
  replaced by the rule, and `website/docs/commands.md` and both `--device`
  help strings say the first free device is used;
- the spec's Pool rule 2 gets a dated amendment (below).

Naming an id still goes through the old resolver, so every existing refusal for
a named device is untouched. No hardware: candidates come from injected list
functions in the tests, and nothing installs or launches on this branch.

## Solution

`selectPoolDevice` from phase 1 is the decision, unchanged and already tested;
this PR is the I/O around it. `selectFromPool` lists candidates, reads the lease
file for each, asks `selectPoolDevice`, and then handles the three answers it
cannot: a held-but-disconnected device (refuse), no candidates (refuse with the
resolver's own words, obtained by running the existing resolver with no id --
so "no device connected", "paired over Wi-Fi", and "unauthorized" all still read
exactly as they do today), and none free (wait).

The wait re-lists devices on each poll rather than re-reading one lease file, so
a phone plugged in mid-wait is picked up as well as one released mid-wait. The
holder set is what makes `STIM_DEVICE_BUSY` different here: it names every
holder, not one.

"Held device wins" reads the workspace's own record, but only counts it when
the lease file still backs it under that token and has not expired -- the same
staleness rule #230 landed for the differing-id refusal, so a Ctrl-C'd run's
leftover record cannot pin the next run to a device it no longer holds.

`--no-wait` had to reach the pool too: with every candidate leased it takes the
first one anyway and leaves the bypass to the run, which is where the warning
about terminating the holder's app already lives.

### The spec amendment

Pool rule 2 said that when this workspace's leased device is not connected, "an
id selects another device". That contradicts the "ios and android" section: a
run whose id differs from this workspace's leased device refuses with
`STIM_NO_DEVICE`. Naming an id does not escape a lease you hold. The rule now
says `unlock` first, or use that device, and the section carries a dated
amendment saying what changed and why -- the refusal message says the same
thing, so the code and the spec now agree.

### A corrupt lease file is not a free device

The first cut read only the lease files that parse, which meant a candidate
whose file is corrupt looked *free* -- and, sorting first, would have been
picked over a device that really was free. Rule 1 of the protocol says an
unparseable file is held by an unknown holder, so such a candidate is now
excluded from the free set and named in the refusal instead. When every
candidate is unreadable the refusal says that, rather than claiming no device is
connected.

## Test plan

- `engine-device-pool.test.ts` (15 tests, injected clock and file layer):
  candidate filtering on both platforms (wired/paired/Developer Mode; emulators
  out, TCP serials in), id order, the held-device preference, a stale record not
  pinning, the disconnected-held refusal, no candidates, a device freed mid-wait,
  a device *plugged in* mid-wait (the re-list), the busy refusal naming every
  holder, `--wait 0`, the waiting-line cadence, and `--no-wait`.
- Command tests on all three commands: `ios --device` with two phones (first in
  id order, skipping a leased one, this workspace's own winning out of order,
  the disconnected-held refusal, all-leased with both holders named, no device
  at all, and a named udid still using the resolver); the same for
  `android --device` including a TCP serial and an emulator serial; and
  `device lock` with no id on both platforms.
- The corrupt-file cases: `A-CORRUPT` sorting first with `B-FREE` free (B is
  chosen), every candidate unreadable (busy, naming the files), and an
  unreadable file named beside the holders when the rest are leased.
- A command-level `--device --no-wait` with every connected phone leased: the
  bypass warning names the holder, the run installs, `lease` is null, and no new
  lease file is written.
- Battery from the repo root: format:check, lint, build, typecheck, `pnpm test`
  (82 files, 3157 tests), knip.

Fixes #233.

