### PR TITLE
feat: aggregate build and cache statistics behind `stim stats`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ worktree create -> start -> ios|android -> logs --errors -> stop -> worktree rem
 ```
 
 The command surface is `doctor`, `worktree create|remove`, `start`, `stop`,
-`ios`, `android`, `device lock|unlock`, `logs`, `status`, `gc`, and `guide`. Do not add commands or
-flags without an explicit product decision. Projects can wrap Stim when they
-need custom behavior.
+`ios`, `android`, `device lock|unlock`, `logs`, `status`, `stats`, `gc`, and
+`guide`. Do not add commands or flags without an explicit product decision.
+Projects can wrap Stim when they need custom behavior.
 
 Runtime state belongs under `$STIM_HOME/workspaces/`, not in the project
 tree. Stim has no init step; do not add one. `doctor` reports setup that

--- a/packages/stim-cli/bin/cli.ts
+++ b/packages/stim-cli/bin/cli.ts
@@ -10,6 +10,7 @@ import androidCommand from '../src/commands/android.ts';
 import deviceCommand from '../src/commands/device.ts';
 import logsCommand from '../src/commands/logs.ts';
 import statusCommand from '../src/commands/status.ts';
+import statsCommand from '../src/commands/stats.ts';
 import gcCommand from '../src/commands/gc.ts';
 import guideCommand from '../src/commands/guide.ts';
 
@@ -27,6 +28,7 @@ androidCommand(program);
 deviceCommand(program);
 logsCommand(program);
 statusCommand(program);
+statsCommand(program);
 gcCommand(program);
 guideCommand(program, pkg.version);
 

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -140,9 +140,7 @@ and the conflict is visible before anything runs.
 
 Decide at the start of a session, not after the third failure: either run Stim
 with the harness's sandbox disabled, or ask the user to allow those three.
-`stim guide errors` lists what to allow. The same boundary catches other
-commands: a git credential helper prints `failed to store` on a fetch that
-worked.
+`stim guide errors` lists what to allow.
 
 ## Load advanced guidance only when needed
 
@@ -168,6 +166,7 @@ Run the guide before tasks involving any of these:
 - custom Metro processes or public tunnels;
 - cache bypasses, cache misses, or concurrent builds;
 - machine capacity limits;
+- cache hit rates or the time the cache saved, which `stim stats` reports;
 - worktree carry-over warnings;
 - fingerprint exclusions;
 - `gc`, `--force`, cleanup failures, or unfamiliar cleanup states and error

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
@@ -43,6 +43,7 @@ import { BUILD_ERROR } from '../engine/gradle.ts';
 import { ADB_INSTALL_TIMEOUT_MS, LAUNCH_UNVERIFIED } from '../engine/app-install.ts';
 import type { AssetManifest } from '../engine/asset-manifest.ts';
 import { PREBUILD_ERROR } from '../engine/prebuild.ts';
+import type { RecordStatsResult, StatsRun } from '../engine/stats.ts';
 import { asProcessExit, makeChildProcess, makeError, makeExecutor } from './_factories.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
 
@@ -4367,5 +4368,122 @@ describe('the emulator system-image flag', () => {
     const stdout0 = h.stdout[0];
     assert(stdout0);
     expect(JSON.parse(stdout0).systemImage).toBe('system-images;android-36;google_apis;arm64-v8a');
+  });
+});
+
+describe('run statistics', () => {
+  function recorder(result: RecordStatsResult = { recorded: true, note: null }) {
+    const runs: Array<{ run: StatsRun; now: number }> = [];
+    const recordStats = (statsRun: StatsRun, now: number) => {
+      runs.push({ run: statsRun, now });
+      return result;
+    };
+    return { runs, recordStats };
+  }
+
+  test('a successful run is recorded once, with its cache result and duration', async () => {
+    const { runs, recordStats } = recorder();
+    let clock = 1_700_000_000_000;
+    const h = harness({ recordStats, now: () => (clock += 1000) });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run).toEqual({
+      platform: 'android',
+      projectKey: realpathSync(root),
+      failed: false,
+      cacheHit: false,
+      waitedForBuild: false,
+      durationMs: expect.any(Number),
+    });
+    expect((runs[0]?.run.durationMs as number) > 0).toBe(true);
+    expect(runs[0]?.now).toBe(clock);
+  });
+
+  test('a cache hit is recorded as a hit', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({ recordStats, resolveCached: () => fakeApk(), build: never('the build') });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.cacheHit).toBe('local');
+  });
+
+  test('a run that ends through fail() is recorded once as failed', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({
+      recordStats,
+      build: async () => ({ failed: true, code: BUILD_ERROR, reason: 'Gradle failed.', durationMs: 1, lastLines: [] }),
+    });
+
+    expect((await h.run()).ok).toBe(false);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(true);
+  });
+
+  test('a refusal before a cache key exists is not a run', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({ recordStats, fingerprint: async () => ({ hash: null, sources: [] }) });
+
+    expect((await h.run()).ok).toBe(false);
+    expect(runs).toEqual([]);
+  });
+
+  test('an uncaught exception after the cache key is recorded as failed, once', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({
+      recordStats,
+      build: async () => {
+        throw new Error('gradle exploded');
+      },
+    });
+
+    await expect(h.run()).rejects.toThrow(/gradle exploded/);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(true);
+  });
+
+  test('a recorder that throws leaves the result alone and says so once', async () => {
+    const throwing = () => {
+      throw new Error('stats disk is full');
+    };
+    const ok = harness({ recordStats: throwing });
+    expect((await ok.run()).ok).toBe(true);
+    expect(ok.stderr.join('\n')).toMatch(/Run statistics could not be recorded: stats disk is full/);
+
+    const failed = harness({
+      recordStats: throwing,
+      build: async () => ({ failed: true, code: BUILD_ERROR, reason: 'Gradle failed.', durationMs: 1, lastLines: [] }),
+    });
+    expect((await failed.run()).ok).toBe(false);
+  });
+
+  test('a note from the recorder is printed as one dim line', async () => {
+    const { recordStats } = recorder({ recorded: false, note: 'stats.json is from a newer Stim' });
+    const h = harness({ recordStats });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.stderr.join('\n')).toContain('stats.json is from a newer Stim');
+  });
+
+  test('a throw after the success reporter recorded does not add a second, failed run', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({
+      recordStats,
+      createWriter: (file: string) => ({
+        file,
+        write: () => true,
+        close: () => {
+          throw new Error('the build log vanished');
+        },
+        written: 0,
+        dropped: 0,
+        lastError: null,
+      }),
+    });
+
+    await expect(h.run()).rejects.toThrow(/the build log vanished/);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(false);
   });
 });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -1,4 +1,4 @@
-import { formatDuration, formatElapsed, phaseLine, shortHash } from '../command-output.ts';
+import { formatDuration, formatElapsed, formatLongDuration, phaseLine, shortHash } from '../command-output.ts';
 
 test('formatDuration uses one format for every command', () => {
   expect(formatDuration(0)).toBe('0ms');
@@ -23,6 +23,19 @@ test('formatElapsed keeps seconds at every scale, so a 30s progress line never r
   expect(formatElapsed(605_000)).toBe('10m05s');
   expect(formatElapsed(-5)).toBe('0s');
   expect(formatElapsed(undefined)).toBe('0s');
+});
+
+test('formatLongDuration adds hours and pads the smaller unit at every scale', () => {
+  expect(formatLongDuration(0)).toBe('0s');
+  expect(formatLongDuration(31_000)).toBe('31s');
+  expect(formatLongDuration(245_000)).toBe('4m05s');
+  expect(formatLongDuration(252_000)).toBe('4m12s');
+  expect(formatLongDuration(2_460_000)).toBe('41m');
+  expect(formatLongDuration(3_900_000)).toBe('1h05m');
+  expect(formatLongDuration(7_980_000)).toBe('2h13m');
+  expect(formatLongDuration(7_200_000)).toBe('2h');
+  expect(formatLongDuration(-1)).toBe('unknown');
+  expect(formatLongDuration(undefined)).toBe('unknown');
 });
 
 test('phaseLine uses one indented column', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -114,13 +114,14 @@ test('the facts topic says Android artifacts use the post-Gradle fingerprint', (
 test('the one-line JSON sentence names every command whose --json payload is a single line', () => {
   const body = renderTopic('facts');
   assert(body);
-  const singleLineJsonCommands = ['start', 'ios', 'android', 'stop', 'status', 'doctor'];
+  const singleLineJsonCommands = ['start', 'ios', 'android', 'stop', 'status', 'stats', 'doctor'];
   const files: Record<string, string> = {
     start: 'start.ts',
     ios: 'ios.ts',
     android: 'android.ts',
     stop: 'stop.ts',
     status: 'status.ts',
+    stats: 'stats.ts',
     doctor: 'doctor.ts',
     device: 'device.ts',
   };
@@ -958,6 +959,7 @@ test('the binary command surface remains intentional', () => {
     'ios',
     'logs',
     'start',
+    'stats',
     'status',
     'stop',
     'worktree',
@@ -1154,4 +1156,61 @@ test('the facts topic documents the model, runtime and system image the run repo
   expect(flat).toMatch(/runtime that simulator's iOS runtime version/);
   expect(flat).toMatch(/systemImage the sdkmanager package id the owned AVD was created from/);
   expect(flat).toMatch(/a run driven by the ios\.deviceType setting reports it too/);
+});
+
+test('the guide states the rule that turns runs into the numbers `stats` prints', () => {
+  const facts = renderTopic('facts');
+  assert(facts);
+
+  expect(facts).toMatch(/HOW A RUN IS COUNTED/);
+  expect(facts).toMatch(/got as far as computing a\s+cache key is one run/i);
+  expect(facts).toMatch(/app's path IN THE MAIN WORKING TREE/);
+  expect(facts).toMatch(/worktree of a repository pools into one bucket/i);
+  expect(facts).toMatch(/ends through an error or an uncaught exception counts\s+only as `failed`/i);
+  expect(facts).toMatch(/"local" or "remote"\s+is a HIT, false is a MISS/);
+  expect(facts).toMatch(/mean cold run BEFORE it, minus its own duration, floored at zero/i);
+  expect(facts).toMatch(/WAITED for another workspace's build[\s\S]*credited nothing/i);
+  expect(facts).toMatch(/no cold run recorded for this project and platform/i);
+  expect(facts).toMatch(/ESTIMATE/);
+  expect(facts).toMatch(/stim stats --json/);
+  expect(facts).toMatch(/timeSavedMs/);
+});
+
+test('the guide routes the two report questions to the two commands', () => {
+  const lifecycle = renderTopic('lifecycle');
+  const cleanup = renderTopic('cleanup');
+  assert(lifecycle);
+  assert(cleanup);
+
+  expect(lifecycle).toMatch(/"What is running" is `stim status`/);
+  expect(lifecycle).toMatch(/"How much the\s+cache saved" is `stim stats`/);
+  expect(lifecycle).toMatch(/stats\s+--json/);
+  expect(lifecycle).toMatch(/\$STIM_HOME\/stats\.json/);
+  expect(cleanup).toMatch(/gc` never reports or trims the run\s+counters/i);
+  expect(cleanup).toMatch(/no reset flag[\s\S]*Delete that one file/i);
+  expect(cleanup).toMatch(/cannot read[\s\S]*one dim line on stderr/i);
+  expect(cleanup).toMatch(/stats\.json\.corrupt-<unix ms>/);
+});
+
+test('the skill routes cache-saving questions to `stim stats` without teaching the payload', () => {
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+
+  expect(skill).toMatch(/`stim stats` reports/);
+  expect(skill).not.toContain('timeSavedMs');
+  expect(skill).not.toContain('stats.json');
+});
+
+test('the website documents the stats command and its JSON shape', () => {
+  const website = readFileSync(new URL('../../../../website/docs/commands.md', import.meta.url), 'utf-8');
+
+  expect(website).toContain('## `stats`');
+  expect(website).toContain('stim stats [--json]');
+  expect(website).toMatch(/"project": \{ "key"/);
+  expect(website).toMatch(/no reset flag/i);
+});
+
+test('the repository guide names stats in the command surface', () => {
+  const agents = readFileSync(new URL('../../../../AGENTS.md', import.meta.url), 'utf-8');
+
+  expect(agents).toMatch(/The command surface is[\s\S]*`status`, `stats`, `gc`/);
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -42,6 +42,7 @@ import {
 import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroResolution } from './_factories.ts';
 import { RELEASE_VERIFY_WAIT_MS } from '../engine/app-install.ts';
 import { DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../engine/ios-device.ts';
+import type { RecordStatsResult, StatsRun } from '../engine/stats.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
 
 const RUNTIMES = [
@@ -4540,5 +4541,143 @@ describe('the simulator model and runtime flags', () => {
     const payload = parseFirst(logs);
     expect(payload.deviceType).toBe(null);
     expect(payload.runtime).toBe(null);
+  });
+});
+
+describe('run statistics', () => {
+  function recorder(result: RecordStatsResult = { recorded: true, note: null }) {
+    const runs: Array<{ run: StatsRun; now: number }> = [];
+    const recordStats = (statsRun: StatsRun, now: number) => {
+      runs.push({ run: statsRun, now });
+      return result;
+    };
+    return { runs, recordStats };
+  }
+
+  test('a successful run is recorded once, with its cache result and duration', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    let clock = 1_700_000_000_000;
+    const { exitCode } = await run({}, { recordStats, now: () => (clock += 1000) });
+
+    expect(exitCode).toBe(null);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run).toEqual({
+      platform: 'ios',
+      projectKey: root,
+      failed: false,
+      cacheHit: false,
+      waitedForBuild: false,
+      durationMs: expect.any(Number),
+    });
+    expect((runs[0]?.run.durationMs as number) > 0).toBe(true);
+    expect(runs[0]?.now).toBe(clock);
+  });
+
+  test('a cache hit is recorded as a hit', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    await run({}, { recordStats, resolveBuild: (_platform, _key) => join(root, 'cached', 'Fixture.app') });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.cacheHit).toBe('local');
+  });
+
+  test('a run that ends through fail() is recorded once as failed', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    const { exitCode } = await run(
+      {},
+      {
+        recordStats,
+        buildIos: async () => ({ failed: true, code: 'STIM_BUILD_FAILED', durationMs: 90000, diagnostics: [] }),
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(true);
+  });
+
+  test('a refusal before a cache key exists is not a run', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    const { exitCode } = await run({}, { recordStats, resolveProjectMetro: async () => ({ missing: true }) });
+
+    expect(exitCode).toBe(1);
+    expect(runs).toEqual([]);
+  });
+
+  test('an uncaught exception after the cache key is recorded as failed, once', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    await expect(() =>
+      run(
+        {},
+        {
+          recordStats,
+          buildIos: async () => {
+            throw new Error('xcodebuild exploded');
+          },
+        },
+      ),
+    ).rejects.toThrow(/xcodebuild exploded/);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(true);
+  });
+
+  test('a recorder that throws leaves the exit status alone and says so once', async () => {
+    reserve();
+    const throwing = () => {
+      throw new Error('stats disk is full');
+    };
+    const ok = await run({}, { recordStats: throwing });
+    expect(ok.exitCode).toBe(null);
+    expect(ok.stderr).toMatch(/Run statistics could not be recorded: stats disk is full/);
+
+    const failed = await run(
+      {},
+      {
+        recordStats: throwing,
+        buildIos: async () => ({ failed: true, code: 'STIM_BUILD_FAILED', durationMs: 90000, diagnostics: [] }),
+      },
+    );
+    expect(failed.exitCode).toBe(1);
+  });
+
+  test('a note from the recorder is printed as one dim line', async () => {
+    reserve();
+    const { recordStats } = recorder({ recorded: false, note: 'stats.json is from a newer Stim' });
+    const { exitCode, stderr } = await run({}, { recordStats });
+
+    expect(exitCode).toBe(null);
+    expect(stderr).toContain('stats.json is from a newer Stim');
+  });
+
+  test('a throw after the success reporter recorded does not add a second, failed run', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    await expect(() =>
+      run(
+        {},
+        {
+          recordStats,
+          createWriter: (file: string) => ({
+            file,
+            write: () => true,
+            close: () => {
+              throw new Error('the build log vanished');
+            },
+            written: 0,
+            dropped: 0,
+            lastError: null,
+          }),
+        },
+      ),
+    ).rejects.toThrow(/the build log vanished/);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.run.failed).toBe(false);
   });
 });

