### PR TITLE
fix: separate iOS install proof from dev-client preparation

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -226,6 +226,34 @@ describe('ios', () => {
     ]);
   });
 
+  test('installIosApp times the artifact step separately from dev-client preparation', () => {
+    const exec = recordingExec();
+    const times = [0, 500, 1300];
+    const appPath = '/tmp/My App.app';
+    const result = installIosApp(
+      {
+        udid: 'U1',
+        appPath,
+        bundleId: 'com.example.app',
+        devClientScheme: 'myapp',
+      },
+      {
+        exec,
+        now: () => {
+          const time = times.shift();
+          assert(time !== undefined);
+          return time;
+        },
+      },
+    );
+    expect(result).toEqual({
+      ok: true,
+      appPath,
+      artifactDurationMs: 500,
+      devClientPreparationDurationMs: 800,
+    });
+  });
+
   test('a failed dev-client preference write reports a failed install result', () => {
     const exec = recordingExec({ fail: 'EXDevMenuShowsAtLaunch' });
     const result = installIosApp(

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -22,6 +22,14 @@ test('the facts topic pins how an owned emulator gets its console port', () => {
   expect(body).toMatch(/A boot that fails releases the port again and\s+keeps the AVD recorded for `gc`/);
 });
 
+test('the lifecycle topic separates an iOS install proof from dev-client preparation', () => {
+  const body = renderTopic('lifecycle');
+  assert(body);
+  expect(body).toMatch(/install\s+unchanged; .*already holds this app; proof/);
+  expect(body).toMatch(/dev client\s+prepared/);
+  expect(body).toMatch(/slow simulator command is never charged\s+to an install that did not run/);
+});
+
 test('an unknown topic renders nothing rather than throwing', () => {
   expect(renderTopic('nope')).toBe(null);
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3328,14 +3328,24 @@ test('a local hit leaves no provider download directory behind', async () => {
 });
 
 describe('an app the simulator already holds', () => {
-  test('the skip is named on the install line and carried in the facts', async () => {
+  test('the install proof and dev-client preparation get separate phase lines', async () => {
     reserve();
     const { logs, stderr } = await run(
       { json: true },
-      { installIosApp: (args) => ({ ok: true, appPath: args.appPath, skipped: true }) },
+      {
+        devClientScheme: () => 'fixture',
+        installIosApp: (args) => ({
+          ok: true,
+          appPath: args.appPath,
+          skipped: true,
+          artifactDurationMs: 45_600,
+          devClientPreparationDurationMs: 1200,
+        }),
+      },
     );
 
-    expect(stderr).toMatch(/skipped; .*already holds this app/);
+    expect(stderr).toMatch(/install\s+unchanged; .*already holds this app; proof \(45\.6s\)/);
+    expect(stderr).toMatch(/dev client\s+prepared \(1\.2s\)/);
     expect(parseFirst(logs).installSkipped).toBe(true);
   });
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1434,10 +1434,17 @@ AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
   Before installing, Stim hashes the artifact it is about to install and the
   one the device already has -- \`pm path\` then \`sha256sum\` on Android, the
   \`simctl get_app_container\` bundle on iOS. Byte-identical means the install
-  is skipped and the run goes straight to launch, which is under a second
-  instead of the ~43s a 400MB APK costs over USB.
+  is skipped. The phase still reports the cost of proving that identity, but
+  avoids the ~43s a 400MB APK can cost to copy and install over USB.
 
     install     skipped; emulator-5584 already holds this APK (0.4s)
+
+  On iOS the install line names the identity proof separately from the Expo
+  dev-client preference writes, so a slow simulator command is never charged
+  to an install that did not run:
+
+    install     unchanged; stim-app (BF2A..) already holds this app; proof (0.4s)
+    dev client  prepared (0.9s)
 
   The skip needs PROOF. A package that is not installed, a split install, an
   image without \`sha256sum\`, and any adb or simctl failure all read as

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1479,7 +1479,7 @@ async function finishIosRun({
     );
   } else {
     const installTimer = stepTimer(d.now);
-    const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme });
+    const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme }, { now: d.now });
     if (installed?.failed) {
       return fail({
         code: installed.code || 'STIM_INSTALL_FAILED',
@@ -1489,12 +1489,19 @@ async function finishIosRun({
       });
     }
     installSkipped = Boolean(installed?.skipped);
+    const artifactDuration =
+      installed?.artifactDurationMs === undefined
+        ? installTimer()
+        : `(${formatDuration(installed.artifactDurationMs)})`;
     phase(
       'install',
       installSkipped
-        ? `skipped; ${deviceLabel(device, udid)} already holds this app ${installTimer()}`
-        : `-> ${deviceLabel(device, udid)} ${installTimer()}`,
+        ? `unchanged; ${deviceLabel(device, udid)} already holds this app; proof ${artifactDuration}`
+        : `-> ${deviceLabel(device, udid)} ${artifactDuration}`,
     );
+    if (!remoteDevice && installed?.devClientPreparationDurationMs !== undefined) {
+      phase('dev client', `prepared (${formatDuration(installed.devClientPreparationDurationMs)})`);
+    }
 
     dropSwapDir();
 

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -18,12 +18,15 @@ const ANDROID_DISABLE_AUTO_LAUNCH_EXTRA = 'EXDevMenuDisableAutoLaunch';
 
 interface ExecOpt {
   exec?: Executor | null;
+  now?: (() => number) | null;
 }
 
 export type IosInstallResult = {
   ok?: boolean;
   appPath?: string;
   skipped?: boolean;
+  artifactDurationMs?: number;
+  devClientPreparationDurationMs?: number;
   failed?: boolean;
   code?: string;
   reason?: string;
@@ -72,9 +75,10 @@ export function installIosApp(
     bundleId = null,
     devClientScheme = null,
   }: { udid: string; appPath: string; bundleId?: string | null; devClientScheme?: string | null },
-  { exec = null }: ExecOpt = {},
+  { exec = null, now = null }: ExecOpt = {},
 ): IosInstallResult {
   const e = exec || getExecutor();
+  const artifactStartedAt = now?.();
   const skipped = bundleId ? deviceHoldsBundle({ udid, bundleId, appPath }, { exec: e }) : false;
   if (!skipped) {
     try {
@@ -83,6 +87,12 @@ export function installIosApp(
       return { failed: true, code: INSTALL_ERROR, reason: `simctl install failed for ${appPath}: ${describe(err)}` };
     }
   }
+  const artifactFinishedAt = now?.();
+  const artifactDurationMs =
+    artifactStartedAt !== undefined && artifactFinishedAt !== undefined
+      ? artifactFinishedAt - artifactStartedAt
+      : undefined;
+  const preparationStartedAt = bundleId && devClientScheme ? artifactFinishedAt : undefined;
   if (bundleId && devClientScheme) {
     try {
       for (const key of IOS_DEV_MENU_OFF_KEYS) {
@@ -109,7 +119,13 @@ export function installIosApp(
       };
     }
   }
-  return skipped ? { ok: true, appPath, skipped: true } : { ok: true, appPath };
+  const devClientPreparationDurationMs =
+    now && preparationStartedAt !== undefined ? now() - preparationStartedAt : undefined;
+  const timing = {
+    ...(artifactDurationMs === undefined ? {} : { artifactDurationMs }),
+    ...(devClientPreparationDurationMs === undefined ? {} : { devClientPreparationDurationMs }),
+  };
+  return skipped ? { ok: true, appPath, skipped: true, ...timing } : { ok: true, appPath, ...timing };
 }
 
 export function jsLocationValue(metroPort: number | string): string {


### PR DESCRIPTION
## Description

A warm `stim ios` reported 45.6 seconds as `install skipped` because one timer wrapped both the exact bundle-identity proof and the Expo dev-client simulator preference writes. The phase could not show whether the installed-container hash or one of four `simctl spawn defaults write` calls was slow.

On a recreated 186 MB Trailhead fixture, the exact proof cost 238–307 ms and dev-client preparation cost 665–919 ms, so the original delay did not reproduce as a stable hashing cost. The scope is local iOS simulator reporting: install/preparation order and the `installSkipped` JSON field are unchanged, while Android, physical-device, and remote flows are untouched.

## Solution

`installIosApp` now returns separate internal durations for the artifact step and dev-client preparation. The iOS command reports an unchanged app as a timed proof, then gives preference preparation its own phase:

```text
install     unchanged; stim-app (BF2A..) already holds this app; proof (284ms)
dev client  prepared (677ms)
```

The version-matched lifecycle guide and command-level tests pin that separation, so a future slow simulator operation is attributed to the step that actually ran.

## Test plan

- Expo SDK 57 dev-client fixture, 186 MB cached app, owned iOS simulator: ran the branch CLI on a warm cache hit and verified the two phase lines above, `installSkipped: true`, and `launched: true` in a 7.2-second run.
- Timed the exact rc.8 functions directly: container lookup 156 ms, installed hash 110 ms, local hash 110 ms, and four preference writes at 224–237 ms each.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip`, `pnpm test` (82 files / 3,184 tests), and `pnpm run test:e2e` (20 tests).

Fixes #245
