### PR TITLE
fix: store Android builds under the post-Gradle fingerprint

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -468,7 +468,7 @@ describe('explicit remote backend behavior', () => {
       expect(selected).toEqual([backend]);
       expect(remoteCalls).toEqual(['ensureDevice', 'ensureDeviceBooted', 'install', 'launch']);
       expect(h.calls.ensureDevice).toEqual([]);
-      expect(h.calls.fingerprint.length).toBe(1);
+      expect(h.calls.fingerprint.length).toBe(2);
     },
   );
 
@@ -2735,9 +2735,9 @@ test('android fingerprints with platforms scoped to android', async () => {
     },
   });
   await h.run();
-  expect(seen.length).toBe(1);
-  expect(seen[0]?.path).toBe(root);
-  expect(seen[0]?.options?.platform).toBe('android');
+  expect(seen).toHaveLength(2);
+  expect(seen.every((call) => call.path === root)).toBe(true);
+  expect(seen.every((call) => call.options?.platform === 'android')).toBe(true);
 });
 
 describe('concurrency limits', () => {
@@ -3295,13 +3295,101 @@ describe('re-fingerprint after prebuild', () => {
     expect(h.calls.storeCached[0]?.[1]).toBe(`${WARM}-debug-sim`);
   });
 
-  test('a tree that needs no prebuild fingerprints exactly once and prints no shift line', async () => {
+  test('a Gradle build re-fingerprints once and prints no shift line when the tree is stable', async () => {
     const h = harness();
     await h.run();
-    expect(h.calls.fingerprint.length).toBe(1);
+    expect(h.calls.fingerprint.length).toBe(2);
     expect(h.stderr.some((line) => /fingerprint\s+\S+ -> /.test(line))).toBe(false);
     expect(h.calls.storeCached[0]?.[1]).toBe(h.calls.resolveCached[0]?.[1]);
     expect(h.calls.resolveCached.length).toBe(1);
+  });
+});
+
+describe('re-fingerprint after Gradle', () => {
+  const BEFORE_BUILD = 'before1111';
+  const AFTER_BUILD = 'after2222';
+
+  test('stores under the fingerprint after a build mutation and hits it on the next run', async () => {
+    const manifest = join(root, 'node_modules', 'example', 'android', 'src', 'main', 'AndroidManifest.xml');
+    mkdirSync(join(root, 'node_modules', 'example', 'android', 'src', 'main'), { recursive: true });
+    writeFileSync(manifest, 'before');
+    const configuredUploads: unknown[] = [];
+    const fingerprint = async () => ({
+      hash: readFileSync(manifest, 'utf8') === 'before' ? BEFORE_BUILD : AFTER_BUILD,
+      sources: [{ type: 'dir', filePath: 'android' }],
+    });
+    const h = harness({
+      fingerprint,
+      build: async () => {
+        writeFileSync(manifest, 'after');
+        return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      },
+      resolveCacheProvider: () => ({ provider: './cache.cjs', options: {}, baseDir: root }),
+      loadCacheProviderModule: async () => ({
+        name: './cache.cjs',
+        provider: { builds: { resolve: () => null, store: (input: unknown) => configuredUploads.push(input) } },
+      }),
+      loadProvider: async () => ({ provider: { plugin: {}, options: {} }, name: 'eas' }),
+    });
+    const result = await h.run();
+
+    expect(h.calls.storeCached[0]?.[1]).toBe(`${AFTER_BUILD}-debug-sim`);
+    expect(configuredUploads[0]).toMatchObject({ key: `${AFTER_BUILD}-debug-sim` });
+    expect(h.calls.uploadRemoteBuild[0]?.fingerprintHash).toBe(AFTER_BUILD);
+    expect(result.facts?.fingerprint).toBe(AFTER_BUILD);
+    expect(result.facts?.cacheKey).toBe(`${AFTER_BUILD}-debug-sim`);
+    expect(readState().lastBuild.cacheKey).toBe(`${AFTER_BUILD}-debug-sim`);
+    expect(h.stderr.some((line) => /after Gradle/.test(line))).toBe(true);
+
+    const storedKey = String(h.calls.storeCached[0]?.[1]);
+    const cachedApk = fakeApk();
+    const lookedUp: string[] = [];
+
+    const warm = harness({
+      fingerprint,
+      resolveCached: (_platform: string, key: string) => {
+        lookedUp.push(key);
+        return key === storedKey ? cachedApk : null;
+      },
+      build: never('gradle'),
+    });
+    const warmResult = await warm.run();
+
+    expect(lookedUp).toEqual([`${AFTER_BUILD}-debug-sim`]);
+    expect(warmResult.facts?.cacheHit).toBe('local');
+    expect(warmResult.facts?.cacheKey).toBe(`${AFTER_BUILD}-debug-sim`);
+  });
+
+  test.each([
+    ['throws', async () => Promise.reject(new Error('fingerprint failed'))],
+    ['returns no hash', async () => ({ hash: '', sources: [] })],
+  ])('does not cache when the post-Gradle fingerprint %s', async (_label, unavailableFingerprint) => {
+    let fingerprintCalls = 0;
+    const configuredUploads: unknown[] = [];
+    const h = harness({
+      fingerprint: async () => {
+        if (fingerprintCalls++ === 0) return { hash: BEFORE_BUILD, sources: [] };
+        return unavailableFingerprint();
+      },
+      resolveCacheProvider: () => ({ provider: './cache.cjs', options: {}, baseDir: root }),
+      loadCacheProviderModule: async () => ({
+        name: './cache.cjs',
+        provider: { builds: { resolve: () => null, store: (input: unknown) => configuredUploads.push(input) } },
+      }),
+      loadProvider: async () => ({ provider: { plugin: {}, options: {} }, name: 'eas' }),
+    });
+
+    const result = await h.run();
+
+    expect(result.ok).toBe(true);
+    expect(h.calls.storeCached).toEqual([]);
+    expect(configuredUploads).toEqual([]);
+    expect(h.calls.uploadRemoteBuild).toEqual([]);
+    expect(result.facts?.fingerprint).toBeNull();
+    expect(result.facts?.cacheKey).toBeNull();
+    expect(readState().lastBuild.fingerprint).toBeNull();
+    expect(readState().lastBuild.cacheKey).toBeNull();
+    expect(h.stderr.some((line) => /installed but not cached/.test(line))).toBe(true);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -81,6 +81,14 @@ test('the facts topic documents the fields each --json payload actually carries'
   }
 });
 
+test('the facts topic says Android artifacts use the post-Gradle fingerprint', () => {
+  const body = renderTopic('facts');
+  assert(body);
+  expect(body).toMatch(/Android also fingerprints after Gradle/);
+  expect(body).toMatch(/stored only under that post-build hash/);
+  expect(body).toMatch(/fingerprint and cacheKey are null/);
+});
+
 test('the one-line JSON sentence names every command whose --json payload is a single line', () => {
   const body = renderTopic('facts');
   assert(body);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -943,8 +943,6 @@ interface ReportAndroidResultArgs {
   androidPackage: string;
   installSkipped: boolean;
   record: AndroidRecord;
-  storeHash: string;
-  storeKey: string;
   waitedForBuild: WaitedForBuild | null;
   remote: LoadProjectProviderResult | null;
   providerName: string | null;
@@ -967,8 +965,6 @@ function reportAndroidResult({
   androidPackage,
   installSkipped,
   record,
-  storeHash,
-  storeKey,
   waitedForBuild,
   remote,
   providerName,
@@ -985,8 +981,8 @@ function reportAndroidResult({
     debugHttpHost: launched.debugHttpHost ?? null,
     debugHttpHostNote: launched.debugHttpHostNote ?? null,
     devClientUrl: launched.devClientUrl ?? null,
-    fingerprint: storeHash,
-    cacheKey: storeKey,
+    fingerprint: record.fingerprint,
+    cacheKey: record.cacheKey,
     variant,
     metroPort,
     cacheHit: record.cacheHit,
@@ -1059,8 +1055,6 @@ interface FinishAndroidRunArgs {
   androidPackage: string | null;
   swapDir: string | null;
   record: AndroidRecord;
-  storeHash: string;
-  storeKey: string;
   waitedForBuild: WaitedForBuild | null;
   uploadPending: Promise<RemoteUploadLike> | null;
   providerUpload: Promise<ProviderCallResult<void>> | null;
@@ -1116,8 +1110,6 @@ async function finishAndroidRun({
   androidPackage: initialPackage,
   swapDir,
   record,
-  storeHash,
-  storeKey,
   waitedForBuild,
   uploadPending,
   providerUpload,
@@ -1361,8 +1353,6 @@ async function finishAndroidRun({
     androidPackage,
     installSkipped,
     record,
-    storeHash,
-    storeKey,
     waitedForBuild,
     remote,
     providerName,
@@ -2387,37 +2377,65 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
           phase('build', `${basename(apkPath!)} (${formatDuration(built.durationMs)})`);
           if (built.apkNote) phase('build', chalk.yellow(built.apkNote));
 
-          const assetManifest = release ? captureAssets(root, { variant }) : null;
-          try {
-            const stored = await storeTieredBuild({
-              local: filesystemBuildCapability({
-                resolve: resolveCached,
-                store: storeCached,
-                sources: storeSources,
-                assetManifest,
-              }),
-              loadProvider: loadTieredProvider,
-              target: { projectRoot: root, platform: PLATFORM, key: storeKey },
-              sourcePath: apkPath!,
-              overwrite: !useBuildCache || swapFellBack,
-              warn: cacheWarn,
-            });
-            providerUpload = stored.providerUpload;
-            providerName = stored.providerName ?? providerName;
-          } catch (err) {
-            phase('cache', chalk.yellow(`could not store the build: ${(err as Error)?.message || err}`));
-          }
+          const beforeBuildHash = storeHash;
+          const afterBuild = await refingerprintAfterMutation({
+            projectRoot: root,
+            platform: PLATFORM,
+            previousHash: beforeBuildHash,
+            fingerprint,
+          });
+          if (!afterBuild) {
+            record.fingerprint = null;
+            record.cacheKey = null;
+            phase('fingerprint', chalk.yellow('unavailable after Gradle; the build will be installed but not cached'));
+          } else {
+            if (afterBuild.moved) {
+              storeHash = afterBuild.hash;
+              storeSources = afterBuild.sources;
+              storeKey = buildCacheKey(PLATFORM, afterBuild.hash, variant ? { variant } : {});
+              record.fingerprint = storeHash;
+              record.cacheKey = storeKey;
+              phase(
+                'fingerprint',
+                chalk.dim(
+                  `${shortHash(beforeBuildHash)} -> ${shortHash(storeHash)} after Gradle; ` +
+                    'storing under the new key, which is the one the next run looks up',
+                ),
+              );
+            }
 
-          if (remote) {
-            uploadPending = uploadRemoteBuild({
-              logWriter: writer,
-              provider: remote.provider,
-              platform: PLATFORM,
-              projectRoot: root,
-              fingerprintHash: storeHash,
-              buildPath: apkPath!,
-              runOptions: variant ? { variant } : null,
-            });
+            const assetManifest = release ? captureAssets(root, { variant }) : null;
+            try {
+              const stored = await storeTieredBuild({
+                local: filesystemBuildCapability({
+                  resolve: resolveCached,
+                  store: storeCached,
+                  sources: storeSources,
+                  assetManifest,
+                }),
+                loadProvider: loadTieredProvider,
+                target: { projectRoot: root, platform: PLATFORM, key: storeKey },
+                sourcePath: apkPath!,
+                overwrite: !useBuildCache || swapFellBack,
+                warn: cacheWarn,
+              });
+              providerUpload = stored.providerUpload;
+              providerName = stored.providerName ?? providerName;
+            } catch (err) {
+              phase('cache', chalk.yellow(`could not store the build: ${(err as Error)?.message || err}`));
+            }
+
+            if (remote) {
+              uploadPending = uploadRemoteBuild({
+                logWriter: writer,
+                provider: remote.provider,
+                platform: PLATFORM,
+                projectRoot: root,
+                fingerprintHash: storeHash,
+                buildPath: apkPath!,
+                runOptions: variant ? { variant } : null,
+              });
+            }
           }
         }
       } finally {
@@ -2501,8 +2519,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       androidPackage,
       swapDir,
       record,
-      storeHash,
-      storeKey,
       waitedForBuild,
       uploadPending,
       providerUpload,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -45,12 +45,17 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   computed AFTER those steps -- the one the next run in this
                   tree computes -- and this field reports that one. The shift
                   is printed on stderr as one dim line naming both short
-                  hashes; no shift, no line, and no second fingerprint.
-                  A shift is RE-LOOKED-UP before anything compiles (\`cache
+                  hashes. A prebuild shift is RE-LOOKED-UP before anything
+                  compiles (\`cache
                   hit under the post-prebuild key\`), so a cold tree -- a
                   fresh worktree or clone of a CNG app -- installs an entry
                   another workspace already built instead of compiling
-                  beside it
+                  beside it. Android also fingerprints after Gradle because
+                  Gradle plugins can rewrite native inputs while they build;
+                  its artifact is stored only under that post-build hash. A
+                  stable second fingerprint prints no shift line. If that
+                  fingerprint cannot be computed, the build is installed but
+                  not cached, and fingerprint and cacheKey are null
   configuration   the Xcode configuration that was built ("Release" from
                   --configuration or the ios.configuration setting); null for
                   the default Debug


### PR DESCRIPTION
## Description

Gradle or autolinking can rewrite fingerprinted Android inputs during a build. Stim stored that artifact under the pre-build hash, so the immediate next run missed the cache even when the user changed nothing.

Fixes #247.

## Solution

Re-fingerprint after a successful Gradle build and use only the post-build hash for cache storage, JSON facts, and `lastBuild`. The initial lookup and single-flight lock stay on the pre-build key; a stable fingerprint adds no extra status line. If re-fingerprinting fails, the APK is installed without writing any cache and its reported cache identity is `null`.

## Test plan

- Regression test: a fake Gradle build rewrites a fingerprinted Android manifest, and the next run gets `cacheHit: "local"`.
- Full checks: format, lint, typecheck, build, knip, 3,186 unit tests, 20 end-to-end tests, and the runtime-floor test.

No additional device QA was run; the rc.8 manual Android QA captured the original mutation and further QA was intentionally skipped for this follow-up.
