### PR TITLE
fix: stop, status, and doctor print --json on one line

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import {
   checkBuildCacheProvider,
   checkCompilationCache,
@@ -20,6 +21,7 @@ import {
   parseXcodeMajor,
   checkConcurrency,
 } from '../doctor.ts';
+import doctorCommand from '../commands/doctor.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import type { EasAuthResult } from '../engine/remote-cache.ts';
 import assert from 'node:assert';
@@ -943,4 +945,34 @@ test.each([
   } finally {
     rmSync(project, { recursive: true, force: true });
   }
+});
+
+test('doctor --json prints exactly one line of JSON on stdout', async () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-'));
+  const home = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-home-'));
+  process.env.STIM_HOME = home;
+  const cwd = process.cwd();
+  const logs: string[] = [];
+  const originalLog = console.log;
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
+  const program = new Command();
+  doctorCommand(program);
+  console.log = (msg) => logs.push(String(msg));
+  process.chdir(project);
+  try {
+    await program.parseAsync(['node', 'stim', 'doctor', '--json']);
+  } finally {
+    process.chdir(cwd);
+    console.log = originalLog;
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+  expect(logs.length).toBe(1);
+  const [line] = logs;
+  assert(line);
+  expect(line).not.toContain('\n');
+  const payload = JSON.parse(line);
+  expect(Array.isArray(payload.findings)).toBe(true);
+  expect(typeof payload.project).toBe('string');
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -73,6 +73,31 @@ test('the facts topic documents the fields each --json payload actually carries'
   }
 });
 
