### PR TITLE
feat: per-invocation simulator model and runtime flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,12 @@ Metro from the project's dependencies. Expo runs its fixed start command. iOS
 and Android use fixed `xcodebuild` and Gradle arguments.
 
 The supported build selectors are `ios --configuration <name>` and
-`android --variant <name>`. `android --device [serial]` and
+`android --variant <name>`. `ios --device-type <name>`, `ios --runtime
+<version>`, and `android --system-image <id>` select the model and version of
+the owned simulator or emulator for one invocation, overriding
+`ios.deviceType`, `ios.runtime`, and `android.systemImage`; a name that is not
+installed refuses with `STIM_BAD_ARG` and prints the installed names.
+`android --device [serial]` and
 `ios --device [udid]` select a connected physical device, and take
 `--wait <seconds>` or `--no-wait` for the lease on it. Non-Debug iOS
 configurations and Android variants ending in `Release` skip Metro. A release

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -16,9 +16,11 @@ import {
   NO_METRO,
   androidDevClientScheme,
   androidFacts,
+  androidSystemImageSetting,
   androidVariantSetting,
   collectorLogFile,
   isReleaseVariant,
+  resolveSystemImage,
   resolveVariant,
   apkPackage,
   apkDevClientFacts,
@@ -43,6 +45,7 @@ import type { AssetManifest } from '../engine/asset-manifest.ts';
 import { PREBUILD_ERROR } from '../engine/prebuild.ts';
 import { asProcessExit, makeChildProcess, makeError, makeExecutor } from './_factories.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
+import { unknownAndroidSystemImageRefusal } from '../engine/device.ts';
 import { DEBUG_VERIFY_STEP_MS, type RunLease } from '../engine/device-lease-run.ts';
 
 const FINGERPRINT = 'a3f9b1c2d3e4f5a6b7c8d9e0f1a2b3c4';
@@ -244,6 +247,7 @@ function harness(overrides = {}) {
       calls.ensureDevice.push(args);
       return { avdName: 'stim-app-412', consolePort: 5584, owned: true };
     },
+    unknownSystemImage: () => null,
     ensureDeviceBooted: async (args: unknown = {}) => {
       calls.booted.push(args);
       return { ok: true, serial: 'emulator-5584' };
@@ -1003,6 +1007,7 @@ describe('a cache hit', () => {
       serial: 'emulator-5584',
       avdName: 'stim-app-412',
       deviceName: 'stim-app-412',
+      systemImage: null,
       fingerprint: FINGERPRINT,
       cacheKey: CACHE_KEY,
       variant: null,
@@ -2293,6 +2298,7 @@ describe('the pure parts', () => {
       serial: null,
       avdName: null,
       deviceName: null,
+      systemImage: null,
       fingerprint: null,
       cacheKey: null,
       variant: null,
@@ -4238,5 +4244,101 @@ describe('--device with no serial: the pool', () => {
     const result = await h.run();
     expect(result.ok).toBe(false);
     expect(result.error?.message).toMatch(/is not connected\. adb reports these physical devices/);
+  });
+});
+
+describe('the emulator system-image flag', () => {
+  test('resolveSystemImage puts the flag over the setting', () => {
+    const settings = { android: { systemImage: 'system-images;android-36;google_apis;arm64-v8a' } };
+    expect(resolveSystemImage('system-images;android-35;google_apis;arm64-v8a', settings)).toBe(
+      'system-images;android-35;google_apis;arm64-v8a',
+    );
+    expect(resolveSystemImage(null, settings)).toBe('system-images;android-36;google_apis;arm64-v8a');
+    expect(resolveSystemImage('  ', settings)).toBe('system-images;android-36;google_apis;arm64-v8a');
+    expect(resolveSystemImage(null, {})).toBe(null);
+    expect(resolveSystemImage(null, null)).toBe(null);
+  });
+
+  test('androidSystemImageSetting reads android.systemImage and nothing shaped differently', () => {
+    expect(androidSystemImageSetting({ android: { systemImage: 'system-images;android-36;google_apis;x86_64' } })).toBe(
+      'system-images;android-36;google_apis;x86_64',
+    );
+    expect(androidSystemImageSetting({ android: { systemImage: '  ' } })).toBe(null);
+    expect(androidSystemImageSetting({ android: { systemImage: 7 } })).toBe(null);
+    expect(androidSystemImageSetting({ android: [] })).toBe(null);
+    expect(androidSystemImageSetting(null)).toBe(null);
+  });
+
+  test('the flag reaches the engine and overrides the setting for that invocation', async () => {
+    const settings = { android: { systemImage: 'system-images;android-36;google_apis;arm64-v8a' } };
+    const fromSetting = harness({ resolveSettingsFor: () => settings });
+    await fromSetting.run();
+    expect(fromSetting.calls.ensureDevice[0]).toMatchObject({
+      flags: { systemImage: 'system-images;android-36;google_apis;arm64-v8a' },
+    });
+
+    const fromFlag = harness({
+      resolveSettingsFor: () => settings,
+      systemImage: 'system-images;android-35;google_apis;arm64-v8a',
+    });
+    await fromFlag.run();
+    expect(fromFlag.calls.ensureDevice[0]).toMatchObject({
+      flags: { systemImage: 'system-images;android-35;google_apis;arm64-v8a' },
+    });
+
+    const neither = harness();
+    await neither.run();
+    expect(neither.calls.ensureDevice[0]).toMatchObject({ flags: { systemImage: null } });
+  });
+
+  test('an unknown system image refuses with STIM_BAD_ARG naming the installed ids, before anything is created', async () => {
+    const h = harness({
+      json: true,
+      systemImage: 'system-images;android-99;google_apis;arm64-v8a',
+      unknownSystemImage: (requested: string | null | undefined) =>
+        unknownAndroidSystemImageRefusal(requested, [
+          { api: 36, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-36;google_apis;arm64-v8a' },
+          { api: 35, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-35;google_apis;arm64-v8a' },
+        ]),
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    const stdout0 = h.stdout[0];
+    assert(stdout0);
+    const payload = JSON.parse(stdout0);
+    expect(payload.code).toBe('STIM_BAD_ARG');
+    expect(payload.message).toMatch(/No installed Android system image is named "system-images;android-99/);
+    expect(payload.message).toMatch(
+      /system-images;android-36;google_apis;arm64-v8a, system-images;android-35;google_apis;arm64-v8a/,
+    );
+    expect(payload.remedy).toMatch(/--system-image/);
+    expect(h.calls.ensureDevice.length).toBe(0);
+  });
+
+  test('a blank value is STIM_BAD_ARG on its own', async () => {
+    const h = harness({ json: true, systemImage: '   ' });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    const stdout0 = h.stdout[0];
+    assert(stdout0);
+    expect(JSON.parse(stdout0).code).toBe('STIM_BAD_ARG');
+    expect(JSON.parse(stdout0).message).toMatch(/--system-image was given an empty id/);
+    expect(h.calls.ensureDevice.length).toBe(0);
+  });
+
+  test('the --json payload reports the system image the owned AVD actually has', async () => {
+    const h = harness({
+      json: true,
+      ensureDevice: async () => ({
+        avdName: 'stim-app-412',
+        consolePort: 5584,
+        owned: true,
+        systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+      }),
+    });
+    await h.run();
+    const stdout0 = h.stdout[0];
+    assert(stdout0);
+    expect(JSON.parse(stdout0).systemImage).toBe('system-images;android-36;google_apis;arm64-v8a');
   });
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -45,7 +45,11 @@ import type { AssetManifest } from '../engine/asset-manifest.ts';
 import { PREBUILD_ERROR } from '../engine/prebuild.ts';
 import { asProcessExit, makeChildProcess, makeError, makeExecutor } from './_factories.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
-import { unknownAndroidSystemImageRefusal } from '../engine/device.ts';
+
+const IMAGES = [
+  { api: 36, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-36;google_apis;arm64-v8a' },
+  { api: 35, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-35;google_apis;arm64-v8a' },
+];
 import { DEBUG_VERIFY_STEP_MS, type RunLease } from '../engine/device-lease-run.ts';
 
 const FINGERPRINT = 'a3f9b1c2d3e4f5a6b7c8d9e0f1a2b3c4';
@@ -247,7 +251,7 @@ function harness(overrides = {}) {
       calls.ensureDevice.push(args);
       return { avdName: 'stim-app-412', consolePort: 5584, owned: true };
     },
-    unknownSystemImage: () => null,
+    listSystemImages: () => IMAGES,
     ensureDeviceBooted: async (args: unknown = {}) => {
       calls.booted.push(args);
       return { ok: true, serial: 'emulator-5584' };
@@ -4292,15 +4296,7 @@ describe('the emulator system-image flag', () => {
   });
 
   test('an unknown system image refuses with STIM_BAD_ARG naming the installed ids, before anything is created', async () => {
-    const h = harness({
-      json: true,
-      systemImage: 'system-images;android-99;google_apis;arm64-v8a',
-      unknownSystemImage: (requested: string | null | undefined) =>
-        unknownAndroidSystemImageRefusal(requested, [
-          { api: 36, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-36;google_apis;arm64-v8a' },
-          { api: 35, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-35;google_apis;arm64-v8a' },
-        ]),
-    });
+    const h = harness({ json: true, systemImage: 'system-images;android-99;google_apis;arm64-v8a' });
     const result = await h.run();
     expect(result.ok).toBe(false);
     const stdout0 = h.stdout[0];
@@ -4312,6 +4308,37 @@ describe('the emulator system-image flag', () => {
       /system-images;android-36;google_apis;arm64-v8a, system-images;android-35;google_apis;arm64-v8a/,
     );
     expect(payload.remedy).toMatch(/--system-image/);
+    expect(h.calls.ensureDevice.length).toBe(0);
+  });
+
+  test('a plain run with neither flag nor setting never reads the system-image listing', async () => {
+    let listed = 0;
+    const h = harness({
+      listSystemImages: () => {
+        listed += 1;
+        return IMAGES;
+      },
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(listed).toBe(0);
+  });
+
+  test('an unreadable SDK is a structured refusal, not a stack trace', async () => {
+    const h = harness({
+      json: true,
+      systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+      listSystemImages: () => {
+        throw new Error('EACCES: permission denied');
+      },
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    const stdout0 = h.stdout[0];
+    assert(stdout0);
+    const payload = JSON.parse(stdout0);
+    expect(payload.code).toBe(NO_DEVICE);
+    expect(payload.message).toMatch(/Could not read the installed Android system images: EACCES/);
     expect(h.calls.ensureDevice.length).toBe(0);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1246,39 +1246,66 @@ const RUNTIMES = [
   },
 ];
 
+const VISION_PRO = { identifier: 'com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro', name: 'Apple Vision Pro' };
+const SIMCTL_DEVICE_TYPES = [...TYPES, VISION_PRO];
+
 const IMAGES = [
   { api: 36, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-36;google_apis;arm64-v8a' },
 ];
 
 describe('the unknown-name refusals', () => {
-  test('an installed device type passes and nothing is refused when none was asked for', () => {
-    expect(unknownIosDeviceTypeRefusal('iPhone 17 Pro', TYPES)).toBe(null);
-    expect(unknownIosDeviceTypeRefusal(null, TYPES)).toBe(null);
+  test('a device type an installed runtime supports passes, and nothing is refused when none was asked for', () => {
+    expect(unknownIosDeviceTypeRefusal('iPhone 17 Pro', RUNTIMES)).toBe(null);
+    expect(unknownIosDeviceTypeRefusal(null, RUNTIMES)).toBe(null);
     expect(unknownIosDeviceTypeRefusal(undefined, [])).toBe(null);
   });
 
-  test('an uninstalled device type is refused and every installed name is printed', () => {
-    const refusal = unknownIosDeviceTypeRefusal('iPad Pro 99-inch', TYPES);
+  test('a device type simctl lists but no iOS runtime can create is refused, not left to fail at creation', () => {
+    expect(SIMCTL_DEVICE_TYPES.some((d) => d.name === VISION_PRO.name)).toBe(true);
+    const refusal = unknownIosDeviceTypeRefusal(VISION_PRO.name, RUNTIMES);
     assert(refusal);
-    expect(refusal.message).toMatch(/No installed simulator device type is named "iPad Pro 99-inch"/);
-    expect(refusal.message).toMatch(/Installed device types: iPhone 17 Pro, iPhone 16\./);
+    expect(refusal.message).toMatch(
+      /No device type named "Apple Vision Pro" can be created on any installed simulator runtime/,
+    );
+    expect(refusal.message).toMatch(/Device types the installed runtimes support: iPhone 17 Pro, iPhone 16\./);
+    expect(refusal.message).not.toMatch(/Apple Vision Pro\./);
     expect(refusal.remedy).toMatch(/--device-type/);
-    expect(refusal.remedy).toMatch(/ios\.deviceType/);
+    expect(refusal.remedy).toMatch(/watchOS, tvOS and visionOS/);
+  });
+
+  test('the printed set narrows to the requested runtime, and a pair no runtime offers is refused', () => {
+    const runtimes = [
+      ...RUNTIMES,
+      {
+        identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-5',
+        name: 'iOS 18.5',
+        version: '18.5',
+        supportedDeviceTypes: [TYPE_16],
+      },
+    ];
+    expect(unknownIosDeviceTypeRefusal('iPhone 17 Pro', runtimes, '26.2')).toBe(null);
+    const refusal = unknownIosDeviceTypeRefusal('iPhone 17 Pro', runtimes, '18.5');
+    assert(refusal);
+    expect(refusal.message).toMatch(/No device type named "iPhone 17 Pro" can be created on runtime 18\.5/);
+    expect(refusal.message).toMatch(/Device types runtime 18\.5 supports: iPhone 16\./);
   });
 
   test('a machine with nothing installed says so rather than printing an empty list', () => {
     const refusal = unknownIosDeviceTypeRefusal('iPhone 17 Pro', []);
     assert(refusal);
-    expect(refusal.message).toMatch(/Installed device types: none\./);
+    expect(refusal.message).toMatch(/Device types the installed runtimes support: none\./);
   });
 
-  test('a runtime matches by version or by name suffix, the way creation matches it', () => {
+  test('a runtime matches by exact version or exact name, never by suffix', () => {
     expect(unknownIosRuntimeRefusal('26.2', RUNTIMES)).toBe(null);
     expect(unknownIosRuntimeRefusal('iOS 26.2', RUNTIMES)).toBe(null);
+    expect(unknownIosRuntimeRefusal('6.2', RUNTIMES)).not.toBe(null);
+    expect(unknownIosRuntimeRefusal('2', RUNTIMES)).not.toBe(null);
     const refusal = unknownIosRuntimeRefusal('18.5', RUNTIMES);
     assert(refusal);
     expect(refusal.message).toMatch(/No installed simulator runtime matches "18\.5"\. Installed runtimes: 26\.2\./);
     expect(refusal.remedy).toMatch(/ios\.runtime/);
+    expect(refusal.remedy).toMatch(/"iOS 26\.5"/);
   });
 
   test('an Android system image is matched on the exact sdkmanager package id', () => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -8,13 +8,22 @@ import {
   deviceTypeMismatch,
   ensureBooted,
   ensureOwnedDevice,
+  unknownAndroidSystemImageRefusal,
+  unknownIosDeviceTypeRefusal,
+  unknownIosRuntimeRefusal,
 } from '../engine/device.ts';
 import { allConsolePortsAndSerials, getProject, setDevice, upsertProject } from '../config.ts';
 import type { DeviceRecord } from '../types.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { makeAdbDevices, makeConfig, makeIosSim } from './_factories.ts';
 
-type SimEntry = { udid: string; name: string; state: string; isAvailable: boolean };
+type SimEntry = {
+  udid: string;
+  name: string;
+  state: string;
+  isAvailable: boolean;
+  deviceTypeIdentifier?: string;
+};
 
 let tmpHome: string;
 let savedAndroidHome: string | undefined;
@@ -1225,5 +1234,153 @@ describe('deviceCapacityRefusal', () => {
     });
     assert(refusal);
     expect(refusal.code).toBe('STIM_AT_CAPACITY');
+  });
+});
+
+const RUNTIMES = [
+  {
+    identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+    name: 'iOS 26.2',
+    version: '26.2',
+    supportedDeviceTypes: TYPES,
+  },
+];
+
+const IMAGES = [
+  { api: 36, tag: 'google_apis', arch: 'arm64-v8a', pkg: 'system-images;android-36;google_apis;arm64-v8a' },
+];
+
+describe('the unknown-name refusals', () => {
+  test('an installed device type passes and nothing is refused when none was asked for', () => {
+    expect(unknownIosDeviceTypeRefusal('iPhone 17 Pro', TYPES)).toBe(null);
+    expect(unknownIosDeviceTypeRefusal(null, TYPES)).toBe(null);
+    expect(unknownIosDeviceTypeRefusal(undefined, [])).toBe(null);
+  });
+
+  test('an uninstalled device type is refused and every installed name is printed', () => {
+    const refusal = unknownIosDeviceTypeRefusal('iPad Pro 99-inch', TYPES);
+    assert(refusal);
+    expect(refusal.message).toMatch(/No installed simulator device type is named "iPad Pro 99-inch"/);
+    expect(refusal.message).toMatch(/Installed device types: iPhone 17 Pro, iPhone 16\./);
+    expect(refusal.remedy).toMatch(/--device-type/);
+    expect(refusal.remedy).toMatch(/ios\.deviceType/);
+  });
+
+  test('a machine with nothing installed says so rather than printing an empty list', () => {
+    const refusal = unknownIosDeviceTypeRefusal('iPhone 17 Pro', []);
+    assert(refusal);
+    expect(refusal.message).toMatch(/Installed device types: none\./);
+  });
+
+  test('a runtime matches by version or by name suffix, the way creation matches it', () => {
+    expect(unknownIosRuntimeRefusal('26.2', RUNTIMES)).toBe(null);
+    expect(unknownIosRuntimeRefusal('iOS 26.2', RUNTIMES)).toBe(null);
+    const refusal = unknownIosRuntimeRefusal('18.5', RUNTIMES);
+    assert(refusal);
+    expect(refusal.message).toMatch(/No installed simulator runtime matches "18\.5"\. Installed runtimes: 26\.2\./);
+    expect(refusal.remedy).toMatch(/ios\.runtime/);
+  });
+
+  test('an Android system image is matched on the exact sdkmanager package id', () => {
+    expect(unknownAndroidSystemImageRefusal('system-images;android-36;google_apis;arm64-v8a', IMAGES)).toBe(null);
+    expect(unknownAndroidSystemImageRefusal(null, IMAGES)).toBe(null);
+    const refusal = unknownAndroidSystemImageRefusal('system-images;android-99;google_apis;arm64-v8a', IMAGES);
+    assert(refusal);
+    expect(refusal.message).toMatch(/No installed Android system image is named/);
+    expect(refusal.message).toMatch(/Installed system images: system-images;android-36;google_apis;arm64-v8a\./);
+    expect(refusal.remedy).toMatch(/android\.systemImage/);
+  });
+});
+
+describe('ensureOwnedDevice: the requested model against the sim this workspace already owns', () => {
+  test('a different model refuses with the reap-then-rerun remedy and boots nothing', async () => {
+    const root = projectDir();
+    try {
+      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-app' });
+      const { run, exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'stim-app',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_16.identifier,
+        },
+      ]);
+      setExecutor(exec);
+
+      await expect(
+        ensureOwnedDevice({
+          platform: 'ios',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+          flags: { deviceType: 'iPhone 17 Pro' },
+        }),
+      ).rejects.toThrow(
+        /this project's sim is iPhone 16, but --device-type asked for iPhone 17 Pro\. Stim will not silently boot a different model\. Run `stim worktree remove` \(or `stim gc --delete`\) to reap the current sim, then `stim ios` again to create the requested one\./,
+      );
+
+      expect(run.some((cmd) => /simctl boot/.test(cmd))).toBe(false);
+      expect(run.some((cmd) => /simctl create/.test(cmd))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a matching model reuses the sim and reports its model and runtime', async () => {
+    const root = projectDir();
+    try {
+      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-app' });
+      const { exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'stim-app',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_16.identifier,
+        },
+      ]);
+      setExecutor(exec);
+
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+        flags: { deviceType: 'iPhone 16' },
+      });
+
+      expect(device.deviceType).toBe('iPhone 16');
+      expect(device.runtime).toBe('26.2');
+      expect(getProject(root)?.platforms?.ios?.deviceType).toBe(undefined);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a created sim reports the model and runtime it was created with', async () => {
+    const root = projectDir();
+    try {
+      const { run, exec } = iosExecutor([]);
+      setExecutor(exec);
+
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+        flags: { deviceType: 'iPhone 16', runtime: '26.2' },
+      });
+
+      expect(device.deviceType).toBe('iPhone 16');
+      expect(device.runtime).toBe('26.2');
+      expect(run.some((cmd) => cmd.includes(`simctl create "stim-app" "${TYPE_16.identifier}"`))).toBe(true);
+      expect(getProject(root)?.platforms?.ios?.runtime).toBe(undefined);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -65,6 +65,8 @@ test('the facts topic documents the fields each --json payload actually carries'
       'installSkipped',
       'launched',
       'metroPort',
+      'deviceType',
+      'runtime',
     ],
     android: [
       'serial',
@@ -80,6 +82,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'installSkipped',
       'launched',
       'durationMs',
+      'systemImage',
     ],
   };
   for (const [command, names] of Object.entries(fields)) {
@@ -138,8 +141,25 @@ test('the flags the guide advertises are the flags the commands define', () => {
   assert(lifecycle);
   const advertised = {
     'start.ts': ['--json', '--wait', '--remote'],
-    'ios.ts': ['--json', '--no-metro-check', '--no-build-cache', '--configuration', '--device', '--remote'],
-    'android.ts': ['--json', '--no-metro-check', '--no-build-cache', '--variant', '--device', '--remote'],
+    'ios.ts': [
+      '--json',
+      '--no-metro-check',
+      '--no-build-cache',
+      '--configuration',
+      '--device-type',
+      '--runtime',
+      '--device',
+      '--remote',
+    ],
+    'android.ts': [
+      '--json',
+      '--no-metro-check',
+      '--no-build-cache',
+      '--variant',
+      '--system-image',
+      '--device',
+      '--remote',
+    ],
     'stop.ts': ['--json', '--force'],
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
     'gc.ts': ['--delete', '--older-than', '--cache'],
@@ -1081,4 +1101,41 @@ test('the guide documents the pool an id-less --device picks from', () => {
   expect(lifecycle).not.toMatch(/refuses with the candidate\s+list/);
   expect(lifecycle).toMatch(/no serial it takes the first device it can lease/);
   expect(lifecycle).toMatch(/with no UDID it takes the\s+first device it can lease/);
+});
+
+test('the option surface lists the model and runtime flags on both platforms', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(lifecycle).toMatch(/ios\s+--json[^\n]*--device-type <name> --runtime <version>/);
+  expect(lifecycle).toMatch(/android\s+--json[^\n]*--system-image <id>/);
+  expect(lifecycle).toMatch(/Each overrides its\s+setting \(ios\.deviceType, ios\.runtime, android\.systemImage\)/);
+  expect(lifecycle).toMatch(/exactly as `--configuration` overrides ios\.configuration/);
+  expect(lifecycle).toMatch(/reap the current\s+sim with `stim worktree remove` \(or `stim gc --delete`\)/);
+});
+
+test('the settings topic says the flag overrides each device-model key', () => {
+  const settings = renderTopic('settings');
+  assert(settings);
+  const flat = settings.replace(/\s+/g, ' ');
+  expect(flat).toMatch(/ios\.deviceType[^|]*The `--device-type` flag overrides this per invocation/);
+  expect(flat).toMatch(/ios\.runtime[^|]*The `--runtime` flag overrides this per invocation/);
+  expect(flat).toMatch(/android\.systemImage[^|]*The `--system-image` flag overrides this per invocation/);
+});
+
+test('the errors topic names an uninstalled device name as a STIM_BAD_ARG cause with the printed-names remedy', () => {
+  const errors = renderTopic('errors');
+  assert(errors);
+  const section = errors.slice(errors.indexOf('STIM_BAD_ARG')).replace(/\s+/g, ' ');
+  expect(section).toMatch(/`--device-type`, `--runtime` or `--system-image` name that is BLANK or is not installed/);
+  expect(section).toMatch(/the installed names are printed in the message/);
+});
+
+test('the facts topic documents the model, runtime and system image the run reports', () => {
+  const facts = renderTopic('facts');
+  assert(facts);
+  const flat = facts.replace(/\s+/g, ' ');
+  expect(flat).toMatch(/deviceType the owned simulator's MODEL/);
+  expect(flat).toMatch(/runtime that simulator's iOS runtime version/);
+  expect(flat).toMatch(/systemImage the sdkmanager package id the owned AVD was created from/);
+  expect(flat).toMatch(/a run driven by the ios\.deviceType setting reports it too/);
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1128,6 +1128,22 @@ test('the errors topic names an uninstalled device name as a STIM_BAD_ARG cause 
   const section = errors.slice(errors.indexOf('STIM_BAD_ARG')).replace(/\s+/g, ' ');
   expect(section).toMatch(/`--device-type`, `--runtime` or `--system-image` name that is BLANK or is not installed/);
   expect(section).toMatch(/the installed names are printed in the message/);
+  expect(section).toMatch(/the check applies even when this workspace ALREADY owns a device/);
+  expect(section).toMatch(/runs only when a name was actually given/);
+  expect(section).toMatch(/a listing that fails is reported as STIM_NO_DEVICE naming the tool, never as a crash/);
+  expect(section).not.toMatch(/before anything is spawned/);
+});
+
+test('the guide says what counts as an installed model, and the two runtime forms', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  const flat = lifecycle.replace(/\s+/g, ' ');
+  expect(flat).toMatch(/what an installed RUNTIME can create, not what `xcrun simctl list devicetypes` prints/);
+  expect(flat).toMatch(/narrowed to the one runtime when `--runtime` also resolved/);
+  expect(flat).toMatch(/`--runtime` takes a version \(`26\.5`\) or a runtime's full name \(`iOS 26\.5`\), exactly/);
+  const settings = renderTopic('settings');
+  assert(settings);
+  expect(settings.replace(/\s+/g, ' ')).toMatch(/as a version \("26\.2"\) or a runtime's full name \("iOS 26\.2"\)/);
 });
 
 test('the facts topic documents the model, runtime and system image the run reports', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -23,6 +23,8 @@ import {
   isReleaseConfiguration,
   lastBuildRecord,
   resolveConfiguration,
+  resolveDeviceType,
+  resolveRuntime,
   phaseLine,
   podAction,
   ensureWorkspaceStorageSafely,
@@ -41,6 +43,7 @@ import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroReso
 import { RELEASE_VERIFY_WAIT_MS } from '../engine/app-install.ts';
 import { DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../engine/ios-device.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
+import { unknownIosDeviceTypeRefusal, unknownIosRuntimeRefusal } from '../engine/device.ts';
 import { DEBUG_VERIFY_STEP_MS, type RunLease } from '../engine/device-lease-run.ts';
 
 const UDID = 'BF2A1C3D-4E5F-6071-8293-A4B5C6D7E8F9';
@@ -169,6 +172,8 @@ function harness(overrides: LooseDeps = {}) {
       record('ensureOwnedDevice', args);
       return { deviceUdid: UDID, deviceName: 'stim-fixture', owned: true };
     },
+    unknownDeviceType: () => null,
+    unknownRuntime: () => null,
     ensureBooted: async (args) => {
       record('ensureBooted', args);
       return { ok: true, udid: UDID };
@@ -2095,6 +2100,8 @@ describe('iosFacts', () => {
       platform: 'ios',
       udid: UDID,
       deviceName: 'stim-x',
+      deviceType: null,
+      runtime: null,
       fingerprint: 'abc',
       configuration: null,
       cacheKey: 'abc-debug-sim',
@@ -4349,5 +4356,121 @@ describe('ios --device: the lease on the phone', () => {
     } finally {
       process.argv = argv;
     }
+  });
+});
+
+describe('the simulator model and runtime flags', () => {
+  test('resolveDeviceType and resolveRuntime put the flag over the setting', () => {
+    const settings = { ios: { deviceType: 'iPhone 17 Pro', runtime: '26.2' } };
+    expect(resolveDeviceType('iPad Pro 13-inch (M4)', settings)).toBe('iPad Pro 13-inch (M4)');
+    expect(resolveRuntime('18.5', settings)).toBe('18.5');
+    expect(resolveDeviceType(null, settings)).toBe('iPhone 17 Pro');
+    expect(resolveRuntime(null, settings)).toBe('26.2');
+    expect(resolveDeviceType('  ', settings)).toBe('iPhone 17 Pro');
+    expect(resolveRuntime('  ', settings)).toBe('26.2');
+    expect(resolveDeviceType(null, {})).toBe(null);
+    expect(resolveRuntime(null, null)).toBe(null);
+  });
+
+  test('the flags reach the engine and override the settings for that invocation', async () => {
+    reserve();
+    const settings = { ios: { deviceType: 'iPhone 17 Pro', runtime: '26.2' } };
+    const fromSetting = await run({}, { resolveSettings: () => settings });
+    expect(fromSetting.calls.args['ensureOwnedDevice']).toMatchObject({
+      flags: { deviceType: 'iPhone 17 Pro', runtime: '26.2' },
+    });
+    const fromFlag = await run(
+      { deviceType: 'iPad Pro 13-inch (M4)', runtime: '18.5' },
+      { resolveSettings: () => settings },
+    );
+    expect(fromFlag.calls.args['ensureOwnedDevice']).toMatchObject({
+      flags: { deviceType: 'iPad Pro 13-inch (M4)', runtime: '18.5' },
+    });
+    const neither = await run({});
+    expect(neither.calls.args['ensureOwnedDevice']).toMatchObject({ flags: { deviceType: null, runtime: null } });
+  });
+
+  test('an unknown device type refuses with STIM_BAD_ARG naming the installed models, before anything is created', async () => {
+    reserve();
+    const { exitCode, logs, errs, calls } = await run(
+      { deviceType: 'iPad Pro 99-inch', json: true },
+      {
+        unknownDeviceType: (requested: string | null | undefined) =>
+          unknownIosDeviceTypeRefusal(requested, [
+            { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17', name: 'iPhone 17' },
+            { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-M4', name: 'iPad Pro 13-inch (M4)' },
+          ]),
+      },
+    );
+    expect(exitCode).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_BAD_ARG');
+    expect(payload.message).toMatch(/No installed simulator device type is named "iPad Pro 99-inch"/);
+    expect(payload.message).toMatch(/iPhone 17, iPad Pro 13-inch \(M4\)/);
+    expect(payload.remedy).toMatch(/--device-type/);
+    expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+    expect(calls.order.includes('buildIos')).toBeFalsy();
+    expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
+  });
+
+  test('an unknown runtime refuses the same way, naming the installed versions', async () => {
+    reserve();
+    const { exitCode, logs, calls } = await run(
+      { runtime: '99.9', json: true },
+      {
+        unknownRuntime: (requested: string | null | undefined) =>
+          unknownIosRuntimeRefusal(requested, [
+            {
+              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-5',
+              name: 'iOS 18.5',
+              version: '18.5',
+              supportedDeviceTypes: [],
+            },
+          ]),
+      },
+    );
+    expect(exitCode).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_BAD_ARG');
+    expect(payload.message).toMatch(/No installed simulator runtime matches "99\.9"\. Installed runtimes: 18\.5\./);
+    expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+  });
+
+  test('a blank value is STIM_BAD_ARG on its own', async () => {
+    reserve();
+    const blankType = await run({ deviceType: '   ', json: true });
+    expect(blankType.exitCode).toBe(1);
+    expect(parseFirst(blankType.logs).code).toBe('STIM_BAD_ARG');
+    expect(parseFirst(blankType.logs).message).toMatch(/--device-type was given an empty name/);
+    const blankRuntime = await run({ runtime: '', json: true });
+    expect(blankRuntime.exitCode).toBe(1);
+    expect(parseFirst(blankRuntime.logs).message).toMatch(/--runtime was given an empty version/);
+  });
+
+  test('the --json payload reports the model and runtime the owned simulator actually has', async () => {
+    reserve();
+    const { logs } = await run(
+      { json: true },
+      {
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture',
+          owned: true,
+          deviceType: 'iPad Pro 13-inch (M4)',
+          runtime: '18.5',
+        }),
+      },
+    );
+    const payload = parseFirst(logs);
+    expect(payload.deviceType).toBe('iPad Pro 13-inch (M4)');
+    expect(payload.runtime).toBe('18.5');
+  });
+
+  test('a device Stim does not own reports both as null', async () => {
+    reserve();
+    const { logs } = await run({ json: true });
+    const payload = parseFirst(logs);
+    expect(payload.deviceType).toBe(null);
+    expect(payload.runtime).toBe(null);
   });
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -43,7 +43,26 @@ import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroReso
 import { RELEASE_VERIFY_WAIT_MS } from '../engine/app-install.ts';
 import { DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../engine/ios-device.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
-import { unknownIosDeviceTypeRefusal, unknownIosRuntimeRefusal } from '../engine/device.ts';
+
+const RUNTIMES = [
+  {
+    identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+    name: 'iOS 26.5',
+    version: '26.5',
+    supportedDeviceTypes: [
+      { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro', name: 'iPhone 17 Pro' },
+      { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-M4', name: 'iPad Pro 13-inch (M4)' },
+    ],
+  },
+  {
+    identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-5',
+    name: 'iOS 18.5',
+    version: '18.5',
+    supportedDeviceTypes: [
+      { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro', name: 'iPhone 17 Pro' },
+    ],
+  },
+];
 import { DEBUG_VERIFY_STEP_MS, type RunLease } from '../engine/device-lease-run.ts';
 
 const UDID = 'BF2A1C3D-4E5F-6071-8293-A4B5C6D7E8F9';
@@ -172,8 +191,7 @@ function harness(overrides: LooseDeps = {}) {
       record('ensureOwnedDevice', args);
       return { deviceUdid: UDID, deviceName: 'stim-fixture', owned: true };
     },
-    unknownDeviceType: () => null,
-    unknownRuntime: () => null,
+    listIosRuntimes: () => RUNTIMES,
     ensureBooted: async (args) => {
       record('ensureBooted', args);
       return { ok: true, udid: UDID };
@@ -4374,66 +4392,116 @@ describe('the simulator model and runtime flags', () => {
 
   test('the flags reach the engine and override the settings for that invocation', async () => {
     reserve();
-    const settings = { ios: { deviceType: 'iPhone 17 Pro', runtime: '26.2' } };
+    const settings = { ios: { deviceType: 'iPhone 17 Pro', runtime: '18.5' } };
     const fromSetting = await run({}, { resolveSettings: () => settings });
     expect(fromSetting.calls.args['ensureOwnedDevice']).toMatchObject({
-      flags: { deviceType: 'iPhone 17 Pro', runtime: '26.2' },
+      flags: { deviceType: 'iPhone 17 Pro', runtime: '18.5' },
     });
     const fromFlag = await run(
-      { deviceType: 'iPad Pro 13-inch (M4)', runtime: '18.5' },
+      { deviceType: 'iPad Pro 13-inch (M4)', runtime: '26.5' },
       { resolveSettings: () => settings },
     );
     expect(fromFlag.calls.args['ensureOwnedDevice']).toMatchObject({
-      flags: { deviceType: 'iPad Pro 13-inch (M4)', runtime: '18.5' },
+      flags: { deviceType: 'iPad Pro 13-inch (M4)', runtime: '26.5' },
     });
     const neither = await run({});
     expect(neither.calls.args['ensureOwnedDevice']).toMatchObject({ flags: { deviceType: null, runtime: null } });
   });
 
-  test('an unknown device type refuses with STIM_BAD_ARG naming the installed models, before anything is created', async () => {
+  test('a device type no installed runtime can create refuses with STIM_BAD_ARG, before anything is created', async () => {
     reserve();
-    const { exitCode, logs, errs, calls } = await run(
-      { deviceType: 'iPad Pro 99-inch', json: true },
-      {
-        unknownDeviceType: (requested: string | null | undefined) =>
-          unknownIosDeviceTypeRefusal(requested, [
-            { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17', name: 'iPhone 17' },
-            { identifier: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-M4', name: 'iPad Pro 13-inch (M4)' },
-          ]),
-      },
-    );
+    const { exitCode, logs, errs, calls } = await run({ deviceType: 'iPad Pro 99-inch', json: true });
     expect(exitCode).toBe(1);
     const payload = parseFirst(logs);
     expect(payload.code).toBe('STIM_BAD_ARG');
-    expect(payload.message).toMatch(/No installed simulator device type is named "iPad Pro 99-inch"/);
-    expect(payload.message).toMatch(/iPhone 17, iPad Pro 13-inch \(M4\)/);
+    expect(payload.message).toMatch(
+      /No device type named "iPad Pro 99-inch" can be created on any installed simulator runtime/,
+    );
+    expect(payload.message).toMatch(/iPhone 17 Pro, iPad Pro 13-inch \(M4\)/);
     expect(payload.remedy).toMatch(/--device-type/);
     expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
     expect(calls.order.includes('buildIos')).toBeFalsy();
     expect(errs.join('\n')).toMatch(/STIM_BAD_ARG/);
   });
 
-  test('an unknown runtime refuses the same way, naming the installed versions', async () => {
+  test('a name simctl lists but no runtime supports is refused here, not left to fail at creation', async () => {
     reserve();
-    const { exitCode, logs, calls } = await run(
-      { runtime: '99.9', json: true },
-      {
-        unknownRuntime: (requested: string | null | undefined) =>
-          unknownIosRuntimeRefusal(requested, [
-            {
-              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-5',
-              name: 'iOS 18.5',
-              version: '18.5',
-              supportedDeviceTypes: [],
-            },
-          ]),
-      },
-    );
+    const { exitCode, logs, calls } = await run({ deviceType: 'Apple Vision Pro', json: true });
+    expect(exitCode).toBe(1);
+    expect(parseFirst(logs).code).toBe('STIM_BAD_ARG');
+    expect(parseFirst(logs).message).not.toMatch(/Apple Vision Pro\./);
+    expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+  });
+
+  test('a device-type and runtime pair no runtime offers is refused against that runtime alone', async () => {
+    reserve();
+    const { exitCode, logs, calls } = await run({
+      deviceType: 'iPad Pro 13-inch (M4)',
+      runtime: '18.5',
+      json: true,
+    });
     expect(exitCode).toBe(1);
     const payload = parseFirst(logs);
     expect(payload.code).toBe('STIM_BAD_ARG');
-    expect(payload.message).toMatch(/No installed simulator runtime matches "99\.9"\. Installed runtimes: 18\.5\./);
+    expect(payload.message).toMatch(
+      /No device type named "iPad Pro 13-inch \(M4\)" can be created on runtime 18\.5\. Device types runtime 18\.5 supports: iPhone 17 Pro\./,
+    );
     expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+
+    const ok = await run({ deviceType: 'iPad Pro 13-inch (M4)', runtime: '26.5', json: true });
+    expect(ok.calls.order.includes('ensureOwnedDevice')).toBeTruthy();
+  });
+
+  test('an unknown runtime refuses first, naming the installed versions', async () => {
+    reserve();
+    const { exitCode, logs, calls } = await run({ runtime: '99.9', json: true });
+    expect(exitCode).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_BAD_ARG');
+    expect(payload.message).toMatch(
+      /No installed simulator runtime matches "99\.9"\. Installed runtimes: 26\.5, 18\.5\./,
+    );
+    expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+
+    const suffix = await run({ runtime: '5', json: true });
+    expect(suffix.exitCode).toBe(1);
+    expect(parseFirst(suffix.logs).message).toMatch(/No installed simulator runtime matches "5"/);
+  });
+
+  test('a plain run with neither flag nor setting never spawns the runtime listing', async () => {
+    reserve();
+    let listed = 0;
+    const { exitCode } = await run(
+      {},
+      {
+        listIosRuntimes: () => {
+          listed += 1;
+          return RUNTIMES;
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(listed).toBe(0);
+  });
+
+  test('an xcrun failure while listing is a structured refusal, not a stack trace', async () => {
+    reserve();
+    const { exitCode, logs, errs, calls } = await run(
+      { deviceType: 'iPhone 17 Pro', json: true },
+      {
+        listIosRuntimes: () => {
+          throw new Error('xcrun: error: unable to find utility "simctl"');
+        },
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(logs.length).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_NO_DEVICE');
+    expect(payload.message).toMatch(/Could not read the installed simulator runtimes: xcrun: error/);
+    expect(payload.remedy).toMatch(/stim doctor/);
+    expect(calls.order.includes('ensureOwnedDevice')).toBeFalsy();
+    expect(errs.join('\n')).not.toMatch(/at .*\(/);
   });
 
   test('a blank value is STIM_BAD_ARG on its own', async () => {

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -33,6 +33,8 @@ import {
   pickDefaultSystemImage,
   hostSystemImageArch,
   ownedAvdDirectory,
+  ownedAvdSystemImage,
+  parseAvdSystemImage,
   deleteAvd,
   resolveOwnedAvdSerial,
   physicalDeviceModel,
@@ -919,4 +921,32 @@ test('memoizeEmulatorProbe probes a serial once and reuses the result across rep
   expect(probe('emulator-5554')).toBe(true);
   expect(probe('RFCR7081Q9L')).toBe(false);
   expect(calls).toEqual(['emulator-5554', 'RFCR7081Q9L']);
+});
+
+test('parseAvdSystemImage turns the config.ini image directory back into an sdkmanager package id', () => {
+  expect(
+    parseAvdSystemImage(
+      'avd.ini.encoding=UTF-8\nimage.sysdir.1=system-images/android-36/google_apis/arm64-v8a/\ntag.id=google_apis\n',
+    ),
+  ).toBe('system-images;android-36;google_apis;arm64-v8a');
+  expect(parseAvdSystemImage('image.sysdir.1 = system-images/android-35/default/x86_64')).toBe(
+    'system-images;android-35;default;x86_64',
+  );
+  expect(parseAvdSystemImage('image.sysdir.1=\n')).toBe(null);
+  expect(parseAvdSystemImage('hw.cpu.arch=arm64\n')).toBe(null);
+  expect(parseAvdSystemImage('')).toBe(null);
+});
+
+test('ownedAvdSystemImage reads the AVD Stim owns and stays null when it cannot', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'stim-avd-image-'));
+  try {
+    writeFileSync(join(dir, 'config.ini'), 'image.sysdir.1=system-images/android-36/google_apis/arm64-v8a/\n');
+    expect(ownedAvdSystemImage('stim-app', { avdDirectory: () => dir })).toBe(
+      'system-images;android-36;google_apis;arm64-v8a',
+    );
+    expect(ownedAvdSystemImage('stim-app', { avdDirectory: () => null })).toBe(null);
+    expect(ownedAvdSystemImage('stim-app', { avdDirectory: () => join(dir, 'gone') })).toBe(null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -105,6 +105,7 @@ import {
   extractEmulatorFailure,
   findBuildTool,
   listAdbDevices,
+  listInstalledSystemImages,
   physicalDeviceModel,
   probeEmulatorSerial,
   resolvePhysicalDevice,
@@ -115,7 +116,6 @@ import {
   ensureOwnedDevice,
   unknownAndroidSystemImageRefusal,
   type OwnedDeviceRecord,
-  type UnknownDeviceNameRefusal,
 } from '../engine/device.ts';
 import {
   REMOTE_SESSION_ERROR,
@@ -199,23 +199,36 @@ function systemImageRefusal({
   resolved,
   physical,
   remoteBackend,
-  unknown,
+  listImages,
 }: {
   flag: string | null | undefined;
   resolved: string | null;
   physical: boolean;
   remoteBackend: string | null;
-  unknown: typeof unknownAndroidSystemImageRefusal;
-}): UnknownDeviceNameRefusal | null {
+  listImages: typeof listInstalledSystemImages;
+}): { code: string; message: string; remedy: string } | null {
   if (typeof flag === 'string' && flag.trim() === '') {
     return {
+      code: 'STIM_BAD_ARG',
       message: '--system-image was given an empty id.',
       remedy:
         'Pass `--system-image <id>` with an sdkmanager package id, e.g. "system-images;android-36;google_apis;arm64-v8a".',
     };
   }
   if (physical || remoteBackend) return null;
-  return unknown(resolved);
+  if (!resolved) return null;
+  let images;
+  try {
+    images = listImages();
+  } catch (error) {
+    return {
+      code: NO_DEVICE,
+      message: `Could not read the installed Android system images: ${(error as Error)?.message || error}`,
+      remedy: 'Check that ANDROID_HOME points at a readable SDK, then try again.',
+    };
+  }
+  const refusal = unknownAndroidSystemImageRefusal(resolved, images);
+  return refusal ? { code: 'STIM_BAD_ARG', message: refusal.message, remedy: refusal.remedy } : null;
 }
 
 export function isReleaseVariant(variant: string | null | undefined): boolean {
@@ -751,7 +764,7 @@ interface RunAndroidOptions {
   useBuildCache?: boolean;
   variant?: string | null;
   systemImage?: string | null;
-  unknownSystemImage?: typeof unknownAndroidSystemImageRefusal;
+  listSystemImages?: typeof listInstalledSystemImages;
   device?: string | boolean | null;
   wait?: string | boolean;
   waitConflict?: boolean;
@@ -1514,7 +1527,7 @@ function resolveRunAndroidOptions(
     acquireSlot = acquireBuildSlot,
     releaseSlot = releaseBuildSlot,
     ensureDevice = ensureOwnedDevice,
-    unknownSystemImage = unknownAndroidSystemImageRefusal,
+    listSystemImages = listInstalledSystemImages,
     ensureDeviceBooted = ensureBooted,
     resolveMetro = resolveProjectMetro,
     resolveMetroRetrying = resolveMetroWithRetry,
@@ -1587,7 +1600,7 @@ function resolveRunAndroidOptions(
     acquireSlot,
     releaseSlot,
     ensureDevice,
-    unknownSystemImage,
+    listSystemImages,
     ensureDeviceBooted,
     resolveMetro,
     resolveMetroRetrying,
@@ -1662,7 +1675,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     acquireSlot,
     releaseSlot,
     ensureDevice,
-    unknownSystemImage,
+    listSystemImages,
     ensureDeviceBooted,
     resolveMetro,
     resolveMetroRetrying,
@@ -1887,9 +1900,9 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     resolved: systemImage,
     physical,
     remoteBackend,
-    unknown: unknownSystemImage,
+    listImages: listSystemImages,
   });
-  if (imageRefusal) return fail('STIM_BAD_ARG', imageRefusal.message, imageRefusal.remedy);
+  if (imageRefusal) return fail(imageRefusal.code, imageRefusal.message, imageRefusal.remedy);
   const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
   let androidPackage = detectAndroidPackage(root);
   record.bundleId = androidPackage;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -109,7 +109,14 @@ import {
   probeEmulatorSerial,
   resolvePhysicalDevice,
 } from '../sim/android.ts';
-import { checkDeviceCapacity, ensureBooted, ensureOwnedDevice } from '../engine/device.ts';
+import {
+  checkDeviceCapacity,
+  ensureBooted,
+  ensureOwnedDevice,
+  unknownAndroidSystemImageRefusal,
+  type OwnedDeviceRecord,
+  type UnknownDeviceNameRefusal,
+} from '../engine/device.ts';
 import {
   REMOTE_SESSION_ERROR,
   binOnPath,
@@ -133,7 +140,6 @@ import {
   type RunLease,
 } from '../engine/device-lease-run.ts';
 import { ownedSessionName } from '../engine/eas-simulator.ts';
-import type { OwnedDeviceRecord } from '../engine/device.ts';
 import { needsPrebuild, runPrebuild } from '../engine/prebuild.ts';
 import { buildAndroid, productFlavorRefusal, readProductFlavors } from '../engine/gradle.ts';
 import { resolveKeystore, swapApkBundle } from '../engine/apk-swap.ts';
@@ -171,6 +177,45 @@ export function resolveVariant(
 ): string | null {
   const fromFlag = typeof flag === 'string' && flag.trim() !== '' ? flag.trim() : null;
   return fromFlag || androidVariantSetting(settings);
+}
+
+export function androidSystemImageSetting(settings: SettingsObject | null | undefined): string | null {
+  const android = settings?.['android'];
+  if (!android || typeof android !== 'object' || Array.isArray(android)) return null;
+  const raw = (android as Record<string, unknown>)['systemImage'];
+  return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null;
+}
+
+export function resolveSystemImage(
+  flag: string | null | undefined,
+  settings: SettingsObject | null | undefined,
+): string | null {
+  const fromFlag = typeof flag === 'string' && flag.trim() !== '' ? flag.trim() : null;
+  return fromFlag || androidSystemImageSetting(settings);
+}
+
+function systemImageRefusal({
+  flag,
+  resolved,
+  physical,
+  remoteBackend,
+  unknown,
+}: {
+  flag: string | null | undefined;
+  resolved: string | null;
+  physical: boolean;
+  remoteBackend: string | null;
+  unknown: typeof unknownAndroidSystemImageRefusal;
+}): UnknownDeviceNameRefusal | null {
+  if (typeof flag === 'string' && flag.trim() === '') {
+    return {
+      message: '--system-image was given an empty id.',
+      remedy:
+        'Pass `--system-image <id>` with an sdkmanager package id, e.g. "system-images;android-36;google_apis;arm64-v8a".',
+    };
+  }
+  if (physical || remoteBackend) return null;
+  return unknown(resolved);
 }
 
 export function isReleaseVariant(variant: string | null | undefined): boolean {
@@ -247,6 +292,7 @@ interface AndroidCommandOptions {
   metroCheck?: boolean;
   buildCache?: boolean;
   variant?: string;
+  systemImage?: string;
   remote?: RemoteDeviceBackend;
   device?: string | boolean;
   wait?: string | boolean;
@@ -269,6 +315,7 @@ interface AndroidRecord {
   bundleId?: string | null;
   avdName?: string | null;
   deviceName?: string | null;
+  systemImage?: string | null;
 }
 
 export const NO_METRO = 'STIM_NO_METRO';
@@ -469,6 +516,7 @@ export function androidFacts({
   serial,
   avdName = null,
   deviceName = null,
+  systemImage = null,
   fingerprint,
   cacheKey = null,
   variant = null,
@@ -490,6 +538,7 @@ export function androidFacts({
   serial?: string | null;
   avdName?: string | null;
   deviceName?: string | null;
+  systemImage?: string | null;
   fingerprint?: string | null;
   cacheKey?: string | null;
   variant?: string | null;
@@ -513,6 +562,7 @@ export function androidFacts({
     serial: serial ?? null,
     avdName: avdName ?? null,
     deviceName: deviceName ?? avdName ?? null,
+    systemImage: systemImage ?? null,
     fingerprint: fingerprint ?? null,
     cacheKey: cacheKey ?? null,
     variant: variant ?? null,
@@ -645,6 +695,12 @@ export function registerAndroid(program: Command): void {
       'Gradle variant to assemble and install (e.g. productionDebug on a flavored project); overrides the android.variant setting. A variant ending in Release embeds the JS bundle and skips Metro entirely. Default: debug',
     )
     .option(
+      '--system-image <id>',
+      "Android system image to create this workspace's owned AVD from, as the sdkmanager package id " +
+        '(e.g. "system-images;android-36;google_apis;arm64-v8a"). Overrides the android.systemImage setting for this ' +
+        'invocation. An unknown id refuses with STIM_BAD_ARG and prints the installed images.',
+    )
+    .option(
       '--device [serial]',
       "Install and launch on a connected physical device instead of this workspace's owned emulator. " +
         'With no serial, the first connected device this workspace can lease is used. Stim never creates, boots, or deletes a physical device.',
@@ -678,6 +734,7 @@ export function registerAndroid(program: Command): void {
         metroCheck: opts.metroCheck !== false,
         useBuildCache: opts.buildCache !== false,
         variant: opts.variant ?? null,
+        systemImage: opts.systemImage ?? null,
         remoteDevice: opts.remote ?? null,
         device: opts.device ?? null,
         wait: opts.wait,
@@ -693,6 +750,8 @@ interface RunAndroidOptions {
   metroCheck?: boolean;
   useBuildCache?: boolean;
   variant?: string | null;
+  systemImage?: string | null;
+  unknownSystemImage?: typeof unknownAndroidSystemImageRefusal;
   device?: string | boolean | null;
   wait?: string | boolean;
   waitConflict?: boolean;
@@ -983,6 +1042,7 @@ function reportAndroidResult({
     serial,
     avdName: record.avdName,
     deviceName: record.deviceName,
+    systemImage: record.systemImage,
     debugHttpHost: launched.debugHttpHost ?? null,
     debugHttpHostNote: launched.debugHttpHostNote ?? null,
     devClientUrl: launched.devClientUrl ?? null,
@@ -1437,6 +1497,7 @@ function resolveRunAndroidOptions(
     metroCheck = true,
     useBuildCache = true,
     variant: variantFlag = null,
+    systemImage: systemImageFlag = null,
     device: deviceFlag = null,
     wait: waitFlag = undefined,
     waitConflict = false,
@@ -1453,6 +1514,7 @@ function resolveRunAndroidOptions(
     acquireSlot = acquireBuildSlot,
     releaseSlot = releaseBuildSlot,
     ensureDevice = ensureOwnedDevice,
+    unknownSystemImage = unknownAndroidSystemImageRefusal,
     ensureDeviceBooted = ensureBooted,
     resolveMetro = resolveProjectMetro,
     resolveMetroRetrying = resolveMetroWithRetry,
@@ -1508,6 +1570,7 @@ function resolveRunAndroidOptions(
     metroCheck,
     useBuildCache,
     variantFlag,
+    systemImageFlag,
     deviceFlag,
     waitFlag,
     waitConflict,
@@ -1524,6 +1587,7 @@ function resolveRunAndroidOptions(
     acquireSlot,
     releaseSlot,
     ensureDevice,
+    unknownSystemImage,
     ensureDeviceBooted,
     resolveMetro,
     resolveMetroRetrying,
@@ -1581,6 +1645,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     metroCheck,
     useBuildCache,
     variantFlag,
+    systemImageFlag,
     deviceFlag,
     waitFlag,
     waitConflict,
@@ -1597,6 +1662,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     acquireSlot,
     releaseSlot,
     ensureDevice,
+    unknownSystemImage,
     ensureDeviceBooted,
     resolveMetro,
     resolveMetroRetrying,
@@ -1767,6 +1833,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       `Set ios.remote and android.remote to one of: ${REMOTE_DEVICE_BACKENDS.join(', ')}.`,
     );
   }
+  const systemImage = resolveSystemImage(systemImageFlag, settings);
   const variant = resolveVariant(variantFlag, settings);
   const flavorRefusal = productFlavorRefusal({ flavors: readProductFlavors(root), variant });
   if (flavorRefusal) return fail(flavorRefusal.code, flavorRefusal.reason, flavorRefusal.remedy);
@@ -1815,6 +1882,14 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   const waitSeconds = waitParsed.seconds;
 
   const remoteBackend = physical ? null : (commandRemoteBackend ?? remoteAndroidSetting(settings));
+  const imageRefusal = systemImageRefusal({
+    flag: systemImageFlag,
+    resolved: systemImage,
+    physical,
+    remoteBackend,
+    unknown: unknownSystemImage,
+  });
+  if (imageRefusal) return fail('STIM_BAD_ARG', imageRefusal.message, imageRefusal.remedy);
   const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
   let androidPackage = detectAndroidPackage(root);
   record.bundleId = androidPackage;
@@ -1957,7 +2032,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         settingsRoot,
         label,
         settings,
-        flags: {},
+        flags: { systemImage },
         note: out,
         out,
         logFile: emuLog,
@@ -2026,6 +2101,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   }
   record.avdName = device.avdName ?? null;
   record.deviceName = device.deviceName ?? device.avdName ?? null;
+  record.systemImage = device.systemImage;
 
   let hash = '';
   let providerUpload: Promise<ProviderCallResult<void>> | null = null;

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1148,13 +1148,19 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   no variant selected (the refusal names the debug variants), or a
   \`--device-type\`, \`--runtime\` or \`--system-image\` name that is BLANK or
   is not installed on this machine. For the unknown-name case the installed
-  names are printed in the message -- the models \`xcrun simctl list
-  devicetypes\` reports, the versions \`xcrun simctl list runtimes\` reports,
-  or the system images the SDK has -- so the remedy is to re-run with one of
-  them (an ios.deviceType, ios.runtime or android.systemImage setting is
-  checked the same way).
-  These errors are caught before the port is reserved and before anything is
-  spawned, so nothing was started.
+  names are printed in the message -- the versions \`xcrun simctl list
+  runtimes\` reports, the models those runtimes can actually CREATE (not the
+  whole \`simctl list devicetypes\` table, which also names watchOS, tvOS and
+  visionOS models no iOS runtime offers), or the system images the SDK has --
+  so the remedy is to re-run with one of them. An ios.deviceType, ios.runtime
+  or android.systemImage setting is checked the same way, and the check applies
+  even when this workspace ALREADY owns a device, so a name that could never
+  create anything is caught rather than left to a later run.
+  These errors are caught before the port is reserved and before any build or
+  device work, so nothing was started. The one listing they need
+  (\`simctl list runtimes\`, the SDK's system-images directory) runs only when
+  a name was actually given, and a listing that fails is reported as
+  STIM_NO_DEVICE naming the tool, never as a crash.
 
 "@stim-cli/metro is not installed ... so bundler and client logs will not be
 captured"  (in metro.ndjson, bare RN)
@@ -1701,10 +1707,19 @@ THE OPTION SURFACE, IN FULL
   invocation, exactly as \`--configuration\` overrides ios.configuration.
 
   A name that is not INSTALLED on this machine refuses with STIM_BAD_ARG
-  before anything is created, and the message lists the installed names --
-  \`xcrun simctl list devicetypes\` and \`runtimes\` on iOS, the SDK's own
-  system-images on Android -- so a wrong guess is one command, not a created
-  simulator. A blank value is the same refusal.
+  before anything is created, and the message lists the installed names, so a
+  wrong guess is one command, not a created simulator. A blank value is the
+  same refusal.
+
+  What counts as installed for \`--device-type\` is what an installed RUNTIME
+  can create, not what \`xcrun simctl list devicetypes\` prints: that table
+  also names watchOS, tvOS and visionOS models, and older iPhones no current
+  runtime supports, none of which \`simctl create\` would accept. So the
+  refusal lists the models the installed runtimes offer -- narrowed to the one
+  runtime when \`--runtime\` also resolved, which is what catches a pair like
+  \`--device-type "iPhone 8" --runtime 26.5\` that each half would pass alone.
+  \`--runtime\` takes a version (\`26.5\`) or a runtime's full name
+  (\`iOS 26.5\`), exactly; no prefix or suffix matches.
 
   These flags describe a device that does not exist yet. When this workspace
   ALREADY owns a simulator and \`--device-type\` names a different model,
@@ -2242,13 +2257,16 @@ belongs there:
 KEYS STIM READS
   ios.deviceType        e.g. "iPhone 17 Pro" -- the simulator model this
                         workspace's owned sim is created as, spelled exactly as
-                        \`xcrun simctl list devicetypes\` names it. The
-                        \`--device-type\` flag overrides this per invocation.
-                        An uninstalled name is STIM_BAD_ARG and the installed
-                        names are printed
-  ios.runtime           e.g. "26.2" -- the iOS runtime that sim is created on.
-                        The \`--runtime\` flag overrides this per invocation,
-                        and an uninstalled version refuses the same way
+                        \`xcrun simctl list devicetypes\` names it, and one an
+                        installed runtime can create. The \`--device-type\`
+                        flag overrides this per invocation. A name no installed
+                        runtime offers is STIM_BAD_ARG and the creatable names
+                        are printed
+  ios.runtime           e.g. "26.2" -- the iOS runtime that sim is created on,
+                        as a version ("26.2") or a runtime's full name
+                        ("iOS 26.2"); nothing else matches. The \`--runtime\`
+                        flag overrides this per invocation, and an uninstalled
+                        version refuses the same way
   ios.configuration     e.g. "Release" -- the Xcode configuration to build
                         (simulator only). Committing
                         { "ios": { "configuration": "Release" } } makes every

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -36,6 +36,14 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   physical device gets no config entry, so \`stop\` and \`gc\`
                   never see it
   deviceName      its name, or null
+  deviceType      the owned simulator's MODEL, as
+                  \`xcrun simctl list devicetypes\` names it ("iPad Pro 13-inch
+                  (M4)"). Read from the simulator itself, so a run driven by
+                  the ios.deviceType setting reports it too, not only a
+                  \`--device-type\` run. Null on \`--device\` and on a
+                  simulator Stim does not own
+  runtime         that simulator's iOS runtime version ("18.5"), from the same
+                  record. Null on the same paths as deviceType
   fingerprint     the @expo/fingerprint hash of the native inputs, AS STORED.
                   A run that had to \`expo prebuild\` or \`pod install\`
                   rewrote fingerprinted files while it worked (the generated
@@ -236,6 +244,12 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   one serial. A boot that fails releases the port again and
                   keeps the AVD recorded for \`gc\`
   deviceName      the same name, matching the iOS payload's field
+  systemImage     the sdkmanager package id the owned AVD was created from
+                  ("system-images;android-36;google_apis;arm64-v8a"), read from
+                  the AVD's own config.ini, so a run driven by the
+                  android.systemImage setting reports it too, not only a
+                  \`--system-image\` run. Null on \`--device\` and on an
+                  emulator Stim does not own
   fingerprint / cacheKey / cacheHit / cacheSkipped / waitedForBuild /
   appPath / installSkipped / launched
                   as above -- cacheKey keys on the VARIANT here
@@ -1129,9 +1143,16 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   android.avdConfig key or fragment, a malformed ios.signingIdentity,
   ios.signingIdentitySha1 or ios.lanHost value, \`--device\` with an empty
   serial or UDID, \`--device\` together with \`--remote\`, a working directory
-  with no package.json above it, or an android/app/build.gradle that
+  with no package.json above it, an android/app/build.gradle that
   declares product flavors with
-  no variant selected (the refusal names the debug variants).
+  no variant selected (the refusal names the debug variants), or a
+  \`--device-type\`, \`--runtime\` or \`--system-image\` name that is BLANK or
+  is not installed on this machine. For the unknown-name case the installed
+  names are printed in the message -- the models \`xcrun simctl list
+  devicetypes\` reports, the versions \`xcrun simctl list runtimes\` reports,
+  or the system images the SDK has -- so the remedy is to re-run with one of
+  them (an ios.deviceType, ios.runtime or android.systemImage setting is
+  checked the same way).
   These errors are caught before the port is reserved and before anything is
   spawned, so nothing was started.
 
@@ -1639,8 +1660,8 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
 
 THE OPTION SURFACE, IN FULL
   start           --json --wait <seconds> --remote
-  ios             --json --no-metro-check --no-build-cache --configuration <name> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
-  android         --json --no-metro-check --no-build-cache --variant <name> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
+  ios             --json --no-metro-check --no-build-cache --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
+  android         --json --no-metro-check --no-build-cache --variant <name> --system-image <id> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
   device          lock <ios|android> [id] --for <duration> --wait <seconds> --json;
                   unlock [ios|android] --json
   logs            --source --level --since --grep --tail --follow --errors --json
@@ -1668,6 +1689,32 @@ THE OPTION SURFACE, IN FULL
   and leave nothing to pick from. That parse is best-effort: flavors built
   from a variable, a loop, or an applied script are not detected, and such a
   project builds as before.
+
+  \`ios --device-type <name>\` and \`ios --runtime <version>\` choose the
+  MODEL and the iOS version of the simulator this workspace owns --
+  \`--device-type "iPad Pro 13-inch (M4)" --runtime 18.5\` is how a ticket that
+  says "happens on iPad on iOS 18.5" gets reproduced without writing a
+  \`.stim.json\`. \`android --system-image <id>\` is the Android half, taking
+  the sdkmanager package id
+  ("system-images;android-36;google_apis;arm64-v8a"). Each overrides its
+  setting (ios.deviceType, ios.runtime, android.systemImage) for that one
+  invocation, exactly as \`--configuration\` overrides ios.configuration.
+
+  A name that is not INSTALLED on this machine refuses with STIM_BAD_ARG
+  before anything is created, and the message lists the installed names --
+  \`xcrun simctl list devicetypes\` and \`runtimes\` on iOS, the SDK's own
+  system-images on Android -- so a wrong guess is one command, not a created
+  simulator. A blank value is the same refusal.
+
+  These flags describe a device that does not exist yet. When this workspace
+  ALREADY owns a simulator and \`--device-type\` names a different model,
+  Stim refuses rather than silently booting the wrong one: reap the current
+  sim with \`stim worktree remove\` (or \`stim gc --delete\`), then run
+  \`stim ios\` again to create the requested one. \`--runtime\` and
+  \`--system-image\` apply at creation only, so an existing device keeps the
+  version it was made with. The --json payload reports what was actually
+  used: \`deviceType\` and \`runtime\` on iOS, \`systemImage\` on Android,
+  read from the device itself, so a settings-driven run reports them too.
 
   \`android --device [serial]\` installs and launches on a physical device
   connected to this machine instead of this workspace's owned emulator. With
@@ -2193,8 +2240,15 @@ belongs there:
   }
 
 KEYS STIM READS
-  ios.deviceType        e.g. "iPhone 17 Pro"
-  ios.runtime           e.g. "26.2"
+  ios.deviceType        e.g. "iPhone 17 Pro" -- the simulator model this
+                        workspace's owned sim is created as, spelled exactly as
+                        \`xcrun simctl list devicetypes\` names it. The
+                        \`--device-type\` flag overrides this per invocation.
+                        An uninstalled name is STIM_BAD_ARG and the installed
+                        names are printed
+  ios.runtime           e.g. "26.2" -- the iOS runtime that sim is created on.
+                        The \`--runtime\` flag overrides this per invocation,
+                        and an uninstalled version refuses the same way
   ios.configuration     e.g. "Release" -- the Xcode configuration to build
                         (simulator only). Committing
                         { "ios": { "configuration": "Release" } } makes every
@@ -2243,6 +2297,10 @@ KEYS STIM READS
                         heuristic, so Stim and a plain Xcode run pick the same
                         interface.
   android.systemImage   e.g. "system-images;android-36;google_apis;arm64-v8a"
+                        -- the sdkmanager package id the owned AVD is created
+                        from. The \`--system-image\` flag overrides this per
+                        invocation, and an id this SDK has not installed is
+                        STIM_BAD_ARG with the installed ids printed
   android.dataPartitionSizeGb
                         whole GiB for a newly created owned AVD's data
                         partition. Defaults to 8; accepts 6 through 16384.

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -63,8 +63,8 @@ import {
   ensureOwnedDevice,
   unknownIosDeviceTypeRefusal,
   unknownIosRuntimeRefusal,
-  type UnknownDeviceNameRefusal,
 } from '../engine/device.ts';
+import { listIosRuntimes } from '../sim/ios.ts';
 import {
   REMOTE_SESSION_ERROR,
   binOnPath,
@@ -373,20 +373,21 @@ function deviceModelRefusal({
   runtimeFlag,
   deviceType,
   runtime,
-  skipUnknown,
-  unknownDeviceType,
-  unknownRuntime,
+  physical,
+  remoteBackend,
+  listRuntimes,
 }: {
   deviceTypeFlag: string | undefined;
   runtimeFlag: string | undefined;
   deviceType: string | null;
   runtime: string | null;
-  skipUnknown: boolean;
-  unknownDeviceType: typeof unknownIosDeviceTypeRefusal;
-  unknownRuntime: typeof unknownIosRuntimeRefusal;
-}): UnknownDeviceNameRefusal | null {
+  physical: boolean;
+  remoteBackend: RemoteDeviceBackend | null;
+  listRuntimes: typeof listIosRuntimes;
+}): { code: string; message: string; remedy: string } | null {
   if (typeof deviceTypeFlag === 'string' && deviceTypeFlag.trim() === '') {
     return {
+      code: 'STIM_BAD_ARG',
       message: '--device-type was given an empty name.',
       remedy:
         'Pass `--device-type <name>` with a model `xcrun simctl list devicetypes` names, e.g. "iPad Pro 13-inch (M4)".',
@@ -394,12 +395,26 @@ function deviceModelRefusal({
   }
   if (typeof runtimeFlag === 'string' && runtimeFlag.trim() === '') {
     return {
+      code: 'STIM_BAD_ARG',
       message: '--runtime was given an empty version.',
       remedy: 'Pass `--runtime <version>` with a runtime `xcrun simctl list runtimes` reports, e.g. "18.5".',
     };
   }
-  if (skipUnknown) return null;
-  return unknownDeviceType(deviceType) ?? unknownRuntime(runtime);
+  if (physical || remoteBackend) return null;
+  if (!deviceType && !runtime) return null;
+  let runtimes;
+  try {
+    runtimes = listRuntimes();
+  } catch (error) {
+    return {
+      code: 'STIM_NO_DEVICE',
+      message: `Could not read the installed simulator runtimes: ${(error as Error)?.message || error}`,
+      remedy: 'Run `stim doctor` to check the simulator toolchain, then try again.',
+    };
+  }
+  const refusal =
+    unknownIosRuntimeRefusal(runtime, runtimes) ?? unknownIosDeviceTypeRefusal(deviceType, runtimes, runtime);
+  return refusal ? { code: 'STIM_BAD_ARG', message: refusal.message, remedy: refusal.remedy } : null;
 }
 
 export function isReleaseConfiguration(configuration: string | null | undefined): boolean {
@@ -832,8 +847,7 @@ interface IosDeps {
   projectShortcut: typeof projectShortcut;
   checkDeviceCapacity: typeof checkDeviceCapacity;
   ensureOwnedDevice: typeof ensureOwnedDevice;
-  unknownDeviceType: typeof unknownIosDeviceTypeRefusal;
-  unknownRuntime: typeof unknownIosRuntimeRefusal;
+  listIosRuntimes: typeof listIosRuntimes;
   ensureBooted: typeof ensureBooted;
   resolveProjectMetro: typeof resolveProjectMetro;
   resolveMetroWithRetry: typeof resolveMetroWithRetry;
@@ -901,8 +915,7 @@ const DEFAULT_DEPS: IosDeps = {
   projectShortcut,
   checkDeviceCapacity,
   ensureOwnedDevice,
-  unknownDeviceType: unknownIosDeviceTypeRefusal,
-  unknownRuntime: unknownIosRuntimeRefusal,
+  listIosRuntimes,
   ensureBooted,
   resolveRemoteContext,
   remoteIosDeps,
@@ -987,13 +1000,14 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     .option(
       '--device-type <name>',
       "Simulator model to create this workspace's owned sim as, exactly as `xcrun simctl list devicetypes` names it " +
-        '(e.g. "iPad Pro 13-inch (M4)"). Overrides the ios.deviceType setting for this invocation. An unknown name refuses ' +
-        'with STIM_BAD_ARG and prints the installed names.',
+        '(e.g. "iPad Pro 13-inch (M4)"). Overrides the ios.deviceType setting for this invocation. A model no installed ' +
+        'runtime can create refuses with STIM_BAD_ARG and prints the models they do offer.',
     )
     .option(
       '--runtime <version>',
-      'Simulator runtime to create this workspace\'s owned sim on (e.g. "18.5"). Overrides the ios.runtime setting for ' +
-        'this invocation. An unknown version refuses with STIM_BAD_ARG and prints the installed runtimes.',
+      'Simulator runtime to create this workspace\'s owned sim on, as a version ("18.5") or a runtime\'s full name ' +
+        '("iOS 18.5"); nothing else matches. Overrides the ios.runtime setting for this invocation. An unknown version ' +
+        'refuses with STIM_BAD_ARG and prints the installed runtimes.',
     )
     .option(
       '--device [udid]',
@@ -1914,13 +1928,11 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     runtimeFlag: opts.runtime,
     deviceType,
     runtime,
-    skipUnknown: Boolean(physical || remoteBackend),
-    unknownDeviceType: d.unknownDeviceType,
-    unknownRuntime: d.unknownRuntime,
+    physical,
+    remoteBackend,
+    listRuntimes: d.listIosRuntimes,
   });
-  if (modelRefusal) {
-    return fail({ code: 'STIM_BAD_ARG', message: modelRefusal.message, remedy: modelRefusal.remedy });
-  }
+  if (modelRefusal) return fail(modelRefusal);
   const registerProject = () => d.upsertProject(root, { bundleId: d.detectBundleId(root) ?? undefined, isExpo });
   if (remoteBackend !== 'eas') registerProject();
   const proj = d.getProject(root);

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -57,7 +57,14 @@ import {
 } from '../engine/build-lock.ts';
 import { acquireBuildSlot, releaseBuildSlot, type BuildSlotHandle } from '../engine/build-slots.ts';
 import { readPodState, podsAreStale, runPodInstall } from '../engine/deps.ts';
-import { checkDeviceCapacity, ensureBooted, ensureOwnedDevice } from '../engine/device.ts';
+import {
+  checkDeviceCapacity,
+  ensureBooted,
+  ensureOwnedDevice,
+  unknownIosDeviceTypeRefusal,
+  unknownIosRuntimeRefusal,
+  type UnknownDeviceNameRefusal,
+} from '../engine/device.ts';
 import {
   REMOTE_SESSION_ERROR,
   binOnPath,
@@ -173,6 +180,8 @@ interface DeviceLike {
   deviceName?: string | null;
   name?: string | null;
   avdName?: string | null;
+  deviceType?: string | null;
+  runtime?: string | null;
 }
 
 interface IosBootLike {
@@ -242,6 +251,8 @@ interface IosCommandOptions {
   metroCheck?: boolean;
   buildCache?: boolean;
   configuration?: string;
+  deviceType?: string;
+  runtime?: string;
   device?: string | boolean;
   remote?: RemoteDeviceBackend;
   wait?: string | boolean;
@@ -332,6 +343,63 @@ export function resolveConfiguration(
 ): string | null {
   const fromFlag = typeof flag === 'string' && flag.trim() !== '' ? flag.trim() : null;
   return fromFlag || iosConfigurationSetting(settings);
+}
+
+function iosStringSetting(settings: SettingsObject | null | undefined, key: string): string | null {
+  const ios = settings?.['ios'];
+  if (!ios || typeof ios !== 'object' || Array.isArray(ios)) return null;
+  const raw = (ios as Record<string, unknown>)[key];
+  return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null;
+}
+
+export function resolveDeviceType(
+  flag: string | null | undefined,
+  settings: SettingsObject | null | undefined,
+): string | null {
+  const fromFlag = typeof flag === 'string' && flag.trim() !== '' ? flag.trim() : null;
+  return fromFlag || iosStringSetting(settings, 'deviceType');
+}
+
+export function resolveRuntime(
+  flag: string | null | undefined,
+  settings: SettingsObject | null | undefined,
+): string | null {
+  const fromFlag = typeof flag === 'string' && flag.trim() !== '' ? flag.trim() : null;
+  return fromFlag || iosStringSetting(settings, 'runtime');
+}
+
+function deviceModelRefusal({
+  deviceTypeFlag,
+  runtimeFlag,
+  deviceType,
+  runtime,
+  skipUnknown,
+  unknownDeviceType,
+  unknownRuntime,
+}: {
+  deviceTypeFlag: string | undefined;
+  runtimeFlag: string | undefined;
+  deviceType: string | null;
+  runtime: string | null;
+  skipUnknown: boolean;
+  unknownDeviceType: typeof unknownIosDeviceTypeRefusal;
+  unknownRuntime: typeof unknownIosRuntimeRefusal;
+}): UnknownDeviceNameRefusal | null {
+  if (typeof deviceTypeFlag === 'string' && deviceTypeFlag.trim() === '') {
+    return {
+      message: '--device-type was given an empty name.',
+      remedy:
+        'Pass `--device-type <name>` with a model `xcrun simctl list devicetypes` names, e.g. "iPad Pro 13-inch (M4)".',
+    };
+  }
+  if (typeof runtimeFlag === 'string' && runtimeFlag.trim() === '') {
+    return {
+      message: '--runtime was given an empty version.',
+      remedy: 'Pass `--runtime <version>` with a runtime `xcrun simctl list runtimes` reports, e.g. "18.5".',
+    };
+  }
+  if (skipUnknown) return null;
+  return unknownDeviceType(deviceType) ?? unknownRuntime(runtime);
 }
 
 export function isReleaseConfiguration(configuration: string | null | undefined): boolean {
@@ -553,6 +621,8 @@ export function lastBuildRecord({
 export function iosFacts({
   udid,
   deviceName,
+  deviceType = null,
+  runtime = null,
   fingerprint,
   configuration = null,
   cacheKey,
@@ -572,6 +642,8 @@ export function iosFacts({
 }: {
   udid: string;
   deviceName?: string | null;
+  deviceType?: string | null;
+  runtime?: string | null;
   fingerprint?: string | null;
   configuration?: string | null;
   cacheKey?: string | null;
@@ -593,6 +665,8 @@ export function iosFacts({
     platform: PLATFORM,
     udid,
     deviceName: deviceName ?? null,
+    deviceType: deviceType ?? null,
+    runtime: runtime ?? null,
     fingerprint,
     configuration: configuration ?? null,
     cacheKey,
@@ -758,6 +832,8 @@ interface IosDeps {
   projectShortcut: typeof projectShortcut;
   checkDeviceCapacity: typeof checkDeviceCapacity;
   ensureOwnedDevice: typeof ensureOwnedDevice;
+  unknownDeviceType: typeof unknownIosDeviceTypeRefusal;
+  unknownRuntime: typeof unknownIosRuntimeRefusal;
   ensureBooted: typeof ensureBooted;
   resolveProjectMetro: typeof resolveProjectMetro;
   resolveMetroWithRetry: typeof resolveMetroWithRetry;
@@ -825,6 +901,8 @@ const DEFAULT_DEPS: IosDeps = {
   projectShortcut,
   checkDeviceCapacity,
   ensureOwnedDevice,
+  unknownDeviceType: unknownIosDeviceTypeRefusal,
+  unknownRuntime: unknownIosRuntimeRefusal,
   ensureBooted,
   resolveRemoteContext,
   remoteIosDeps,
@@ -905,6 +983,17 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     .option(
       '--configuration <name>',
       'Xcode configuration to build (e.g. Release). A non-Debug configuration embeds the JS bundle and skips Metro entirely. Overrides the ios.configuration setting. Default: Debug',
+    )
+    .option(
+      '--device-type <name>',
+      "Simulator model to create this workspace's owned sim as, exactly as `xcrun simctl list devicetypes` names it " +
+        '(e.g. "iPad Pro 13-inch (M4)"). Overrides the ios.deviceType setting for this invocation. An unknown name refuses ' +
+        'with STIM_BAD_ARG and prints the installed names.',
+    )
+    .option(
+      '--runtime <version>',
+      'Simulator runtime to create this workspace\'s owned sim on (e.g. "18.5"). Overrides the ios.runtime setting for ' +
+        'this invocation. An unknown version refuses with STIM_BAD_ARG and prints the installed runtimes.',
     )
     .option(
       '--device [udid]',
@@ -1208,6 +1297,8 @@ function reportIosResult({
   const facts = iosFacts({
     udid,
     deviceName: device?.deviceName ?? null,
+    deviceType: device?.deviceType,
+    runtime: device?.runtime,
     fingerprint: storeHash,
     configuration,
     cacheKey: storeKey,
@@ -1768,6 +1859,9 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   const configuration = resolveConfiguration(opts.configuration, settings);
   const release = isReleaseConfiguration(configuration);
 
+  const deviceType = resolveDeviceType(opts.deviceType, settings);
+  const runtime = resolveRuntime(opts.runtime, settings);
+
   const deviceFlag = opts.device;
   const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;
   if (physical && deviceFlag === '') {
@@ -1815,6 +1909,18 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
 
   const isExpo = d.detectIsExpo(root);
   const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
+  const modelRefusal = deviceModelRefusal({
+    deviceTypeFlag: opts.deviceType,
+    runtimeFlag: opts.runtime,
+    deviceType,
+    runtime,
+    skipUnknown: Boolean(physical || remoteBackend),
+    unknownDeviceType: d.unknownDeviceType,
+    unknownRuntime: d.unknownRuntime,
+  });
+  if (modelRefusal) {
+    return fail({ code: 'STIM_BAD_ARG', message: modelRefusal.message, remedy: modelRefusal.remedy });
+  }
   const registerProject = () => d.upsertProject(root, { bundleId: d.detectBundleId(root) ?? undefined, isExpo });
   if (remoteBackend !== 'eas') registerProject();
   const proj = d.getProject(root);
@@ -1905,7 +2011,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         settingsRoot: settingsRepoRoot ?? root,
         label,
         settings,
-        flags: {},
+        flags: { deviceType, runtime },
         note,
         out: note,
       });

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -15,8 +15,8 @@ import {
   createOwnedIosSim,
   IOS_BOOT_TIMEOUT_MS,
   listAllIosSims,
+  iosRuntimeMatches,
   listIosDeviceTypes,
-  listIosRuntimes,
   parseRuntimeVersion,
   resolveOwnedIosSim,
   type IosRuntime,
@@ -28,7 +28,6 @@ import {
   getAvdNameForSerial,
   listAdbDevices,
   listAvds,
-  listInstalledSystemImages,
   nextConsolePort,
   ownedAvdName,
   ownedAvdSystemImage,
@@ -692,35 +691,44 @@ function installedNames(names: Array<string | null | undefined>): string {
   return unique.length > 0 ? unique.join(', ') : 'none';
 }
 
-export function unknownIosDeviceTypeRefusal(
-  requested: string | null | undefined,
-  deviceTypes: DeviceTypeInfo[] = listIosDeviceTypes(),
-): UnknownDeviceNameRefusal | null {
-  if (!requested) return null;
-  if ((deviceTypes || []).some((d) => d.name === requested)) return null;
-  return {
-    message: `No installed simulator device type is named "${requested}". Installed device types: ${installedNames((deviceTypes || []).map((d) => d.name))}.`,
-    remedy:
-      'Pass `--device-type` (or set ios.deviceType) to one of the names printed above, exactly as `xcrun simctl list devicetypes` spells it. Install more models through Xcode.',
-  };
-}
-
 export function unknownIosRuntimeRefusal(
   requested: string | null | undefined,
-  runtimes: IosRuntime[] = listIosRuntimes(),
+  runtimes: IosRuntime[],
 ): UnknownDeviceNameRefusal | null {
   if (!requested) return null;
-  if ((runtimes || []).some((r) => r.version === requested || r.name.endsWith(requested))) return null;
+  if ((runtimes || []).some((r) => iosRuntimeMatches(r, requested))) return null;
   return {
     message: `No installed simulator runtime matches "${requested}". Installed runtimes: ${installedNames((runtimes || []).map((r) => r.version))}.`,
     remedy:
-      'Pass `--runtime` (or set ios.runtime) to one of the versions printed above, as `xcrun simctl list runtimes` reports them. Install more runtimes through Xcode.',
+      'Pass `--runtime` (or set ios.runtime) a version printed above ("26.5") or a runtime\'s full name ("iOS 26.5"); nothing else matches. Install more runtimes through Xcode.',
+  };
+}
+
+function creatableIosDeviceTypeNames(runtimes: IosRuntime[], runtime?: string | null): string[] {
+  const scoped = runtime ? (runtimes || []).filter((r) => iosRuntimeMatches(r, runtime)) : runtimes || [];
+  return scoped.flatMap((r) => (r.supportedDeviceTypes || []).map((d) => d.name));
+}
+
+export function unknownIosDeviceTypeRefusal(
+  requested: string | null | undefined,
+  runtimes: IosRuntime[],
+  runtime?: string | null,
+): UnknownDeviceNameRefusal | null {
+  if (!requested) return null;
+  const creatable = creatableIosDeviceTypeNames(runtimes, runtime);
+  if (creatable.includes(requested)) return null;
+  const scope = runtime ? `runtime ${runtime}` : 'any installed simulator runtime';
+  const offered = runtime ? `Device types runtime ${runtime} supports` : 'Device types the installed runtimes support';
+  return {
+    message: `No device type named "${requested}" can be created on ${scope}. ${offered}: ${installedNames(creatable)}.`,
+    remedy:
+      'Pass `--device-type` (or set ios.deviceType) one of the names printed above, exactly as `xcrun simctl list devicetypes` spells it. `xcrun simctl list devicetypes` also lists watchOS, tvOS and visionOS models, which no iOS runtime can create. Install more models through Xcode.',
   };
 }
 
 export function unknownAndroidSystemImageRefusal(
   requested: string | null | undefined,
-  images: SystemImage[] = listInstalledSystemImages(),
+  images: SystemImage[],
 ): UnknownDeviceNameRefusal | null {
   if (!requested) return null;
   if ((images || []).some((i) => i.pkg === requested)) return null;

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -16,7 +16,10 @@ import {
   IOS_BOOT_TIMEOUT_MS,
   listAllIosSims,
   listIosDeviceTypes,
+  listIosRuntimes,
+  parseRuntimeVersion,
   resolveOwnedIosSim,
+  type IosRuntime,
 } from '../sim/ios.ts';
 import {
   bootAndroidEmulator,
@@ -25,10 +28,13 @@ import {
   getAvdNameForSerial,
   listAdbDevices,
   listAvds,
+  listInstalledSystemImages,
   nextConsolePort,
   ownedAvdName,
+  ownedAvdSystemImage,
   resolveOwnedAvdSerial,
   waitForBoot,
+  type SystemImage,
 } from '../sim/android.ts';
 import { androidAvdConfigSetting, androidDataPartitionSizeGbSetting, iosSimSlimProfileSetting } from '../settings.ts';
 import { teardownOwnedAvd } from '../teardown.ts';
@@ -44,6 +50,9 @@ export interface OwnedDeviceRecord {
   serial?: string;
   setupIncomplete?: boolean;
   simslimManaged?: boolean;
+  deviceType?: string | null;
+  runtime?: string | null;
+  systemImage?: string | null;
 }
 
 interface DeviceSettings {
@@ -57,9 +66,9 @@ interface DeviceSettings {
 }
 
 interface DeviceFlags {
-  deviceType?: string;
-  runtime?: string;
-  systemImage?: string;
+  deviceType?: string | null;
+  runtime?: string | null;
+  systemImage?: string | null;
 }
 
 type Notify = (msg: string) => void;
@@ -176,7 +185,8 @@ async function ensureOwnedIosDevice({
       } else {
         const sim = resolved.sim as SimRecord;
         const wantedType = flags.deviceType || settings?.ios?.deviceType;
-        const mismatch = deviceTypeMismatch(sim.deviceTypeIdentifier, wantedType, listIosDeviceTypes());
+        const deviceTypes = listIosDeviceTypes();
+        const mismatch = deviceTypeMismatch(sim.deviceTypeIdentifier, wantedType, deviceTypes);
         if (mismatch) {
           throw new Error(
             `${mismatch}. Stim will not silently boot a different model. ` +
@@ -193,13 +203,17 @@ async function ensureOwnedIosDevice({
           deviceName: record.deviceName ?? sim.name,
           ...(record.simslimManaged ? { simslimManaged: true } : {}),
         };
-        return configureOwnedIosSim({
-          record: updated,
-          projectPath,
-          profile: simslimProfile,
-          out,
-          reconcileIosSimulator,
-        });
+        return {
+          ...(await configureOwnedIosSim({
+            record: updated,
+            projectPath,
+            profile: simslimProfile,
+            out,
+            reconcileIosSimulator,
+          })),
+          deviceType: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
+          runtime: parseRuntimeVersion(sim.runtime),
+        };
       }
     } else {
       const sim = listAllIosSims().find((s) => s.udid === record.deviceUdid);
@@ -236,7 +250,7 @@ async function ensureOwnedIosDevice({
     out,
     reconcileIosSimulator,
   });
-  return { ...configured, created: true };
+  return { ...configured, created: true, deviceType: created.deviceType, runtime: created.runtime };
 }
 
 async function configureOwnedIosSim({
@@ -337,21 +351,24 @@ async function ensureOwnedAndroidDevice({
           deviceName: record.deviceName ?? record.avdName,
         };
         setDevice(projectPath, 'android', updated);
-        return updated;
+        return { ...updated, systemImage: ownedAvdSystemImage(record.avdName) };
       } else if (!resolved.missing) {
         out(
           chalk.dim(
             `Recorded port for owned AVD ${record.avdName} is not currently ours; booting it on a freshly allocated port...`,
           ),
         );
-        return await bootOwnedAvdOnFreshPort({
-          avdName: record.avdName,
-          projectPath,
-          deviceName: record.deviceName,
-          out,
-          logFile,
-          alive,
-        });
+        return {
+          ...(await bootOwnedAvdOnFreshPort({
+            avdName: record.avdName,
+            projectPath,
+            deviceName: record.deviceName,
+            out,
+            logFile,
+            alive,
+          })),
+          systemImage: ownedAvdSystemImage(record.avdName),
+        };
       }
     } else {
       const avdExists = listAvds().includes(record.avdName);
@@ -382,7 +399,7 @@ async function ensureOwnedAndroidDevice({
     note(chalk.dim('Creating an owned emulator instead. Pass `--device` to build for a connected device.'));
   }
 
-  let created: { avdName: string };
+  let created: { avdName: string; systemImage: string | null };
   let fresh = false;
   try {
     created = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
@@ -406,7 +423,7 @@ async function ensureOwnedAndroidDevice({
           { cause: e },
         );
       }
-      created = { avdName };
+      created = { avdName, systemImage: ownedAvdSystemImage(avdName) };
       out(chalk.dim(`Recovered existing owned AVD ${avdName} (unrecorded from a prior run)`));
     } else {
       throw e;
@@ -438,14 +455,17 @@ async function ensureOwnedAndroidDevice({
     }
   }
   out(chalk.dim(`Created owned AVD ${created.avdName}`));
-  return bootOwnedAvdOnFreshPort({
-    avdName: created.avdName,
-    projectPath,
-    deviceName: created.avdName,
-    out,
-    logFile,
-    alive,
-  });
+  return {
+    ...(await bootOwnedAvdOnFreshPort({
+      avdName: created.avdName,
+      projectPath,
+      deviceName: created.avdName,
+      out,
+      logFile,
+      alive,
+    })),
+    systemImage: created.systemImage,
+  };
 }
 
 export interface AndroidConsolePortClaim {
@@ -660,6 +680,55 @@ export function deviceTypeMismatch(
   if (wanted.identifier === recordedTypeId) return null;
   const recorded = (deviceTypes || []).find((d) => d.identifier === recordedTypeId);
   return `this project's sim is ${recorded ? recorded.name : recordedTypeId}, but --device-type asked for ${requestedName}`;
+}
+
+export interface UnknownDeviceNameRefusal {
+  message: string;
+  remedy: string;
+}
+
+function installedNames(names: Array<string | null | undefined>): string {
+  const unique = [...new Set(names.filter((n): n is string => typeof n === 'string' && n !== ''))];
+  return unique.length > 0 ? unique.join(', ') : 'none';
+}
+
+export function unknownIosDeviceTypeRefusal(
+  requested: string | null | undefined,
+  deviceTypes: DeviceTypeInfo[] = listIosDeviceTypes(),
+): UnknownDeviceNameRefusal | null {
+  if (!requested) return null;
+  if ((deviceTypes || []).some((d) => d.name === requested)) return null;
+  return {
+    message: `No installed simulator device type is named "${requested}". Installed device types: ${installedNames((deviceTypes || []).map((d) => d.name))}.`,
+    remedy:
+      'Pass `--device-type` (or set ios.deviceType) to one of the names printed above, exactly as `xcrun simctl list devicetypes` spells it. Install more models through Xcode.',
+  };
+}
+
+export function unknownIosRuntimeRefusal(
+  requested: string | null | undefined,
+  runtimes: IosRuntime[] = listIosRuntimes(),
+): UnknownDeviceNameRefusal | null {
+  if (!requested) return null;
+  if ((runtimes || []).some((r) => r.version === requested || r.name.endsWith(requested))) return null;
+  return {
+    message: `No installed simulator runtime matches "${requested}". Installed runtimes: ${installedNames((runtimes || []).map((r) => r.version))}.`,
+    remedy:
+      'Pass `--runtime` (or set ios.runtime) to one of the versions printed above, as `xcrun simctl list runtimes` reports them. Install more runtimes through Xcode.',
+  };
+}
+
+export function unknownAndroidSystemImageRefusal(
+  requested: string | null | undefined,
+  images: SystemImage[] = listInstalledSystemImages(),
+): UnknownDeviceNameRefusal | null {
+  if (!requested) return null;
+  if ((images || []).some((i) => i.pkg === requested)) return null;
+  return {
+    message: `No installed Android system image is named "${requested}". Installed system images: ${installedNames((images || []).map((i) => i.pkg))}.`,
+    remedy:
+      'Pass `--system-image` (or set android.systemImage) to one of the package ids printed above. Install more with `sdkmanager "system-images;android-36;google_apis;arm64-v8a"`.',
+  };
 }
 
 const BOOT_POLL_MS = 500;

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -139,7 +139,7 @@ function androidTool(tool: AndroidTool): string {
   return resolved === tool ? tool : `"${resolved}"`;
 }
 
-function listInstalledSystemImages(): SystemImage[] {
+export function listInstalledSystemImages(): SystemImage[] {
   const root = join(androidHome(), 'system-images');
   const images: SystemImage[] = [];
   if (!existsSync(root)) return images;
@@ -190,7 +190,10 @@ export function pickDefaultSystemImage(
   );
 }
 
-export function createOwnedAvd(label: string, { systemImage }: { systemImage?: string } = {}): { avdName: string } {
+export function createOwnedAvd(
+  label: string,
+  { systemImage }: { systemImage?: string } = {},
+): { avdName: string; systemImage: string } {
   const pick = pickDefaultSystemImage(listInstalledSystemImages(), { systemImage });
   if (!pick) {
     const arch = hostSystemImageArch();
@@ -200,7 +203,38 @@ export function createOwnedAvd(label: string, { systemImage }: { systemImage?: s
   }
   const avdName = ownedAvdName(label);
   getExecutor().run(`echo no | ${androidTool('avdmanager')} create avd -n "${avdName}" -k "${pick.pkg}"`);
-  return { avdName };
+  return { avdName, systemImage: pick.pkg };
+}
+
+export function parseAvdSystemImage(configIni: string): string | null {
+  for (const line of String(configIni).split(/\r?\n/)) {
+    const separator = line.indexOf('=');
+    if (separator < 0) continue;
+    if (line.slice(0, separator).trim() !== 'image.sysdir.1') continue;
+    const dir = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/\/+$/, '');
+    if (!dir) return null;
+    return dir.split('/').join(';');
+  }
+  return null;
+}
+
+export function ownedAvdSystemImage(
+  avdName: string,
+  {
+    avdDirectory = ownedAvdDirectory,
+    readFile = (path: string) => readFileSync(path, 'utf8'),
+  }: { avdDirectory?: typeof ownedAvdDirectory; readFile?: (path: string) => string } = {},
+): string | null {
+  const directory = avdDirectory(avdName);
+  if (!directory) return null;
+  try {
+    return parseAvdSystemImage(readFile(join(directory, 'config.ini')));
+  } catch {
+    return null;
+  }
 }
 
 function sanitizeAvdLabel(label: string): string {

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -143,7 +143,7 @@ export function listInstalledSystemImages(): SystemImage[] {
   const root = join(androidHome(), 'system-images');
   const images: SystemImage[] = [];
   if (!existsSync(root)) return images;
-  for (const apiDir of readdirSync(root)) {
+  for (const apiDir of safeList(root)) {
     const m = apiDir.match(/^android-(\d+)$/);
     if (!m) continue;
     const apiPath = join(root, apiDir);

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -169,6 +169,10 @@ function rankIphone(name: string): { gen: number; variant: number } {
   };
 }
 
+export function iosRuntimeMatches(runtime: IosRuntime, requested: string): boolean {
+  return runtime.version === requested || runtime.name === requested;
+}
+
 export function pickDefaultIosCreation(
   _deviceTypes: IosDeviceType[],
   runtimes: IosRuntime[],
@@ -177,7 +181,7 @@ export function pickDefaultIosCreation(
   const rts = runtimes.toSorted((a, b) =>
     String(b.version).localeCompare(String(a.version), undefined, { numeric: true }),
   );
-  const wantedRts = runtime ? rts.filter((r) => r.version === runtime || r.name.endsWith(runtime)) : rts;
+  const wantedRts = runtime ? rts.filter((r) => iosRuntimeMatches(r, runtime)) : rts;
   for (const rt of wantedRts) {
     const supported = (rt.supportedDeviceTypes || []).filter((d) =>
       deviceType ? d.name === deviceType : /^iPhone/i.test(d.name),

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -208,8 +208,10 @@ export function ownedSimName(label: string): string {
 export function createOwnedIosSim(
   label: string,
   { deviceType, runtime }: { deviceType?: string; runtime?: string } = {},
-): { udid: string; name: string } {
-  const pick = pickDefaultIosCreation(listIosDeviceTypes(), listIosRuntimes(), { deviceType, runtime });
+): { udid: string; name: string; deviceType: string | null; runtime: string | null } {
+  const deviceTypes = listIosDeviceTypes();
+  const runtimes = listIosRuntimes();
+  const pick = pickDefaultIosCreation(deviceTypes, runtimes, { deviceType, runtime });
   if (!pick) {
     throw new Error(
       'No matching simulator device type / runtime is installed. Install one via Xcode, or pass --device-type / --runtime.',
@@ -217,7 +219,12 @@ export function createOwnedIosSim(
   }
   const name = ownedSimName(label);
   const udid = getExecutor().run(`xcrun simctl create "${name}" "${pick.deviceTypeId}" "${pick.runtimeId}"`).trim();
-  return { udid, name };
+  return {
+    udid,
+    name,
+    deviceType: deviceTypes.find((d) => d.identifier === pick.deviceTypeId)?.name ?? null,
+    runtime: runtimes.find((r) => r.identifier === pick.runtimeId)?.version ?? null,
+  };
 }
 
 export function resolveOwnedIosSim(udid: string): ResolvedIosSim {
@@ -238,7 +245,7 @@ export function deleteIosSim(udid: string): void {
   getExecutor().run(`xcrun simctl delete ${udid}`);
 }
 
-function listIosRuntimes(): IosRuntime[] {
+export function listIosRuntimes(): IosRuntime[] {
   const out = getExecutor().run('xcrun simctl list runtimes --json');
   const data = JSON.parse(out) as {
     runtimes?: Array<{

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -110,6 +110,8 @@ export interface IosFacts {
   platform: string;
   udid: string;
   deviceName: string | null;
+  deviceType: string | null;
+  runtime: string | null;
   fingerprint?: string | null;
   configuration: string | null;
   cacheKey?: string | null;
@@ -133,6 +135,7 @@ export interface AndroidFacts {
   serial: string | null;
   avdName: string | null;
   deviceName: string | null;
+  systemImage: string | null;
   fingerprint: string | null;
   cacheKey: string | null;
   variant: string | null;

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -64,7 +64,8 @@ project is reused.
 ## `ios`
 
 ```text
-stim ios [--configuration <name>] [--device [udid]] [--remote <proxy|eas>]
+stim ios [--configuration <name>] [--device-type <name>] [--runtime <version>]
+         [--device [udid]] [--remote <proxy|eas>]
          [--no-metro-check] [--no-build-cache] [--json]
 ```
 
@@ -73,6 +74,11 @@ app, opens it, and checks launch logs. The build always runs on the local
 machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
+- `--device-type <name>` creates this workspace's owned simulator as that model,
+  overriding `ios.deviceType` for one invocation; an uninstalled name refuses
+  with `STIM_BAD_ARG` and prints the installed names.
+- `--runtime <version>` creates it on that iOS runtime, overriding `ios.runtime`
+  the same way.
 - `--device [udid]` builds, installs, and launches on a connected iPhone instead
   of the owned simulator. With no UDID it takes the first connected device it
   can lease. Stim never creates, boots, or deletes hardware.
@@ -121,7 +127,8 @@ a later phase of [#178](https://github.com/appandflow/stim/issues/178).
 ## `android`
 
 ```text
-stim android [--variant <name>] [--device [serial]] [--remote <proxy|eas>]
+stim android [--variant <name>] [--system-image <id>] [--device [serial]]
+             [--remote <proxy|eas>]
              [--no-metro-check] [--no-build-cache] [--json]
 ```
 
@@ -129,6 +136,10 @@ Builds or restores the Android app. Stim then boots an owned emulator, installs
 the app, opens it, and checks launch logs.
 
 - `--variant <name>` selects a Gradle variant. The default is `debug`.
+- `--system-image <id>` creates this workspace's owned AVD from that sdkmanager
+  package id, overriding `android.systemImage` for one invocation; an id this
+  SDK has not installed refuses with `STIM_BAD_ARG` and prints the installed
+  ids.
 - `--remote proxy` uses a configured Agent Device daemon.
 - `--remote eas` uses an EAS remote emulator.
 - `--no-metro-check` skips the Debug dev-server gate.

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -75,10 +75,11 @@ machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
 - `--device-type <name>` creates this workspace's owned simulator as that model,
-  overriding `ios.deviceType` for one invocation; an uninstalled name refuses
-  with `STIM_BAD_ARG` and prints the installed names.
+  overriding `ios.deviceType` for one invocation. A model no installed runtime
+  can create refuses with `STIM_BAD_ARG` and prints the ones they do offer.
 - `--runtime <version>` creates it on that iOS runtime, overriding `ios.runtime`
-  the same way.
+  the same way. It takes a version (`26.5`) or a runtime's full name
+  (`iOS 26.5`), exactly.
 - `--device [udid]` builds, installs, and launches on a connected iPhone instead
   of the owned simulator. With no UDID it takes the first connected device it
   can lease. Stim never creates, boots, or deletes hardware.


### PR DESCRIPTION
## Description

The simulator model and runtime could only come from settings (`ios.deviceType`,
`ios.runtime`, `android.systemImage`), so an agent handed a ticket that says
"happens on iPad on iOS 18.5" had to write a `.stim.json` in its worktree to get
there. Nothing in Stim listed what is installed on the machine either, so a
wrong guess at `simctl` spelling only surfaced as a failed creation. The engine
has had the per-invocation hook all along -- `ensureOwnedDevice` already reads
`flags.deviceType || settings.ios.deviceType`; the command surface never grew
the flags.

Product decision by the maintainer (2026-09-02), recorded in #255.

## Solution

`ios --device-type <name>`, `ios --runtime <version>`, and
`android --system-image <id>` override their settings for one invocation, with
the same precedence as `--configuration` over `ios.configuration`, feeding the
engine's existing `flags` path.

Two things to know before the rest:

- **Behavior changes for people who never pass the flags.** The check runs on
  the *resolved* value, so a stale `ios.deviceType` in a committed `.stim.json`
  now fails `STIM_BAD_ARG` with the creatable names instead of the old generic
  `STIM_NO_DEVICE` from `createOwnedIosSim`. Separately, `ios.runtime` now
  matches a runtime's exact version or exact name only -- the previous
  `name.endsWith(...)` match in `pickDefaultIosCreation` meant `"5"` silently
  created on 26.5.
- **Android was not device-tested.** Unit tests only; no emulator was created on
  this machine. Reasoning in the test plan.

The refusal is the point of the feature, not a side effect: a name that is not
installed refuses **before** the device is created, and the message carries the
installed names so the next command is right rather than another guess. A blank
value is the same refusal. Both are skipped on `--device` and `--remote`, where a
local model name means nothing.

What counts as "installed" for `--device-type` is what an installed *runtime*
can create, not what `xcrun simctl list devicetypes` prints. Those are very
different sets -- 124 vs 65 on this machine -- because that table also names
watchOS, tvOS and visionOS models and old iPhones no current runtime supports.
Validating against the table would have let `--device-type "iPhone 8"` and
`--device-type "Apple Vision Pro"` through the gate only to fail at
`simctl create`, which is the wrong-guess loop these flags exist to remove. So
the gate takes the union of `supportedDeviceTypes` across `listIosRuntimes()`,
narrowed to the one runtime when `--runtime` also resolved -- that narrowing is
what catches a pair like `--device-type "iPhone 8" --runtime 26.5` that each
half would pass alone. `listIosDeviceTypes()` is still used, but only by
`deviceTypeMismatch`, to map a recorded identifier back to a name.

The listings are the ones already in use: `xcrun simctl list runtimes -j` on
iOS (`listIosRuntimes` existed, just unexported), and on Android the engine's
own `listInstalledSystemImages`, a read of `$ANDROID_HOME/system-images`. No new
tool call -- `sdkmanager --list_installed` was not needed, because that
filesystem listing is the one AVD creation already picks from, so the names
printed are exactly the names creation accepts. Each runs only when a name
actually resolved, so a plain `stim ios` spawns nothing extra, and a listing
that throws becomes a structured `STIM_NO_DEVICE` rather than escaping as a
stack trace (invariant 7).

The refuse-on-mismatch rule for a simulator this workspace already owns is
unchanged, remedy verbatim. `--runtime` and `--system-image` apply at creation
only, so an existing device keeps what it was made with.

The run JSON gains `deviceType` and `runtime` (iOS) and `systemImage` (Android).
These are read from the device itself -- the sim's own `deviceTypeIdentifier`
and runtime id, the AVD's `config.ini` `image.sysdir.1` -- not echoed back from
the flag, so a settings-driven run reports them too and a run that reused an
existing device reports what it actually got. They are attached to the value
`ensureOwnedDevice` returns and deliberately not written through `setDevice`, so
the project registry's shape is unchanged.

`runIos` and `runAndroid` were already at the repo's complexity ceiling, so the
new checks live in small helpers (`deviceModelRefusal`, `systemImageRefusal`)
rather than inline.

Guide, `AGENTS.md` invariant 3's option list, and the website command pages are
updated, with contract tests pinning the option-surface lines, the settings
entries, the new `STIM_BAD_ARG` cause, and the payload fields.

## Test plan

`pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (3224 passed,
82 files), and `pnpm run knip` pass from the repo root.

Real-tool check (invariant 9) in scratch workspaces made from a real Expo app,
with the built CLI. Creation on a model that is not the default iPhone, and
`simctl` agreeing it really is that model -- so the payload is not echoing the
flag back:

```
$ stim ios --device-type "iPad Pro 13-inch (M4)" --json
Created owned sim stim-qa-ipad (2392EA42-3270-4B90-8C7D-207ED908D5E2)
  device      stim-qa-ipad (2392..) created (25.1s)
  install     -> stim-qa-ipad (2392..) (5.2s)
  launch      com.appandflow.trailhead (501ms)
{"platform":"ios","udid":"2392EA42-...","deviceName":"stim-qa-ipad","deviceType":"iPad Pro 13-inch (M4)","runtime":"26.5",...,"launched":true,"metroPort":8083,"durationMs":59257}

$ xcrun simctl list devices | grep stim-qa-ipad
    stim-qa-ipad (2392EA42-3270-4B90-8C7D-207ED908D5E2) (Booted)
# deviceTypeIdentifier: ...SimDeviceType.iPad-Pro-13-inch-M4-8GB
# runtime:              ...SimRuntime.iOS-26-5
```

The mismatch rule against that owned sim:

```
$ stim ios --device-type "iPhone 17" --json
{"code":"STIM_NO_DEVICE","message":"Could not ensure an owned iOS simulator: this project's sim is iPad Pro 13-inch (M4), but --device-type asked for iPhone 17. Stim will not silently boot a different model. Run `stim worktree remove` (or `stim gc --delete`) to reap the current sim, then `stim ios` again to create the requested one.", ...}
```

The gate itself, re-run in a second scratch worktree against real `simctl`
(no simulator is created for any of these, so it costs nothing). This machine
has 124 device types in `simctl list devicetypes` and 65 that an installed
runtime can create; `iPhone 8` and `Apple Vision Pro` are both in the first set
and neither is in the second:

```
$ stim ios --device-type "iPhone 8" --json
STIM_BAD_ARG
No device type named "iPhone 8" can be created on any installed simulator runtime. Device types the installed runtimes support: iPhone 17 Pro, iPhone 17 Pro Max, iPhone 17e, iPhone Air, iPhone 17, iPhone 16 Pro ...
names listed: 65

$ stim ios --device-type "iPad Pro 13-inch (M4)" --runtime "18.5" --json
STIM_BAD_ARG   No installed simulator runtime matches "18.5". Installed runtimes: 26.5.

$ stim ios --device-type "iPhone 17 Pro" --runtime "5" --json      # old suffix match accepted this
STIM_BAD_ARG   No installed simulator runtime matches "5". Installed runtimes: 26.5.

$ stim ios --device-type "iPad Pro 13-inch (M4)" --runtime "26.5" --json   # valid pair passes the gate
STIM_NO_METRO  No Metro port is reserved for this workspace, ...
```

`--device-type ""` refuses with `"--device-type was given an empty name."` All
of these land before any device work: no `simctl create`, no boot, no build.

`stop --json` then `worktree remove --force` shut down and deleted
`stim-qa-ipad`, and both scratch worktrees are gone; the only `stim-*` sim left
on the machine belongs to another workspace and predates this run.

For the Android JSON field, `parseAvdSystemImage` was run against this machine's
real AVD `config.ini`
(`~/.android/avd/Android16_16KB.avd/config.ini`, `image.sysdir.1=system-images/android-36/google_apis_playstore_ps16k/arm64-v8a/`).
It produced `system-images;android-36;google_apis_playstore_ps16k;arm64-v8a`,
which round-trips: that package id names a directory that really exists under
`$ANDROID_HOME/system-images`, and it is the one entry
`listInstalledSystemImages()` reports here.

The rest of Android's half is unit-tested only. Its listing is that same
filesystem read -- no new tool call -- and `avdmanager create avd -k <pkg>`
receives the same package id it received before, so the changed argument list on
that side is one already exercised.

Fixes #255