--- a/packages/stim-cli/src/__tests__/stats.test.ts
+++ b/packages/stim-cli/src/__tests__/stats.test.ts
@@ -1,0 +1,423 @@
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { resetExecutor, setExecutor } from '../exec.ts';
+import statsCommand from '../commands/stats.ts';
+import {
+  emptyStats,
+  readStats,
+  recordRunStats,
+  statsFile,
+  statsProjectKey,
+  updateStats,
+  type StatsBucket,
+  type StatsRecord,
+  type StatsRun,
+} from '../engine/stats.ts';
+
+const T0 = Date.parse('2026-09-01T10:00:00.000Z');
+const T1 = Date.parse('2026-09-02T10:00:00.000Z');
+
+let tmpHome: string;
+let root: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'stim-test-'));
+  process.env.STIM_HOME = tmpHome;
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'stim-ws-')));
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fixture' }));
+  setExecutor({
+    run: () => '',
+    runQuiet: () => null,
+    spawn() {
+      throw new Error('stats spawns nothing');
+    },
+  });
+});
+
+afterEach(() => {
+  resetExecutor();
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+function run(overrides: Partial<StatsRun> = {}): StatsRun {
+  return {
+    platform: 'ios',
+    projectKey: '/repo/app',
+    failed: false,
+    cacheHit: false,
+    waitedForBuild: false,
+    durationMs: 60_000,
+    ...overrides,
+  };
+}
+
+function bucketOf(record: StatsRecord, key: string): StatsBucket {
+  const bucket = record.projects[key]?.ios;
+  assert(bucket);
+  return bucket;
+}
+
+describe('the update rule', () => {
+  test('a miss records a cold run and creates the bucket with both timestamps', () => {
+    const record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket).toEqual({
+      runs: 1,
+      failed: 0,
+      hits: 0,
+      misses: 1,
+      coldRuns: 1,
+      coldRunMs: 240_000,
+      hitRuns: 0,
+      hitRunMs: 0,
+      timeSavedMs: 0,
+      firstRunAt: '2026-09-01T10:00:00.000Z',
+      lastRunAt: '2026-09-01T10:00:00.000Z',
+    });
+    expect(record.machine.ios).toEqual(bucket);
+    expect(record.version).toBe(1);
+  });
+
+  test('a hit after a cold run is credited the mean cold run minus its own duration', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    record = updateStats(record, run({ durationMs: 120_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 30_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.runs).toBe(3);
+    expect(bucket.hits).toBe(1);
+    expect(bucket.misses).toBe(2);
+    expect(bucket.hitRuns).toBe(1);
+    expect(bucket.hitRunMs).toBe(30_000);
+    expect(bucket.timeSavedMs).toBe(150_000);
+    expect(bucket.coldRunMs).toBe(360_000);
+    expect(bucket.firstRunAt).toBe('2026-09-01T10:00:00.000Z');
+    expect(bucket.lastRunAt).toBe('2026-09-02T10:00:00.000Z');
+  });
+
+  test('a remote hit counts like a local one', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 200_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'remote', durationMs: 20_000 }), T1);
+
+    expect(bucketOf(record, '/repo/app').hits).toBe(1);
+    expect(bucketOf(record, '/repo/app').timeSavedMs).toBe(180_000);
+  });
+
+  test('a hit slower than the mean cold run credits nothing rather than a negative', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 20_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 90_000 }), T1);
+
+    expect(bucketOf(record, '/repo/app').timeSavedMs).toBe(0);
+    expect(bucketOf(record, '/repo/app').hitRunMs).toBe(90_000);
+  });
+
+  test('a hit that waited for another workspace counts as a hit and nothing else', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', waitedForBuild: true, durationMs: 30_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.runs).toBe(2);
+    expect(bucket.hits).toBe(1);
+    expect(bucket.hitRuns).toBe(0);
+    expect(bucket.hitRunMs).toBe(0);
+    expect(bucket.timeSavedMs).toBe(0);
+    expect(record.machine.ios?.timeSavedMs).toBe(0);
+  });
+
+  test('a hit with no cold run for this project and platform credits nothing', () => {
+    let record = updateStats(emptyStats(), run({ platform: 'android', durationMs: 600_000 }), T0);
+    record = updateStats(record, run({ projectKey: '/repo/other', durationMs: 600_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 30_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(record.machine.ios?.coldRuns).toBe(1);
+    expect(bucket.hits).toBe(1);
+    expect(bucket.timeSavedMs).toBe(0);
+    expect(record.machine.ios?.timeSavedMs).toBe(0);
+  });
+
+  test('a failed run counts as a run and a failure and nothing else', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    record = updateStats(record, run({ failed: true, cacheHit: 'local', durationMs: 5_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.runs).toBe(2);
+    expect(bucket.failed).toBe(1);
+    expect(bucket.hits).toBe(0);
+    expect(bucket.misses).toBe(1);
+    expect(bucket.hitRuns).toBe(0);
+    expect(bucket.coldRuns).toBe(1);
+    expect(bucket.lastRunAt).toBe('2026-09-02T10:00:00.000Z');
+  });
+
+  test('the machine bucket moves in lockstep with the projects that feed it', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    record = updateStats(record, run({ projectKey: '/repo/other', durationMs: 400_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 40_000 }), T1);
+    record = updateStats(record, run({ projectKey: '/repo/other', cacheHit: 'local', durationMs: 40_000 }), T1);
+
+    const machine = record.machine.ios;
+    assert(machine);
+    expect(machine.runs).toBe(4);
+    expect(machine.hits).toBe(2);
+    expect(machine.coldRunMs).toBe(640_000);
+    expect(machine.timeSavedMs).toBe(200_000 + 360_000);
+    expect(machine.timeSavedMs).toBe(
+      bucketOf(record, '/repo/app').timeSavedMs + bucketOf(record, '/repo/other').timeSavedMs,
+    );
+  });
+
+  test('a platform keeps its own bucket', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 100_000 }), T0);
+    record = updateStats(record, run({ platform: 'android', durationMs: 300_000 }), T0);
+
+    expect(record.projects['/repo/app']?.ios?.coldRunMs).toBe(100_000);
+    expect(record.projects['/repo/app']?.android?.coldRunMs).toBe(300_000);
+    expect(record.machine.android?.runs).toBe(1);
+  });
+
+  test('milliseconds stay whole numbers', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000.6 }), T0);
+    record = updateStats(record, run({ durationMs: 100_001 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 30_000.4 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.coldRunMs).toBe(340_002);
+    expect(bucket.hitRunMs).toBe(30_000);
+    expect(bucket.timeSavedMs).toBe(140_001);
+    expect(Number.isInteger(bucket.timeSavedMs)).toBe(true);
+  });
+
+  test('the input record is not mutated', () => {
+    const before = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    const snapshot = JSON.stringify(before);
+    updateStats(before, run({ cacheHit: 'local', durationMs: 10_000 }), T1);
+
+    expect(JSON.stringify(before)).toBe(snapshot);
+  });
+});
+
+describe('the stats file', () => {
+  test('a run is written under the config lock and read back', () => {
+    const outcome = recordRunStats(run({ projectKey: root, durationMs: 240_000 }), T0);
+
+    expect(outcome).toEqual({ recorded: true, note: null });
+    expect(existsSync(statsFile())).toBe(true);
+    expect(readStats().record?.projects[root]?.ios?.coldRunMs).toBe(240_000);
+    expect(readFileSync(statsFile(), 'utf-8').split('\n')).toHaveLength(2);
+  });
+
+  test('a file from a newer Stim is left untouched and the run records nothing', () => {
+    const newer = JSON.stringify({ version: 2, machine: {}, projects: {} });
+    writeFileSync(statsFile(), newer);
+
+    const outcome = recordRunStats(run({ projectKey: root }), T0);
+
+    expect(outcome.recorded).toBe(false);
+    expect(outcome.note).toMatch(/version 2/);
+    expect(readFileSync(statsFile(), 'utf-8')).toBe(newer);
+    expect(readStats().record).toBe(null);
+    expect(readStats().note).toMatch(/version 2/);
+  });
+
+  test('a corrupt file is renamed aside, a fresh one is started, and the run is recorded', () => {
+    writeFileSync(statsFile(), '{ this is not json');
+
+    const outcome = recordRunStats(run({ projectKey: root, durationMs: 5_000 }), T0);
+
+    expect(outcome.recorded).toBe(true);
+    expect(outcome.note).toMatch(/moved to /);
+    expect(readFileSync(`${statsFile()}.corrupt-${T0}`, 'utf-8')).toBe('{ this is not json');
+    expect(readStats().record?.projects[root]?.ios?.runs).toBe(1);
+  });
+
+  test('a file that parses to something other than a versioned object is corrupt too', () => {
+    writeFileSync(statsFile(), JSON.stringify([1, 2, 3]));
+    expect(recordRunStats(run({ projectKey: root }), T0).note).toMatch(/moved to /);
+
+    writeFileSync(statsFile(), JSON.stringify({ machine: {}, projects: {} }));
+    expect(recordRunStats(run({ projectKey: root }), T1).note).toMatch(/moved to /);
+    expect(readdirSync(tmpHome).filter((name) => name.includes('corrupt-'))).toHaveLength(2);
+  });
+
+  test('the recorder writes nowhere but STIM_HOME and creates no config.json', () => {
+    recordRunStats(run({ projectKey: root }), T0);
+
+    expect(statsFile()).toBe(join(tmpHome, 'stats.json'));
+    expect(existsSync(join(tmpHome, 'config.json'))).toBe(false);
+  });
+
+  test('the project key is the app path in the main working tree, canonical', () => {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), 'stim-repo-')));
+    const worktree = join(repo, 'worktrees', 'agent-1');
+
+    expect(
+      statsProjectKey({ root: join(worktree, 'apps', 'mobile'), commonDir: join(repo, '.git'), repoRoot: worktree }),
+    ).toBe(join(repo, 'apps', 'mobile'));
+    expect(statsProjectKey({ root, commonDir: null, repoRoot: null })).toBe(root);
+    expect(statsProjectKey({ root, commonDir: join(repo, 'bare.git'), repoRoot: repo })).toBe(root);
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+});
+
+function runStats(argv: string[] = []): { out: string[]; err: string[] } {
+  const program = new Command();
+  statsCommand(program);
+  const out: string[] = [];
+  const err: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (msg) => out.push(String(msg));
+  console.error = (msg) => err.push(String(msg));
+  try {
+    program.parse(['node', 'stim', 'stats', ...argv]);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  return { out, err };
+}
+
+function inDir<T>(dir: string, fn: () => T): T {
+  const previous = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+describe('stim stats', () => {
+  test('prints the project section and the machine section', () => {
+    let record = updateStats(emptyStats(), run({ projectKey: root, durationMs: 252_000 }), T0);
+    record = updateStats(record, run({ projectKey: root, cacheHit: 'local', durationMs: 31_000 }), T1);
+    record = updateStats(record, run({ projectKey: root, failed: true, durationMs: 4_000 }), T1);
+    record = updateStats(record, run({ projectKey: '/elsewhere', platform: 'android', durationMs: 400_000 }), T1);
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    const { out: lines, err } = inDir(root, () => runStats());
+
+    expect(lines[0]).toBe(`project ${root}`);
+    expect(lines[1]).toMatch(
+      /^ {2}ios {6}3 runs \(1 failed\) {3}1 hits \(50%\) {3}cold run 4m12s avg {3}hit run 31s avg {3}saved ~3m41s \(estimated\) {3}since 2026-09-01$/,
+    );
+    expect(err).toEqual([]);
+    expect(lines).toContain('machine');
+    const machine = lines.slice(lines.indexOf('machine') + 1);
+    expect(machine.some((line) => line.includes('android') && line.includes('cold run 6m40s avg'))).toBe(true);
+    expect(existsSync(join(tmpHome, 'config.json'))).toBe(false);
+  });
+
+  test('an hours estimate reads in hours', () => {
+    let record = updateStats(emptyStats(), run({ projectKey: root, durationMs: 8_000_000 }), T0);
+    record = updateStats(record, run({ projectKey: root, cacheHit: 'local', durationMs: 20_000 }), T1);
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    const { out: lines } = inDir(root, () => runStats());
+
+    expect(lines[1]).toContain('saved ~2h13m (estimated)');
+  });
+
+  test('a section with no bucket says so, and a column with no denominator prints -', () => {
+    const record = updateStats(emptyStats(), run({ projectKey: '/elsewhere', durationMs: 100_000 }), T0);
+    record.projects[root] = {
+      android: {
+        runs: 1,
+        failed: 1,
+        hits: 0,
+        misses: 0,
+        coldRuns: 0,
+        coldRunMs: 0,
+        hitRuns: 0,
+        hitRunMs: 0,
+        timeSavedMs: 0,
+        firstRunAt: '2026-09-01T10:00:00.000Z',
+        lastRunAt: '2026-09-01T10:00:00.000Z',
+      },
+    };
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    const { out: lines } = inDir(root, () => runStats());
+
+    expect(lines[1]).toContain('1 runs (1 failed)   0 hits (-)   cold run - avg   hit run - avg');
+    expect(lines[1]).not.toContain('ios');
+  });
+
+  test('with no file at all both sections report no runs', () => {
+    const { out: lines, err } = inDir(root, () => runStats());
+
+    expect(err).toEqual([]);
+    expect(lines).toEqual([`project ${root}`, '  no runs recorded', 'machine', '  no runs recorded']);
+    expect(existsSync(statsFile())).toBe(false);
+  });
+
+  test('outside a project only the machine section prints', () => {
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'stim-outside-')));
+    writeFileSync(statsFile(), JSON.stringify(updateStats(emptyStats(), run({ projectKey: '/elsewhere' }), T0)));
+
+    const { out: lines } = inDir(outside, () => runStats());
+
+    expect(lines[0]).toBe('machine');
+    expect(lines.some((line) => line.startsWith('project '))).toBe(false);
+
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('--json prints exactly one parseable line in the documented shape', () => {
+    const record = updateStats(emptyStats(), run({ projectKey: root, durationMs: 240_000 }), T0);
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    const { out: lines, err } = inDir(root, () => runStats(['--json']));
+
+    expect(lines).toHaveLength(1);
+    const payload = JSON.parse(lines[0] as string);
+    expect(payload.version).toBe(1);
+    expect(payload.project.key).toBe(root);
+    expect(payload.project.ios.coldRunMs).toBe(240_000);
+    expect(payload.project.android).toBe(null);
+    expect(payload.machine.ios.runs).toBe(1);
+    expect(payload.machine.android).toBe(null);
+    expect(err).toEqual([]);
+  });
+
+  test('a file this Stim cannot use costs one stderr line and leaves stdout alone', () => {
+    writeFileSync(statsFile(), JSON.stringify({ version: 2, machine: {}, projects: {} }));
+    const newer = inDir(root, () => runStats());
+
+    expect(newer.err).toHaveLength(1);
+    expect(newer.err[0]).toMatch(/are version 2, which this Stim does not understand/);
+    expect(newer.out).toEqual([`project ${root}`, '  no runs recorded', 'machine', '  no runs recorded']);
+
+    writeFileSync(statsFile(), '{ this is not json');
+    const corrupt = inDir(root, () => runStats(['--json']));
+
+    expect(corrupt.err).toHaveLength(1);
+    expect(corrupt.err[0]).toMatch(/could not be read; the next ios or android run moves them aside/);
+    expect(corrupt.out).toHaveLength(1);
+    expect(JSON.parse(corrupt.out[0] as string).project.ios).toBe(null);
+    expect(readFileSync(statsFile(), 'utf-8')).toBe('{ this is not json');
+  });
+
+  test('--json outside a project reports a null project', () => {
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'stim-outside-')));
+
+    const { out: lines } = inDir(outside, () => runStats(['--json']));
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] as string)).toEqual({
+      version: 1,
+      project: null,
+      machine: { ios: null, android: null },
+    });
+
+    rmSync(outside, { recursive: true, force: true });
+  });
+});

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -14,6 +14,18 @@ export function formatDuration(ms: unknown): string {
   return `${seconds}s`;
 }
 
