### PR TITLE
fix: turn the dev menu and its FAB off with launch arguments on a phone

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../collector/android.ts';
 import {
   deviceConsoleArgs,
+  DEV_MENU_LAUNCH_ARGS,
   deviceConsoleLevel,
   parseDeviceConsoleLine,
   CONSOLE_ENV,
@@ -290,7 +291,27 @@ describe('ios: the physical-device console', () => {
 
   test('a dev-client deep link travels as --payload-url, before the bundle id', () => {
     const args = deviceConsoleArgs({ udid: 'U1', bundleId: 'com.example.app', payloadUrl: 'stim://x?url=y' });
-    expect(args.slice(-3)).toEqual(['--payload-url', 'stim://x?url=y', 'com.example.app']);
+    expect(args.slice(-8, -5)).toEqual(['--payload-url', 'stim://x?url=y', 'com.example.app']);
+  });
+
+  test('the dev-menu arguments follow the bundle id, after the -- devicectl passes on', () => {
+    const args = deviceConsoleArgs({ udid: 'U1', bundleId: 'com.example.app', payloadUrl: 'stim://x?url=y' });
+    expect(args.slice(-6)).toEqual([
+      'com.example.app',
+      '--',
+      '-EXDevMenuShowsAtLaunch',
+      '0',
+      '-EXDevMenuShowFloatingActionButton',
+      '0',
+    ]);
+    expect(DEV_MENU_LAUNCH_ARGS).toEqual(['-EXDevMenuShowsAtLaunch', '0', '-EXDevMenuShowFloatingActionButton', '0']);
+  });
+
+  test('a launch with no deep link carries no dev-menu arguments: a release app has no dev menu', () => {
+    const args = deviceConsoleArgs({ udid: 'U1', bundleId: 'com.example.app' });
+    expect(args).not.toContain('--');
+    expect(args.join(' ')).not.toMatch(/EXDevMenu/);
+    expect(args.at(-1)).toBe('com.example.app');
   });
 });
 

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -345,7 +345,8 @@ describe('the ios device collector, spawned for real against a fake devicectl', 
   test('launches the app itself, parses BOTH streams, and clears the registration on SIGTERM', async () => {
     const expected =
       'devicectl device process launch --quiet --device UDID-1 --console --terminate-existing ' +
-      '--environment-variables {"OS_ACTIVITY_DT_MODE":"enable"} --payload-url stim://open com.example.MyApp';
+      '--environment-variables {"OS_ACTIVITY_DT_MODE":"enable"} --payload-url stim://open com.example.MyApp ' +
+      '-- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0';
     writeShim(
       'xcrun',
       [

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -194,6 +194,18 @@ describe('ios', () => {
         'U1',
         'defaults',
         'write',
+        'com.example.app',
+        'EXDevMenuShowFloatingActionButton',
+        '-bool',
+        'false',
+      ],
+      [
+        'xcrun',
+        'simctl',
+        'spawn',
+        'U1',
+        'defaults',
+        'write',
         'com.apple.launchservices.schemeapproval',
         'com.apple.CoreSimulator.CoreSimulatorBridge-->com.example.app',
         '-string',
@@ -755,7 +767,8 @@ describe('unverifiedLaunchLines', () => {
     }).join('\n');
     expect(phone).toContain(
       "--payload-url 'io.tlon.groups://expo-development-client/" +
-        "?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups",
+        "?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups" +
+        ' -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0',
     );
 
     const android = unverifiedLaunchLines({
@@ -883,6 +896,7 @@ describe('unverifiedLaunchLines: the routed Local Network remedy', () => {
       /xcrun devicectl device process launch --device BF2A1C3D --terminate-existing io\.tlon\.groups/,
     );
     expect(text).not.toMatch(/--payload-url/);
+    expect(text).not.toMatch(/EXDevMenu/);
     expect(text).not.toMatch(/label="Reload"/);
   });
 
@@ -895,12 +909,17 @@ describe('unverifiedLaunchLines: the routed Local Network remedy', () => {
     expect(text).not.toMatch(/LOCAL NETWORK PERMISSION IS NOT GRANTED/);
   });
 
-  test('the Close press stays, because the deep link finishes onboarding only', () => {
+  test('the Close press is the fallback for an app this launch did not start', () => {
     const text = devClientLines().join('\n');
-    expect(text).toMatch(/On a fresh install the Expo dev menu can be over the app first/);
-    expect(text).toMatch(/finishes the launcher's onboarding, not EXDevMenuShowsAtLaunch/);
-    expect(text).toMatch(/defaults true on iOS/);
+    expect(text).toMatch(/This launch carried -EXDevMenuShowsAtLaunch 0/);
+    expect(text).toMatch(/the Expo dev menu is not over the app/);
+    expect(text).toMatch(/if the app was started another way and the menu is on screen/);
     expect(text).toContain(`agent-device press 'label="Close"'`);
+    expect(text).toContain(
+      `--payload-url 'io.tlon.groups://expo-development-client/` +
+        `?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups` +
+        ' -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0',
+    );
   });
 
   test('a simulator never takes the routed remedy, whatever the flag says', () => {
@@ -2032,6 +2051,7 @@ describe('skipping an install the device already holds', () => {
     expect(result).toEqual({ ok: true, appPath, skipped: true });
     expect(exec.calls.some((c) => c.includes('install'))).toBe(false);
     expect(exec.calls.some((c) => c.includes('EXDevMenuShowsAtLaunch'))).toBe(true);
+    expect(exec.calls.some((c) => c.includes('EXDevMenuShowFloatingActionButton'))).toBe(true);
     expect(exec.calls.some((c) => c.includes('com.apple.CoreSimulator.CoreSimulatorBridge-->myapp'))).toBe(true);
   });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -439,8 +439,11 @@ test('the guide gives the Local Network recovery commands and the taps that have
   }
   expect(errors).toMatch(/THE GRANT ALONE IS NOT ENOUGH[\s\S]*does not\s+retry/);
   expect(errors).toContain(`agent-device press 'label="Close"'`);
-  expect(errors).toMatch(/ON A FRESH\s+INSTALL the Expo dev menu can be over the app first/);
-  expect(errors).toMatch(/finishes the launcher's ONBOARDING, but not\s+EXDevMenuShowsAtLaunch/);
+  expect(errors).toMatch(
+    /Stim's own launch\s+ends in `-- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0`/,
+  );
+  expect(errors).toMatch(/the Expo dev menu is not over the app, fresh install or not/);
+  expect(errors).toMatch(/An app started\s+ANOTHER way does not carry those arguments/);
   expect(errors).toMatch(/A BARE APP \(no expo-dev-client\)[\s\S]*Could not connect to development server/);
   expect(errors).toMatch(/reads that reason alone and knows nothing about dev\s+clients/);
   expect(errors).toMatch(/neither that text nor the button's accessibility label has been read\s+off hardware/);
@@ -459,12 +462,11 @@ test('the guide gives the Local Network recovery commands and the taps that have
 });
 
 // The preapproval is `simctl spawn defaults write`, which has no devicectl
-// equivalent, and the copied-plist route loses its keys to cfprefsd. The deep
-// link's flag replaces only half of it: EXDevMenuShowsAtLaunch defaults true on
-// iOS and DevMenuManager arms auto-launch on `showsAtLaunch ||
-// shouldShowOnboarding()`, so a phone still opens the menu once per fresh
-// install. Android's intent extra sets both preferences.
-test('the guide scopes the dev-menu preapproval to a simulator and says what a phone still costs', () => {
+// equivalent, and the copied-plist route loses its keys to cfprefsd. On a phone
+// the launch arguments take its place: devicectl passes everything after `--`
+// to the app and NSUserDefaults reads the argument domain first, so nothing is
+// written to the device. Android's intent extra sets both preferences.
+test('the guide scopes the dev-menu preapproval to a simulator and names what covers a phone', () => {
   const facts = renderTopic('facts');
   assert(facts);
 
@@ -477,15 +479,24 @@ test('the guide scopes the dev-menu preapproval to a simulator and says what a p
   );
   expect(facts).toContain("-d '<devClientUrl>'\n                  --ez EXDevMenuDisableAutoLaunch true");
   expect(facts).toMatch(/ON A SIMULATOR, before a local dev-client openurl, Stim\s+preapproves/);
-  expect(facts).toMatch(/the two together are what keep the menu off a simulator\s+entirely/);
+  expect(facts).toMatch(/those together are what keep the menu and its\s+button off a simulator entirely/);
+  expect(facts).toContain('EXDevMenuShowFloatingActionButton=false');
   expect(facts).toMatch(/ON A PHONE NONE OF THAT PREAPPROVAL APPLIES/);
   expect(facts).toMatch(/devicectl has\s+no defaults command/);
   expect(facts).toMatch(/cfprefsd serves its cached domain and rewrites\s+the file/);
-  expect(facts).toMatch(/THE FLAG DOES NOT REPLACE THAT WRITE ON A\s+PHONE/);
+  expect(facts).toMatch(/THE FLAG ALONE DOES NOT COVER A PHONE/);
   expect(facts).toMatch(/EXDevMenuShowsAtLaunch defaults to TRUE on iOS/);
   expect(facts).toMatch(/`showsAtLaunch \|\|\s+shouldShowOnboarding\(\)`/);
-  expect(facts).toMatch(/ONCE PER FRESH INSTALL/);
-  expect(facts).toMatch(/the launcher sets\s+showsAtLaunch false itself/);
+  expect(facts).toMatch(/THE LAUNCH ARGUMENTS COVER THE REST/);
+  expect(facts).toContain('-EXDevMenuShowsAtLaunch 0');
+  expect(facts).toContain('-EXDevMenuShowFloatingActionButton 0');
+  expect(facts).toMatch(/devicectl passes\s+everything after `--` to the app/);
+  expect(facts).toMatch(/reads\s+the argument domain AHEAD of the persisted one/);
+  expect(facts).toMatch(/a fresh install comes up on the\s+app, not on the menu, and with no floating button/);
+  expect(facts).toMatch(/THE FAB IS REAL ON A PHONE, and a screenshot is the only\s+way to see it/);
+  expect(facts).toMatch(/no accessibility label after the fade, so\s+`agent-device snapshot -i` stops listing it/);
+  expect(facts).toMatch(/the corner is clean at 4s and at 12s/);
+  expect(facts).toMatch(/an app started ANOTHER way -- a home-screen\s+tap/);
   expect(facts).toContain(`agent-device press 'label="Close"'`);
   expect(facts).toMatch(/survive an\s+UPGRADE install/);
 });

--- a/packages/stim-cli/src/collector/ios-device.ts
+++ b/packages/stim-cli/src/collector/ios-device.ts
@@ -7,6 +7,17 @@ import type { NdjsonRecord } from '../ndjson.ts';
 // writes alone, and React Native logs through os_log (React/Base/RCTLog.mm).
 export const CONSOLE_ENV: Record<string, string> = { OS_ACTIVITY_DT_MODE: 'enable' };
 
+// devicectl passes everything after `--` to the app, and NSUserDefaults reads
+// the argument domain ahead of the persisted one, so these turn expo-dev-menu's
+// auto-launch and floating button off for this launch without writing to the
+// phone -- which devicectl cannot do (it has no `defaults` command).
+export const DEV_MENU_LAUNCH_ARGS: readonly string[] = [
+  '-EXDevMenuShowsAtLaunch',
+  '0',
+  '-EXDevMenuShowFloatingActionButton',
+  '0',
+];
+
 // Anchored, because a message that merely quotes one of these is an app
 // logging about a crash, not a crash. Swift prints its own file:line first.
 export const FATAL_MARKERS: RegExp[] = [
@@ -84,6 +95,7 @@ export function deviceConsoleArgs({
   ];
   if (payloadUrl) args.push('--payload-url', payloadUrl);
   args.push(bundleId);
+  if (payloadUrl) args.push('--', ...DEV_MENU_LAUNCH_ARGS);
   return args;
 }
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -127,9 +127,11 @@ other line goes to stderr, so it is always safe to pipe.
                   bundle id and discovered scheme on its owned simulator. That
                   suppresses iOS's first-launch confirmation;
                   unrelated schemes remain unapproved. It also writes
-                  EXDevMenuShowsAtLaunch=false, which the flag does NOT cover,
-                  and the two together are what keep the menu off a simulator
-                  entirely, so device automation opens on the app. The
+                  EXDevMenuShowsAtLaunch=false and
+                  EXDevMenuShowFloatingActionButton=false, which the flag does
+                  NOT cover, and those together are what keep the menu and its
+                  button off a simulator entirely, so device automation opens
+                  on the app. The
                   unverified warning therefore leads with the picker, then
                   prints the openurl
                   retry. ON ANDROID the same deep link also carries the
@@ -148,20 +150,37 @@ other line goes to stderr, so it is always safe to pipe.
                   onto Library/Preferences/<bundleId>.plist with the app
                   terminated, copies successfully and then loses the seeded
                   keys, because cfprefsd serves its cached domain and rewrites
-                  the file. THE FLAG DOES NOT REPLACE THAT WRITE ON A
-                  PHONE. EXDevMenuShowsAtLaunch defaults to TRUE on iOS
+                  the file. THE FLAG ALONE DOES NOT COVER A PHONE:
+                  EXDevMenuShowsAtLaunch defaults to TRUE on iOS
                   (DevMenuPreferences.setup), and DevMenuManager arms its
                   auto-launch observer when \`showsAtLaunch ||
                   shouldShowOnboarding()\`, so finishing onboarding clears
-                  only the second half. The dev menu can therefore still open
-                  over the app ONCE PER FRESH INSTALL -- the runtime version,
-                  Close, Reload, Go home -- after which the launcher sets
-                  showsAtLaunch false itself and later launches come up clean.
+                  only the second half. THE LAUNCH ARGUMENTS COVER THE REST.
+                  The device launch ends in
+                  \`<bundleId> -- -EXDevMenuShowsAtLaunch 0
+                  -EXDevMenuShowFloatingActionButton 0\`: devicectl passes
+                  everything after \`--\` to the app, and NSUserDefaults reads
+                  the argument domain AHEAD of the persisted one, so the menu
+                  and its floating button are off for that launch and nothing
+                  is written to the phone. So a fresh install comes up on the
+                  app, not on the menu, and with no floating button.
+                  THE FAB IS REAL ON A PHONE, and a screenshot is the only
+                  way to see it: about four seconds after launch a blue gear
+                  labelled Tools appears top-right over the app, the label
+                  fades after roughly ten seconds, and the gear stays as a
+                  translucent grey circle for the life of the app. It carries
+                  no accessibility label after the fade, so
+                  \`agent-device snapshot -i\` stops listing it. Measured
+                  with the argument on: the corner is clean at 4s and at 12s.
+                  Stim's own launch is the only one that
+                  carries these: an app started ANOTHER way -- a home-screen
+                  tap, a relaunch without the arguments -- still gets the
+                  stored value, and on a fresh install that is the menu
+                  (runtime version, Close, Reload, Go home) and the button.
                   \`agent-device press 'label="Close"'\` dismisses it -- or
-                  \`snapshot -i\` and the ref. What the flag buys on a phone
-                  is the onboarding screen, not that menu. The keys it and the
-                  launcher write, and the Local Network grant, all survive an
-                  UPGRADE install. Android needs none of this: its intent
+                  \`snapshot -i\` and the ref. The onboarding key the flag
+                  writes and the Local Network grant both survive an
+                  UPGRADE install. Android needs neither mechanism: its intent
                   extra sets both preferences.
                   The phone's unverified remedy is also ROUTED, not a fixed
                   list. When this launch's device records carry the Local
@@ -865,13 +884,12 @@ LAUNCH UNVERIFIED, LOCAL NETWORK NOT GRANTED (not a code -- a routed remedy)
   retry, and stays on "Failed to load app ... The Internet connection appears
   to be offline." with a Reload button, which is why the last two lines are
   there. The text form of the press target is \`label="Reload"\` (or
-  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. ON A FRESH
-  INSTALL the Expo dev menu can be over the app first and \`snapshot -i\` shows
-  it instead: \`agent-device press 'label="Close"'\` dismisses it, then press
-  Reload. Stim's deep link finishes the launcher's ONBOARDING, but not
-  EXDevMenuShowsAtLaunch, which defaults true on iOS and which Stim cannot
-  write on a phone -- so the menu opens that once and the launcher clears the
-  key itself. See \`guide facts\`, under \`launched\`.
+  \`text="Reload"\`); a bare \`press "Reload"\` is rejected. Stim's own launch
+  ends in \`-- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0\`,
+  so the Expo dev menu is not over the app, fresh install or not. An app started
+  ANOTHER way does not carry those arguments and \`snapshot -i\` can show the
+  menu instead: \`agent-device press 'label="Close"'\` dismisses it, then press
+  Reload. See \`guide facts\`, under \`launched\`.
 
   A BARE APP (no expo-dev-client) gets the same first two commands and a
   different third. The prompt fires the same way, because it is fired by any
@@ -889,8 +907,10 @@ LAUNCH UNVERIFIED, LOCAL NETWORK NOT GRANTED (not a code -- a routed remedy)
 
   Without agent-device,
   \`xcrun devicectl device process launch --device <udid> --terminate-existing
-  [--payload-url '<devClientUrl>'] <bundleId>\` also recovers, and it costs the
-  device log: it replaces the process the collector follows, so
+  [--payload-url '<devClientUrl>'] <bundleId>
+  [-- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0]\`
+  also recovers, and it costs the device log:
+  it replaces the process the collector follows, so
   \`stim logs --source device\` stops for the rest of that run. For a dev
   client, pressing Reload is cheaper and keeps the collector alive. For a bare
   app the relaunch is the cleanest recovery, because it re-reads ip.txt. By
@@ -1760,8 +1780,10 @@ THE POOL: WHICH DEVICE AN ID-LESS \`--device\` PICKS
   the host and USB carries no reverse forward. Stim picks a non-internal IPv4
   address (en0 first, RN's own order from react-native-xcode.sh), gates it as
   this workspace's Metro, and then wires the app to it: an expo-dev-client app
-  through the deep link, passed to devicectl as \`--payload-url\`, and a bare
-  app by writing \`<addr>:<port>\` into the app bundle's ip.txt --
+  through the deep link, passed to devicectl as \`--payload-url\` and followed
+  by \`-- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0\`,
+  which is how a phone gets what a simulator gets from a defaults write, and a
+  bare app by writing \`<addr>:<port>\` into the app bundle's ip.txt --
   RCTBundleURLProvider's own mechanism, which honours a colon-bearing value
   verbatim and never consults the compiled RCT_METRO_PORT. Stim never sets
   that define: it would put the reserved port into a compiled input and fork

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
+import { DEV_MENU_LAUNCH_ARGS } from '../collector/ios-device.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -11,7 +12,7 @@ export const DEFAULT_METRO_PORT = 8081;
 
 const IOS_SCHEME_APPROVAL_DOMAIN = 'com.apple.launchservices.schemeapproval';
 const IOS_SCHEME_APPROVAL_OPENER = 'com.apple.CoreSimulator.CoreSimulatorBridge';
-const IOS_DEV_MENU_SHOWS_AT_LAUNCH_KEY = 'EXDevMenuShowsAtLaunch';
+const IOS_DEV_MENU_OFF_KEYS = ['EXDevMenuShowsAtLaunch', 'EXDevMenuShowFloatingActionButton'];
 const DEV_CLIENT_ONBOARDING_QUERY = 'disableOnboarding=1';
 const ANDROID_DISABLE_AUTO_LAUNCH_EXTRA = 'EXDevMenuDisableAutoLaunch';
 
@@ -84,17 +85,9 @@ export function installIosApp(
   }
   if (bundleId && devClientScheme) {
     try {
-      e.runFile('xcrun', [
-        'simctl',
-        'spawn',
-        udid,
-        'defaults',
-        'write',
-        bundleId,
-        IOS_DEV_MENU_SHOWS_AT_LAUNCH_KEY,
-        '-bool',
-        'false',
-      ]);
+      for (const key of IOS_DEV_MENU_OFF_KEYS) {
+        e.runFile('xcrun', ['simctl', 'spawn', udid, 'defaults', 'write', bundleId, key, '-bool', 'false']);
+      }
       for (const key of iosSchemeApprovalKeys(bundleId, devClientScheme)) {
         e.runFile('xcrun', [
           'simctl',
@@ -988,7 +981,8 @@ export function unverifiedLaunchLines({
     const relaunch =
       `xcrun devicectl device process launch --device ${udid} --terminate-existing ` +
       (url ? `--payload-url '${url}' ` : '') +
-      bundleId;
+      bundleId +
+      (url ? ` -- ${DEV_MENU_LAUNCH_ARGS.join(' ')}` : '');
     if (localNetwork) {
       push(
         `See the prompt: agent-device alert get --platform ios --udid ${udid}. It reads the alert without opening ` +
@@ -1006,10 +1000,10 @@ export function unverifiedLaunchLines({
         push(
           'The app does NOT retry after the grant -- it stays on "Failed to load app ... The Internet connection ' +
             `appears to be offline." with a Reload button. Press it: agent-device snapshot -i --platform ios --udid ${udid}, ` +
-            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. On a fresh install the Expo dev ` +
-            `menu can be over the app first -- the deep link finishes the launcher's onboarding, not ` +
-            `EXDevMenuShowsAtLaunch, which defaults true on iOS -- so agent-device press 'label="Close"' ` +
-            `--platform ios --udid ${udid} dismisses it.`,
+            `then agent-device press 'label="Reload"' --platform ios --udid ${udid}. This launch carried ` +
+            `-EXDevMenuShowsAtLaunch 0, so the Expo dev menu is not over the app; if the app was started another ` +
+            `way and the menu is on screen, agent-device press 'label="Close"' --platform ios --udid ${udid} ` +
+            'dismisses it.',
         );
         push(
           `Without agent-device, relaunching also recovers: ${relaunch}. It costs the device log -- it replaces the ` +
@@ -1065,7 +1059,7 @@ export function unverifiedLaunchLines({
       if (url && udid) {
         push(
           `Retry the deep link: xcrun devicectl device process launch --device ${udid} --terminate-existing ` +
-            `--payload-url '${url}' ${bundleId}`,
+            `--payload-url '${url}' ${bundleId} -- ${DEV_MENU_LAUNCH_ARGS.join(' ')}`,
         );
       }
     } else {


### PR DESCRIPTION
## Description

#241 closed the dev-menu onboarding on a phone with `disableOnboarding=1`, and
its review found the remaining half: `EXDevMenuShowsAtLaunch` registers a
default of `true` on iOS, and `DevMenuManager.updateAutoLaunchObserver` arms
auto-launch on `showsAtLaunch || shouldShowOnboarding()`, so a fresh install
still opened the plain menu once. Nothing on the Mac could fix it -- devicectl
has no `defaults` command, and a copied preferences plist loses its keys to
cfprefsd.

There is a third channel, measured on the phone (see #240): **devicectl passes
everything after `--` to the app, and NSUserDefaults reads the argument domain
ahead of the persisted one.** A launch ending in `-- -EXDevMenuShowsAtLaunch 1`
opened the menu on a phone whose stored value was `false`, and the stored value
stayed `false` afterwards. That is the phone-side equivalent of the simulator's
defaults write, with no persistent write at all.

The floating action button is the same story. `EXDevMenuShowFloatingActionButton`
also defaults `true`, `DevMenuManager.updateFABVisibility` gates only on that
preference plus "app running" and "menu not visible", and there is no URL
parameter or intent extra for it in either launcher.

## Solution

The collector's devicectl launch -- which *is* the launch on a phone -- now ends
in `<bundleId> -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0`
whenever it carries a `--payload-url`. Gating on the payload URL keeps the
arguments off a Release device launch, which has no dev menu to suppress.

The simulator keeps its `simctl spawn defaults write` (a `simctl openurl`
carries no argv to replace it) and gains `EXDevMenuShowFloatingActionButton
-bool false` beside the existing `EXDevMenuShowsAtLaunch` write.

The two remedy strings that print the devicectl relaunch carry the arguments
too, so a pasted recovery command behaves like stim's own launch. They share
the exported `DEV_MENU_LAUNCH_ARGS` with the argv builder rather than
re-spelling it, which is what keeps them from drifting.

`guide facts` and `guide errors` change again: the menu no longer opens on a
fresh install because the launch carries the arguments, and `Close` becomes the
fallback for an app started some other way (a home-screen tap, a relaunch
without them). The cfprefsd sentence stays -- it is still why a plist copy is
not an option. `docs/field-test-protocol.md` never described the dev menu, so
there was nothing to correct there.

## Test plan

**Hardware, Old iPhone `00008101-000A10913C89001E`, Metro on 8082.** This
branch's built CLI, then the positive control the issue asks for.

The run verifies:

```
$ node packages/stim-cli/dist/cli.mjs ios --device --json
  launch      com.appandflow.trailhead pid 1051 on the phone, opened on the dev-client URL (1.4s)
  verify      bundle loaded, process alive, stable for 3s (2.7s total)
  "launched": true
```

and the argv it actually launched with, read off the live collector process:

```
devicectl device process launch --quiet --device 00008101-... --console --terminate-existing
  --environment-variables {"OS_ACTIVITY_DT_MODE":"enable"}
  --payload-url com.appandflow.trailhead://expo-development-client/?url=http%3A%2F%2F10.0.0.188%3A8082%2F%3FdisableOnboarding%3D1
  com.appandflow.trailhead -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0
```

**Positive control** -- same command, same already-installed app, only the value
flipped to `1`:

```
$ xcrun devicectl device process launch --device 00008101-... --terminate-existing \
    --payload-url '<the url above>' com.appandflow.trailhead -- -EXDevMenuShowsAtLaunch 1
Launched application with com.appandflow.trailhead bundle identifier.

$ agent-device snapshot -i --platform ios --udid 00008101-...
@e3 [text] "Runtime version: exposdk:57.0.0"
@e4 [button] "Close"
@e7 [button] "Reload"
@e8 [button] "Go home"
@e9 [text] "TOOLS"
```

The menu opened although the phone's stored `EXDevMenuShowsAtLaunch` is `false`
-- so the argument, not the stored value, decided it. Relaunching with `0`
(stim's own arguments) put the app back on its own screen with no menu:

```
@e1 [application] "Trailhead"   @e3 [other] "Trails"   @e4 [text-field] "Search trails"
```

**What is inferred, not observed by me.** The FAB itself: the maintainer's
screenshots on this phone show a blue `Tools` gear top-right about 4s after
launch, fading to a translucent grey circle that carries no accessibility label
-- which is why `snapshot -i` never lists it and why only a screenshot sees it
-- and a clean corner at 4s and 12s with
`-EXDevMenuShowFloatingActionButton 0`. I did not re-shoot those. The simulator
half of the FAB change is inferred rather than observed: I did not boot a
simulator, and the inference is that `updateFABVisibility` gates only on the
preference, the app running, and the menu not being visible, with no
simulator/device branch in that code path.

The changed argv is exercised end to end by
`collector-run.test.ts`, which spawns the real collector against a fake
`devicectl` whose shim rejects any argv but the expected one -- it caught this
change before the hardware run did. `deviceConsoleArgs` (with and without a
payload URL), the simulator write, and the two remedy strings are pinned by unit
tests, as is the `guide` contract.

Fixes #240
