### PR TITLE
fix: report Android run duration in JSON

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -987,7 +987,13 @@ describe('a cache hit', () => {
   });
 
   test('--json puts the facts on stdout and nothing else', async () => {
-    const h = harness({ json: true, resolveCached: () => '/cache/app-debug.apk', build: never('the build') });
+    const timestamps = [1000, 1050, 1200, 1600];
+    const h = harness({
+      json: true,
+      resolveCached: () => '/cache/app-debug.apk',
+      build: never('the build'),
+      now: () => timestamps.shift() ?? 1600,
+    });
     const result = await h.run();
     expect(h.stdout.length).toBe(1);
     const stdout0 = h.stdout[0];
@@ -1012,6 +1018,7 @@ describe('a cache hit', () => {
       debugHttpHostNote: null,
       devClientUrl: null,
       logs: workspaceLogsDir(root),
+      durationMs: 600,
     });
     assert(result.facts);
     expect(JSON.parse(stdout0)).toEqual(result.facts);
@@ -2301,6 +2308,7 @@ describe('the pure parts', () => {
       debugHttpHostNote: null,
       devClientUrl: null,
       logs: null,
+      durationMs: null,
     });
     expect(androidFacts({ variant: 'productionDebug' }).variant).toBe('productionDebug');
     expect(androidFacts({ cacheKey: `${FINGERPRINT}-productionrelease-sim` }).cacheKey).toBe(
@@ -2311,6 +2319,7 @@ describe('the pure parts', () => {
       deviceName: androidFacts({ avdName: 'stim-app-412' }).deviceName,
     }).toEqual({ avdName: 'stim-app-412', deviceName: 'stim-app-412' });
     expect(androidFacts({ cacheHit: 'remote' }).cacheHit).toBe('remote');
+    expect(androidFacts({ durationMs: 123 }).durationMs).toBe(123);
     expect(androidFacts({ cacheHit: true }).cacheHit).toBe(false);
     expect(androidFacts({ cacheHit: 'local', waitedForBuild: { pid: 41233, ms: 761000 } }).waitedForBuild).toEqual({
       pid: 41233,

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -71,6 +71,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'bundleId',
       'installSkipped',
       'launched',
+      'durationMs',
     ],
   };
   for (const [command, names] of Object.entries(fields)) {
@@ -79,6 +80,16 @@ test('the facts topic documents the fields each --json payload actually carries'
       expect(sources[command as keyof typeof sources].includes(f)).toBeTruthy();
     }
   }
+});
+
+test('the facts topic documents durationMs for both run commands', () => {
+  const body = renderTopic('facts');
+  assert(body);
+  const ios = body.slice(body.indexOf('stim ios --json'), body.indexOf('stim android --json'));
+  const android = body.slice(body.indexOf('stim android --json'), body.indexOf('ON FAILURE'));
+
+  expect(ios).toMatch(/durationMs\s+wall time for the whole run/);
+  expect(android).toMatch(/durationMs\s+wall time for the whole run/);
 });
 
 test('the facts topic says Android artifacts use the post-Gradle fingerprint', () => {

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -484,6 +484,7 @@ export function androidFacts({
   debugHttpHost = null,
   debugHttpHostNote = null,
   devClientUrl = null,
+  durationMs,
   lease,
 }: {
   serial?: string | null;
@@ -504,6 +505,7 @@ export function androidFacts({
   debugHttpHost?: string | null;
   debugHttpHostNote?: string | null;
   devClientUrl?: string | null;
+  durationMs?: number;
   lease?: { kind: string; expiresAt: string } | null;
 }): AndroidFacts {
   return {
@@ -526,6 +528,7 @@ export function androidFacts({
     debugHttpHostNote: debugHttpHostNote ?? null,
     devClientUrl: devClientUrl ?? null,
     logs: logs ?? null,
+    durationMs: typeof durationMs === 'number' && Number.isFinite(durationMs) ? durationMs : null,
     ...(lease === undefined ? {} : { lease }),
   };
 }
@@ -948,6 +951,7 @@ interface ReportAndroidResultArgs {
   providerName: string | null;
   launchState: boolean | string;
   launched: LaunchResultLike;
+  durationMs: number;
   writer: AndroidWriter;
   emit: (line: string) => void;
 }
@@ -970,6 +974,7 @@ function reportAndroidResult({
   providerName,
   launchState,
   launched,
+  durationMs,
   writer,
   emit,
   lease,
@@ -993,6 +998,7 @@ function reportAndroidResult({
     installSkipped,
     launched: launchState,
     logs: logsDir,
+    durationMs,
     lease,
   });
   writer.close();
@@ -1358,6 +1364,7 @@ async function finishAndroidRun({
     providerName,
     launchState,
     launched,
+    durationMs: now() - started,
     writer,
     emit,
     lease: physical ? leaseFacts : undefined,

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -271,6 +271,7 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   a plain launcher start. This is the command that puts the
                   app back on THIS workspace's bundle
   logs            the workspace log directory
+  durationMs      wall time for the whole run
 
 ON FAILURE
   \`start\`, \`ios\` and \`android\` all print the error contract instead,

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -148,6 +148,7 @@ export interface AndroidFacts {
   debugHttpHostNote: string | null;
   devClientUrl: string | null;
   logs: string | null;
+  durationMs: number | null;
   lease?: RunLeaseFacts | null;
 }
 


### PR DESCRIPTION
## Description

`stim guide facts` documents `durationMs` as the wall time for a complete native run, but `stim android --json` omitted it while iOS included it.

Fixes #248.

## Solution

Measure elapsed wall time at the end of the successful Android run and include it in `AndroidFacts`. Document the field in the Android facts table and keep the helper's empty/default contract explicit with `null`.

## Test plan

- Android JSON test uses injected timestamps and verifies the one-line payload reports the complete 600 ms run.
- Guide contract verifies both iOS and Android document `durationMs`.
- Full repository checks passed, including 3,187 unit tests, 20 end-to-end tests, and the runtime-floor test.
