### PR TITLE
fix: disable the dev menu through the dev-client deep link

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2531,7 +2531,7 @@ describe('the dev-client deep link', () => {
   });
 
   test('the deep-link launch says so, and the url is in the facts', async () => {
-    const url = 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082';
+    const url = 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1';
     const h = harness({
       resolveDevClientScheme: () => 'exp+app',
       launch: () => ({ ok: true, mode: 'deep-link', devClientUrl: url, reversed: [], debugHttpHost: '10.0.2.2:8082' }),
@@ -2574,7 +2574,7 @@ describe('the dev-client deep link', () => {
     expect(link > 0).toBeTruthy();
     expect(link < picker).toBeTruthy();
     expect(text).toMatch(
-      /adb -s emulator-5584 shell am start -a android\.intent\.action\.VIEW -d 'exp\+app:\/\/expo-development-client\/\?url=http%3A%2F%2F10\.0\.2\.2%3A8082'/,
+      /adb -s emulator-5584 shell am start -a android\.intent\.action\.VIEW -d 'exp\+app:\/\/expo-development-client\/\?url=http%3A%2F%2F10\.0\.2\.2%3A8082%2F%3FdisableOnboarding%3D1' --ez EXDevMenuDisableAutoLaunch true/,
     );
     expect(steps.length >= 2).toBeTruthy();
   });

--- a/packages/stim-cli/src/__tests__/device-remote.test.ts
+++ b/packages/stim-cli/src/__tests__/device-remote.test.ts
@@ -783,7 +783,9 @@ describe('install and launch match their local counterparts', () => {
     });
     expect(result.mode).toBe('openurl');
     const open = exec.calls.find((c) => c.args[0] === 'open');
-    expect(open?.args[2]).toBe('myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082');
+    expect(open?.args[2]).toBe(
+      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+    );
   });
 
   test('a bare RN launch has no url positional', async () => {
@@ -978,7 +980,9 @@ describe('Metro reachability', () => {
     await deps.ensureBooted({});
     deps.launchIosApp({ udid: 'drs_42', bundleId: 'com.example.app', metroPort: 8082, devClientScheme: 'myapp' });
     const open = exec.calls.find((c) => c.args[0] === 'open');
-    expect(open?.args[2]).toBe('myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com');
+    expect(open?.args[2]).toBe(
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+    );
   });
 });
 
@@ -1468,7 +1472,9 @@ describe('the android adapter', () => {
     deps.launch({ serial: 'drs_42', packageName: 'com.example.app', metroPort: 8082, devClientScheme: 'myapp' });
     const open = exec.calls.find((c) => c.args[0] === 'open');
     expect(open?.args[1]).toBe('com.example.app');
-    expect(open?.args[2]).toBe('myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com');
+    expect(open?.args[2]).toBe(
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+    );
     const flat = (open?.args ?? []).join(' ');
     expect(flat).not.toContain('10.0.2.2');
     expect(flat).not.toContain('reverse');

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -895,13 +895,12 @@ describe('unverifiedLaunchLines: the routed Local Network remedy', () => {
     expect(text).not.toMatch(/LOCAL NETWORK PERMISSION IS NOT GRANTED/);
   });
 
-  test('the Close press is the fallback for an app opened without the deep link', () => {
+  test('the Close press stays, because the deep link finishes onboarding only', () => {
     const text = devClientLines().join('\n');
-    expect(text).toMatch(/This launch's deep link carried disableOnboarding=1/);
-    expect(text).toMatch(/the Expo dev menu is not over the app/);
-    expect(text).toMatch(/if the app was started from the home screen instead/);
+    expect(text).toMatch(/On a fresh install the Expo dev menu can be over the app first/);
+    expect(text).toMatch(/finishes the launcher's onboarding, not EXDevMenuShowsAtLaunch/);
+    expect(text).toMatch(/defaults true on iOS/);
     expect(text).toContain(`agent-device press 'label="Close"'`);
-    expect(text).not.toMatch(/On a fresh install the Expo dev/);
   });
 
   test('a simulator never takes the routed remedy, whatever the flag says', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -20,6 +20,7 @@ import {
   amStartError,
   androidAppProcess,
   androidDevClientUrl,
+  devClientDeepLink,
   debugHttpHostScript,
   deviceShellArg,
   ADB_INSTALL_TIMEOUT_MS,
@@ -101,8 +102,34 @@ describe('the two pure port-wiring shapes', () => {
   });
 
   test('devClientUrl matches the shape expo-dev-launcher asserts on', () => {
-    expect(devClientUrl('myapp', 8082)).toBe('myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082');
-    expect(devClientUrl('scheme', 8081)).toBe('scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081');
+    expect(devClientUrl('myapp', 8082)).toBe(
+      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+    );
+    expect(devClientUrl('scheme', 8081)).toBe(
+      'scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2F%3FdisableOnboarding%3D1',
+    );
+  });
+
+  test('disableOnboarding=1 sits INSIDE the project url, never on the deep link', () => {
+    const urls = [
+      devClientUrl('myapp', 8082),
+      devClientUrl('myapp', 8082, '10.0.0.188'),
+      androidDevClientUrl('myapp', 8082, false),
+      androidDevClientUrl('myapp', 8082, true),
+      devClientDeepLink('myapp', 'https://abc.trycloudflare.com'),
+    ];
+    for (const url of urls) {
+      const link = new URL(url);
+      expect(link.searchParams.get('disableOnboarding')).toBe(null);
+      const projectUrl = new URL(link.searchParams.get('url') as string);
+      expect(projectUrl.searchParams.get('disableOnboarding')).toBe('1');
+    }
+    expect(devClientUrl('myapp', 8082, '10.0.0.188')).toBe(
+      'myapp://expo-development-client/?url=http%3A%2F%2F10.0.0.188%3A8082%2F%3FdisableOnboarding%3D1',
+    );
+    expect(devClientDeepLink('myapp', 'https://abc.trycloudflare.com')).toBe(
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+    );
   });
 
   test('iOS scheme approvals cover the bundle id and dev-client scheme without duplicates', () => {
@@ -156,18 +183,6 @@ describe('ios', () => {
         'defaults',
         'write',
         'com.example.app',
-        'EXDevMenuIsOnboardingFinished',
-        '-bool',
-        'true',
-      ],
-      [
-        'xcrun',
-        'simctl',
-        'spawn',
-        'U1',
-        'defaults',
-        'write',
-        'com.example.app',
         'EXDevMenuShowsAtLaunch',
         '-bool',
         'false',
@@ -200,7 +215,7 @@ describe('ios', () => {
   });
 
   test('a failed dev-client preference write reports a failed install result', () => {
-    const exec = recordingExec({ fail: 'EXDevMenuIsOnboardingFinished' });
+    const exec = recordingExec({ fail: 'EXDevMenuShowsAtLaunch' });
     const result = installIosApp(
       {
         udid: 'U1',
@@ -249,7 +264,13 @@ describe('ios', () => {
     expect(result.mode).toBe('openurl');
     expect(exec.calls).toEqual([
       ['xcrun', 'simctl', 'spawn', 'U1', 'defaults', 'write', 'com.example.app', 'RCT_jsLocation', 'localhost:8082'],
-      ['xcrun', 'simctl', 'openurl', 'U1', 'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082'],
+      [
+        'xcrun',
+        'simctl',
+        'openurl',
+        'U1',
+        'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+      ],
     ]);
   });
 
@@ -708,6 +729,47 @@ describe('unverifiedLaunchLines', () => {
     expect(text).toMatch(/adb -s emulator-5584 shell monkey -p com\.x 1/);
     expect(text).toMatch(/DEVELOPMENT SERVERS/);
   });
+
+  test('every printed retry command carries disableOnboarding inside the project url', () => {
+    const simulator = unverifiedLaunchLines({
+      platform: 'ios',
+      metroPort: 8082,
+      bundleId: 'io.tlon.groups',
+      udid: 'BF2A1C3D',
+      devClientUrl: devClientUrl('io.tlon.groups', 8082),
+    }).join('\n');
+    expect(simulator).toContain(
+      "xcrun simctl openurl BF2A1C3D 'io.tlon.groups://expo-development-client/" +
+        "?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1'",
+    );
+
+    const phone = unverifiedLaunchLines({
+      platform: 'ios',
+      metroPort: 8082,
+      bundleId: 'io.tlon.groups',
+      udid: 'BF2A1C3D',
+      physical: true,
+      devClient: true,
+      lanOrigin: 'http://10.0.0.132:8082',
+      devClientUrl: devClientUrl('io.tlon.groups', 8082, '10.0.0.132'),
+    }).join('\n');
+    expect(phone).toContain(
+      "--payload-url 'io.tlon.groups://expo-development-client/" +
+        "?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups",
+    );
+
+    const android = unverifiedLaunchLines({
+      platform: 'android',
+      metroPort: 8082,
+      bundleId: 'com.x',
+      serial: 'emulator-5584',
+      devClientUrl: androidDevClientUrl('exp+app', 8082),
+    }).join('\n');
+    expect(android).toContain(
+      "-d 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1'" +
+        ' --ez EXDevMenuDisableAutoLaunch true',
+    );
+  });
 });
 
 describe('unverifiedLaunchLines: the action comes first', () => {
@@ -831,6 +893,15 @@ describe('unverifiedLaunchLines: the routed Local Network remedy', () => {
     expect(text).not.toMatch(/cannot be granted from this machine/);
     expect(text).toMatch(/socketfilterfw/);
     expect(text).not.toMatch(/LOCAL NETWORK PERMISSION IS NOT GRANTED/);
+  });
+
+  test('the Close press is the fallback for an app opened without the deep link', () => {
+    const text = devClientLines().join('\n');
+    expect(text).toMatch(/This launch's deep link carried disableOnboarding=1/);
+    expect(text).toMatch(/the Expo dev menu is not over the app/);
+    expect(text).toMatch(/if the app was started from the home screen instead/);
+    expect(text).toContain(`agent-device press 'label="Close"'`);
+    expect(text).not.toMatch(/On a fresh install the Expo dev/);
   });
 
   test('a simulator never takes the routed remedy, whatever the flag says', () => {
@@ -969,9 +1040,11 @@ describe('the debug_http_host script, run for real under sh', () => {
 describe('the Android dev-client deep link', () => {
   test('the url is the iOS shape pointed at the emulator loopback', () => {
     expect(androidDevClientUrl('exp+app', 8085)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085',
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1',
     );
-    expect(devClientUrl('exp+app', 8085)).toBe('exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085');
+    expect(devClientUrl('exp+app', 8085)).toBe(
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1',
+    );
   });
 
   test('launchAndroidApp sends it, quoted for the device shell, and skips resolve-activity', () => {
@@ -981,7 +1054,9 @@ describe('the Android dev-client deep link', () => {
       { exec },
     );
     expect(result.mode).toBe('deep-link');
-    expect(result.devClientUrl).toBe('exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082');
+    expect(result.devClientUrl).toBe(
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1',
+    );
     expect(exec.calls.at(-1)).toEqual([
       'adb',
       '-s',
@@ -992,7 +1067,10 @@ describe('the Android dev-client deep link', () => {
       '-a',
       'android.intent.action.VIEW',
       '-d',
-      `'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082'`,
+      `'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1'`,
+      '--ez',
+      'EXDevMenuDisableAutoLaunch',
+      'true',
     ]);
     expect(!exec.calls.some((c: string[]) => c.includes('resolve-activity'))).toBeTruthy();
     expect(result.debugHttpHost).toBe('10.0.2.2:8082');
@@ -1798,10 +1876,10 @@ describe('the Metro host for a physical device', () => {
 
   test('the dev-client url targets localhost on a physical device', () => {
     expect(androidDevClientUrl('exp+app', 8085, true)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085',
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1',
     );
     expect(androidDevClientUrl('exp+app', 8085, false)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085',
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1',
     );
   });
 
@@ -1818,7 +1896,9 @@ describe('the Metro host for a physical device', () => {
       { exec },
     );
     expect(result.ok).toBe(true);
-    expect(result.devClientUrl).toBe('exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082');
+    expect(result.devClientUrl).toBe(
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+    );
   });
 });
 
@@ -1952,7 +2032,7 @@ describe('skipping an install the device already holds', () => {
     );
     expect(result).toEqual({ ok: true, appPath, skipped: true });
     expect(exec.calls.some((c) => c.includes('install'))).toBe(false);
-    expect(exec.calls.some((c) => c.includes('EXDevMenuIsOnboardingFinished'))).toBe(true);
+    expect(exec.calls.some((c) => c.includes('EXDevMenuShowsAtLaunch'))).toBe(true);
     expect(exec.calls.some((c) => c.includes('com.apple.CoreSimulator.CoreSimulatorBridge-->myapp'))).toBe(true);
   });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -439,8 +439,8 @@ test('the guide gives the Local Network recovery commands and the taps that have
   }
   expect(errors).toMatch(/THE GRANT ALONE IS NOT ENOUGH[\s\S]*does not\s+retry/);
   expect(errors).toContain(`agent-device press 'label="Close"'`);
-  expect(errors).toMatch(/Stim's own launch\s+carries disableOnboarding=1 in its project url/);
-  expect(errors).toMatch(/started WITHOUT that deep link[\s\S]*shows the menu instead/);
+  expect(errors).toMatch(/ON A FRESH\s+INSTALL the Expo dev menu can be over the app first/);
+  expect(errors).toMatch(/finishes the launcher's ONBOARDING, but not\s+EXDevMenuShowsAtLaunch/);
   expect(errors).toMatch(/A BARE APP \(no expo-dev-client\)[\s\S]*Could not connect to development server/);
   expect(errors).toMatch(/reads that reason alone and knows nothing about dev\s+clients/);
   expect(errors).toMatch(/neither that text nor the button's accessibility label has been read\s+off hardware/);
@@ -459,28 +459,35 @@ test('the guide gives the Local Network recovery commands and the taps that have
 });
 
 // The preapproval is `simctl spawn defaults write`, which has no devicectl
-// equivalent, and the copied-plist route loses its keys to cfprefsd. What
-// closes the dev menu on every platform is the deep link's own flag.
-test('the guide scopes the dev-menu preapproval to a simulator and says what covers a phone instead', () => {
+// equivalent, and the copied-plist route loses its keys to cfprefsd. The deep
+// link's flag replaces only half of it: EXDevMenuShowsAtLaunch defaults true on
+// iOS and DevMenuManager arms auto-launch on `showsAtLaunch ||
+// shouldShowOnboarding()`, so a phone still opens the menu once per fresh
+// install. Android's intent extra sets both preferences.
+test('the guide scopes the dev-menu preapproval to a simulator and says what a phone still costs', () => {
   const facts = renderTopic('facts');
   assert(facts);
 
   expect(facts).toMatch(/EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1\s+INSIDE ITS PROJECT URL/);
   expect(facts).toContain('?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1');
-  expect(facts).toMatch(/on the outer deep link it does\s+nothing/);
-  expect(facts).toMatch(/the dev menu does not open over the app on a\s+first launch/);
+  expect(facts).toMatch(/ON iOS it has to sit on the\s+PROJECT url/);
+  expect(facts).toMatch(/on the\s+outer deep link it does nothing there\. Android reads it on\s+either/);
   expect(facts).toMatch(
     /ON ANDROID the same deep link also carries the\s+`EXDevMenuDisableAutoLaunch` boolean intent extra/,
   );
   expect(facts).toContain("-d '<devClientUrl>'\n                  --ez EXDevMenuDisableAutoLaunch true");
   expect(facts).toMatch(/ON A SIMULATOR, before a local dev-client openurl, Stim\s+preapproves/);
+  expect(facts).toMatch(/the two together are what keep the menu off a simulator\s+entirely/);
   expect(facts).toMatch(/ON A PHONE NONE OF THAT PREAPPROVAL APPLIES/);
   expect(facts).toMatch(/devicectl has\s+no defaults command/);
   expect(facts).toMatch(/cfprefsd serves its cached domain and rewrites\s+the file/);
-  expect(facts).toMatch(/only comes up over an app that something ELSE\s+started/);
+  expect(facts).toMatch(/THE FLAG DOES NOT REPLACE THAT WRITE ON A\s+PHONE/);
+  expect(facts).toMatch(/EXDevMenuShowsAtLaunch defaults to TRUE on iOS/);
+  expect(facts).toMatch(/`showsAtLaunch \|\|\s+shouldShowOnboarding\(\)`/);
+  expect(facts).toMatch(/ONCE PER FRESH INSTALL/);
+  expect(facts).toMatch(/the launcher sets\s+showsAtLaunch false itself/);
   expect(facts).toContain(`agent-device press 'label="Close"'`);
   expect(facts).toMatch(/survive an\s+UPGRADE install/);
-  expect(facts).not.toMatch(/ONCE PER\s+FRESH INSTALL/);
 });
 
 test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -439,7 +439,8 @@ test('the guide gives the Local Network recovery commands and the taps that have
   }
   expect(errors).toMatch(/THE GRANT ALONE IS NOT ENOUGH[\s\S]*does not\s+retry/);
   expect(errors).toContain(`agent-device press 'label="Close"'`);
-  expect(errors).toMatch(/On a FRESH install[\s\S]*Expo dev menu is over the app first/);
+  expect(errors).toMatch(/Stim's own launch\s+carries disableOnboarding=1 in its project url/);
+  expect(errors).toMatch(/started WITHOUT that deep link[\s\S]*shows the menu instead/);
   expect(errors).toMatch(/A BARE APP \(no expo-dev-client\)[\s\S]*Could not connect to development server/);
   expect(errors).toMatch(/reads that reason alone and knows nothing about dev\s+clients/);
   expect(errors).toMatch(/neither that text nor the button's accessibility label has been read\s+off hardware/);
@@ -458,19 +459,28 @@ test('the guide gives the Local Network recovery commands and the taps that have
 });
 
 // The preapproval is `simctl spawn defaults write`, which has no devicectl
-// equivalent, and the copied-plist route loses its keys to cfprefsd.
-test('the guide scopes the dev-menu preapproval to a simulator and says what a phone costs instead', () => {
+// equivalent, and the copied-plist route loses its keys to cfprefsd. What
+// closes the dev menu on every platform is the deep link's own flag.
+test('the guide scopes the dev-menu preapproval to a simulator and says what covers a phone instead', () => {
   const facts = renderTopic('facts');
   assert(facts);
 
+  expect(facts).toMatch(/EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1\s+INSIDE ITS PROJECT URL/);
+  expect(facts).toContain('?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1');
+  expect(facts).toMatch(/on the outer deep link it does\s+nothing/);
+  expect(facts).toMatch(/the dev menu does not open over the app on a\s+first launch/);
+  expect(facts).toMatch(
+    /ON ANDROID the same deep link also carries the\s+`EXDevMenuDisableAutoLaunch` boolean intent extra/,
+  );
+  expect(facts).toContain("-d '<devClientUrl>'\n                  --ez EXDevMenuDisableAutoLaunch true");
   expect(facts).toMatch(/ON A SIMULATOR, before a local dev-client openurl, Stim\s+preapproves/);
   expect(facts).toMatch(/ON A PHONE NONE OF THAT PREAPPROVAL APPLIES/);
   expect(facts).toMatch(/devicectl has\s+no defaults command/);
   expect(facts).toMatch(/cfprefsd serves its cached domain and rewrites\s+the file/);
-  expect(facts).toMatch(/ONCE PER\s+FRESH INSTALL/);
+  expect(facts).toMatch(/only comes up over an app that something ELSE\s+started/);
   expect(facts).toContain(`agent-device press 'label="Close"'`);
-  expect(facts).toMatch(/survive an UPGRADE install/);
-  expect(facts).toMatch(/Stim does not write to the\s+phone to avoid it/);
+  expect(facts).toMatch(/survive an\s+UPGRADE install/);
+  expect(facts).not.toMatch(/ONCE PER\s+FRESH INSTALL/);
 });
 
 test('the errors topic documents every code the build commands and the iOS signing gate can emit', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3596,7 +3596,7 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     );
     const collector = calls.args.replaceCollector as Record<string, unknown>;
     expect(collector.payloadUrl).toBe(
-      `com.example.app://expo-development-client/?url=${encodeURIComponent('http://192.168.1.5:8082')}`,
+      `com.example.app://expo-development-client/?url=${encodeURIComponent('http://192.168.1.5:8082/?disableOnboarding=1')}`,
     );
     expect(calls.order.includes('sealAppForDevice')).toBe(false);
     expect(calls.order.includes('gateProfileForDevice')).toBe(true);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -115,20 +115,23 @@ other line goes to stderr, so it is always safe to pipe.
                   EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1
                   INSIDE ITS PROJECT URL
                   (\`...?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1\`),
-                  and expo-dev-launcher finishes its own dev-menu onboarding
-                  when it reads it. The flag has to sit on the PROJECT url --
-                  the value of the \`url\` parameter -- because that is the
-                  URL iOS hands to the check; on the outer deep link it does
-                  nothing. So the dev menu does not open over the app on a
-                  first launch, on a simulator, an emulator or a phone alike.
+                  and expo-dev-launcher finishes its own dev-menu ONBOARDING
+                  when it reads it. That is all the flag does: it sets
+                  EXDevMenuIsOnboardingFinished. ON iOS it has to sit on the
+                  PROJECT url -- the value of the \`url\` parameter -- because
+                  that is the URL the launcher hands to the check; on the
+                  outer deep link it does nothing there. Android reads it on
+                  either.
                   ON A SIMULATOR, before a local dev-client openurl, Stim
                   preapproves CoreSimulatorBridge for exactly the installed
                   bundle id and discovered scheme on its owned simulator. That
                   suppresses iOS's first-launch confirmation;
-                  unrelated schemes remain unapproved. It also disables the
-                  menu's automatic launch, which the flag does not cover, so
-                  device automation opens on the app. The unverified warning
-                  therefore leads with the picker, then prints the openurl
+                  unrelated schemes remain unapproved. It also writes
+                  EXDevMenuShowsAtLaunch=false, which the flag does NOT cover,
+                  and the two together are what keep the menu off a simulator
+                  entirely, so device automation opens on the app. The
+                  unverified warning therefore leads with the picker, then
+                  prints the openurl
                   retry. ON ANDROID the same deep link also carries the
                   \`EXDevMenuDisableAutoLaunch\` boolean intent extra, which
                   the launcher reads to set BOTH preferences -- so the
@@ -145,16 +148,21 @@ other line goes to stderr, so it is always safe to pipe.
                   onto Library/Preferences/<bundleId>.plist with the app
                   terminated, copies successfully and then loses the seeded
                   keys, because cfprefsd serves its cached domain and rewrites
-                  the file. The deep link's flag is what covers the phone
-                  instead, and Stim still writes nothing to it. The Expo dev
-                  menu therefore only comes up over an app that something ELSE
-                  started -- a home-screen tap, a relaunch with no
-                  \`--payload-url\` -- and it shows the runtime version,
-                  Close, Reload, Go home.
+                  the file. THE FLAG DOES NOT REPLACE THAT WRITE ON A
+                  PHONE. EXDevMenuShowsAtLaunch defaults to TRUE on iOS
+                  (DevMenuPreferences.setup), and DevMenuManager arms its
+                  auto-launch observer when \`showsAtLaunch ||
+                  shouldShowOnboarding()\`, so finishing onboarding clears
+                  only the second half. The dev menu can therefore still open
+                  over the app ONCE PER FRESH INSTALL -- the runtime version,
+                  Close, Reload, Go home -- after which the launcher sets
+                  showsAtLaunch false itself and later launches come up clean.
                   \`agent-device press 'label="Close"'\` dismisses it -- or
-                  \`snapshot -i\` and the ref. The onboarding flag the
-                  launcher writes and the Local Network grant both survive an
-                  UPGRADE install.
+                  \`snapshot -i\` and the ref. What the flag buys on a phone
+                  is the onboarding screen, not that menu. The keys it and the
+                  launcher write, and the Local Network grant, all survive an
+                  UPGRADE install. Android needs none of this: its intent
+                  extra sets both preferences.
                   The phone's unverified remedy is also ROUTED, not a fixed
                   list. When this launch's device records carry the Local
                   Network path reason, the remedy leads with that evidence and
@@ -857,12 +865,13 @@ LAUNCH UNVERIFIED, LOCAL NETWORK NOT GRANTED (not a code -- a routed remedy)
   retry, and stays on "Failed to load app ... The Internet connection appears
   to be offline." with a Reload button, which is why the last two lines are
   there. The text form of the press target is \`label="Reload"\` (or
-  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. Stim's own launch
-  carries disableOnboarding=1 in its project url, so the Expo dev menu is not
-  over the app. If the app was started WITHOUT that deep link -- from the home
-  screen -- \`snapshot -i\` shows the menu instead:
-  \`agent-device press 'label="Close"'\` dismisses it, then press Reload. See
-  \`guide facts\`, under \`launched\`.
+  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. ON A FRESH
+  INSTALL the Expo dev menu can be over the app first and \`snapshot -i\` shows
+  it instead: \`agent-device press 'label="Close"'\` dismisses it, then press
+  Reload. Stim's deep link finishes the launcher's ONBOARDING, but not
+  EXDevMenuShowsAtLaunch, which defaults true on iOS and which Stim cannot
+  write on a phone -- so the menu opens that once and the launcher clears the
+  key itself. See \`guide facts\`, under \`launched\`.
 
   A BARE APP (no expo-dev-client) gets the same first two commands and a
   different third. The prompt fires the same way, because it is fired by any

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -112,32 +112,49 @@ other line goes to stderr, so it is always safe to pipe.
                                  finishing
                     "unverified" nothing was observed at all: usually a
                                  dev-client server picker awaiting a tap
+                  EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1
+                  INSIDE ITS PROJECT URL
+                  (\`...?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1\`),
+                  and expo-dev-launcher finishes its own dev-menu onboarding
+                  when it reads it. The flag has to sit on the PROJECT url --
+                  the value of the \`url\` parameter -- because that is the
+                  URL iOS hands to the check; on the outer deep link it does
+                  nothing. So the dev menu does not open over the app on a
+                  first launch, on a simulator, an emulator or a phone alike.
                   ON A SIMULATOR, before a local dev-client openurl, Stim
                   preapproves CoreSimulatorBridge for exactly the installed
                   bundle id and discovered scheme on its owned simulator. That
                   suppresses iOS's first-launch confirmation;
-                  unrelated schemes remain unapproved. It also finishes Expo
-                  dev-menu onboarding and disables the menu's automatic launch,
-                  so device automation opens on the app. The unverified warning
+                  unrelated schemes remain unapproved. It also disables the
+                  menu's automatic launch, which the flag does not cover, so
+                  device automation opens on the app. The unverified warning
                   therefore leads with the picker, then prints the openurl
-                  retry. On ANDROID the list leads with the dev-client deep
-                  link (\`am start -a android.intent.action.VIEW -d
-                  '<devClientUrl>'\`), which is the whole answer when the app
-                  has a scheme.
-                  ON A PHONE NONE OF THAT PREAPPROVAL APPLIES. Both writes go
+                  retry. ON ANDROID the same deep link also carries the
+                  \`EXDevMenuDisableAutoLaunch\` boolean intent extra, which
+                  the launcher reads to set BOTH preferences -- so the
+                  emulator and the phone need no writes at all -- and the
+                  list leads with that command (\`am start -a
+                  android.intent.action.VIEW -d '<devClientUrl>'
+                  --ez EXDevMenuDisableAutoLaunch true\`), which is the whole
+                  answer when the app has a scheme.
+                  ON A PHONE NONE OF THAT PREAPPROVAL APPLIES. The
+                  preapproval and that write both go
                   through \`simctl spawn defaults write\`, and devicectl has
                   no defaults command; the one file route,
                   \`devicectl device copy to --domain-type appDataContainer\`
                   onto Library/Preferences/<bundleId>.plist with the app
                   terminated, copies successfully and then loses the seeded
                   keys, because cfprefsd serves its cached domain and rewrites
-                  the file. So the Expo dev menu opens over the app ONCE PER
-                  FRESH INSTALL (it shows the runtime version, Close, Reload,
-                  Go home). \`agent-device press 'label="Close"'\` dismisses
-                  it -- or \`snapshot -i\` and the ref. Both that onboarding
-                  flag and the Local Network grant survive an UPGRADE install,
-                  so it is not a per-run cost, and Stim does not write to the
-                  phone to avoid it.
+                  the file. The deep link's flag is what covers the phone
+                  instead, and Stim still writes nothing to it. The Expo dev
+                  menu therefore only comes up over an app that something ELSE
+                  started -- a home-screen tap, a relaunch with no
+                  \`--payload-url\` -- and it shows the runtime version,
+                  Close, Reload, Go home.
+                  \`agent-device press 'label="Close"'\` dismisses it -- or
+                  \`snapshot -i\` and the ref. The onboarding flag the
+                  launcher writes and the Local Network grant both survive an
+                  UPGRADE install.
                   The phone's unverified remedy is also ROUTED, not a fixed
                   list. When this launch's device records carry the Local
                   Network path reason, the remedy leads with that evidence and
@@ -840,10 +857,12 @@ LAUNCH UNVERIFIED, LOCAL NETWORK NOT GRANTED (not a code -- a routed remedy)
   retry, and stays on "Failed to load app ... The Internet connection appears
   to be offline." with a Reload button, which is why the last two lines are
   there. The text form of the press target is \`label="Reload"\` (or
-  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. On a FRESH install
-  the Expo dev menu is over the app first and \`snapshot -i\` shows it instead:
-  \`agent-device press 'label="Close"'\` dismisses it, then press Reload. Stim
-  cannot pre-dismiss it on a phone -- see \`guide facts\`, under \`launched\`.
+  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. Stim's own launch
+  carries disableOnboarding=1 in its project url, so the Expo dev menu is not
+  over the app. If the app was started WITHOUT that deep link -- from the home
+  screen -- \`snapshot -i\` shows the menu instead:
+  \`agent-device press 'label="Close"'\` dismisses it, then press Reload. See
+  \`guide facts\`, under \`launched\`.
 
   A BARE APP (no expo-dev-client) gets the same first two commands and a
   different third. The prompt fires the same way, because it is fired by any

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -123,10 +123,12 @@ export function jsLocationValue(metroPort: number | string): string {
   return `localhost:${metroPort}`;
 }
 
-// expo-dev-launcher reads disableOnboarding off the PROJECT url only, not the
-// outer deep link: EXDevLauncherController.m hands `devLauncherUrl.url` to
-// EXDevLauncherURLHelper.disableOnboardingPopupIfNeeded. Android reads either,
-// and also the EXDevMenuDisableAutoLaunch intent extra (DevLauncherController.kt).
+// On iOS expo-dev-launcher reads disableOnboarding off the PROJECT url only,
+// not the outer deep link: EXDevLauncherController.m hands `devLauncherUrl.url`
+// to EXDevLauncherURLHelper.disableOnboardingPopupIfNeeded. It sets
+// EXDevMenuIsOnboardingFinished alone; EXDevMenuShowsAtLaunch is a separate
+// preference. Android reads the flag on either url, and its
+// EXDevMenuDisableAutoLaunch intent extra sets both (DevLauncherController.kt).
 export function devClientDeepLink(scheme: string, projectOrigin: string): string {
   const projectUrl = `${projectOrigin.replace(/\/+$/, '')}/?${DEV_CLIENT_ONBOARDING_QUERY}`;
   return `${scheme}://expo-development-client/?url=${encodeURIComponent(projectUrl)}`;
@@ -1004,9 +1006,10 @@ export function unverifiedLaunchLines({
         push(
           'The app does NOT retry after the grant -- it stays on "Failed to load app ... The Internet connection ' +
             `appears to be offline." with a Reload button. Press it: agent-device snapshot -i --platform ios --udid ${udid}, ` +
-            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. This launch's deep link carried ` +
-            `disableOnboarding=1, so the Expo dev menu is not over the app; if the app was started from the home ` +
-            `screen instead, agent-device press 'label="Close"' --platform ios --udid ${udid} dismisses it.`,
+            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. On a fresh install the Expo dev ` +
+            `menu can be over the app first -- the deep link finishes the launcher's onboarding, not ` +
+            `EXDevMenuShowsAtLaunch, which defaults true on iOS -- so agent-device press 'label="Close"' ` +
+            `--platform ios --udid ${udid} dismisses it.`,
         );
         push(
           `Without agent-device, relaunching also recovers: ${relaunch}. It costs the device log -- it replaces the ` +

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -11,8 +11,9 @@ export const DEFAULT_METRO_PORT = 8081;
 
 const IOS_SCHEME_APPROVAL_DOMAIN = 'com.apple.launchservices.schemeapproval';
 const IOS_SCHEME_APPROVAL_OPENER = 'com.apple.CoreSimulator.CoreSimulatorBridge';
-const IOS_DEV_MENU_ONBOARDING_KEY = 'EXDevMenuIsOnboardingFinished';
 const IOS_DEV_MENU_SHOWS_AT_LAUNCH_KEY = 'EXDevMenuShowsAtLaunch';
+const DEV_CLIENT_ONBOARDING_QUERY = 'disableOnboarding=1';
+const ANDROID_DISABLE_AUTO_LAUNCH_EXTRA = 'EXDevMenuDisableAutoLaunch';
 
 interface ExecOpt {
   exec?: Executor | null;
@@ -90,17 +91,6 @@ export function installIosApp(
         'defaults',
         'write',
         bundleId,
-        IOS_DEV_MENU_ONBOARDING_KEY,
-        '-bool',
-        'true',
-      ]);
-      e.runFile('xcrun', [
-        'simctl',
-        'spawn',
-        udid,
-        'defaults',
-        'write',
-        bundleId,
         IOS_DEV_MENU_SHOWS_AT_LAUNCH_KEY,
         '-bool',
         'false',
@@ -133,8 +123,17 @@ export function jsLocationValue(metroPort: number | string): string {
   return `localhost:${metroPort}`;
 }
 
+// expo-dev-launcher reads disableOnboarding off the PROJECT url only, not the
+// outer deep link: EXDevLauncherController.m hands `devLauncherUrl.url` to
+// EXDevLauncherURLHelper.disableOnboardingPopupIfNeeded. Android reads either,
+// and also the EXDevMenuDisableAutoLaunch intent extra (DevLauncherController.kt).
+export function devClientDeepLink(scheme: string, projectOrigin: string): string {
+  const projectUrl = `${projectOrigin.replace(/\/+$/, '')}/?${DEV_CLIENT_ONBOARDING_QUERY}`;
+  return `${scheme}://expo-development-client/?url=${encodeURIComponent(projectUrl)}`;
+}
+
 export function devClientUrl(scheme: string, metroPort: number | string, host = 'localhost'): string {
-  return `${scheme}://expo-development-client/?url=${encodeURIComponent(`http://${host}:${metroPort}`)}`;
+  return devClientDeepLink(scheme, `http://${host}:${metroPort}`);
 }
 
 export function iosSchemeApprovalKeys(bundleId: string, devClientScheme: string): string[] {
@@ -434,6 +433,9 @@ export function openAndroidDevClientUrl(
       'android.intent.action.VIEW',
       '-d',
       deviceShellArg(url),
+      '--ez',
+      ANDROID_DISABLE_AUTO_LAUNCH_EXTRA,
+      'true',
     ]);
   } catch (err) {
     return { failed: true, reason: `am start -d ${url} failed on ${serial}: ${describe(err)}` };
@@ -1002,8 +1004,9 @@ export function unverifiedLaunchLines({
         push(
           'The app does NOT retry after the grant -- it stays on "Failed to load app ... The Internet connection ' +
             `appears to be offline." with a Reload button. Press it: agent-device snapshot -i --platform ios --udid ${udid}, ` +
-            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. On a fresh install the Expo dev ` +
-            `menu is over the app first; agent-device press 'label="Close"' --platform ios --udid ${udid} dismisses it.`,
+            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. This launch's deep link carried ` +
+            `disableOnboarding=1, so the Expo dev menu is not over the app; if the app was started from the home ` +
+            `screen instead, agent-device press 'label="Close"' --platform ios --udid ${udid} dismisses it.`,
         );
         push(
           `Without agent-device, relaunching also recovers: ${relaunch}. It costs the device log -- it replaces the ` +
@@ -1082,7 +1085,7 @@ export function unverifiedLaunchLines({
   } else {
     if (url && serial) {
       push(
-        `Re-send the dev-client deep link -- this is the command that points the app at THIS workspace's Metro: adb -s ${serial} shell am start -a android.intent.action.VIEW -d '${url}'`,
+        `Re-send the dev-client deep link -- this is the command that points the app at THIS workspace's Metro: adb -s ${serial} shell am start -a android.intent.action.VIEW -d '${url}' --ez ${ANDROID_DISABLE_AUTO_LAUNCH_EXTRA} true`,
       );
     }
     push(picker);

--- a/packages/stim-cli/src/engine/device-remote.ts
+++ b/packages/stim-cli/src/engine/device-remote.ts
@@ -19,7 +19,7 @@ import {
   remoteProfilePath,
 } from './agent-device.ts';
 import { planMetroReach, PUBLIC_METRO_ENV, type ManagedProvider, type TunnelMode } from './metro-reach.ts';
-import { INSTALL_ERROR, isBundleProof, LAUNCH_ERROR, readMetroRecords } from './app-install.ts';
+import { devClientDeepLink, INSTALL_ERROR, isBundleProof, LAUNCH_ERROR, readMetroRecords } from './app-install.ts';
 import {
   createSessionArgs,
   getSessionArgs,
@@ -344,9 +344,7 @@ function remoteDeviceDeps(ctx: RemoteContext) {
         return { failed: true, code: REMOTE_METRO_ERROR, reason: `${origin.failed} ${origin.remedy}` };
       }
 
-      const url = devClientScheme
-        ? `${devClientScheme}://expo-development-client/?url=${encodeURIComponent(origin.origin)}`
-        : null;
+      const url = devClientScheme ? devClientDeepLink(devClientScheme, origin.origin) : null;
       try {
         exec().runFile(ctx.agentDeviceBin, openArgs(session.profilePath, appId, url, metroHintFrom(origin.origin)), {
           cwd: ctx.root,


### PR DESCRIPTION
## Description

On a physical iPhone the Expo dev menu opened over the app on the first launch
after a fresh install (`Runtime version / Close / Reload`), and `guide` told
agents to press `Close` once per install. The simulator avoided it with a
`simctl spawn defaults write`; devicectl has no `defaults` command, and the one
file route (`devicectl device copy to --domain-type appDataContainer` onto
`Library/Preferences/<bundleId>.plist`) copies successfully and then loses the
seeded keys to cfprefsd.

expo-dev-launcher can be told to suppress it from the launch itself -- fully on
Android, partly on iOS:

- **iOS.** `EXDevLauncherURLHelper.disableOnboardingPopupIfNeeded` sets
  `EXDevMenuIsOnboardingFinished` when the URL it is handed carries
  `disableOnboarding=1`, and `EXDevLauncherController.m` hands it
  `devLauncherUrl.url` -- the PROJECT url, the value of the deep link's `url`
  parameter. So the flag has to sit inside the encoded `url`; on the outer deep
  link it does nothing (measured on hardware, see #239).
- **Android.** `DevLauncherController.kt` accepts `disableOnboarding=1` on
  either URL, and separately reads an `EXDevMenuDisableAutoLaunch` boolean
  intent extra that sets `showsAtLaunch = false` AND `isOnboardingFinished =
  true` ("used by appetize for snack").

Expo CLI never sends either, so these are launcher hooks rather than documented
CLI features, but both have been in the launcher for years.

## Solution

Two changes, both replacing a preference write with a launch parameter:

- `devClientUrl` appends `?disableOnboarding=1` to the project url for every
  dev-client launch -- simulator, emulator, physical, remote. (The remote
  adapter built the same deep link by hand; it now shares `devClientDeepLink`.)
  The deep link's own query is untouched, so the host stays
  `expo-development-client` and the `BUNDLE_URL_PATH` bundle-request detector
  still matches.
- The Android `am start` gains `--ez EXDevMenuDisableAutoLaunch true`, which
  covers the auto-launch preference the url flag does not.

**The iOS flag only finishes onboarding -- it does not close the menu on a
phone.** `DevMenuManager.updateAutoLaunchObserver` arms auto-launch when
`showsAtLaunch || shouldShowOnboarding()`, and `EXDevMenuShowsAtLaunch`
registers a default of `true` on iOS (`DevMenuPreferences.setup`). The flag
clears only the second disjunct. A phone therefore still opens the plain menu
once per fresh install, after which `DevMenuManager.autoLaunch` writes
`showsAtLaunch = false` itself and later launches come up clean. What the flag
buys on iOS hardware is the onboarding screen and one fewer thing that can only
be fixed by writing to the device; on Android the intent extra covers both
preferences outright.

**I dropped the simulator's `EXDevMenuIsOnboardingFinished` write.** It is
redundant: the flag sets the same key at the top of `loadApp`, and the only
simulator path that installs with a dev-client scheme is the one that then
launches through `simctl openurl` with that deep link -- nothing reads the key
in between. The `EXDevMenuShowsAtLaunch=false` write stays and is now the load-
bearing half on a simulator, as does the CoreSimulatorBridge preapproval.

Blast radius is the launch URL and argv on every dev-client path. Worst case is
an app that does not come up because a project url with a query is rejected
somewhere; the hardware run below shows it loads. Revert is small.

`guide facts` and `guide errors` are rewritten to that reading: the flag sets
one key, the simulator's kept write plus the flag are what keep the menu off a
simulator, a phone still costs one `Close` press per fresh install, and Android
needs neither. The cfprefsd paragraph stays -- it is still why a plist copy is
not an option.

## Test plan

**What was NOT verified:** no clean-install run. The phone's
`EXDevMenuShowsAtLaunch` was already `false` (cleared by the launcher itself
during the manual investigation in #239), so every hardware run here started
from a state where the menu would not open regardless. The claim that the menu
still opens once on a genuinely fresh install is read off the launcher source
above, not observed. The Android `am start` argv is also not exercised against
a real emulator (invariant 9): none was booted and no stim-owned Android
workspace existed, so proving it would have meant an AVD plus a full Gradle
build of a scratch project. `--ez` is documented with exactly this argv order
(`--ez extra_key extra_boolean_value`, "Add boolean data as a key-value pair"),
and the extra is read via `getBooleanExtra` on the same VIEW intent whose
`data` we already set, so a wrong key would be ignored rather than fail the
launch. Both are worth a run before this ships.

What did run -- Old iPhone `00008101-000A10913C89001E`, Metro on 8082, this
branch's built CLI:

```
$ node packages/stim-cli/dist/cli.mjs ios --device --json
  launch      com.appandflow.trailhead pid 1032 on the phone, opened on the dev-client URL (1.4s)
  verify      bundle loaded, process alive, stable for 3s (3.1s total)
  "launched": true
```

The URL that launch used, read off the collector's devicectl process, and the
screen right after it:

```
--payload-url com.appandflow.trailhead://expo-development-client/?url=http%3A%2F%2F10.0.0.188%3A8082%2F%3FdisableOnboarding%3D1

$ agent-device snapshot -i --platform ios --udid 00008101-...
App: com.appandflow.trailhead
@e1 [application] "Trailhead"    @e6 [text-field] "Search trails"    @e20 [text] "200 trails"
```

So: the new URL shape reaches the phone, the launch verifies, and the app is
usable. That is the regression check, not proof of the menu suppression.

`devClientUrl` on both platforms and hosts, the `am start` and `simctl openurl`
argv, the remedy strings that print either command, and the `guide` contract
are pinned by unit tests.

Fixes #239
