### PR TITLE
fix: pool refusal lists each unhealthy device's own reason

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -4101,6 +4101,17 @@ describe('--device with no serial: the pool', () => {
     expect(result.error?.code).toBe(NO_DEVICE);
   });
 
+  test('two emulator-only serials refuse with each one own reason, not the count message', async () => {
+    const h = pool([FIRST, SECOND], { isEmulatorDevice: () => true });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(NO_DEVICE);
+    expect(result.error?.message).toMatch(new RegExp(`${FIRST} is an emulator, not a physical device`));
+    expect(result.error?.message).toMatch(new RegExp(`${SECOND} is an emulator, not a physical device`));
+    expect(result.error?.message).not.toMatch(/Several physical devices are connected/);
+    expect(result.error?.remedy).toMatch(/without --device/);
+  });
+
   test('a leased device that is not connected refuses, naming it and the way out', async () => {
     takeLease({ root, platform: 'android', id: 'GONE-SERIAL', kind: 'declared' });
     const h = pool([FIRST]);

--- a/packages/stim-cli/src/__tests__/device-command.test.ts
+++ b/packages/stim-cli/src/__tests__/device-command.test.ts
@@ -277,6 +277,53 @@ describe('stim device lock', () => {
     expect(facts.deviceName).toBe('SM-G996W');
   });
 
+  test('with no id and two unhealthy cabled iOS phones, the refusal names each one own reason', async () => {
+    const SECOND = '00008120-000A11223C44201E';
+    const h = harness({
+      listIosDevices: () => [
+        {
+          udid: PHONE,
+          name: 'Old iPhone',
+          bootState: 'booted',
+          developerModeStatus: 'disabled',
+          pairingState: 'paired',
+          transportType: 'wired',
+        },
+        {
+          udid: SECOND,
+          name: 'Second',
+          bootState: 'booted',
+          developerModeStatus: 'enabled',
+          pairingState: 'unpaired',
+          transportType: 'wired',
+        },
+      ],
+    });
+    const failure = await runLock('ios', undefined, {}, h.deps);
+    assert('code' in failure);
+    expect(failure.code).toBe('STIM_NO_DEVICE');
+    expect(failure.message).toMatch(new RegExp(`${PHONE} \\(Old iPhone\\) has Developer Mode disabled`));
+    expect(failure.message).toMatch(new RegExp(`${SECOND} \\(Second\\) is connected but unpaired`));
+    expect(failure.message).not.toMatch(/Several devices are connected/);
+  });
+
+  test('with no id and two emulator-probed android serials, the refusal names each one own reason', async () => {
+    const h = harness({
+      listAdbDevices: () => ({
+        emulators: [],
+        physical: [{ serial: 'ZY224' }, { serial: 'RFCR7081Q9L' }],
+        unhealthy: [],
+      }),
+      probeEmulatorSerial: () => true,
+    });
+    const failure = await runLock('android', undefined, {}, h.deps);
+    assert('code' in failure);
+    expect(failure.code).toBe('STIM_NO_DEVICE');
+    expect(failure.message).toMatch(/ZY224 is an emulator, not a physical device/);
+    expect(failure.message).toMatch(/RFCR7081Q9L is an emulator, not a physical device/);
+    expect(failure.message).not.toMatch(/Several physical devices are connected/);
+  });
+
   test('a device this workspace leases but is not connected refuses, naming the way out', async () => {
     const h = harness();
     takeLease({ root, platform: 'ios', id: 'GONE-PHONE', kind: 'declared' }, h.io);

--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -17,6 +17,7 @@ import {
   localNetworkPending,
   parseDevicectlDevices,
   parseDeviceProcesses,
+  iosPoolNoCandidatesRefusal,
   resolveIosPhysicalDevice,
   verifyIosDeviceReleaseLaunch,
   type IosDeviceEntry,
@@ -133,6 +134,27 @@ test('resolveIosPhysicalDevice does not invent a health problem from absent fiel
     udid: PHONE,
     name: 'Test Phone',
   });
+});
+
+test('iosPoolNoCandidatesRefusal names each unhealthy cabled device with its own reason, not the count message', () => {
+  const refusal = iosPoolNoCandidatesRefusal([
+    entry({ developerModeStatus: 'disabled' }),
+    entry({ udid: OTHER, name: 'Second', pairingState: 'unpaired' }),
+  ]);
+  expect(refusal.udid).toBeUndefined();
+  expect(refusal.error).toContain(resolveIosPhysicalDevice(null, [entry({ developerModeStatus: 'disabled' })]).error);
+  expect(refusal.error).toContain(
+    resolveIosPhysicalDevice(null, [entry({ udid: OTHER, name: 'Second', pairingState: 'unpaired' })]).error,
+  );
+  expect(refusal.error).not.toMatch(/Several devices are connected/);
+  expect(refusal.remedy).toMatch(/Developer Mode/);
+  expect(refusal.remedy).toMatch(/Trust/);
+});
+
+test('iosPoolNoCandidatesRefusal falls back to the resolver when nothing is cabled', () => {
+  expect(iosPoolNoCandidatesRefusal([])).toEqual(resolveIosPhysicalDevice(null, []));
+  const wireless = entry({ transportType: 'localNetwork' });
+  expect(iosPoolNoCandidatesRefusal([wireless])).toEqual(resolveIosPhysicalDevice(null, [wireless]));
 });
 
 test('lanCandidates orders en0 first and the remaining en* by index', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3411,6 +3411,24 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(parseFirst(logs).deviceName).toBe('Test Phone');
   });
 
+  test('two unhealthy cabled phones refuse with each one own reason, not the count message', async () => {
+    reserve();
+    const SECOND = '00008120-000A11223C44201E';
+    const { errs, exitCode } = await run(
+      { device: true },
+      connected([
+        { udid: PHONE, developerModeStatus: 'disabled' },
+        { udid: SECOND, name: 'Second', pairingState: 'unpaired' },
+      ]),
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
+    expect(errs.join('\n')).toMatch(new RegExp(`${PHONE} \\(Test Phone\\) has Developer Mode disabled`));
+    expect(errs.join('\n')).toMatch(new RegExp(`${SECOND} \\(Second\\) is connected but unpaired`));
+    expect(errs.join('\n')).not.toMatch(/Several devices are connected/);
+    expect(errs.join('\n')).not.toMatch(/Name the one to build for/);
+  });
+
   test('a phone another workspace leases is skipped for the free one, whatever the order', async () => {
     reserve();
     takeLease({ root: '/worktree/theirs', platform: 'ios', id: PHONE, kind: 'declared' });

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -16,6 +16,7 @@ import { setExecutor, resetExecutor } from '../exec.ts';
 import {
   MAX_EMULATOR_FAILURE_LINES,
   androidToolPath,
+  androidPoolNoCandidatesRefusal,
   buildToolsMajor,
   emulatorFailureRemedy,
   extractEmulatorFailure,
@@ -24,6 +25,7 @@ import {
   bootAndroidEmulator,
   configureNewOwnedAvd,
   listAvds,
+  memoizeEmulatorProbe,
   parseAvdList,
   parseAdbDevices,
   nextConsolePort,
@@ -887,4 +889,34 @@ test('resolvePhysicalDevice reports the whole adb status, not its first word', (
   const result = resolvePhysicalDevice(null, adb);
   expect(result.error).toMatch(/no permissions/);
   expect(result.error).not.toMatch(/but no,/);
+});
+
+test('androidPoolNoCandidatesRefusal names each emulator-only physical serial with its own reason, not the count message', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n0123456789ABCDEF\tdevice\n`);
+  const result = androidPoolNoCandidatesRefusal(adb, () => true);
+  expect(result.serial).toBeUndefined();
+  expect(result.error).toContain(resolvePhysicalDevice('RFCR7081Q9L', adb, () => true).error);
+  expect(result.error).toContain(resolvePhysicalDevice('0123456789ABCDEF', adb, () => true).error);
+  expect(result.error).not.toMatch(/Several physical devices are connected/);
+  expect(result.remedy).toMatch(/without --device/);
+});
+
+test('androidPoolNoCandidatesRefusal falls back to the resolver when a physical device is genuine', () => {
+  const adb = parseAdbDevices(`List of devices attached\nRFCR7081Q9L\tdevice\n`);
+  expect(androidPoolNoCandidatesRefusal(adb, () => false)).toEqual(resolvePhysicalDevice(null, adb, () => false));
+  const none = parseAdbDevices(`List of devices attached\n`);
+  expect(androidPoolNoCandidatesRefusal(none)).toEqual(resolvePhysicalDevice(null, none));
+});
+
+test('memoizeEmulatorProbe probes a serial once and reuses the result across repeated calls', () => {
+  const calls: string[] = [];
+  const probe = memoizeEmulatorProbe((serial) => {
+    calls.push(serial);
+    return serial === 'emulator-5554';
+  });
+  expect(probe('emulator-5554')).toBe(true);
+  expect(probe('RFCR7081Q9L')).toBe(false);
+  expect(probe('emulator-5554')).toBe(true);
+  expect(probe('RFCR7081Q9L')).toBe(false);
+  expect(calls).toEqual(['emulator-5554', 'RFCR7081Q9L']);
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -98,6 +98,7 @@ import {
 import {
   androidHome,
   androidPoolCandidates,
+  androidPoolNoCandidatesRefusal,
   memoizeEmulatorProbe,
   emulatorDiskSpaceRemedy,
   emulatorFailureRemedy,
@@ -1403,7 +1404,7 @@ async function pooledAndroidDevice({
     idLabel: 'serial',
     list: () => androidPoolCandidates(listDevices(), isEmulator).map((entry) => ({ id: entry.serial })),
     noCandidates: () => {
-      const resolved = resolvePhysicalDevice(null, listDevices(), isEmulator);
+      const resolved = androidPoolNoCandidatesRefusal(listDevices(), isEmulator);
       return { message: resolved.error as string, remedy: resolved.remedy as string };
     },
     waitSeconds,

--- a/packages/stim-cli/src/commands/device.ts
+++ b/packages/stim-cli/src/commands/device.ts
@@ -11,10 +11,16 @@ import {
 } from '../engine/device-lease.ts';
 import { parseDeviceWait, waitForDevice } from '../engine/device-lease-run.ts';
 import { selectFromPool } from '../engine/device-pool.ts';
-import { iosPoolCandidates, listIosDevices, resolveIosPhysicalDevice } from '../engine/ios-device.ts';
+import {
+  iosPoolCandidates,
+  iosPoolNoCandidatesRefusal,
+  listIosDevices,
+  resolveIosPhysicalDevice,
+} from '../engine/ios-device.ts';
 import { findProjectRoot } from '../project.ts';
 import {
   androidPoolCandidates,
+  androidPoolNoCandidatesRefusal,
   listAdbDevices,
   memoizeEmulatorProbe,
   physicalDeviceModel,
@@ -157,8 +163,8 @@ async function poolDevice(
     noCandidates: () => {
       const resolved =
         platform === 'ios'
-          ? resolveIosPhysicalDevice(null, d.listIosDevices())
-          : resolvePhysicalDevice(null, d.listAdbDevices(), isEmulator);
+          ? iosPoolNoCandidatesRefusal(d.listIosDevices())
+          : androidPoolNoCandidatesRefusal(d.listAdbDevices(), isEmulator);
       return { message: resolved.error as string, remedy: resolved.remedy as string };
     },
     waitSeconds,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -73,6 +73,7 @@ import {
   installIosDeviceApp,
   iosDeviceProcess,
   iosPoolCandidates,
+  iosPoolNoCandidatesRefusal,
   listIosDevices,
   localNetworkPending,
   resolveIosPhysicalDevice,
@@ -1844,7 +1845,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       idLabel: 'udid',
       list: () => iosPoolCandidates(d.listIosDevices()).map((entry) => ({ id: entry.udid, name: entry.name })),
       noCandidates: () => {
-        const resolved = resolveIosPhysicalDevice(null, d.listIosDevices());
+        const resolved = iosPoolNoCandidatesRefusal(d.listIosDevices());
         return { message: resolved.error as string, remedy: resolved.remedy as string };
       },
       waitSeconds,

--- a/packages/stim-cli/src/engine/ios-device.ts
+++ b/packages/stim-cli/src/engine/ios-device.ts
@@ -121,6 +121,20 @@ export function iosPoolCandidates(devices: readonly IosDeviceEntry[]): IosDevice
   return (Array.isArray(devices) ? devices : []).filter((device) => isWired(device) && unhealthy(device) === null);
 }
 
+export function iosPoolNoCandidatesRefusal(devices: readonly IosDeviceEntry[]): ResolvedIosDevice {
+  const listed = Array.isArray(devices) ? devices : [];
+  const cabled = listed.filter(isWired);
+  const problems = cabled.map((device) => unhealthy(device));
+  if (cabled.length > 0 && problems.every((problem) => problem !== null)) {
+    const reasons = problems as ResolvedIosDevice[];
+    return {
+      error: reasons.map((reason) => reason.error!).join(' '),
+      remedy: [...new Set(reasons.map((reason) => reason.remedy!))].join(' '),
+    };
+  }
+  return resolveIosPhysicalDevice(null, listed);
+}
+
 export function resolveIosPhysicalDevice(requested: string | null, devices: IosDeviceEntry[]): ResolvedIosDevice {
   const listed = Array.isArray(devices) ? devices : [];
   const cabled = listed.filter(isWired);

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -350,6 +350,21 @@ export function androidPoolCandidates(
   return (adb?.physical ?? []).filter((entry) => !isEmulator(entry.serial));
 }
 
+export function androidPoolNoCandidatesRefusal(
+  adb: AdbDevices,
+  isEmulator: (serial: string) => boolean = probeEmulatorSerial,
+): ResolvedPhysicalDevice {
+  const physical = adb?.physical ?? [];
+  if (physical.length > 0 && physical.every((entry) => isEmulator(entry.serial))) {
+    const reasons = physical.map((entry) => emulatorRefusal(entry.serial));
+    return {
+      error: reasons.map((reason) => reason.error!).join(' '),
+      remedy: [...new Set(reasons.map((reason) => reason.remedy!))].join(' '),
+    };
+  }
+  return resolvePhysicalDevice(null, adb, isEmulator);
+}
+
 export function resolvePhysicalDevice(
   requested: string | null,
   adb: AdbDevices,


### PR DESCRIPTION
## Description

Two cabled iPhones that are both unhealthy (Developer Mode off, unpaired) make an id-less `ios --device` take a detour: the pool has no healthy candidate, so it falls back to the single-device resolver, and that resolver checks the cabled *count* before health. It answers "Several devices are connected ... Name the one to build for" instead of the Developer Mode or pairing remedy. Naming one device then produces the right refusal, so it's a detour, not a dead end -- but it hides the actual problem from an agent that only ever runs id-less. Android has the same shape when every physical serial is an emulator.

The same `noCandidates` mistake exists at three call sites: `runIos` (`commands/ios.ts`), `pooledAndroidDevice` (`commands/android.ts`), and `poolDevice` (`commands/device.ts`, behind an id-less `stim device lock`).

## Solution

`iosPoolNoCandidatesRefusal` (`engine/ios-device.ts`) and `androidPoolNoCandidatesRefusal` (`sim/android.ts`) replace the resolver call at all three call sites. When the pool has cabled/physical devices but none is a valid candidate, they build the refusal from each device's own reason instead of the ambiguous-count branch -- reusing the resolver's exact per-device wording (`unhealthy()` on iOS, `emulatorRefusal()` on Android), not new text.

The old count-message branch is still there and still reachable, just narrower: it now only fires when the pool has zero cabled/physical devices connected at all.

## Test plan

Each repro test below was red against the pre-fix code (asserted the buggy "Several devices are connected" / "Several physical devices are connected" text) before the corresponding call site was fixed, then green after.

- `ios-command.test.ts` / `android-command.test.ts`: end-to-end repro for `runIos` / `pooledAndroidDevice` -- two cabled phones (one Developer-Mode-off, one unpaired) / two emulator-probed serials, `--device` with no id now refuses `STIM_NO_DEVICE` naming each device's own reason.
- `device-command.test.ts`: same repro for `poolDevice`, via an id-less `stim device lock ios` / `stim device lock android`.
- `engine-ios-device.test.ts` / `sim-android.test.ts`: unit tests for the two new pure functions, including their fallback to the existing resolver when nothing is cabled/connected.
- `sim-android.test.ts`: new unit test for `memoizeEmulatorProbe` -- one probe per serial across repeated calls.
- Checked `guide.ts` for a pinned "Several devices" sentence -- none exists, so no guide update was needed.
- Full battery from the repo root: `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm test` (82 files, 3166 tests) all pass.

Fixes #235
