### PR TITLE
fix: add the dev-menu FAB suppression flag

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2531,7 +2531,8 @@ describe('the dev-client deep link', () => {
   });
 
   test('the deep-link launch says so, and the url is in the facts', async () => {
-    const url = 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1';
+    const url =
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1';
     const h = harness({
       resolveDevClientScheme: () => 'exp+app',
       launch: () => ({ ok: true, mode: 'deep-link', devClientUrl: url, reversed: [], debugHttpHost: '10.0.2.2:8082' }),
@@ -2574,7 +2575,7 @@ describe('the dev-client deep link', () => {
     expect(link > 0).toBeTruthy();
     expect(link < picker).toBeTruthy();
     expect(text).toMatch(
-      /adb -s emulator-5584 shell am start -a android\.intent\.action\.VIEW -d 'exp\+app:\/\/expo-development-client\/\?url=http%3A%2F%2F10\.0\.2\.2%3A8082%2F%3FdisableOnboarding%3D1' --ez EXDevMenuDisableAutoLaunch true/,
+      /adb -s emulator-5584 shell am start -a android\.intent\.action\.VIEW -d 'exp\+app:\/\/expo-development-client\/\?url=http%3A%2F%2F10\.0\.2\.2%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1' --ez EXDevMenuDisableAutoLaunch true/,
     );
     expect(steps.length >= 2).toBeTruthy();
   });

--- a/packages/stim-cli/src/__tests__/device-remote.test.ts
+++ b/packages/stim-cli/src/__tests__/device-remote.test.ts
@@ -784,7 +784,7 @@ describe('install and launch match their local counterparts', () => {
     expect(result.mode).toBe('openurl');
     const open = exec.calls.find((c) => c.args[0] === 'open');
     expect(open?.args[2]).toBe(
-      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 
@@ -981,7 +981,7 @@ describe('Metro reachability', () => {
     deps.launchIosApp({ udid: 'drs_42', bundleId: 'com.example.app', metroPort: 8082, devClientScheme: 'myapp' });
     const open = exec.calls.find((c) => c.args[0] === 'open');
     expect(open?.args[2]).toBe(
-      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 });
@@ -1473,7 +1473,7 @@ describe('the android adapter', () => {
     const open = exec.calls.find((c) => c.args[0] === 'open');
     expect(open?.args[1]).toBe('com.example.app');
     expect(open?.args[2]).toBe(
-      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     const flat = (open?.args ?? []).join(' ');
     expect(flat).not.toContain('10.0.2.2');

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -103,14 +103,14 @@ describe('the two pure port-wiring shapes', () => {
 
   test('devClientUrl matches the shape expo-dev-launcher asserts on', () => {
     expect(devClientUrl('myapp', 8082)).toBe(
-      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     expect(devClientUrl('scheme', 8081)).toBe(
-      'scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2F%3FdisableOnboarding%3D1',
+      'scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 
-  test('disableOnboarding=1 sits INSIDE the project url, never on the deep link', () => {
+  test('onboarding stays inside the project url and the session-only FAB flag stays outside', () => {
     const urls = [
       devClientUrl('myapp', 8082),
       devClientUrl('myapp', 8082, '10.0.0.188'),
@@ -121,14 +121,15 @@ describe('the two pure port-wiring shapes', () => {
     for (const url of urls) {
       const link = new URL(url);
       expect(link.searchParams.get('disableOnboarding')).toBe(null);
+      expect(link.searchParams.get('disableFab')).toBe('1');
       const projectUrl = new URL(link.searchParams.get('url') as string);
       expect(projectUrl.searchParams.get('disableOnboarding')).toBe('1');
     }
     expect(devClientUrl('myapp', 8082, '10.0.0.188')).toBe(
-      'myapp://expo-development-client/?url=http%3A%2F%2F10.0.0.188%3A8082%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=http%3A%2F%2F10.0.0.188%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     expect(devClientDeepLink('myapp', 'https://abc.trycloudflare.com')).toBe(
-      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1',
+      'myapp://expo-development-client/?url=https%3A%2F%2Fabc.trycloudflare.com%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 
@@ -281,7 +282,7 @@ describe('ios', () => {
         'simctl',
         'openurl',
         'U1',
-        'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+        'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
       ],
     ]);
   });
@@ -752,7 +753,7 @@ describe('unverifiedLaunchLines', () => {
     }).join('\n');
     expect(simulator).toContain(
       "xcrun simctl openurl BF2A1C3D 'io.tlon.groups://expo-development-client/" +
-        "?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1'",
+        "?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1'",
     );
 
     const phone = unverifiedLaunchLines({
@@ -767,7 +768,7 @@ describe('unverifiedLaunchLines', () => {
     }).join('\n');
     expect(phone).toContain(
       "--payload-url 'io.tlon.groups://expo-development-client/" +
-        "?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups" +
+        "?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1' io.tlon.groups" +
         ' -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0',
     );
 
@@ -779,7 +780,7 @@ describe('unverifiedLaunchLines', () => {
       devClientUrl: androidDevClientUrl('exp+app', 8082),
     }).join('\n');
     expect(android).toContain(
-      "-d 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1'" +
+      "-d 'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1'" +
         ' --ez EXDevMenuDisableAutoLaunch true',
     );
   });
@@ -917,7 +918,7 @@ describe('unverifiedLaunchLines: the routed Local Network remedy', () => {
     expect(text).toContain(`agent-device press 'label="Close"'`);
     expect(text).toContain(
       `--payload-url 'io.tlon.groups://expo-development-client/` +
-        `?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1' io.tlon.groups` +
+        `?url=http%3A%2F%2F10.0.0.132%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1' io.tlon.groups` +
         ' -- -EXDevMenuShowsAtLaunch 0 -EXDevMenuShowFloatingActionButton 0',
     );
   });
@@ -1058,10 +1059,10 @@ describe('the debug_http_host script, run for real under sh', () => {
 describe('the Android dev-client deep link', () => {
   test('the url is the iOS shape pointed at the emulator loopback', () => {
     expect(androidDevClientUrl('exp+app', 8085)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     expect(devClientUrl('exp+app', 8085)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 
@@ -1073,7 +1074,7 @@ describe('the Android dev-client deep link', () => {
     );
     expect(result.mode).toBe('deep-link');
     expect(result.devClientUrl).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     expect(exec.calls.at(-1)).toEqual([
       'adb',
@@ -1085,7 +1086,7 @@ describe('the Android dev-client deep link', () => {
       '-a',
       'android.intent.action.VIEW',
       '-d',
-      `'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1'`,
+      `'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1'`,
       '--ez',
       'EXDevMenuDisableAutoLaunch',
       'true',
@@ -1894,10 +1895,10 @@ describe('the Metro host for a physical device', () => {
 
   test('the dev-client url targets localhost on a physical device', () => {
     expect(androidDevClientUrl('exp+app', 8085, true)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8085%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
     expect(androidDevClientUrl('exp+app', 8085, false)).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8085%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 
@@ -1915,7 +1916,7 @@ describe('the Metro host for a physical device', () => {
     );
     expect(result.ok).toBe(true);
     expect(result.devClientUrl).toBe(
-      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1',
+      'exp+app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
     );
   });
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -502,23 +502,24 @@ test('the guide gives the Local Network recovery commands and the taps that have
   expect(facts).toMatch(/developer trust, has no API at all and is always the user's/);
 });
 
-// The preapproval is `simctl spawn defaults write`, which has no devicectl
-// equivalent, and the copied-plist route loses its keys to cfprefsd. On a phone
-// the launch arguments take its place: devicectl passes everything after `--`
-// to the app and NSUserDefaults reads the argument domain first, so nothing is
-// written to the device. Android's intent extra sets both preferences.
-test('the guide scopes the dev-menu preapproval to a simulator and names what covers a phone', () => {
+test('the guide scopes each platform dev-menu suppression mechanism accurately', () => {
   const facts = renderTopic('facts');
   assert(facts);
 
   expect(facts).toMatch(/EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1\s+INSIDE ITS PROJECT URL/);
-  expect(facts).toContain('?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1');
+  expect(facts).toContain('?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1&disableFab=1');
   expect(facts).toMatch(/ON iOS it has to sit on the\s+PROJECT url/);
   expect(facts).toMatch(/on the\s+outer deep link it does nothing there\. Android reads it on\s+either/);
   expect(facts).toMatch(
-    /ON ANDROID the same deep link also carries the\s+`EXDevMenuDisableAutoLaunch` boolean intent extra/,
+    /ON LOCAL ANDROID the same deep link also carries the\s+`EXDevMenuDisableAutoLaunch` boolean intent extra/,
   );
   expect(facts).toContain("-d '<devClientUrl>'\n                  --ez EXDevMenuDisableAutoLaunch true");
+  expect(facts).toMatch(/set EXDevMenuShowsAtLaunch=false and\s+EXDevMenuIsOnboardingFinished=true/);
+  expect(facts).toMatch(/does NOT set expo-dev-menu's\s+showFab preference/);
+  expect(facts).toMatch(/Remote Android opens only the URL, so that intent-extra\s+suppression does not apply there/);
+  expect(facts).toMatch(/outer `disableFab=1`\s+query parameter/);
+  expect(facts).toContain('expo/expo#49651');
+  expect(facts).toMatch(/Stim does\s+not rewrite expo-dev-menu's private SharedPreferences XML/);
   expect(facts).toMatch(/ON A SIMULATOR, before a local dev-client openurl, Stim\s+preapproves/);
   expect(facts).toMatch(/those together are what keep the menu and its\s+button off a simulator entirely/);
   expect(facts).toContain('EXDevMenuShowFloatingActionButton=false');

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3596,7 +3596,7 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     );
     const collector = calls.args.replaceCollector as Record<string, unknown>;
     expect(collector.payloadUrl).toBe(
-      `com.example.app://expo-development-client/?url=${encodeURIComponent('http://192.168.1.5:8082/?disableOnboarding=1')}`,
+      `com.example.app://expo-development-client/?url=${encodeURIComponent('http://192.168.1.5:8082/?disableOnboarding=1')}&disableFab=1`,
     );
     expect(calls.order.includes('sealAppForDevice')).toBe(false);
     expect(calls.order.includes('gateProfileForDevice')).toBe(true);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -123,7 +123,7 @@ line by design (see \`guide logs\`), not this single-payload contract.
                                  dev-client server picker awaiting a tap
                   EVERY DEV-CLIENT DEEP LINK CARRIES disableOnboarding=1
                   INSIDE ITS PROJECT URL
-                  (\`...?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1\`),
+                  (\`...?url=http%3A%2F%2Fhost%3Aport%2F%3FdisableOnboarding%3D1&disableFab=1\`),
                   and expo-dev-launcher finishes its own dev-menu ONBOARDING
                   when it reads it. That is all the flag does: it sets
                   EXDevMenuIsOnboardingFinished. ON iOS it has to sit on the
@@ -143,14 +143,23 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   on the app. The
                   unverified warning therefore leads with the picker, then
                   prints the openurl
-                  retry. ON ANDROID the same deep link also carries the
+                  retry. ON LOCAL ANDROID the same deep link also carries the
                   \`EXDevMenuDisableAutoLaunch\` boolean intent extra, which
-                  the launcher reads to set BOTH preferences -- so the
-                  emulator and the phone need no writes at all -- and the
-                  list leads with that command (\`am start -a
+                  the launcher reads to set EXDevMenuShowsAtLaunch=false and
+                  EXDevMenuIsOnboardingFinished=true. It stops the menu
+                  opening automatically, but does NOT set expo-dev-menu's
+                  showFab preference, so its floating Tools button can remain.
+                  Remote Android opens only the URL, so that intent-extra
+                  suppression does not apply there.
+                  Every Stim deep link also carries an outer \`disableFab=1\`
+                  query parameter. Versions with expo/expo#49651 use that as a
+                  session-only override; earlier versions ignore it. Stim does
+                  not rewrite expo-dev-menu's private SharedPreferences XML:
+                  that internal file is not a supported API, and changing it
+                  would persist over the user's own Tools-button setting. The
+                  list leads with the supported launch command (\`am start -a
                   android.intent.action.VIEW -d '<devClientUrl>'
-                  --ez EXDevMenuDisableAutoLaunch true\`), which is the whole
-                  answer when the app has a scheme.
+                  --ez EXDevMenuDisableAutoLaunch true\`).
                   ON A PHONE NONE OF THAT PREAPPROVAL APPLIES. The
                   preapproval and that write both go
                   through \`simctl spawn defaults write\`, and devicectl has
@@ -189,8 +198,9 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   \`agent-device press 'label="Close"'\` dismisses it -- or
                   \`snapshot -i\` and the ref. The onboarding key the flag
                   writes and the Local Network grant both survive an
-                  UPGRADE install. Android needs neither mechanism: its intent
-                  extra sets both preferences.
+                  UPGRADE install. Android's intent extra prevents the menu's
+                  automatic launch; versions with expo/expo#49651 also honor
+                  the session-only FAB flag in Stim's deep link.
                   The phone's unverified remedy is also ROUTED, not a fixed
                   list. When this launch's device records carry the Local
                   Network path reason, the remedy leads with that evidence and

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -14,6 +14,7 @@ const IOS_SCHEME_APPROVAL_DOMAIN = 'com.apple.launchservices.schemeapproval';
 const IOS_SCHEME_APPROVAL_OPENER = 'com.apple.CoreSimulator.CoreSimulatorBridge';
 const IOS_DEV_MENU_OFF_KEYS = ['EXDevMenuShowsAtLaunch', 'EXDevMenuShowFloatingActionButton'];
 const DEV_CLIENT_ONBOARDING_QUERY = 'disableOnboarding=1';
+const DEV_CLIENT_DISABLE_FAB_QUERY = 'disableFab=1';
 const ANDROID_DISABLE_AUTO_LAUNCH_EXTRA = 'EXDevMenuDisableAutoLaunch';
 
 interface ExecOpt {
@@ -120,11 +121,12 @@ export function jsLocationValue(metroPort: number | string): string {
 // not the outer deep link: EXDevLauncherController.m hands `devLauncherUrl.url`
 // to EXDevLauncherURLHelper.disableOnboardingPopupIfNeeded. It sets
 // EXDevMenuIsOnboardingFinished alone; EXDevMenuShowsAtLaunch is a separate
-// preference. Android reads the flag on either url, and its
-// EXDevMenuDisableAutoLaunch intent extra sets both (DevLauncherController.kt).
+// preference. Android reads the flag on either url. DevLauncherController.kt's
+// EXDevMenuDisableAutoLaunch extra does not disable the FAB; expo/expo#49651
+// adds the outer disableFab query parameter for that.
 export function devClientDeepLink(scheme: string, projectOrigin: string): string {
   const projectUrl = `${projectOrigin.replace(/\/+$/, '')}/?${DEV_CLIENT_ONBOARDING_QUERY}`;
-  return `${scheme}://expo-development-client/?url=${encodeURIComponent(projectUrl)}`;
+  return `${scheme}://expo-development-client/?url=${encodeURIComponent(projectUrl)}&${DEV_CLIENT_DISABLE_FAB_QUERY}`;
 }
 
 export function devClientUrl(scheme: string, metroPort: number | string, host = 'localhost'): string {


### PR DESCRIPTION
## Description

The Android `EXDevMenuDisableAutoLaunch` intent extra only disables automatic menu launch; it does not hide expo-dev-menu's floating Tools button. Stim's guide incorrectly claimed both preferences were covered.

Fixes #249.

## Solution

Add the upstream session-only `disableFab=1` parameter to the outer dev-client link on both platforms. Expo versions without expo/expo#49651 ignore it; versions containing that change hide the FAB without persisting over user preferences. Keep Android's existing intent extra for automatic launch and correct the guide instead of rewriting Expo's private SharedPreferences XML.

## Test plan

- No device QA: the upstream behavior is not released and no Stim-owned Android device is attached. Expo SDK 57 is expected to ignore the new parameter while preserving existing launch behavior.
- URL contract tests verify `disableOnboarding` stays inside the encoded project URL and `disableFab` stays outside across simulator, device, and remote flows.
