### PR TITLE
fix: claim an emulator console port under the config lock before boot

### DIFF
--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -13,6 +13,7 @@ import {
   upsertProject,
   removeProject,
   setDevice,
+  releaseAndroidConsolePort,
   clearDevice,
   allMetroPorts,
   allConsolePortsAndSerials,
@@ -241,6 +242,23 @@ test('allConsolePortsAndSerials collects physical serials (no avdName)', () => {
   setDevice(a, 'android', { serial: 'R5CR70XXXXX' });
   const result = allConsolePortsAndSerials();
   expect(result.androidPhysicalSerials).toEqual(['R5CR70XXXXX']);
+});
+
+test('releaseAndroidConsolePort frees the claimed port and keeps the AVD recorded for gc', () => {
+  const a = liveProjectDir('a');
+  upsertProject(a, { bundleId: 'com.a', androidPackage: 'com.a', isExpo: false });
+  setDevice(a, 'android', { avdName: 'stim-a', consolePort: 5554, owned: true, deviceName: 'stim-a' });
+  expect(releaseAndroidConsolePort(a, 5554)).toBe(true);
+  expect(getProject(a)?.platforms?.android).toEqual({ avdName: 'stim-a', owned: true, deviceName: 'stim-a' });
+  expect(allConsolePortsAndSerials().androidConsolePorts).toEqual([]);
+});
+
+test('releaseAndroidConsolePort leaves a port the record no longer holds', () => {
+  const a = liveProjectDir('a');
+  upsertProject(a, { bundleId: 'com.a', androidPackage: 'com.a', isExpo: false });
+  setDevice(a, 'android', { avdName: 'stim-a', consolePort: 5556, owned: true });
+  expect(releaseAndroidConsolePort(a, 5554)).toBe(false);
+  expect(getProject(a)?.platforms?.android?.consolePort).toBe(5556);
 });
 
 test('removeProject deletes entry', () => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -2,8 +2,15 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import assert from 'node:assert';
-import { deviceCapacityRefusal, deviceTypeMismatch, ensureBooted, ensureOwnedDevice } from '../engine/device.ts';
-import { getProject, setDevice, upsertProject } from '../config.ts';
+import {
+  claimAndroidConsolePort,
+  deviceCapacityRefusal,
+  deviceTypeMismatch,
+  ensureBooted,
+  ensureOwnedDevice,
+} from '../engine/device.ts';
+import { allConsolePortsAndSerials, getProject, setDevice, upsertProject } from '../config.ts';
+import type { DeviceRecord } from '../types.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { makeAdbDevices, makeConfig, makeIosSim } from './_factories.ts';
 
@@ -706,11 +713,17 @@ describe('ensureOwnedDevice: android', () => {
     createAvdError = null,
     writeAvdFiles = true,
     beforeCreateAvdError = () => {},
+    bootCompletes = true,
+    runningAvdName = '',
+    onSpawn = () => {},
   }: {
     avds?: string[];
     createAvdError?: string | null;
     writeAvdFiles?: boolean;
     beforeCreateAvdError?: () => void;
+    bootCompletes?: boolean;
+    runningAvdName?: string;
+    onSpawn?: () => void;
   } = {}) {
     const run: string[] = [];
     const spawn: { cmd: string; args: readonly string[]; opts?: object }[] = [];
@@ -740,8 +753,8 @@ describe('ensureOwnedDevice: android', () => {
           }
           if (/delete avd/.test(cmd)) return '';
           if (cmd === 'adb devices') return 'List of devices attached\n';
-          if (/emu avd name/.test(cmd)) return '';
-          if (/getprop sys\.boot_completed/.test(cmd)) return '1';
+          if (/emu avd name/.test(cmd)) return runningAvdName;
+          if (/getprop sys\.boot_completed/.test(cmd)) return bootCompletes ? '1' : '';
           if (/getprop /.test(cmd)) return '';
           throw new Error(`unexpected run: ${cmd}`);
         },
@@ -756,6 +769,7 @@ describe('ensureOwnedDevice: android', () => {
           return '';
         },
         spawn(cmd: string, args: readonly string[], opts?: object) {
+          onSpawn();
           spawn.push({ cmd, args, opts });
           return { pid: 9999, unref() {} };
         },
@@ -1009,6 +1023,128 @@ describe('ensureOwnedDevice: android', () => {
       rmSync(other, { recursive: true, force: true });
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  test('the console port is recorded before the emulator process is spawned', async () => {
+    const root = projectDir();
+    try {
+      let recordedAtSpawn: DeviceRecord | undefined;
+      const { spawn, exec } = androidExecutor({
+        onSpawn: () => {
+          recordedAtSpawn = getProject(root)?.platforms?.android;
+        },
+      });
+      setExecutor(exec);
+      const result = await ensureOwnedDevice({
+        platform: 'android',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(result.consolePort).toBe(5554);
+      expect(recordedAtSpawn).toMatchObject({ avdName: 'stim-app', consolePort: 5554, owned: true });
+      expect(spawn[0]?.args).toContain('5554');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a failed boot releases the port claim and keeps the owned AVD recorded for gc', async () => {
+    const root = projectDir();
+    try {
+      const { exec } = androidExecutor({ bootCompletes: false });
+      setExecutor(exec);
+      await expect(
+        ensureOwnedDevice({
+          platform: 'android',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+          alive: () => false,
+        }),
+      ).rejects.toThrow(/exited before the device finished booting/);
+      const record = getProject(root)?.platforms?.android;
+      expect(record).toMatchObject({ avdName: 'stim-app', owned: true });
+      expect(record?.consolePort).toBeUndefined();
+      expect(allConsolePortsAndSerials().androidConsolePorts).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('an emulator that booted another AVD on the claimed serial is refused and the claim released', async () => {
+    const root = projectDir();
+    try {
+      const { exec } = androidExecutor({ runningAvdName: 'Pixel_7_API_35\nOK' });
+      setExecutor(exec);
+      await expect(
+        ensureOwnedDevice({
+          platform: 'android',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+        }),
+      ).rejects.toThrow(/emulator-5554 is running AVD Pixel_7_API_35, not this workspace's owned AVD stim-app/);
+      expect(getProject(root)?.platforms?.android?.consolePort).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('claimAndroidConsolePort', () => {
+  function fakeRegistry() {
+    const ports = new Map<string, number>();
+    let depth = 0;
+    const seenDepths: number[] = [];
+    return {
+      ports,
+      seenDepths,
+      lock: <T>(fn: () => T): T => {
+        expect(depth).toBe(0);
+        depth += 1;
+        try {
+          return fn();
+        } finally {
+          depth -= 1;
+        }
+      },
+      recordedPorts: () => {
+        seenDepths.push(depth);
+        return [...ports.values()];
+      },
+      record: (projectPath: string, _platform: string, fields: DeviceRecord) => {
+        seenDepths.push(depth);
+        ports.set(projectPath, fields.consolePort as number);
+      },
+    };
+  }
+
+  test('two workspaces claiming at once take distinct ports because the read and the record share one lock', () => {
+    const registry = fakeRegistry();
+    const deps = { lock: registry.lock, recordedPorts: registry.recordedPorts, record: registry.record };
+    const first = claimAndroidConsolePort({ projectPath: '/w/a', avdName: 'stim-a' }, deps);
+    const second = claimAndroidConsolePort({ projectPath: '/w/b', avdName: 'stim-b' }, deps);
+    expect(first.consolePort).toBe(5554);
+    expect(second.consolePort).toBe(5556);
+    expect([...registry.ports]).toEqual([
+      ['/w/a', 5554],
+      ['/w/b', 5556],
+    ]);
+    expect(registry.seenDepths).toEqual([1, 1, 1, 1]);
+  });
+
+  test('live emulator ports outside the registry are claimed too', () => {
+    const registry = fakeRegistry();
+    const claim = claimAndroidConsolePort(
+      { projectPath: '/w/a', avdName: 'stim-a', deviceName: 'stim-a', livePorts: [5554, 5556] },
+      { lock: registry.lock, recordedPorts: registry.recordedPorts, record: registry.record },
+    );
+    expect(claim.consolePort).toBe(5558);
+    expect(registry.ports.get('/w/a')).toBe(5558);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -14,6 +14,14 @@ test('every advertised topic renders non-empty content', () => {
   }
 });
 
+test('the facts topic pins how an owned emulator gets its console port', () => {
+  const body = renderTopic('facts');
+  assert(body);
+  expect(body).toMatch(/CHOSEN AND RECORDED under the global config lock\s+BEFORE the emulator starts/);
+  expect(body).toMatch(/passed to it as `-port`/);
+  expect(body).toMatch(/A boot that fails releases the port again and\s+keeps the AVD recorded for `gc`/);
+});
+
 test('an unknown topic renders nothing rather than throwing', () => {
   expect(renderTopic('nope')).toBe(null);
 });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -210,7 +210,12 @@ other line goes to stderr, so it is always safe to pipe.
   avdName         the AVD's NAME (stim-<label>). The serial is a slot --
                   emulator-5554 is whatever booted into that console port
                   first -- so this is what addresses the emulator in
-                  \`emulator -avd\`, avdmanager, or a device tool
+                  \`emulator -avd\`, avdmanager, or a device tool. The console
+                  port is CHOSEN AND RECORDED under the global config lock
+                  BEFORE the emulator starts, then passed to it as \`-port\`,
+                  so two workspaces booting at the same moment cannot land on
+                  one serial. A boot that fails releases the port again and
+                  keeps the AVD recorded for \`gc\`
   deviceName      the same name, matching the iOS payload's field
   fingerprint / cacheKey / cacheHit / cacheSkipped / waitedForBuild /
   appPath / installSkipped / launched

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -143,11 +143,11 @@ export function setDevice(projectPath: string, platform: string, deviceFields: D
   });
 }
 
-export function releaseAndroidConsolePort(projectPath: string): boolean {
+export function releaseAndroidConsolePort(projectPath: string, consolePort: number): boolean {
   return withConfigLock(() => {
     const cfg = loadConfig();
     const android = cfg?.projects?.[projectPath]?.platforms?.android;
-    if (!cfg || !android || typeof android.consolePort !== 'number') return false;
+    if (!cfg || !android || android.consolePort !== consolePort) return false;
     delete android.consolePort;
     saveConfig(cfg);
     return true;

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -143,6 +143,17 @@ export function setDevice(projectPath: string, platform: string, deviceFields: D
   });
 }
 
+export function releaseAndroidConsolePort(projectPath: string): boolean {
+  return withConfigLock(() => {
+    const cfg = loadConfig();
+    const android = cfg?.projects?.[projectPath]?.platforms?.android;
+    if (!cfg || !android || typeof android.consolePort !== 'number') return false;
+    delete android.consolePort;
+    saveConfig(cfg);
+    return true;
+  });
+}
+
 export function clearDevice(projectPath: string, platform: string): void {
   withConfigLock(() => {
     const cfg = loadConfig();

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -3,7 +3,9 @@ import {
   allConsolePortsAndSerials,
   clearDevice,
   loadConfig,
+  releaseAndroidConsolePort,
   setDevice,
+  withConfigLock,
   type Config,
   type ProjectRecord,
 } from '../config.ts';
@@ -20,6 +22,7 @@ import {
   bootAndroidEmulator,
   configureNewOwnedAvd,
   createOwnedAvd,
+  getAvdNameForSerial,
   listAdbDevices,
   listAvds,
   nextConsolePort,
@@ -445,6 +448,52 @@ async function ensureOwnedAndroidDevice({
   });
 }
 
+export interface AndroidConsolePortClaim {
+  avdName: string;
+  consolePort: number;
+  owned: true;
+  deviceName: string;
+  [key: string]: unknown;
+}
+
+export function claimAndroidConsolePort(
+  {
+    projectPath,
+    avdName,
+    deviceName,
+    livePorts = [],
+  }: { projectPath: string; avdName: string; deviceName?: string; livePorts?: number[] },
+  {
+    lock = withConfigLock,
+    recordedPorts = () => allConsolePortsAndSerials().androidConsolePorts,
+    record = setDevice,
+  }: {
+    lock?: <T>(fn: () => T) => T;
+    recordedPorts?: () => number[];
+    record?: typeof setDevice;
+  } = {},
+): AndroidConsolePortClaim {
+  return lock(() => {
+    const consolePort = nextConsolePort([...recordedPorts(), ...livePorts]);
+    const claim: AndroidConsolePortClaim = {
+      avdName,
+      consolePort,
+      owned: true,
+      deviceName: deviceName ?? avdName,
+    };
+    record(projectPath, 'android', claim);
+    return claim;
+  });
+}
+
+function liveAndroidConsolePorts(): number[] {
+  const adbLive = listAdbDevices();
+  return [
+    ...adbLive.emulators.map((e) => e.consolePort),
+    ...adbLive.unhealthy.map((u) => u.consolePort).filter((p): p is number => p != null),
+  ];
+}
+
 async function bootOwnedAvdOnFreshPort({
   avdName,
   projectPath,
@@ -458,25 +507,33 @@ async function bootOwnedAvdOnFreshPort({
   deviceName?: string;
   out: Notify;
 } & EmulatorLogging): Promise<OwnedDeviceRecord> {
-  const adbLive = listAdbDevices();
-  const livePorts: number[] = [
-    ...adbLive.emulators.map((e) => e.consolePort),
-    ...adbLive.unhealthy.map((u) => u.consolePort).filter((p): p is number => p != null),
-  ];
-  const claimedPorts = [...allConsolePortsAndSerials().androidConsolePorts, ...livePorts];
-  const consolePort = nextConsolePort(claimedPorts);
-  const newRecord = { avdName, consolePort, owned: true, deviceName: deviceName ?? avdName };
-  setDevice(projectPath, 'android', newRecord);
-  const pid = bootAndroidEmulator(avdName, consolePort, { logFile });
-  const serial = `emulator-${consolePort}`;
-  out(chalk.dim(`Waiting for ${serial} to finish booting...`));
-  const result = await waitForBoot(serial, 120000, { aborted: emulatorGone(pid, alive) });
-  if (!result.ok) {
-    throw new Error(
-      `${bootFailurePrefix(serial, result.exited, 120000)} Diagnostic: ${JSON.stringify(result.diagnostic)}`,
-    );
+  const claim = claimAndroidConsolePort({
+    projectPath,
+    avdName,
+    deviceName,
+    livePorts: liveAndroidConsolePorts(),
+  });
+  const serial = `emulator-${claim.consolePort}`;
+  try {
+    const pid = bootAndroidEmulator(avdName, claim.consolePort, { logFile });
+    out(chalk.dim(`Waiting for ${serial} to finish booting...`));
+    const result = await waitForBoot(serial, 120000, { aborted: emulatorGone(pid, alive) });
+    if (!result.ok) {
+      throw new Error(
+        `${bootFailurePrefix(serial, result.exited, 120000)} Diagnostic: ${JSON.stringify(result.diagnostic)}`,
+      );
+    }
+    const running = getAvdNameForSerial(serial);
+    if (running && running !== avdName) {
+      throw new Error(
+        `${serial} is running AVD ${running}, not this workspace's owned AVD ${avdName}; refusing to use it.`,
+      );
+    }
+    return { ...claim, serial };
+  } catch (error) {
+    releaseAndroidConsolePort(projectPath);
+    throw error;
   }
-  return { ...newRecord, serial };
 }
 
 function emulatorGone(pid: number | null, alive: Liveness): () => boolean {
@@ -769,11 +826,7 @@ async function ensureAndroidBooted({
 }
 
 function pickConsolePort(recorded: number | undefined) {
-  const adb = listAdbDevices();
-  const live: number[] = [
-    ...adb.emulators.map((e) => e.consolePort),
-    ...adb.unhealthy.map((u) => u.consolePort).filter((p): p is number => p != null),
-  ];
+  const live = liveAndroidConsolePorts();
   if (recorded && !live.includes(Number(recorded))) return Number(recorded);
   return nextConsolePort([...allConsolePortsAndSerials().androidConsolePorts, ...live]);
 }

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -531,7 +531,7 @@ async function bootOwnedAvdOnFreshPort({
     }
     return { ...claim, serial };
   } catch (error) {
-    releaseAndroidConsolePort(projectPath);
+    releaseAndroidConsolePort(projectPath, claim.consolePort);
     throw error;
   }
 }

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -676,7 +676,7 @@ export function shutdownAndroidEmulator(serial: string): void {
   getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} emu kill`);
 }
 
-function getAvdNameForSerial(serial: string): string | null {
+export function getAvdNameForSerial(serial: string): string | null {
   const out = getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} emu avd name`);
   if (!out) return null;
   return out.split('\n')[0]?.trim() || null;


### PR DESCRIPTION
## Description

Two workspaces booting an owned emulator in the same second both printed
`Waiting for emulator-5558 to finish booting...`. `-port` was already explicit
and `nextConsolePort` already correct; the claim was not atomic.
`bootOwnedAvdOnFreshPort` read the claimed ports unlocked and only then called
`setDevice`, which takes the global config lock for its own write, so two
processes interleave read / read / write / write and land on one port. Evidence
is the rc.8 QA gate on 4d432f4, `qa-caches-expo-android.log` lines 332-335;
sequential boots in the same run got 5554 and 5556, which is why this only
shows up under the cache suite's single-flight leg.

## Solution

Three changes on the owned-emulator boot path.

- **Claim under the lock.** `claimAndroidConsolePort` takes the global config
  lock, derives the claimed set inside it (device records, plus the live
  `adb devices` console ports gathered just before the lock), picks the next
  port, and records `{ avdName, consolePort, owned, deviceName }` before
  returning. The emulator starts only after that record exists, so a second
  workspace sees the port taken. Deriving from the records is what makes a
  crashed boot count as claimed: the record outlives the process.
- **Release the claim on a failed boot,** or the port leaks until teardown.
  Spawn / wait / verify are now one `try`, and any failure calls
  `releaseAndroidConsolePort(projectPath, claim.consolePort)`. That is a
  compare-and-delete: it clears `consolePort` only while the record still holds
  the port this boot claimed, so a slow failing boot cannot release a newer
  claim the same workspace has since made. It leaves `avdName` and `owned: true`
  alone either way -- the AVD stays visible to `gc`, per invariant 2's "keep a
  device record when teardown fails". A port held by an emulator that is alive
  but wedged is still excluded, because the live set includes `adb`'s unhealthy
  entries.
- **Verify the serial really runs this AVD.** After boot the run checks
  `adb -s <serial> emu avd name` and refuses a serial running someone else's
  AVD. Not a new tool call: `getAvdNameForSerial` already existed for
  `resolveOwnedAvdSerial` and is only exported here. It is lenient on purpose --
  an empty or unreadable answer is not a mismatch, so a slow console cannot fail
  a good boot. No distinct error code, because `commands/android.ts` wraps
  everything `ensureDevice` throws into `STIM_NO_DEVICE`; the refusal surfaces
  there with a message naming both AVDs.

Blast radius is the owned-emulator boot path only; iOS and `--device` runs are
untouched.

**Not covered.** `pickConsolePort`, on the `ensureBooted` reboot path, still
picks a port without recording it. Claiming there needs a `projectPath` threaded
through `ensureBooted`, the window is much narrower (recorded port taken by a
foreign emulator), and it is not the path in the issue evidence -- so I left it
rather than widen the branch.

**Not verified on hardware.** No emulator was booted and no AVD created for this
change: a release QA suite owns this machine's devices. Every `adb`/`emulator`
argument list in the diff already shipped, so invariant 9's real-tool check here
is the cache suite's single-flight leg -- the race this fixes -- after the
release gate.

## Test plan

The evidence is `engine-device.test.ts`:

- `claimAndroidConsolePort` > two workspaces claiming at once take distinct
  ports. Fake registry, injected lock that asserts non-overlap; the test pins
  that both the read (`recordedPorts`) and the write (`record`) happen at lock
  depth 1. On the old shape those depths are `[0, 1, 0, 1]`, which is the bug.
- A failed boot releases the port claim and keeps the owned AVD recorded for
  `gc`. Confirmed to fail without the fix: with the `catch` removed the record
  still carries `consolePort: 5554`.
- The console port is recorded before the emulator process is spawned -- reads
  the registry from inside the fake `spawn`.
- An emulator that booted another AVD on the claimed serial is refused and the
  claim released.
- `guide.test.ts` pins the updated `facts` sentence on how the port is chosen.

And in `config.test.ts`: `releaseAndroidConsolePort` frees the claimed port while
keeping the AVD recorded for `gc`, and leaves a port the record no longer holds
(record on 5556, `release(a, 5554)` returns false and 5556 survives). Also
confirmed to fail without the comparison.

Full local run on this branch: `pnpm run format:check`, `lint`, `build`,
`typecheck`, `pnpm test`, `pnpm run knip`. The suite is 82 files / 3179 tests; under three
concurrent native builds one run had three unrelated load failures
(`engine-build-lock` real-process race, plus 5s timeouts in `engine-xcode` and
`worktree`), and all three passed on a single rerun.

Fixes #243