+export function formatLongDuration(ms: unknown): string {
+  const value = Number(ms);
+  if (!Number.isFinite(value) || value < 0) return 'unknown';
+  const totalSeconds = Math.round(value / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds - hours * 3600) / 60);
+  const seconds = totalSeconds - hours * 3600 - minutes * 60;
+  if (hours > 0) return minutes > 0 ? `${hours}h${String(minutes).padStart(2, '0')}m` : `${hours}h`;
+  if (minutes > 0) return seconds > 0 ? `${minutes}m${String(seconds).padStart(2, '0')}s` : `${minutes}m`;
+  return `${seconds}s`;
+}
+
 export function formatElapsed(ms: unknown): string {
   const totalSeconds = Math.max(0, Math.round((Number(ms) || 0) / 1000));
   const minutes = Math.floor(totalSeconds / 60);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -75,6 +75,7 @@ import {
   tunnelModeSetting,
   unknownSettingKeys,
 } from '../settings.ts';
+import { createRunRecorder, recordRunStats, statsProjectKey, type RunRecorder } from '../engine/stats.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
 import { readCollectors } from '../collector/state.ts';
 import { MODE_BARE, MODE_EXPO, readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
@@ -825,6 +826,7 @@ interface RunAndroidOptions {
   kill?: (pid: number, signal: NodeJS.Signals) => boolean;
   createWriter?: typeof createNdjsonWriter;
   writeState?: typeof writeWorkspaceState;
+  recordStats?: typeof recordRunStats;
   now?: () => number;
   out?: (line: string) => void;
   emit?: (line: string) => void;
@@ -1026,6 +1028,7 @@ interface ReportAndroidResultArgs {
   durationMs: number;
   writer: AndroidWriter;
   emit: (line: string) => void;
+  recordRun: RunRecorder['record'];
 }
 
 function reportAndroidResult({
@@ -1050,7 +1053,9 @@ function reportAndroidResult({
   writer,
   emit,
   lease,
+  recordRun,
 }: ReportAndroidResultArgs): AndroidFacts {
+  recordRun({ failed: false, cacheHit: cacheLevel(record.cacheHit), waited: waitedForBuild, durationMs });
   const facts = androidFacts({
     serial,
     avdName: record.avdName,
@@ -1165,6 +1170,7 @@ interface FinishAndroidRunArgs {
   now: () => number;
   out: (line: string) => void;
   emit: (line: string) => void;
+  recordRun: ReportAndroidResultArgs['recordRun'];
 }
 
 async function finishAndroidRun({
@@ -1215,6 +1221,7 @@ async function finishAndroidRun({
   now,
   out,
   emit,
+  recordRun,
 }: FinishAndroidRunArgs): Promise<RunAndroidResult> {
   let androidPackage = initialPackage;
   let leaseWarned = false;
@@ -1441,6 +1448,7 @@ async function finishAndroidRun({
     writer,
     emit,
     lease: physical ? leaseFacts : undefined,
+    recordRun,
   });
   if (remoteWasAbandoned || uploadWasAbandoned) exitAfterFlush(0);
   return { ok: true, facts };
@@ -1564,6 +1572,7 @@ function resolveRunAndroidOptions(
     kill = (pid, signal) => process.kill(pid, signal),
     createWriter = createNdjsonWriter,
     writeState = writeWorkspaceState,
+    recordStats = recordRunStats,
     now = Date.now,
     out = (line) => console.error(line),
     emit = (line) => console.log(line),
@@ -1637,6 +1646,7 @@ function resolveRunAndroidOptions(
     kill,
     createWriter,
     writeState,
+    recordStats,
     now,
     out,
     emit,
@@ -1712,6 +1722,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     kill,
     createWriter,
     writeState,
+    recordStats,
     now,
     out,
     emit,
@@ -1774,6 +1785,15 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   };
 
   const phase = (label: unknown, text: string) => out(phaseLine(label, text));
+
+  const stats = createRunRecorder({
+    platform: PLATFORM,
+    write: recordStats,
+    now,
+    note: (line) => out(phaseLine('stats', chalk.dim(line))),
+  });
+  const recordRun = stats.record;
+
   const fail = (
     code: string | undefined,
     message?: string | null,
@@ -1797,6 +1817,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     for (const line of lines) out(phaseLine('', chalk.dim(line)));
     if (remedy) out(phaseLine('remedy', remedy));
     if (logPath) out(phaseLine('log', logPath));
+    recordRun({ failed: true, durationMs: now() - started });
     if (json) {
       emit(JSON.stringify({ code, message, remedy: remedy ?? null, ...(lease === undefined ? {} : { lease }) }));
     }
@@ -1811,6 +1832,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     gitCommonDir: gitCommonDir(root),
     repoRoot: settingsRepoRoot,
   };
+  stats.setProject(statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot }));
   const settings = resolveSettingsFor(settingsContext);
   const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
   if (shapeError) {
@@ -2155,6 +2177,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     }
     record.fingerprint = hash;
     cacheKey = buildCacheKey(PLATFORM, hash, variant ? { variant } : {});
+    stats.setCacheKey(cacheKey);
     record.cacheKey = cacheKey;
     storeHash = hash;
     storeKey = cacheKey;
@@ -2202,448 +2225,464 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     return true;
   }
 
-  if (!(await resolveInitialFingerprint())) return phaseFailure!;
+  const runFromFingerprint = async (): Promise<RunAndroidResult> => {
+    if (!(await resolveInitialFingerprint())) return phaseFailure!;
 
-  let remote: LoadProjectProviderResult | null = null;
-  let abandonedRemote = false;
-  let uploadPending: Promise<RemoteUploadLike> | null = null;
+    let remote: LoadProjectProviderResult | null = null;
+    let abandonedRemote = false;
+    let uploadPending: Promise<RemoteUploadLike> | null = null;
 
-  async function resolveRemoteArtifact(): Promise<void> {
-    if (!apkPath) {
-      const loaded: LoadProjectProviderResult = await loadProvider(root, { isExpo });
-      if (loaded?.unavailable) {
-        phase('cache', chalk.yellow(`provider not usable: ${loaded.unavailable}`));
-      } else if (loaded?.provider) {
-        remote = loaded;
-      }
-      if (remote?.name === 'eas') {
-        const auth = easAuth({ projectRoot: root, owner: loaded?.owner || null });
-        const authNote = easAuthNote(auth as Parameters<typeof easAuthNote>[0]);
-        if (authNote) phase('cache', chalk.yellow(authNote));
-        if (auth?.code === 'logged-out') remote = null;
-      }
-    }
-
-    if (remote && useBuildCache) {
-      const remoteTimer = stepTimer(now);
-      const hit = await resolveRemoteBuild({
-        logWriter: writer,
-        provider: remote.provider,
-        platform: PLATFORM,
-        projectRoot: root,
-        fingerprintHash: hash,
-        runOptions: variant ? { variant } : null,
-      });
-      if (hit?.appPath) {
-        let stored = null;
-        try {
-          stored = storeCached(PLATFORM, cacheKey, hit.appPath, { sources: fingerprintSources });
-        } catch (err) {
-          phase('cache', chalk.yellow(`remote hit could not be stored locally: ${(err as Error)?.message || err}`));
+    async function resolveRemoteArtifact(): Promise<void> {
+      if (!apkPath) {
+        const loaded: LoadProjectProviderResult = await loadProvider(root, { isExpo });
+        if (loaded?.unavailable) {
+          phase('cache', chalk.yellow(`provider not usable: ${loaded.unavailable}`));
+        } else if (loaded?.provider) {
+          remote = loaded;
         }
-        apkPath = stored || hit.appPath;
-        record.cacheHit = 'remote';
-        phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''} ${remoteTimer()}`);
-      } else if (hit?.timedOut) {
-        abandonedRemote = true;
-        phase(
-          'cache',
-          chalk.yellow(`${remote.name} did not answer within ${formatDuration(RESOLVE_TIMEOUT_MS)}; building instead`),
-        );
-      } else if (hit?.failed) {
-        const authNote =
-          remote.name === 'eas' && isEasAuthFailureText(hit.failed)
-            ? easAuthNote({ code: 'logged-out', reason: hit.failed })
-            : null;
-        phase('cache', chalk.yellow(authNote || `${remote.name} could not be used: ${hit.failed}; building instead`));
-      } else {
-        phase('cache', `remote miss (${remote.name}) ${remoteTimer()}`);
-      }
-    }
-  }
-
-  await resolveRemoteArtifact();
-
-  let waitedForBuild: WaitedForBuild | null = null;
-  async function waitForSharedBuild(): Promise<boolean> {
-    if (!apkPath && useBuildCache) {
-      let attempt: BuildLockHandle | null = null;
-      try {
-        attempt = acquireLock({ platform: PLATFORM, key: cacheKey, root, logFile: buildLog });
-      } catch (err) {
-        phase(
-          'build',
-          chalk.yellow(`could not take the build lock: ${(err as Error)?.message || err}; building anyway`),
-        );
+        if (remote?.name === 'eas') {
+          const auth = easAuth({ projectRoot: root, owner: loaded?.owner || null });
+          const authNote = easAuthNote(auth as Parameters<typeof easAuthNote>[0]);
+          if (authNote) phase('cache', chalk.yellow(authNote));
+          if (auth?.code === 'logged-out') remote = null;
+        }
       }
 
-      if (attempt?.acquired) {
-        buildLock = attempt;
-        if (attempt.tookOver) phase('build', chalk.yellow(takeoverLine(attempt.tookOver)));
-      } else if (attempt?.held) {
-        const holder = attempt.held;
-        const who = holder.projectRoot || 'another workspace';
-        phase(
-          'build',
-          `${who} is already building ${shortHash(hash)} (pid ${holder.pid})` +
-            `${holder.logFile ? ` -- tail ${holder.logFile}` : ''}`,
-        );
-
-        let waited: WaitForBuildResult | null = null;
-        try {
-          waited = await waitForBuild({ platform: PLATFORM, key: cacheKey, out });
-        } catch (err) {
-          const wtErr = err as Error & { code?: string; lockPath?: string };
-          if (wtErr?.code !== 'STIM_BUILD_WAIT_TIMEOUT') throw err;
-          phaseFailure = fail(
-            'STIM_BUILD_WAIT_TIMEOUT',
-            wtErr.message,
-            `Check pid ${holder.pid}; if it is not really building, remove ${wtErr.lockPath} and run \`stim android\` again.`,
-            { lastBuildStatus: true },
+      if (remote && useBuildCache) {
+        const remoteTimer = stepTimer(now);
+        const hit = await resolveRemoteBuild({
+          logWriter: writer,
+          provider: remote.provider,
+          platform: PLATFORM,
+          projectRoot: root,
+          fingerprintHash: hash,
+          runOptions: variant ? { variant } : null,
+        });
+        if (hit?.appPath) {
+          let stored = null;
+          try {
+            stored = storeCached(PLATFORM, cacheKey, hit.appPath, { sources: fingerprintSources });
+          } catch (err) {
+            phase('cache', chalk.yellow(`remote hit could not be stored locally: ${(err as Error)?.message || err}`));
+          }
+          apkPath = stored || hit.appPath;
+          record.cacheHit = 'remote';
+          phase('cache', `remote hit (${remote.name})${stored ? ' -> stored locally' : ''} ${remoteTimer()}`);
+        } else if (hit?.timedOut) {
+          abandonedRemote = true;
+          phase(
+            'cache',
+            chalk.yellow(
+              `${remote.name} did not answer within ${formatDuration(RESOLVE_TIMEOUT_MS)}; building instead`,
+            ),
           );
-          return false;
-        }
-
-        if (waited?.hit) {
-          apkPath = waited.hit ?? null;
-          record.cacheHit = 'local';
-          waitedForBuild = { pid: holder.pid, ms: waited.waitedMs };
-          phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+        } else if (hit?.failed) {
+          const authNote =
+            remote.name === 'eas' && isEasAuthFailureText(hit.failed)
+              ? easAuthNote({ code: 'logged-out', reason: hit.failed })
+              : null;
+          phase('cache', chalk.yellow(authNote || `${remote.name} could not be used: ${hit.failed}; building instead`));
         } else {
+          phase('cache', `remote miss (${remote.name}) ${remoteTimer()}`);
+        }
+      }
+    }
+
+    await resolveRemoteArtifact();
+
+    let waitedForBuild: WaitedForBuild | null = null;
+    async function waitForSharedBuild(): Promise<boolean> {
+      if (!apkPath && useBuildCache) {
+        let attempt: BuildLockHandle | null = null;
+        try {
+          attempt = acquireLock({ platform: PLATFORM, key: cacheKey, root, logFile: buildLog });
+        } catch (err) {
           phase(
             'build',
-            chalk.yellow(`${who}'s build ended without an artifact (${waited?.builderFailed}); building here`),
+            chalk.yellow(`could not take the build lock: ${(err as Error)?.message || err}; building anyway`),
           );
-          try {
-            const takeover = acquireLock({ platform: PLATFORM, key: cacheKey, root, logFile: buildLog });
-            if (takeover?.acquired) buildLock = takeover;
-          } catch {}
-          phase('build', chalk.yellow(takeoverLine(holder)));
         }
-      }
-    }
-    return true;
-  }
 
-  if (!(await waitForSharedBuild())) return phaseFailure!;
+        if (attempt?.acquired) {
+          buildLock = attempt;
+          if (attempt.tookOver) phase('build', chalk.yellow(takeoverLine(attempt.tookOver)));
+        } else if (attempt?.held) {
+          const holder = attempt.held;
+          const who = holder.projectRoot || 'another workspace';
+          phase(
+            'build',
+            `${who} is already building ${shortHash(hash)} (pid ${holder.pid})` +
+              `${holder.logFile ? ` -- tail ${holder.logFile}` : ''}`,
+          );
 
-  let swapDir: string | null = null;
-  let swapFellBack = false;
-  const installableCachedApk = async (key: string, cachedPath: string): Promise<string | null> => {
-    if (!release) return cachedPath;
-    phase('apk swap', `regenerating this workspace's JS for the cached ${variant} APK`);
-    const swap = await swapApk({
-      root,
-      isExpo,
-      cachedApkPath: cachedPath,
-      keystore: resolveKeystore(root, settings),
-      logWriter: writer,
-      storedAssets: storedAssets(PLATFORM, key),
-    });
-    if (swap?.ok && swap.apkPath) {
-      if (swap.note) phase('apk swap', chalk.yellow(swap.note));
-      swapDir = swap.tmpDir ?? null;
-      phase(
-        'apk swap',
-        `${swap.hermes ? 'hermes bytecode' : 'plain JS'} repacked (store), zipaligned and re-signed (${formatDuration(swap.durationMs)})`,
-      );
-      return swap.apkPath;
-    }
-    if (swap?.assetMismatch) {
-      phase(
-        'apk swap',
-        chalk.yellow(
-          `${swap.reason} -- building fresh instead` +
-            (swap.assetDiff ? ' (an APK cannot be made to carry an asset AAPT did not package)' : ''),
-        ),
-      );
-    } else {
-      phase(
-        'apk swap',
-        chalk.yellow(
-          `failed at ${swap?.step || 'unknown step'}: ${swap?.reason || 'unknown reason'} -- ` +
-            `building fresh instead (a cached ${variant} APK carries its builder's JS; it is never installed after a failed swap)`,
-        ),
-      );
-    }
-    for (const line of swap?.lastLines ?? []) phase('', chalk.dim(line));
-    swapFellBack = true;
-    return null;
-  };
-
-  async function prepareCachedArtifact(): Promise<void> {
-    if (apkPath && record.cacheHit) {
-      const prepared = await installableCachedApk(cacheKey, apkPath);
-      apkPath = prepared;
-      if (!prepared) {
-        record.cacheHit = false;
-        waitedForBuild = null;
-      }
-    }
-  }
-
-  async function buildArtifact(): Promise<boolean> {
-    if (!apkPath) {
-      try {
-        if (limits.maxBuilds) {
+          let waited: WaitForBuildResult | null = null;
           try {
-            buildSlot = await acquireSlot({ max: limits.maxBuilds, root, logFile: buildLog, out });
+            waited = await waitForBuild({ platform: PLATFORM, key: cacheKey, out });
           } catch (err) {
+            const wtErr = err as Error & { code?: string; lockPath?: string };
+            if (wtErr?.code !== 'STIM_BUILD_WAIT_TIMEOUT') throw err;
+            phaseFailure = fail(
+              'STIM_BUILD_WAIT_TIMEOUT',
+              wtErr.message,
+              `Check pid ${holder.pid}; if it is not really building, remove ${wtErr.lockPath} and run \`stim android\` again.`,
+              { lastBuildStatus: true },
+            );
+            return false;
+          }
+
+          if (waited?.hit) {
+            apkPath = waited.hit ?? null;
+            record.cacheHit = 'local';
+            waitedForBuild = { pid: holder.pid, ms: waited.waitedMs };
+            phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+          } else {
             phase(
               'build',
-              chalk.yellow(`could not take a build slot: ${(err as Error)?.message || err}; building anyway`),
+              chalk.yellow(`${who}'s build ended without an artifact (${waited?.builderFailed}); building here`),
             );
+            try {
+              const takeover = acquireLock({ platform: PLATFORM, key: cacheKey, root, logFile: buildLog });
+              if (takeover?.acquired) buildLock = takeover;
+            } catch {}
+            phase('build', chalk.yellow(takeoverLine(holder)));
           }
         }
+      }
+      return true;
+    }
 
-        if (needsPrebuildFor(root, PLATFORM, isExpo)) {
-          const pre: PrebuildResultLike = await prebuild(root, PLATFORM, writer, { isExpo });
-          if (pre.failed) {
-            phaseFailure = fail(pre.code!, pre.reason, pre.remedy, {
-              lastBuildStatus: true,
-              lines: tail(pre.lastLines),
-              logPath: displayPath(root, buildLog),
-            });
-            return false;
-          }
-          phase('prebuild', `android/ generated (${formatDuration(pre.durationMs)})`);
-          androidPackage = androidPackage || detectAndroidPackage(root);
-          record.bundleId = androidPackage;
+    if (!(await waitForSharedBuild())) return phaseFailure!;
 
-          const after = await refingerprintAfterMutation({
-            projectRoot: root,
-            platform: PLATFORM,
-            previousHash: hash,
-            fingerprint,
-          });
-          if (after?.moved) {
-            storeHash = after.hash;
-            storeSources = after.sources;
-            storeKey = buildCacheKey(PLATFORM, after.hash, variant ? { variant } : {});
-            record.fingerprint = storeHash;
-            record.cacheKey = storeKey;
-            phase(
-              'fingerprint',
-              chalk.dim(
-                `${shortHash(hash)} -> ${shortHash(storeHash)} after prebuild; ` +
-                  'storing under the new key, which is the one the next run looks up',
-              ),
-            );
+    let swapDir: string | null = null;
+    let swapFellBack = false;
+    const installableCachedApk = async (key: string, cachedPath: string): Promise<string | null> => {
+      if (!release) return cachedPath;
+      phase('apk swap', `regenerating this workspace's JS for the cached ${variant} APK`);
+      const swap = await swapApk({
+        root,
+        isExpo,
+        cachedApkPath: cachedPath,
+        keystore: resolveKeystore(root, settings),
+        logWriter: writer,
+        storedAssets: storedAssets(PLATFORM, key),
+      });
+      if (swap?.ok && swap.apkPath) {
+        if (swap.note) phase('apk swap', chalk.yellow(swap.note));
+        swapDir = swap.tmpDir ?? null;
+        phase(
+          'apk swap',
+          `${swap.hermes ? 'hermes bytecode' : 'plain JS'} repacked (store), zipaligned and re-signed (${formatDuration(swap.durationMs)})`,
+        );
+        return swap.apkPath;
+      }
+      if (swap?.assetMismatch) {
+        phase(
+          'apk swap',
+          chalk.yellow(
+            `${swap.reason} -- building fresh instead` +
+              (swap.assetDiff ? ' (an APK cannot be made to carry an asset AAPT did not package)' : ''),
+          ),
+        );
+      } else {
+        phase(
+          'apk swap',
+          chalk.yellow(
+            `failed at ${swap?.step || 'unknown step'}: ${swap?.reason || 'unknown reason'} -- ` +
+              `building fresh instead (a cached ${variant} APK carries its builder's JS; it is never installed after a failed swap)`,
+          ),
+        );
+      }
+      for (const line of swap?.lastLines ?? []) phase('', chalk.dim(line));
+      swapFellBack = true;
+      return null;
+    };
 
-            const late = useBuildCache ? resolveCached(PLATFORM, storeKey) : null;
-            if (late) {
-              const prepared = await installableCachedApk(storeKey, late);
-              if (prepared) {
-                apkPath = prepared;
-                record.cacheHit = 'local';
-                phase(
-                  'cache',
-                  'hit under the post-prebuild key (this tree was cold, so the first lookup could not find it)',
-                );
-              }
-            }
-          }
+    async function prepareCachedArtifact(): Promise<void> {
+      if (apkPath && record.cacheHit) {
+        const prepared = await installableCachedApk(cacheKey, apkPath);
+        apkPath = prepared;
+        if (!prepared) {
+          record.cacheHit = false;
+          waitedForBuild = null;
         }
+      }
+    }
 
-        if (!apkPath) {
-          phase('build', `compiling ${variant || 'debug'} with Gradle`);
-          const built: BuildAndroidResultLike = await build({ root, logWriter: writer, variant });
-          if (built.failed) {
-            const diagnostics = built.diagnostics || [];
-            for (const diag of diagnostics) {
-              writer.write({ src: 'build', level: 'error', event: 'gradle_diagnostic', msg: formatDiagnostic(diag) });
+    async function buildArtifact(): Promise<boolean> {
+      if (!apkPath) {
+        try {
+          if (limits.maxBuilds) {
+            try {
+              buildSlot = await acquireSlot({ max: limits.maxBuilds, root, logFile: buildLog, out });
+            } catch (err) {
+              phase(
+                'build',
+                chalk.yellow(`could not take a build slot: ${(err as Error)?.message || err}; building anyway`),
+              );
             }
-            phase('build', chalk.red(`FAILED after ${formatDuration(built.durationMs)}`));
-            const extracted = diagnostics.map(formatDiagnostic);
-            if ((built.truncated ?? 0) > 0) extracted.push(`... and ${built.truncated} more diagnostic(s) in the log`);
-            phaseFailure = fail(
-              built.code!,
-              built.reason,
-              diagnostics.find((d) => d.remedy)?.remedy || built.remedy || null,
-              {
+          }
+
+          if (needsPrebuildFor(root, PLATFORM, isExpo)) {
+            const pre: PrebuildResultLike = await prebuild(root, PLATFORM, writer, { isExpo });
+            if (pre.failed) {
+              phaseFailure = fail(pre.code!, pre.reason, pre.remedy, {
                 lastBuildStatus: true,
-                diagnostics: extracted,
-                lines: extracted.length ? [] : tail(built.lastLines),
+                lines: tail(pre.lastLines),
                 logPath: displayPath(root, buildLog),
-              },
-            );
-            return false;
-          }
-          apkPath = built.apkPath ?? null;
-          phase('build', `${basename(apkPath!)} (${formatDuration(built.durationMs)})`);
-          if (built.apkNote) phase('build', chalk.yellow(built.apkNote));
+              });
+              return false;
+            }
+            phase('prebuild', `android/ generated (${formatDuration(pre.durationMs)})`);
+            androidPackage = androidPackage || detectAndroidPackage(root);
+            record.bundleId = androidPackage;
 
-          const beforeBuildHash = storeHash;
-          const afterBuild = await refingerprintAfterMutation({
-            projectRoot: root,
-            platform: PLATFORM,
-            previousHash: beforeBuildHash,
-            fingerprint,
-          });
-          if (!afterBuild) {
-            record.fingerprint = null;
-            record.cacheKey = null;
-            phase('fingerprint', chalk.yellow('unavailable after Gradle; the build will be installed but not cached'));
-          } else {
-            if (afterBuild.moved) {
-              storeHash = afterBuild.hash;
-              storeSources = afterBuild.sources;
-              storeKey = buildCacheKey(PLATFORM, afterBuild.hash, variant ? { variant } : {});
+            const after = await refingerprintAfterMutation({
+              projectRoot: root,
+              platform: PLATFORM,
+              previousHash: hash,
+              fingerprint,
+            });
+            if (after?.moved) {
+              storeHash = after.hash;
+              storeSources = after.sources;
+              storeKey = buildCacheKey(PLATFORM, after.hash, variant ? { variant } : {});
               record.fingerprint = storeHash;
               record.cacheKey = storeKey;
               phase(
                 'fingerprint',
                 chalk.dim(
-                  `${shortHash(beforeBuildHash)} -> ${shortHash(storeHash)} after Gradle; ` +
+                  `${shortHash(hash)} -> ${shortHash(storeHash)} after prebuild; ` +
                     'storing under the new key, which is the one the next run looks up',
                 ),
               );
-            }
 
-            const assetManifest = release ? captureAssets(root, { variant }) : null;
-            try {
-              const stored = await storeTieredBuild({
-                local: filesystemBuildCapability({
-                  resolve: resolveCached,
-                  store: storeCached,
-                  sources: storeSources,
-                  assetManifest,
-                }),
-                loadProvider: loadTieredProvider,
-                target: { projectRoot: root, platform: PLATFORM, key: storeKey },
-                sourcePath: apkPath!,
-                overwrite: !useBuildCache || swapFellBack,
-                warn: cacheWarn,
-              });
-              providerUpload = stored.providerUpload;
-              providerName = stored.providerName ?? providerName;
-            } catch (err) {
-              phase('cache', chalk.yellow(`could not store the build: ${(err as Error)?.message || err}`));
-            }
-
-            if (remote) {
-              uploadPending = uploadRemoteBuild({
-                logWriter: writer,
-                provider: remote.provider,
-                platform: PLATFORM,
-                projectRoot: root,
-                fingerprintHash: storeHash,
-                buildPath: apkPath!,
-                runOptions: variant ? { variant } : null,
-              });
+              const late = useBuildCache ? resolveCached(PLATFORM, storeKey) : null;
+              if (late) {
+                const prepared = await installableCachedApk(storeKey, late);
+                if (prepared) {
+                  apkPath = prepared;
+                  record.cacheHit = 'local';
+                  phase(
+                    'cache',
+                    'hit under the post-prebuild key (this tree was cold, so the first lookup could not find it)',
+                  );
+                }
+              }
             }
           }
+
+          if (!apkPath) {
+            phase('build', `compiling ${variant || 'debug'} with Gradle`);
+            const built: BuildAndroidResultLike = await build({ root, logWriter: writer, variant });
+            if (built.failed) {
+              const diagnostics = built.diagnostics || [];
+              for (const diag of diagnostics) {
+                writer.write({ src: 'build', level: 'error', event: 'gradle_diagnostic', msg: formatDiagnostic(diag) });
+              }
+              phase('build', chalk.red(`FAILED after ${formatDuration(built.durationMs)}`));
+              const extracted = diagnostics.map(formatDiagnostic);
+              if ((built.truncated ?? 0) > 0)
+                extracted.push(`... and ${built.truncated} more diagnostic(s) in the log`);
+              phaseFailure = fail(
+                built.code!,
+                built.reason,
+                diagnostics.find((d) => d.remedy)?.remedy || built.remedy || null,
+                {
+                  lastBuildStatus: true,
+                  diagnostics: extracted,
+                  lines: extracted.length ? [] : tail(built.lastLines),
+                  logPath: displayPath(root, buildLog),
+                },
+              );
+              return false;
+            }
+            apkPath = built.apkPath ?? null;
+            phase('build', `${basename(apkPath!)} (${formatDuration(built.durationMs)})`);
+            if (built.apkNote) phase('build', chalk.yellow(built.apkNote));
+
+            const beforeBuildHash = storeHash;
+            const afterBuild = await refingerprintAfterMutation({
+              projectRoot: root,
+              platform: PLATFORM,
+              previousHash: beforeBuildHash,
+              fingerprint,
+            });
+            if (!afterBuild) {
+              record.fingerprint = null;
+              record.cacheKey = null;
+              phase(
+                'fingerprint',
+                chalk.yellow('unavailable after Gradle; the build will be installed but not cached'),
+              );
+            } else {
+              if (afterBuild.moved) {
+                storeHash = afterBuild.hash;
+                storeSources = afterBuild.sources;
+                storeKey = buildCacheKey(PLATFORM, afterBuild.hash, variant ? { variant } : {});
+                record.fingerprint = storeHash;
+                record.cacheKey = storeKey;
+                phase(
+                  'fingerprint',
+                  chalk.dim(
+                    `${shortHash(beforeBuildHash)} -> ${shortHash(storeHash)} after Gradle; ` +
+                      'storing under the new key, which is the one the next run looks up',
+                  ),
+                );
+              }
+
+              const assetManifest = release ? captureAssets(root, { variant }) : null;
+              try {
+                const stored = await storeTieredBuild({
+                  local: filesystemBuildCapability({
+                    resolve: resolveCached,
+                    store: storeCached,
+                    sources: storeSources,
+                    assetManifest,
+                  }),
+                  loadProvider: loadTieredProvider,
+                  target: { projectRoot: root, platform: PLATFORM, key: storeKey },
+                  sourcePath: apkPath!,
+                  overwrite: !useBuildCache || swapFellBack,
+                  warn: cacheWarn,
+                });
+                providerUpload = stored.providerUpload;
+                providerName = stored.providerName ?? providerName;
+              } catch (err) {
+                phase('cache', chalk.yellow(`could not store the build: ${(err as Error)?.message || err}`));
+              }
+
+              if (remote) {
+                uploadPending = uploadRemoteBuild({
+                  logWriter: writer,
+                  provider: remote.provider,
+                  platform: PLATFORM,
+                  projectRoot: root,
+                  fingerprintHash: storeHash,
+                  buildPath: apkPath!,
+                  runOptions: variant ? { variant } : null,
+                });
+              }
+            }
+          }
+        } finally {
+          releaseHeldLock();
+          releaseHeldSlot();
         }
-      } finally {
-        releaseHeldLock();
-        releaseHeldSlot();
+      }
+      return true;
+    }
+
+    await prepareCachedArtifact();
+    if (!(await buildArtifact())) return phaseFailure!;
+    record.appPath = apkPath;
+
+    let leaseHandle: RunLease | null = null;
+    let stopLeaseSignals: (() => void) | null = null;
+    const releaseLease = () => {
+      const held = leaseHandle;
+      const stopSignals = stopLeaseSignals;
+      leaseHandle = null;
+      stopLeaseSignals = null;
+      stopSignals?.();
+      try {
+        held?.release();
+      } catch (err) {
+        out(phaseLine('lease', chalk.dim(`could not release this run's lease: ${(err as Error)?.message || err}`)));
+      }
+    };
+    if (physical) {
+      const acquired = await acquireLease({
+        root,
+        platform: PLATFORM,
+        id: device.serial!,
+        deviceName: device.deviceName ?? null,
+        idLabel: 'serial',
+        waitSeconds,
+        noWait,
+        installBoundMs: ADB_INSTALL_TIMEOUT_MS,
+        appId: androidPackage,
+        holderAppId: (holder: string) => getProject(holder)?.androidPackage ?? null,
+        now,
+        warn: (line: string) => out(phaseLine('lease', chalk.yellow(line))),
+      });
+      if (acquired.status === 'refused') {
+        return fail(acquired.refusal.code, acquired.refusal.message, acquired.refusal.remedy, {
+          lease: acquired.refusal.lease,
+        });
+      }
+      leaseHandle = makeRunLease({
+        root,
+        platform: PLATFORM,
+        kind: acquired.status === 'leased' ? acquired.kind : null,
+        expiresAt: acquired.status === 'leased' ? acquired.expiresAt : null,
+      });
+      if (acquired.status === 'leased') {
+        stopLeaseSignals = onLeaseSignal(releaseLease);
+        phase('lease', `${acquired.kind} lease on ${device.serial} until ${acquired.expiresAt}`);
       }
     }
-    return true;
-  }
 
-  await prepareCachedArtifact();
-  if (!(await buildArtifact())) return phaseFailure!;
-  record.appPath = apkPath;
-
-  let leaseHandle: RunLease | null = null;
-  let stopLeaseSignals: (() => void) | null = null;
-  const releaseLease = () => {
-    const held = leaseHandle;
-    const stopSignals = stopLeaseSignals;
-    leaseHandle = null;
-    stopLeaseSignals = null;
-    stopSignals?.();
     try {
-      held?.release();
-    } catch (err) {
-      out(phaseLine('lease', chalk.dim(`could not release this run's lease: ${(err as Error)?.message || err}`)));
+      return await finishAndroidRun({
+        lease: leaseHandle,
+        releaseLease,
+        root,
+        json,
+        metroCheck,
+        useBuildCache,
+        variant,
+        release,
+        isExpo,
+        metroPort,
+        logsDir,
+        emuLog,
+        device,
+        physical,
+        remoteDevice,
+        bootPromise,
+        bootDuration: () => bootDuration,
+        apkPath,
+        androidPackage,
+        swapDir,
+        record,
+        waitedForBuild,
+        uploadPending,
+        providerUpload,
+        providerName,
+        remote,
+        abandonedRemote,
+        started,
+        startedAt,
+        writer,
+        phase,
+        fail,
+        readApkPackage,
+        install,
+        launch,
+        launchRelease,
+        resolveDevClientScheme,
+        verifyLaunched,
+        verifyReleaseLaunched,
+        spawn,
+        kill,
+        pidAlive,
+        verifyCollector,
+        writeState,
+        now,
+        out,
+        emit,
+        recordRun,
+      });
+    } finally {
+      releaseLease();
     }
   };
-  if (physical) {
-    const acquired = await acquireLease({
-      root,
-      platform: PLATFORM,
-      id: device.serial!,
-      deviceName: device.deviceName ?? null,
-      idLabel: 'serial',
-      waitSeconds,
-      noWait,
-      installBoundMs: ADB_INSTALL_TIMEOUT_MS,
-      appId: androidPackage,
-      holderAppId: (holder: string) => getProject(holder)?.androidPackage ?? null,
-      now,
-      warn: (line: string) => out(phaseLine('lease', chalk.yellow(line))),
-    });
-    if (acquired.status === 'refused') {
-      return fail(acquired.refusal.code, acquired.refusal.message, acquired.refusal.remedy, {
-        lease: acquired.refusal.lease,
-      });
-    }
-    leaseHandle = makeRunLease({
-      root,
-      platform: PLATFORM,
-      kind: acquired.status === 'leased' ? acquired.kind : null,
-      expiresAt: acquired.status === 'leased' ? acquired.expiresAt : null,
-    });
-    if (acquired.status === 'leased') {
-      stopLeaseSignals = onLeaseSignal(releaseLease);
-      phase('lease', `${acquired.kind} lease on ${device.serial} until ${acquired.expiresAt}`);
-    }
-  }
 
   try {
-    return await finishAndroidRun({
-      lease: leaseHandle,
-      releaseLease,
-      root,
-      json,
-      metroCheck,
-      useBuildCache,
-      variant,
-      release,
-      isExpo,
-      metroPort,
-      logsDir,
-      emuLog,
-      device,
-      physical,
-      remoteDevice,
-      bootPromise,
-      bootDuration: () => bootDuration,
-      apkPath,
-      androidPackage,
-      swapDir,
-      record,
-      waitedForBuild,
-      uploadPending,
-      providerUpload,
-      providerName,
-      remote,
-      abandonedRemote,
-      started,
-      startedAt,
-      writer,
-      phase,
-      fail,
-      readApkPackage,
-      install,
-      launch,
-      launchRelease,
-      resolveDevClientScheme,
-      verifyLaunched,
-      verifyReleaseLaunched,
-      spawn,
-      kill,
-      pidAlive,
-      verifyCollector,
-      writeState,
-      now,
-      out,
-      emit,
-    });
-  } finally {
-    releaseLease();
+    return await runFromFingerprint();
+  } catch (error) {
+    recordRun({ failed: true, durationMs: now() - started });
+    throw error;
   }
 }
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -13,8 +13,8 @@ const TOPICS: Record<string, GuideTopic> = {
       'The --json payloads: `start`, `ios`, `android`, `stop`, `status`, `doctor`, `device lock`/`unlock`, and the error contract',
     body: () => `FACTS CONTRACT
 
-\`start\`, \`ios\`, \`android\`, \`stop\`, \`status\`, \`doctor\`, and
-\`device lock\`/\`device unlock\` each print exactly ONE line of JSON on
+\`start\`, \`ios\`, \`android\`, \`stop\`, \`status\`, \`stats\`, \`doctor\`,
+and \`device lock\`/\`device unlock\` each print exactly ONE line of JSON on
 stdout for \`--json\`. Every other line goes to stderr, so it is always safe
 to pipe. \`logs --json\` is the one exception: it is NDJSON, one record per
 line by design (see \`guide logs\`), not this single-payload contract.
@@ -286,6 +286,36 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   app back on THIS workspace's bundle
   logs            the workspace log directory
   durationMs      wall time for the whole run
+
+  stim stats --json
+
+  { "version": 1,
+    "project": { "key": "<path>", "ios": <bucket|null>,
+                 "android": <bucket|null> } | null,
+    "machine": { "ios": <bucket|null>, "android": <bucket|null> } }
+
+  \`project\` is null outside a project; a platform with no run yet is null.
+  A bucket carries runs, failed, hits, misses, coldRuns, coldRunMs, hitRuns,
+  hitRunMs, timeSavedMs, firstRunAt and lastRunAt. Milliseconds are integers.
+
+HOW A RUN IS COUNTED (\`stats\`)
+  Every \`ios\` or \`android\` invocation that got as far as computing a
+  cache key is one run, in this project's bucket and in the machine-wide one.
+  The project key is the app's path IN THE MAIN WORKING TREE, so every
+  worktree of a repository pools into one bucket and two apps in a monorepo
+  do not. A run that ends through an error or an uncaught exception counts
+  only as \`failed\`; \`launched: "unverified"\` or \`"bundling"\` is a
+  success. Otherwise the run's own \`cacheHit\` decides: "local" or "remote"
+  is a HIT, false is a MISS -- including a release run on a phone and a swap
+  that fell back to a full build. A miss adds its \`durationMs\` to the cold
+  runs; a hit adds it to the hit runs and credits \`timeSavedMs\` with this
+  project's mean cold run BEFORE it, minus its own duration, floored at zero.
+  A hit that WAITED for another workspace's build (\`waitedForBuild\`) counts
+  as a hit and is credited nothing: the compile it skipped was paid for in the
+  wait, and with no cold run recorded for this project and platform there is
+  nothing to compare against, so it credits nothing either. The saved figure
+  is therefore an ESTIMATE and is printed as one. Nothing per run is stored;
+  the file is $STIM_HOME/stats.json (see \`guide lifecycle\`).
 
 ON FAILURE
   \`start\`, \`ios\` and \`android\` all print the error contract instead,
@@ -1517,6 +1547,9 @@ OPTIONAL SIMSLIM PROFILE
 NOTHING ABOVE NEEDS A CHANGE TO THE REPO
 Runtime state is stored outside the project tree under
 $STIM_HOME/workspaces/<project>--<digest>/ (default ~/.stim/workspaces/).
+The aggregate run counters \`stats\` prints live beside it in
+$STIM_HOME/stats.json, one bucket per project and platform plus a machine-wide
+one; nothing per run is kept there.
 No .gitignore entry is created or required.
 Stim runs on a clean checkout. Runtime state is stored outside the project tree.
 runtime state lives under $STIM_HOME/workspaces/<project>--<digest>, and the performance caches ride on the command
@@ -1673,6 +1706,7 @@ THE OPTION SURFACE, IN FULL
   logs            --source --level --since --grep --tail --follow --errors --json
   stop            --json --force
   status          --json          (already machine-wide)
+  stats           --json          (this project and machine-wide)
   doctor          --json --fix    (--fix applies the findings Stim can repair)
   gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
@@ -2019,7 +2053,13 @@ CAPACITY
   A booted iOS sim is roughly 1-2 GB of RAM, an Android emulator 2-3 GB. On a
   16 GB machine plan for 2-3 live environments. Nothing enforces this;
   \`stim status\` is how you check -- it reports every workspace on the
-  machine, not just this one.`,
+  machine, not just this one.
+
+TWO REPORTS, TWO QUESTIONS
+  "What is running" is \`stim status\`: live state, right now. "How much the
+  cache saved" is \`stim stats\`: aggregate counters for this project and for
+  the machine, with a hit rate and an estimate of the time saved (see
+  \`guide facts\`).`,
   },
 
   cleanup: {
@@ -2037,6 +2077,13 @@ WHAT RECLAIMS AN OWNED DEVICE
 Those are the only two commands that delete. \`stim stop\` shuts a device
 DOWN and leaves it assigned, which is what makes returning to a branch cost a
 boot rather than a create, a provision and a reinstall.
+
+Neither touches $STIM_HOME/stats.json: \`gc\` never reports or trims the run
+counters \`stats\` prints, and there is no reset flag. Delete that one file to
+start the counters over. A file this version cannot read -- unparseable, or
+written by a newer Stim -- costs one dim line on stderr and is otherwise left
+alone; only the next \`ios\` or \`android\` run moves an unparseable one aside
+to stats.json.corrupt-<unix ms> and starts a new one.
 
 New owned Android AVDs use an 8 GiB data partition by default. This leaves room
 for repeated app installs while capping userdata growth below the 10 GiB

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -120,6 +120,7 @@ import {
   uploadRemote,
   type LoadProjectProviderResult,
 } from '../engine/remote-cache.ts';
+import { createRunRecorder, recordRunStats, statsProjectKey, type RunRecorder } from '../engine/stats.ts';
 import { swapJsBundle } from '../engine/js-swap.ts';
 import {
   buildIos,
@@ -899,6 +900,7 @@ interface IosDeps {
   stopPreviousCollector: typeof stopPreviousCollector;
   writeWorkspaceState: typeof writeWorkspaceState;
   createWriter: typeof createNdjsonWriter;
+  recordStats: typeof recordRunStats;
   now: () => number;
 }
 
@@ -973,6 +975,7 @@ const DEFAULT_DEPS: IosDeps = {
   stopPreviousCollector,
   writeWorkspaceState,
   createWriter: createNdjsonWriter,
+  recordStats: recordRunStats,
   now: () => Date.now(),
 };
 
@@ -1259,6 +1262,7 @@ interface ReportIosResultArgs {
   closeWriter: () => void;
   webPreviewUrl: string | null;
   lease?: { kind: string; expiresAt: string } | null;
+  recordRun: RunRecorder['record'];
 }
 
 function reportIosResult({
@@ -1289,8 +1293,10 @@ function reportIosResult({
   closeWriter,
   webPreviewUrl,
   lease,
+  recordRun,
 }: ReportIosResultArgs): IosFacts {
   const durationMs = elapsed();
+  recordRun({ failed: false, cacheHit, waited: waitedForBuild, durationMs });
   writeLastBuild(
     root,
     lastBuildRecord({
@@ -1411,6 +1417,7 @@ interface FinishIosRunArgs {
   closeWriter: () => void;
   lease: RunLease | null;
   releaseLease: () => void;
+  recordRun: ReportIosResultArgs['recordRun'];
 }
 
 async function finishIosRun({
@@ -1456,6 +1463,7 @@ async function finishIosRun({
   closeWriter,
   lease,
   releaseLease,
+  recordRun,
 }: FinishIosRunArgs): Promise<IosFacts | null> {
   let bundleId = initialBundleId;
   let leaseWarned = false;
@@ -1708,6 +1716,7 @@ async function finishIosRun({
     closeWriter,
     webPreviewUrl: remoteDevice?.webPreviewUrl() ?? null,
     lease: physical ? leaseFacts : undefined,
+    recordRun,
   });
   if (remoteWasAbandoned || uploadWasAbandoned) exitAfterFlush(0);
   return facts;
@@ -1795,6 +1804,14 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     }
   };
 
+  const stats = createRunRecorder({
+    platform: PLATFORM,
+    write: (statsRun, at) => d.recordStats(statsRun, at),
+    now: () => d.now(),
+    note: (line) => note(chalk.dim(line)),
+  });
+  const recordRun = stats.record;
+
   const fail = ({ code, message, remedy = null, lines = [], logPath = null, build = null, lease }: FailArgs): null => {
     releaseLock();
     releaseSlot();
@@ -1810,6 +1827,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         { write: d.writeWorkspaceState },
       );
     note(chalk.red(phaseLine('failed', code)));
+    recordRun({ failed: true, durationMs: elapsed() });
     if (json) {
       console.log(
         JSON.stringify({
@@ -1831,6 +1849,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     gitCommonDir: d.gitCommonDir(root),
     repoRoot: settingsRepoRoot,
   };
+  stats.setProject(statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot }));
   const settings = d.resolveSettings(settingsContext);
   const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
   if (shapeError) {
@@ -2241,6 +2260,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       ...(configuration ? { configuration } : {}),
       isSimulator: !physical,
     });
+    stats.setCacheKey(cacheKey);
     storeHash = fingerprint;
     storeKey = cacheKey;
     storeSources = fingerprintSources;
@@ -2697,94 +2717,100 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return true;
   }
 
-  if (!(await resolveInitialFingerprint())) return null;
-  await resolveRemoteArtifact();
-  if (!(await waitForSharedBuild())) return null;
-  await prepareCachedArtifact();
-  if (!(await buildArtifact())) return null;
-
-  if (physicalDevice) {
-    const acquired = await d.acquireRunLease({
-      root,
-      platform: PLATFORM,
-      id: physicalDevice.udid,
-      deviceName: physicalDevice.name,
-      idLabel: 'udid',
-      waitSeconds,
-      noWait,
-      installBoundMs: DEVICECTL_INSTALL_TIMEOUT_MS,
-      appId: bundleId ?? proj?.bundleId ?? null,
-      holderAppId: (holder: string) => d.getProject(holder)?.bundleId ?? null,
-      now: d.now,
-      warn: (line: string) => note(chalk.yellow(phaseLine('lease', line))),
-    });
-    if (acquired.status === 'refused') {
-      return fail({
-        code: acquired.refusal.code,
-        message: acquired.refusal.message,
-        remedy: acquired.refusal.remedy,
-        lease: acquired.refusal.lease,
-      });
-    }
-    leaseHandle = d.runLease({
-      root,
-      platform: PLATFORM,
-      kind: acquired.status === 'leased' ? acquired.kind : null,
-      expiresAt: acquired.status === 'leased' ? acquired.expiresAt : null,
-    });
-    if (acquired.status === 'leased') {
-      stopLeaseSignals = d.releaseLeaseOnSignal(releaseLease);
-      phase('lease', `${acquired.kind} lease on ${physicalDevice.udid} until ${acquired.expiresAt}`);
-    }
-  }
-
   try {
-    return await finishIosRun({
-      d,
-      root,
-      json,
-      release,
-      configuration,
-      isExpo,
-      metroCheck,
-      metroPort,
-      logsDir,
-      logFile,
-      device,
-      udid,
-      physical,
-      lanAddress,
-      lanOriginUrl,
-      remoteDevice,
-      bootPromise,
-      bootDuration: () => bootDuration,
-      appPath,
-      bundleId,
-      swapDir,
-      buildFailure,
-      fail,
-      phase,
-      note,
-      logWriter,
-      uploadPending,
-      providerUpload,
-      providerName,
-      remote,
-      abandonedRemote,
-      elapsed,
-      startedAt,
-      storeHash,
-      storeKey,
-      cacheHit,
-      compilationCache,
-      useBuildCache,
-      waitedForBuild,
-      closeWriter: () => writer?.close?.(),
-      lease: leaseHandle,
-      releaseLease,
-    });
-  } finally {
-    releaseLease();
+    if (!(await resolveInitialFingerprint())) return null;
+    await resolveRemoteArtifact();
+    if (!(await waitForSharedBuild())) return null;
+    await prepareCachedArtifact();
+    if (!(await buildArtifact())) return null;
+
+    if (physicalDevice) {
+      const acquired = await d.acquireRunLease({
+        root,
+        platform: PLATFORM,
+        id: physicalDevice.udid,
+        deviceName: physicalDevice.name,
+        idLabel: 'udid',
+        waitSeconds,
+        noWait,
+        installBoundMs: DEVICECTL_INSTALL_TIMEOUT_MS,
+        appId: bundleId ?? proj?.bundleId ?? null,
+        holderAppId: (holder: string) => d.getProject(holder)?.bundleId ?? null,
+        now: d.now,
+        warn: (line: string) => note(chalk.yellow(phaseLine('lease', line))),
+      });
+      if (acquired.status === 'refused') {
+        return fail({
+          code: acquired.refusal.code,
+          message: acquired.refusal.message,
+          remedy: acquired.refusal.remedy,
+          lease: acquired.refusal.lease,
+        });
+      }
+      leaseHandle = d.runLease({
+        root,
+        platform: PLATFORM,
+        kind: acquired.status === 'leased' ? acquired.kind : null,
+        expiresAt: acquired.status === 'leased' ? acquired.expiresAt : null,
+      });
+      if (acquired.status === 'leased') {
+        stopLeaseSignals = d.releaseLeaseOnSignal(releaseLease);
+        phase('lease', `${acquired.kind} lease on ${physicalDevice.udid} until ${acquired.expiresAt}`);
+      }
+    }
+
+    try {
+      return await finishIosRun({
+        d,
+        root,
+        json,
+        release,
+        configuration,
+        isExpo,
+        metroCheck,
+        metroPort,
+        logsDir,
+        logFile,
+        device,
+        udid,
+        physical,
+        lanAddress,
+        lanOriginUrl,
+        remoteDevice,
+        bootPromise,
+        bootDuration: () => bootDuration,
+        appPath,
+        bundleId,
+        swapDir,
+        buildFailure,
+        fail,
+        phase,
+        note,
+        logWriter,
+        uploadPending,
+        providerUpload,
+        providerName,
+        remote,
+        abandonedRemote,
+        elapsed,
+        startedAt,
+        storeHash,
+        storeKey,
+        cacheHit,
+        compilationCache,
+        useBuildCache,
+        waitedForBuild,
+        closeWriter: () => writer?.close?.(),
+        lease: leaseHandle,
+        releaseLease,
+        recordRun,
+      });
+    } finally {
+      releaseLease();
+    }
+  } catch (error) {
+    recordRun({ failed: true, durationMs: elapsed() });
+    throw error;
   }
 }
 

--- a/packages/stim-cli/src/commands/stats.ts
+++ b/packages/stim-cli/src/commands/stats.ts
@@ -1,0 +1,72 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { formatLongDuration } from '../command-output.ts';
+import { readStats, statsProjectKey, STATS_VERSION } from '../engine/stats.ts';
+import type { StatsBucket, StatsPlatform, StatsScope } from '../engine/stats.ts';
+import { findProjectRoot } from '../project.ts';
+import { gitCommonDir, repoRoot } from '../worktree.ts';
+
+const PLATFORMS: StatsPlatform[] = ['ios', 'android'];
+const PLATFORM_WIDTH = 9;
+
+interface StatsOptions {
+  json?: boolean;
+}
+
+export default function statsCommand(program: Command): void {
+  program
+    .command('stats')
+    .description(
+      'Show how many `ios` and `android` runs this project and this machine have recorded, how many hit the build ' +
+        'cache, and an estimate of the time that cache saved.',
+    )
+    .option('--json', 'print the aggregates as JSON')
+    .action((opts: StatsOptions) => {
+      const root = findProjectRoot(process.cwd());
+      const key = root ? statsProjectKey({ root, commonDir: gitCommonDir(root), repoRoot: repoRoot(root) }) : null;
+      const { record, note } = readStats();
+      if (note) console.error(chalk.dim(note));
+      const machine: StatsScope = record?.machine ?? {};
+      const project: StatsScope = key ? (record?.projects?.[key] ?? {}) : {};
+
+      if (opts.json) {
+        console.log(
+          JSON.stringify({
+            version: STATS_VERSION,
+            project: key ? { key, ios: project.ios ?? null, android: project.android ?? null } : null,
+            machine: { ios: machine.ios ?? null, android: machine.android ?? null },
+          }),
+        );
+        return;
+      }
+
+      const lines: string[] = [];
+      if (key) lines.push(`project ${key}`, ...sectionLines(project));
+      lines.push('machine', ...sectionLines(machine));
+      for (const line of lines) console.log(line);
+    });
+}
+
+function sectionLines(scope: StatsScope): string[] {
+  const lines = PLATFORMS.filter((platform) => scope[platform]).map((platform) =>
+    bucketLine(platform, scope[platform] as StatsBucket),
+  );
+  return lines.length ? lines : [chalk.dim('  no runs recorded')];
+}
+
+function bucketLine(platform: string, bucket: StatsBucket): string {
+  const finished = bucket.runs - bucket.failed;
+  const cells = [
+    `${bucket.runs} runs${bucket.failed > 0 ? ` (${bucket.failed} failed)` : ''}`,
+    `${bucket.hits} hits (${finished > 0 ? `${Math.round((bucket.hits / finished) * 100)}%` : '-'})`,
+    `cold run ${average(bucket.coldRunMs, bucket.coldRuns)} avg`,
+    `hit run ${average(bucket.hitRunMs, bucket.hitRuns)} avg`,
+    `saved ~${formatLongDuration(bucket.timeSavedMs)} (estimated)`,
+    `since ${bucket.firstRunAt.slice(0, 10)}`,
+  ];
+  return `  ${platform.padEnd(PLATFORM_WIDTH)}${cells.join('   ')}`;
+}
+
+function average(totalMs: number, runs: number): string {
+  return runs > 0 ? formatLongDuration(Math.round(totalMs / runs)) : '-';
+}

--- a/packages/stim-cli/src/engine/stats.ts
+++ b/packages/stim-cli/src/engine/stats.ts
@@ -1,0 +1,340 @@
+import { readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { getConfigDir, withConfigLock } from '../config.ts';
+import type { CacheHitLevel } from '../types.ts';
+
+export const STATS_VERSION = 1;
+
+export type StatsPlatform = 'ios' | 'android';
+
+export interface StatsBucket {
+  runs: number;
+  failed: number;
+  hits: number;
+  misses: number;
+  coldRuns: number;
+  coldRunMs: number;
+  hitRuns: number;
+  hitRunMs: number;
+  timeSavedMs: number;
+  firstRunAt: string;
+  lastRunAt: string;
+}
+
+export type StatsScope = Partial<Record<StatsPlatform, StatsBucket>>;
+
+export interface StatsRecord {
+  version: number;
+  machine: StatsScope;
+  projects: Record<string, StatsScope>;
+}
+
+export interface StatsRun {
+  platform: StatsPlatform;
+  projectKey: string;
+  failed: boolean;
+  cacheHit: CacheHitLevel;
+  waitedForBuild: boolean;
+  durationMs: number;
+}
+
+export interface RecordStatsResult {
+  recorded: boolean;
+  note: string | null;
+}
+
+export interface ReadStatsResult {
+  record: StatsRecord | null;
+  note: string | null;
+}
+
+interface RunOutcome {
+  failed: boolean;
+  cacheHit?: CacheHitLevel;
+  waited?: unknown;
+  durationMs: number;
+}
+
+export interface RunRecorder {
+  setProject(key: string): void;
+  setCacheKey(key: string): void;
+  record(outcome: RunOutcome): void;
+}
+
+const PLATFORMS: StatsPlatform[] = ['ios', 'android'];
+
+export function statsFile(): string {
+  return join(getConfigDir(), 'stats.json');
+}
+
+export function emptyStats(): StatsRecord {
+  return { version: STATS_VERSION, machine: {}, projects: {} };
+}
+
+export function statsProjectKey({
+  root,
+  commonDir,
+  repoRoot,
+}: {
+  root: string;
+  commonDir: string | null;
+  repoRoot: string | null;
+}): string {
+  if (commonDir && repoRoot && basename(commonDir) === '.git') {
+    return canonical(join(dirname(commonDir), relative(repoRoot, root)));
+  }
+  return canonical(root);
+}
+
+export function updateStats(record: StatsRecord, run: StatsRun, now: number): StatsRecord {
+  const at = new Date(now).toISOString();
+  const durationMs = wholeMs(run.durationMs);
+  const projects: Record<string, StatsScope> = { ...record.projects };
+  const scope: StatsScope = { ...projects[run.projectKey] };
+  const machine: StatsScope = { ...record.machine };
+  const before = scope[run.platform] ?? null;
+  const credit = creditMs(before, run, durationMs);
+
+  scope[run.platform] = applyRun(before, run, { at, durationMs, credit });
+  projects[run.projectKey] = scope;
+  machine[run.platform] = applyRun(machine[run.platform] ?? null, run, { at, durationMs, credit });
+
+  return { version: STATS_VERSION, machine, projects };
+}
+
+export function readStats(): ReadStatsResult {
+  const path = statsFile();
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return { record: null, note: null };
+  }
+  const parsed = parseRecord(text);
+  if (!parsed) {
+    return {
+      record: null,
+      note: `Run statistics at ${path} could not be read; the next ios or android run moves them aside and starts a new file.`,
+    };
+  }
+  if (parsed.version > STATS_VERSION) {
+    return {
+      record: null,
+      note: `Run statistics at ${path} are version ${parsed.version}, which this Stim does not understand, so none are shown.`,
+    };
+  }
+  return { record: normalize(parsed), note: null };
+}
+
+export function recordRunStats(run: StatsRun, now: number): RecordStatsResult {
+  return withConfigLock(() => {
+    const path = statsFile();
+    const loaded = loadForUpdate(path, now);
+    if (loaded.newerVersion !== null) {
+      return {
+        recorded: false,
+        note:
+          `Run statistics at ${path} are version ${loaded.newerVersion}, which this Stim does not understand, ` +
+          'so this run was not recorded.',
+      };
+    }
+    writeStats(path, updateStats(loaded.record, run, now));
+    return { recorded: true, note: loaded.note };
+  });
+}
+
+export function createRunRecorder({
+  platform,
+  write,
+  now,
+  note,
+}: {
+  platform: StatsPlatform;
+  write: (run: StatsRun, now: number) => RecordStatsResult;
+  now: () => number;
+  note: (line: string) => void;
+}): RunRecorder {
+  let projectKey: string | null = null;
+  let cacheKey: string | null = null;
+  let recorded = false;
+  return {
+    setProject(key: string): void {
+      projectKey = key;
+    },
+    setCacheKey(key: string): void {
+      cacheKey = key;
+    },
+    record({ failed, cacheHit = false, waited = null, durationMs }: RunOutcome): void {
+      if (!projectKey || !cacheKey || recorded) return;
+      recorded = true;
+      try {
+        const outcome = write(
+          { platform, projectKey, failed, cacheHit, waitedForBuild: Boolean(waited), durationMs },
+          now(),
+        );
+        if (outcome?.note) note(outcome.note);
+      } catch (error) {
+        note(`Run statistics could not be recorded: ${(error as Error)?.message || error}`);
+      }
+    },
+  };
+}
+
+function loadForUpdate(
+  path: string,
+  now: number,
+): { record: StatsRecord; note: string | null; newerVersion: number | null } {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return { record: emptyStats(), note: null, newerVersion: null };
+  }
+  const parsed = parseRecord(text);
+  if (!parsed) {
+    const aside = `${path}.corrupt-${now}`;
+    renameSync(path, aside);
+    return {
+      record: emptyStats(),
+      note: `Run statistics at ${path} could not be read, so they were moved to ${aside} and a new file was started.`,
+      newerVersion: null,
+    };
+  }
+  if (parsed.version > STATS_VERSION) {
+    return { record: emptyStats(), note: null, newerVersion: parsed.version };
+  }
+  return { record: normalize(parsed), note: null, newerVersion: null };
+}
+
+function writeStats(path: string, record: StatsRecord): void {
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(record)}\n`);
+  try {
+    renameSync(tmp, path);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+}
+
+function parseRecord(text: string): StatsRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const version = (parsed as { version?: unknown }).version;
+  if (typeof version !== 'number' || !Number.isInteger(version)) return null;
+  return parsed as StatsRecord;
+}
+
+function normalize(record: StatsRecord): StatsRecord {
+  const projects: Record<string, StatsScope> = {};
+  const source = record.projects;
+  if (source && typeof source === 'object' && !Array.isArray(source)) {
+    for (const [key, scope] of Object.entries(source)) projects[key] = normalizeScope(scope);
+  }
+  return { version: STATS_VERSION, machine: normalizeScope(record.machine), projects };
+}
+
+function normalizeScope(scope: unknown): StatsScope {
+  const normalized: StatsScope = {};
+  if (!scope || typeof scope !== 'object' || Array.isArray(scope)) return normalized;
+  for (const platform of PLATFORMS) {
+    const bucket = (scope as Record<string, unknown>)[platform];
+    if (bucket && typeof bucket === 'object' && !Array.isArray(bucket)) {
+      normalized[platform] = normalizeBucket(bucket as Record<string, unknown>);
+    }
+  }
+  return normalized;
+}
+
+function normalizeBucket(bucket: Record<string, unknown>): StatsBucket {
+  return {
+    runs: count(bucket.runs),
+    failed: count(bucket.failed),
+    hits: count(bucket.hits),
+    misses: count(bucket.misses),
+    coldRuns: count(bucket.coldRuns),
+    coldRunMs: count(bucket.coldRunMs),
+    hitRuns: count(bucket.hitRuns),
+    hitRunMs: count(bucket.hitRunMs),
+    timeSavedMs: count(bucket.timeSavedMs),
+    firstRunAt: timestamp(bucket.firstRunAt),
+    lastRunAt: timestamp(bucket.lastRunAt),
+  };
+}
+
+function applyRun(
+  bucket: StatsBucket | null,
+  run: StatsRun,
+  { at, durationMs, credit }: { at: string; durationMs: number; credit: number },
+): StatsBucket {
+  const next: StatsBucket = bucket
+    ? { ...bucket }
+    : {
+        runs: 0,
+        failed: 0,
+        hits: 0,
+        misses: 0,
+        coldRuns: 0,
+        coldRunMs: 0,
+        hitRuns: 0,
+        hitRunMs: 0,
+        timeSavedMs: 0,
+        firstRunAt: at,
+        lastRunAt: at,
+      };
+  next.runs += 1;
+  next.lastRunAt = at;
+  if (run.failed) {
+    next.failed += 1;
+    return next;
+  }
+  if (isHit(run.cacheHit)) {
+    next.hits += 1;
+    if (!run.waitedForBuild) {
+      next.hitRuns += 1;
+      next.hitRunMs += durationMs;
+      next.timeSavedMs += credit;
+    }
+    return next;
+  }
+  next.misses += 1;
+  next.coldRuns += 1;
+  next.coldRunMs += durationMs;
+  return next;
+}
+
+function creditMs(bucket: StatsBucket | null, run: StatsRun, durationMs: number): number {
+  if (run.failed || !isHit(run.cacheHit) || run.waitedForBuild) return 0;
+  if (!bucket || bucket.coldRuns <= 0) return 0;
+  return Math.max(0, Math.round(bucket.coldRunMs / bucket.coldRuns) - durationMs);
+}
+
+function isHit(cacheHit: CacheHitLevel): boolean {
+  return cacheHit === 'local' || cacheHit === 'remote';
+}
+
+function wholeMs(value: unknown): number {
+  const ms = Number(value);
+  return Number.isFinite(ms) && ms > 0 ? Math.round(ms) : 0;
+}
+
+function count(value: unknown): number {
+  return wholeMs(value);
+}
+
+function timestamp(value: unknown): string {
+  return typeof value === 'string' && value !== '' ? value : new Date(0).toISOString();
+}
+
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -214,6 +214,36 @@ stim status [--json]
 Shows every Stim environment on the machine. The output includes worktrees,
 ports, devices, supervisors, builds, logs, capacity, and free disk space.
 
+## `stats`
+
+```text
+stim stats [--json]
+```
+
+Shows how many `ios` and `android` runs this project and this machine have
+recorded, how many hit the build cache, the mean cold run and hit run, and an
+estimate of the time the cache saved. Only aggregates are kept, in
+`$STIM_HOME/stats.json`; nothing per run is stored, and every worktree of a
+repository counts into the same project bucket. Outside a project only the
+machine section prints. There is no reset flag: delete that file to start over.
+
+`--json` prints one line:
+
+```json
+{
+  "version": 1,
+  "project": { "key": "/path/to/app", "ios": {}, "android": null },
+  "machine": { "ios": {}, "android": null }
+}
+```
+
+`project` is `null` outside a project, and a platform with no run yet is
+`null`. A bucket carries `runs`, `failed`, `hits`, `misses`, `coldRuns`,
+`coldRunMs`, `hitRuns`, `hitRunMs`, `timeSavedMs`, `firstRunAt` and
+`lastRunAt`. The saved figure is an estimate: each cache hit is credited this
+project's mean cold run at that moment, minus its own duration, floored at
+zero.
+
 ## `worktree create`
 
 ```text


### PR DESCRIPTION
## Description

Nothing recorded what the build cache is worth. The only persisted run data is
`lastBuild`, one record per workspace, so neither a team nor an agent could
answer "what is our hit rate, and how much time did Stim save" without running a
benchmark (#256).

**Read this with `git diff -w`.** The statements from the fingerprint call to
the end of each run in `ios.ts` and `android.ts` are now inside a `try`, so
those two files are almost entirely re-indentation; `-w` leaves only the
wiring. Everything else is additive.

The design is fixed by `docs/specs/2026-09-02-stats-design.md`, merged in #257:
aggregate only, one bucket per project and platform plus a machine-wide one, no
per-run log, no upload, and a read-only `stim stats` to print it. This branch
implements that spec; it does not revisit it.

## Solution

`engine/stats.ts` holds the whole feature. `updateStats(record, run, now)` is
pure and is where every rule lives; the file layer around it reads
`$STIM_HOME/stats.json`, applies the rule and writes temp-then-rename under the
global config lock. `stats` reads with no lock, because those writes are atomic.

The parts worth a reviewer's attention:

- **The project key is the app's path in the main working tree**
  (`join(dirname(gitCommonDir), relative(repoRoot, root))`, realpath'd per
  invariant 6). Every worktree of a repository pools into one bucket -- the
  normal flow is a fresh worktree hitting a cache another checkout filled -- and
  two apps in one monorepo stay apart.
- **The estimate is deliberately weak, and labelled.** A hit is credited this
  project's mean cold run at that moment minus its own duration, floored at
  zero, and nothing at all when it waited for another workspace's build or when
  that project and platform have no cold run to compare against.
- **A statistics failure never changes a run.** `createRunRecorder` holds the
  once-only state both platforms share; the write itself is injectable
  (`d.recordStats` on iOS, a `recordStats` option on Android). It fires exactly
  once per run from three places on each platform: inside `fail()` before it
  exits, in the success reporter before any `exitAfterFlush`, and in that
  `catch` around the run body. A run is only recorded once a cache key exists,
  so every refusal before that -- outside a project, no Metro, a bad flag, at
  capacity -- records nothing. A throw from the recorder, a lock failure, a
  `version` greater than 1, or a corrupt file (renamed aside to
  `stats.json.corrupt-<unix ms>` under the same lock) each cost one dim line on
  stderr and nothing else. A `stats` READ never renames anything: an unreadable
  or newer file costs one dim stderr line and leaves stdout as it would be with
  no file at all.

`runAndroid` sat exactly on the 80-complexity ceiling, so the region the `catch`
covers is now a named `runFromFingerprint` rather than a bare `try` block; the
lines inside it are unchanged.

The rest is a `stats` command modelled on `status`, `formatLongDuration` (a
duration formatter with an hours unit, padding the smaller unit at both scales:
`1h05m`, `4m05s`), and the
guidance the spec's "Guidance deltas" section names: `guide facts` (the payload
and the counting rule), `guide lifecycle` (the option surface, the state layout,
and the `status` vs `stats` routing line), `guide cleanup` (`gc` leaves the file
alone; delete it to reset), the skill's guide-routing list, the AGENTS.md
command surface sentence, and a `## stats` section on the website.

Blast radius: two mutable flags and one closure per run on the two run commands,
and a new file under `$STIM_HOME`. Worst case is a wrong number in a report
nothing else reads; the file has no consumer besides `stats` and can be deleted.

## Test plan

**No device was booted and no `ios`/`android` run was made for this branch**, so
the recorder's three call sites are proven by the injected-recorder tests below,
not by a real build.

- `stats.test.ts`, 24 tests: every update rule (the waited hit, the no-cold-run
  case, the failed run, lockstep machine totals, integer rounding), the
  newer-`version` skip, the corrupt-file rename, the project key, and the
  command with `STIM_HOME` redirected -- the table, the empty section, the `-`
  column, outside a project, no `config.json` created, `--json` as one line.
- A `run statistics` block in `ios-command.test.ts` and in
  `android-command.test.ts`: recorded once on success, once through `fail()`,
  once on an exception, never before a cache key exists, and a throwing recorder
  leaving the exit status alone. One per platform pins the once-only guard
  itself: a writer whose `close()` throws after the success reporter recorded
  makes the run throw, and the `catch` must not add a second, failed run.
  Ablating the guard fails both with "length of 1 but got 2".
- Five guide, skill, and docs contract tests.

Real CLI, built `dist/cli.mjs`, real `git` for the key (invariant 9):

```
$ cd /tmp/scratch && STIM_HOME=$tmp node dist/cli.mjs stats
project /private/tmp/scratch
  no runs recorded
machine
  no runs recorded
$ ls -a $tmp        # no config.json, no stats.json: a read creates nothing
$ cd /tmp && STIM_HOME=$tmp node dist/cli.mjs stats --json
{"version":1,"project":null,"machine":{"ios":null,"android":null}}
```

From this branch's linked worktree the key resolves to the main working tree,
which is the pooling rule end to end:

```
$ cd /private/tmp/stim-issue-256 && node dist/cli.mjs stats --json
{"version":1,"project":{"key":"/Volumes/ExternalSSD/Developer/stim",...}}
```

In `~/Developer/trailhead-bench` (a real repo, no runs there) it prints
`project /Volumes/ExternalSSD/Developer/trailhead-bench` / `no runs recorded`,
exit 0. Rendering a hand-written `stats.json` reproduces the spec's example rows
(`36 hits (92%) ... cold run 4m12s avg ... saved ~2h13m (estimated)`).

A newer-version file and a corrupt one each print their one stderr line while
stdout stays the table, or one JSON line, and the file on disk is untouched;
`1h06m` / `4m05s` render from the built CLI.

Rebased onto `c29c6bd` (#258). `pnpm run format:check`, `lint`, `build`,
`typecheck`, `pnpm test` (3271 passed), `pnpm run knip`, and
`pnpm run test:e2e` (20 passed) all pass.

Fixes #256.