+test('the one-line JSON sentence names every command whose --json payload is a single line', () => {
+  const body = renderTopic('facts');
+  assert(body);
+  const singleLineJsonCommands = ['start', 'ios', 'android', 'stop', 'status', 'doctor'];
+  const files: Record<string, string> = {
+    start: 'start.ts',
+    ios: 'ios.ts',
+    android: 'android.ts',
+    stop: 'stop.ts',
+    status: 'status.ts',
+    doctor: 'doctor.ts',
+    device: 'device.ts',
+  };
+  for (const [, file] of Object.entries(files)) {
+    const src = readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8');
+    expect(src).toMatch(/--json/);
+    expect(src).not.toMatch(/JSON\.stringify\([^)]*,\s*null\s*,\s*2\s*\)/);
+    expect(src).not.toMatch(/JSON\.stringify\(\s*\n/);
+  }
+  for (const command of singleLineJsonCommands) expect(body.includes(`\`${command}\``)).toBeTruthy();
+  expect(body).toMatch(/device lock.*device unlock/s);
+  expect(body).toMatch(/exactly ONE line of JSON/);
+  expect(body).toMatch(/logs --json[^.]*NDJSON/);
+});
+
 test('the flags the guide advertises are the flags the commands define', () => {
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -169,7 +169,11 @@ async function runStatusJson() {
   } finally {
     console.log = originalLog;
   }
-  return JSON.parse(logs.join('\n'));
+  expect(logs.length).toBe(1);
+  const [line] = logs;
+  assert(line);
+  expect(line).not.toContain('\n');
+  return JSON.parse(line);
 }
 
 function writeLogs(root: string, records: NdjsonRecord[]) {

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -3,10 +3,11 @@ import { spawn } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { Command } from 'commander';
 import { saveConfig, getProject } from '../config.ts';
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { ensureWorkspaceStorage, supervisorPidFile, workspaceStateFile } from '../paths.ts';
-import {
+import stopCommand, {
   clearCollectorState,
   clearSupervisorState,
   readCollectorState,
@@ -1153,4 +1154,28 @@ test('stop says nothing about leases when this workspace holds none', async () =
   const r = await runStop({ root: tmpRoot, project: null, state: null, collectors: {}, report: () => {} });
   expect(r.outcomes.releasedLeases).toEqual([]);
   expect(r.summary).not.toMatch(/lease/);
+});
+
+test('stop --json prints exactly one line of JSON on stdout', async () => {
+  writeFileSync(join(tmpRoot, 'package.json'), JSON.stringify({ name: 'app' }));
+  const cwd = process.cwd();
+  const logs: string[] = [];
+  const originalLog = console.log;
+  const program = new Command();
+  stopCommand(program);
+  console.log = (msg) => logs.push(String(msg));
+  process.chdir(tmpRoot);
+  try {
+    await program.parseAsync(['node', 'stim', 'stop', '--json']);
+  } finally {
+    process.chdir(cwd);
+    console.log = originalLog;
+  }
+  expect(logs.length).toBe(1);
+  const [line] = logs;
+  assert(line);
+  expect(line).not.toContain('\n');
+  const payload = JSON.parse(line);
+  expect(typeof payload.root).toBe('string');
+  expect(typeof payload.ok).toBe('boolean');
 });

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -98,7 +98,7 @@ export default function doctorCommand(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify({ project: root, findings }, null, 2));
+        console.log(JSON.stringify({ project: root, findings }));
         return;
       }
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -9,11 +9,15 @@ interface GuideTopic {
 
 const TOPICS: Record<string, GuideTopic> = {
   facts: {
-    summary: 'The --json payloads: `start`, `ios`, `android`, and the error contract',
+    summary:
+      'The --json payloads: `start`, `ios`, `android`, `stop`, `status`, `doctor`, `device lock`/`unlock`, and the error contract',
     body: () => `FACTS CONTRACT
 
-Every command with \`--json\` prints exactly ONE line of JSON on stdout. Every
-other line goes to stderr, so it is always safe to pipe.
+\`start\`, \`ios\`, \`android\`, \`stop\`, \`status\`, \`doctor\`, and
+\`device lock\`/\`device unlock\` each print exactly ONE line of JSON on
+stdout for \`--json\`. Every other line goes to stderr, so it is always safe
+to pipe. \`logs --json\` is the one exception: it is NDJSON, one record per
+line by design (see \`guide logs\`), not this single-payload contract.
 
   stim start --json
 

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -103,17 +103,13 @@ export default function statusCommand(program: Command): void {
 
       if (opts.json) {
         console.log(
-          JSON.stringify(
-            {
-              environments: states.map((state, i) => (labelOnlyRoots[i] ? { ...state, labelOnly: true } : state)),
-              capacity: cap,
-              deviceLeases: leases,
-              unprovisionedWorktrees: orphanWorktrees,
-              simctlAvailable: simsAvailable,
-            },
-            null,
-            2,
-          ),
+          JSON.stringify({
+            environments: states.map((state, i) => (labelOnlyRoots[i] ? { ...state, labelOnly: true } : state)),
+            capacity: cap,
+            deviceLeases: leases,
+            unprovisionedWorktrees: orphanWorktrees,
+            simctlAvailable: simsAvailable,
+          }),
         );
         return;
       }

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -781,7 +781,7 @@ export default function stopCommand(program: Command): void {
       const { ok, outcomes, summary } = await runStop({ root, force: Boolean(opts.force) });
 
       if (opts.json) {
-        console.log(JSON.stringify({ root, ok, ...outcomes }, null, 2));
+        console.log(JSON.stringify({ root, ok, ...outcomes }));
       } else {
         console.log(ok ? chalk.green(summary) : chalk.yellow(summary));
       }


### PR DESCRIPTION
## Description

`stim guide facts` documents the `--json` contract as printing "exactly ONE line of JSON on stdout," but only `start`, `ios`, and `android` actually did. `commands/stop.ts` serialized with `JSON.stringify(..., null, 2)`, and `commands/status.ts` and `commands/doctor.ts` did the same, so their `--json` stdout was pretty-printed and multi-line. The payload was still one parseable JSON value (invariant 7's "one parseable payload" held), but an agent or shell that reads a single line (`read -r line`, `stdout.split('\n')[0]`) got a truncated fragment instead of the full payload.

## Solution

Dropped the `null, 2` indent argument from the three `--json` stdout writers (`stop.ts`, `status.ts`, `doctor.ts`) so each prints one line, matching `start`, `ios`, and `android`. `device.ts` (`device lock`/`unlock`) already printed single-line JSON and needed no change. The indented `JSON.stringify(..., null, 2)` calls elsewhere in `src/` (`config.ts`, `paths.ts`, `sandbox.ts`, `supervisor/state.ts`, `engine/eas-session-ledger.ts`, `engine/device-remote.ts`, `engine/device-lease.ts`) all write files to disk, not `--json` stdout payloads, so they're untouched.

The `guide facts` sentence claimed the one-line contract for "every command with `--json`" but only enumerated `start`/`ios`/`android` in its example section and summary, which is how this went unnoticed. It now names every command the contract actually applies to (`start`, `ios`, `android`, `stop`, `status`, `doctor`, `device lock`/`unlock`) and calls out `logs --json` as the deliberate exception (NDJSON, one record per line, documented separately in `guide logs`).

## Test plan

- Added a CLI-level `--json` stdout test for `doctor` and `stop` (there wasn't one before -- the existing tests exercised `runDoctor`/`runStop` directly, never the command's `console.log` line, which is why the multi-line bug shipped unnoticed) and strengthened `status`'s existing `runStatusJson()` helper to assert `logs.length === 1` and no `\n` in the line, in addition to `JSON.parse`.
- Added a guide test asserting the facts-topic sentence names every single-payload `--json` command, cross-checked against each command's own `--json` option, and asserting none of them use `JSON.stringify(..., null, 2)`.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`: all clean.
- `pnpm test`: 82 files, 3174 tests, all passing (18.81s), no timeouts or retries needed.

Fixes #246