### PR TITLE
fix: one output vocabulary for `ios` and `android` runs

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2461,22 +2461,24 @@ describe('launch verification', () => {
     ).toBeTruthy();
   });
 
-  test('logcat is filtered to the app, so a verified launch keeps printing its device errors', async () => {
+  test('a verified launch counts the device log on Android too', async () => {
     const h = harness({
       verifyLaunched: async () => ({
         verified: true,
         waitedMs: 2500,
         errors: [
-          { src: 'device', proc: 'ReactNativeJS(1234)', msg: 'a native error from the app' },
+          { src: 'device', proc: 'ReactNativeJS(1234)', msg: 'a native framework error' },
           { src: 'client', msg: 'a redbox from the app' },
         ],
       }),
     });
     await h.run();
     const text = h.stderr.join('\n');
-    expect(text).toMatch(/^  launch {6}a native error from the app$/m);
+    expect(text).toMatch(
+      /^  launch {6}1 error-level record in the device log during launch \(logs --errors --source device\)$/m,
+    );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
-    expect(text).not.toMatch(/error-level OS log/);
+    expect(text).not.toMatch(/a native framework error/);
   });
 
   test('the picker: no bundle request makes it launched: "unverified", still exit ok', async () => {
@@ -2512,6 +2514,38 @@ describe('the workspace directory is gitignored first', () => {
     const h = harness();
     await h.run();
     expect(h.calls.ensureStorage).toEqual([root]);
+  });
+});
+
+describe('the owned emulator reports creation and slow preparation', () => {
+  test('a fresh AVD says created, however fast it was', async () => {
+    const h = harness({
+      ensureDevice: async () => ({ avdName: 'stim-app-412', consolePort: 5584, owned: true, created: true }),
+    });
+    await h.run();
+    expect(labelled(h.stderr, 'device')[0]).toMatch(/^  device {6}stim-app-412 created \(\d+m?s?\)$/);
+    expect(h.stderr.some((l) => /Created owned AVD/.test(l))).toBe(false);
+  });
+
+  test('an existing AVD says prepared only when the reconcile cost real time', async () => {
+    for (const [label, elapsedMs, expected] of [
+      ['a fast reconcile', 500, false],
+      ['a slow reconcile', 2000, true],
+    ] as const) {
+      let clock = 0;
+      const h = harness({
+        now: () => {
+          const at = clock;
+          clock += elapsedMs;
+          return at;
+        },
+      });
+      await h.run();
+      expect({ label, prepared: labelled(h.stderr, 'device').some((l) => / prepared \(/.test(l)) }).toEqual({
+        label,
+        prepared: expected,
+      });
+    }
   });
 });
 

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -969,7 +969,7 @@ describe('a cache hit', () => {
     expect(result.facts.cacheHit).toBe('local');
     expect(result.facts.appPath).toBe(cached);
     expect(labelled(h.stderr, 'fingerprint')[0]).toMatch(/a3f9b1\.\. hit/);
-    expect(labelled(h.stderr, 'install')[0]).toMatch(/from local cache/);
+    expect(labelled(h.stderr, 'install')[0]).toMatch(/^  install {5}app-debug\.apk -> emulator-5584 /);
     expect(labelled(h.stderr, 'build').length).toBe(0);
   });
 
@@ -983,7 +983,7 @@ describe('a cache hit', () => {
     expect(labelled(h.stderr, 'logs')[0]).toMatch(/collector pid 9001/);
     expect(labelled(h.stderr, 'fingerprint')[0]).toMatch(/\(\d+m?\d*s\)$/);
     expect(labelled(h.stderr, 'device')[0]).toMatch(/booted \(\d+m?\d*s\)$/);
-    expect(labelled(h.stderr, 'install')[0]).toMatch(/from local cache \(\d+m?\d*s\)$/);
+    expect(labelled(h.stderr, 'install')[0]).toMatch(/app-debug\.apk -> emulator-5584 \(\d+m?\d*s\)$/);
     expect(labelled(h.stderr, 'launch')[0]).toMatch(/\(\d+m?\d*s\)$/);
     expect(h.stdout.length).toBe(1);
     expect(h.stdout[0]).toMatch(/OK: com\.example\.app launched on emulator-5584/);
@@ -1048,7 +1048,7 @@ describe('a cache miss', () => {
     expect(h.calls.install[0]?.apkPath).toBe(h.calls.storeCached[0]?.[2]);
     expect(labelled(h.stderr, 'fingerprint')[0]).toMatch(/miss/);
     expect(labelled(h.stderr, 'build')[0]).toMatch(/compiling debug with Gradle/);
-    expect(labelled(h.stderr, 'build')[1]).toMatch(/app-debug\.apk \(2m41s\)/);
+    expect(labelled(h.stderr, 'build')[1]).toMatch(/^  build {7}ok \(2m41s\)$/);
     assert(result.facts);
     expect(result.facts.cacheHit).toBe(false);
   });
@@ -2461,6 +2461,24 @@ describe('launch verification', () => {
     ).toBeTruthy();
   });
 
+  test('logcat is filtered to the app, so a verified launch keeps printing its device errors', async () => {
+    const h = harness({
+      verifyLaunched: async () => ({
+        verified: true,
+        waitedMs: 2500,
+        errors: [
+          { src: 'device', proc: 'ReactNativeJS(1234)', msg: 'a native error from the app' },
+          { src: 'client', msg: 'a redbox from the app' },
+        ],
+      }),
+    });
+    await h.run();
+    const text = h.stderr.join('\n');
+    expect(text).toMatch(/^  launch {6}a native error from the app$/m);
+    expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
+    expect(text).not.toMatch(/error-level OS log/);
+  });
+
   test('the picker: no bundle request makes it launched: "unverified", still exit ok', async () => {
     const h = harness({ verifyLaunched: async () => ({ verified: false, timedOut: true, waitedMs: 20000 }) });
     const result = await h.run();
@@ -2501,7 +2519,7 @@ describe('the port wiring is reported', () => {
   test('a successful debug_http_host write is a phase line and two facts', async () => {
     const h = harness();
     const result = await h.run();
-    expect(labelled(h.stderr, 'wired')[0]).toMatch(
+    expect(labelled(h.stderr, 'metro').at(-1)).toMatch(
       /debug_http_host 10\.0\.2\.2:8082 \+ adb reverse tcp:8082->tcp:8082/,
     );
     assert(result.facts);
@@ -2521,7 +2539,7 @@ describe('the port wiring is reported', () => {
     });
     const result = await h.run();
     expect(result.ok).toBe(true);
-    const wired = labelled(h.stderr, 'wired')[0];
+    const wired = labelled(h.stderr, 'metro').at(-1);
     expect(wired).toMatch(/not debuggable/);
     expect(wired).toMatch(/adb reverse tcp:8081->tcp:8082/);
     assert(result.facts);
@@ -2558,7 +2576,7 @@ describe('the dev-client deep link', () => {
       launch: () => ({ ok: true, mode: 'deep-link', devClientUrl: url, reversed: [], debugHttpHost: '10.0.2.2:8082' }),
     });
     const result = await h.run();
-    expect(labelled(h.stderr, 'launch')[0]).toMatch(/expo-dev-client deep link/);
+    expect(labelled(h.stderr, 'launch')[0]).toMatch(/^  launch {6}com\.example\.app \(\d+m?s?\)$/);
     assert(result.facts);
     expect(result.facts.devClientUrl).toBe(url);
   });
@@ -2577,7 +2595,7 @@ describe('the dev-client deep link', () => {
     });
     const result = await h.run();
     expect(result.ok).toBe(true);
-    expect(labelled(h.stderr, 'wired').some((l) => /unable to resolve Intent/.test(l))).toBeTruthy();
+    expect(labelled(h.stderr, 'metro').some((l) => /unable to resolve Intent/.test(l))).toBeTruthy();
     const records = parseNdjsonText(readFileSync(join(workspaceLogsDir(root), 'build-android.ndjson'), 'utf-8'));
     expect(records.find((r) => r.event === 'dev_client_link_failed')).toBeTruthy();
   });
@@ -2995,7 +3013,7 @@ describe('the release APK swap', () => {
     assert(result.facts);
     expect(result.facts.appPath).toBe(join(root, 'apk-swap', 'app-production-release.apk'));
     expect(result.facts.cacheHit).toBe('local');
-    expect(labelled(h.stderr, 'apk swap')[1]).toMatch(/hermes bytecode repacked \(store\), zipaligned and re-signed/);
+    expect(labelled(h.stderr, 'swap')[1]).toMatch(/hermes bytecode repacked \(store\), zipaligned and re-signed/);
     expect(existsSync(join(root, 'apk-swap'))).toBe(false);
   });
 
@@ -3062,7 +3080,7 @@ describe('the release APK swap', () => {
     const result = await h.run();
     expect(result.ok).toBe(true);
     const errs = h.stderr.join('\n');
-    expect(errs).toMatch(/apk swap/);
+    expect(errs).toMatch(/^  swap {8}/m);
     expect(errs).toMatch(/changed drawable-mdpi\/logo\.png/);
     expect(errs).toMatch(/building fresh instead/);
     expect(errs).toMatch(/an APK cannot be made to carry an asset AAPT did not package/);
@@ -3252,7 +3270,7 @@ describe('re-fingerprint after prebuild', () => {
     expect(result.ok).toBe(true);
     expect(h.calls.prebuild.length).toBe(1);
     expect(h.calls.install[0]?.apkPath).toBe(cachedApk);
-    expect(h.stderr.some((l) => /hit under the post-prebuild key \(this tree was cold/.test(l))).toBe(true);
+    expect(h.stderr.some((l) => /^  cache {7}hit wwwwww\.\. \(post-prebuild key\)$/.test(l))).toBe(true);
     expect(result.facts?.cacheHit).toBe('local');
     expect(result.facts?.fingerprint).toBe(WARM);
     expect(result.facts?.cacheKey).toBe(`${WARM}-debug-sim`);
@@ -3962,7 +3980,7 @@ test('the wired line reports the reverses that were actually registered', async 
     }),
   });
   await h.run();
-  const wired = labelled(h.stderr, 'wired').join(' ');
+  const wired = labelled(h.stderr, 'metro').join(' ');
   expect(wired).toContain('tcp:8082->tcp:8082');
   expect(wired).not.toContain('tcp:8081');
 });
@@ -3977,7 +3995,7 @@ describe('an APK the device already holds', () => {
     const result = await h.run();
 
     expect(result.ok).toBe(true);
-    expect(labelled(h.stderr, 'install')[0]).toMatch(/skipped; emulator-5584 already holds this APK/);
+    expect(labelled(h.stderr, 'install')[0]).toMatch(/unchanged \(emulator-5584 already has this build\)/);
     assert(result.facts);
     expect(result.facts.installSkipped).toBe(true);
   });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -80,28 +80,29 @@ test('every label ios.ts and android.ts print comes from that one set', () => {
   }
 });
 
-test('a verified launch summarizes the OS log noise and still prints the rest', () => {
+test("a verified launch counts the device log and still prints the app's own errors", () => {
   const records = [
-    { src: 'device', proc: 'Fixture', msg: 'the app itself complained' },
-    { src: 'device', proc: 'SpringBoard', msg: 'attention client lost event tag' },
-    { src: 'device', proc: 'amsengagementd', msg: 'Object decoding failed' },
+    { src: 'device', proc: 'Trailhead', msg: 'Failed to send CA Event for app launch measurements' },
+    { src: 'device', proc: 'Trailhead', msg: 'TCP Conn 0x106f86d00 Failed : error 0:61 [61]' },
+    { src: 'device', proc: 'Trailhead', msg: 'NSBundle (null) initWithPath failed' },
     { src: 'client', msg: 'a redbox' },
+    { src: 'metro', msg: 'a bundler error' },
   ];
-  const report = launchErrorReport(records, {
-    appId: 'com.example.app',
-    fromApp: (record) => record.proc === 'Fixture',
-  });
-  expect(report.summary).toBe(
-    '2 error-level OS log lines during launch, none from com.example.app (logs --source device)',
-  );
-  expect(report.lines).toEqual(['the app itself complained', 'a redbox']);
+  const report = launchErrorReport(records);
+  expect(report.summary).toBe('3 error-level records in the device log during launch (logs --errors --source device)');
+  expect(report.lines).toEqual(['a redbox', 'a bundler error']);
 });
 
-test('one noise line is singular, and no noise means no line at all', () => {
-  expect(launchErrorReport([{ src: 'device', msg: 'x' }], { appId: 'app', fromApp: () => false }).summary).toBe(
-    '1 error-level OS log line during launch, none from app (logs --source device)',
-  );
-  const quiet = launchErrorReport([{ src: 'client', msg: 'x' }], { appId: 'app', fromApp: () => false });
+test('the count never depends on the process a record names', () => {
+  const named = launchErrorReport([{ src: 'device', proc: 'Trailhead', msg: 'x' }]);
+  const unnamed = launchErrorReport([{ src: 'device', msg: 'x' }]);
+  expect(named.summary).toBe(unnamed.summary);
+  expect(named.summary).toBe('1 error-level record in the device log during launch (logs --errors --source device)');
+  expect(named.lines).toEqual([]);
+});
+
+test('no device record means no count line at all', () => {
+  const quiet = launchErrorReport([{ src: 'client', msg: 'x' }]);
   expect(quiet.summary).toBe(null);
   expect(quiet.lines).toEqual(['x']);
 });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -1,4 +1,14 @@
-import { formatDuration, formatElapsed, formatLongDuration, phaseLine, shortHash } from '../command-output.ts';
+import { readFileSync } from 'node:fs';
+import {
+  formatDuration,
+  formatElapsed,
+  formatLongDuration,
+  isOutputLabel,
+  launchErrorReport,
+  OUTPUT_LABELS,
+  phaseLine,
+  shortHash,
+} from '../command-output.ts';
 
 test('formatDuration uses one format for every command', () => {
   expect(formatDuration(0)).toBe('0ms');
@@ -47,4 +57,51 @@ test('shortHash keeps short values and abbreviates long values', () => {
   expect(shortHash('12345678')).toBe('12345678');
   expect(shortHash('123456789')).toBe('123456..');
   expect(shortHash(null)).toBe('');
+});
+
+test('the label set is closed, sorted, and free of duplicates', () => {
+  expect(OUTPUT_LABELS).toEqual(OUTPUT_LABELS.toSorted());
+  expect(new Set(OUTPUT_LABELS).size).toBe(OUTPUT_LABELS.length);
+  expect(isOutputLabel('install')).toBe(true);
+  expect(isOutputLabel('launch err')).toBe(false);
+  expect(isOutputLabel('js swap')).toBe(false);
+  expect(isOutputLabel('wired')).toBe(false);
+});
+
+test('every label ios.ts and android.ts print comes from that one set', () => {
+  for (const command of ['ios', 'android']) {
+    const src = readFileSync(new URL(`../commands/${command}.ts`, import.meta.url), 'utf-8');
+    const labels = new Set<string>();
+    for (const match of src.matchAll(/\bphase(?:Line)?\(\s*'((?:[^'\\]|\\.)*)'/g)) labels.add(match[1]!);
+    expect(labels.size).toBeGreaterThan(10);
+    for (const label of labels) {
+      expect({ command, label, known: isOutputLabel(label) }).toEqual({ command, label, known: true });
+    }
+  }
+});
+
+test('a verified launch summarizes the OS log noise and still prints the rest', () => {
+  const records = [
+    { src: 'device', proc: 'Fixture', msg: 'the app itself complained' },
+    { src: 'device', proc: 'SpringBoard', msg: 'attention client lost event tag' },
+    { src: 'device', proc: 'amsengagementd', msg: 'Object decoding failed' },
+    { src: 'client', msg: 'a redbox' },
+  ];
+  const report = launchErrorReport(records, {
+    appId: 'com.example.app',
+    fromApp: (record) => record.proc === 'Fixture',
+  });
+  expect(report.summary).toBe(
+    '2 error-level OS log lines during launch, none from com.example.app (logs --source device)',
+  );
+  expect(report.lines).toEqual(['the app itself complained', 'a redbox']);
+});
+
+test('one noise line is singular, and no noise means no line at all', () => {
+  expect(launchErrorReport([{ src: 'device', msg: 'x' }], { appId: 'app', fromApp: () => false }).summary).toBe(
+    '1 error-level OS log line during launch, none from app (logs --source device)',
+  );
+  const quiet = launchErrorReport([{ src: 'client', msg: 'x' }], { appId: 'app', fromApp: () => false });
+  expect(quiet.summary).toBe(null);
+  expect(quiet.lines).toEqual(['x']);
 });

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -192,7 +192,7 @@ describe('runPodInstall', () => {
     });
     expect(result.ok).toBe(true);
     expect(beats.length >= 1).toBe(true);
-    expect(beats[0]).toMatch(/^pods\s+still running \(/);
+    expect(beats[0]).toMatch(/^ {2}pods\s+still running \(/);
     expect(beats[0]).toMatch(/Installing FlipperKit/);
   });
 
@@ -390,7 +390,7 @@ describe('runPodInstall through bundler (#137)', () => {
     });
     expect(result.ok).toBe(true);
     expect(calls[1]?.opts.cwd).toBe(root);
-    expect(beats[0]).toMatch(/^gems\s+still running \(/);
+    expect(beats[0]).toMatch(/^ {2}gems\s+still running \(/);
     expect(beats[0]).toMatch(/Fetching cocoapods/);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -501,7 +501,7 @@ describe('buildAndroid', () => {
     );
     expect((on as BuildAndroidResultLike).ok).toBe(true);
     expect(notes.length).toBe(1);
-    expect(notes[0]).toMatch(/gradle build cache on for this build: --build-cache/);
+    expect(notes[0]).toMatch(/^ {2}cache {7}gradle build cache on \(--build-cache/);
 
     notes.length = 0;
     calls.length = 0;
@@ -682,7 +682,7 @@ describe('buildAndroid', () => {
     child.stdout.emit('data', '> Task :app:compileDebugKotlin\n');
     await new Promise((r) => setTimeout(r, 80));
     expect(beats.length).toBeGreaterThanOrEqual(1);
-    expect(beats[0]).toMatch(/^build {6} still running \(\d+s\): > Task :app:compileDebugKotlin$/);
+    expect(beats[0]).toMatch(/^ {2}build {6} still running \(\d+s\): > Task :app:compileDebugKotlin$/);
     writeApk();
     child.emit('exit', 0, null);
     const result = await promise;

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -629,7 +629,7 @@ describe('reading the bundle id', () => {
 
 describe('the heartbeat line', () => {
   test('carries the activity hint, truncated to one readable line', () => {
-    expect(heartbeatLine(30_000, 'CompileC App.o')).toBe('build       still running (30s): CompileC App.o');
+    expect(heartbeatLine(30_000, 'CompileC App.o')).toBe('  build       still running (30s): CompileC App.o');
     const long = 'x'.repeat(200);
     const line = heartbeatLine(30_000, long);
     expect(line.endsWith('...')).toBe(true);
@@ -637,7 +637,7 @@ describe('the heartbeat line', () => {
   });
 
   test('omits the hint before the child has printed anything', () => {
-    expect(heartbeatLine(30_000, '')).toBe('build       still running (30s)');
+    expect(heartbeatLine(30_000, '')).toBe('  build       still running (30s)');
   });
 });
 
@@ -694,9 +694,9 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     stop();
     expect(beats).toEqual([
-      'build       still running (30s)',
-      'build       still running (1m00s)',
-      'build       still running (1m30s)',
+      '  build       still running (30s)',
+      '  build       still running (1m00s)',
+      '  build       still running (1m30s)',
     ]);
     expect(scheduler.idle()).toBe(true);
   });
@@ -711,10 +711,10 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     stop();
     expect(beats).toEqual([
-      'build       still running (30s)',
-      'build       still running (5m30s)',
-      'build       still running (6m00s)',
-      'build       still running (6m30s)',
+      '  build       still running (30s)',
+      '  build       still running (5m30s)',
+      '  build       still running (6m00s)',
+      '  build       still running (6m30s)',
     ]);
   });
 
@@ -725,10 +725,10 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     scheduler.jump(29_999);
     scheduler.fire();
-    expect(beats).toEqual(['build       still running (30s)']);
+    expect(beats).toEqual(['  build       still running (30s)']);
     scheduler.advance(1);
     stop();
-    expect(beats).toEqual(['build       still running (30s)', 'build       still running (1m00s)']);
+    expect(beats).toEqual(['  build       still running (30s)', '  build       still running (1m00s)']);
   });
 
   test('a non-positive interval schedules nothing at all', () => {
@@ -845,7 +845,7 @@ describe('buildIos with a mocked executor', () => {
     child.emit('close', 0, null);
     await promise;
     expect(notes.length).toBe(1);
-    expect(notes[0]).toMatch(/compilation cache on for this build: CAS at .*compilation-cache/);
+    expect(notes[0]).toMatch(/^ {2}cache {7}compilation cache on \(CAS at .*compilation-cache\)$/);
     const args = spawnCalls[0]?.args ?? [];
     expect(args).toContain('COMPILATION_CACHE_ENABLE_CACHING=YES');
     expect(args).toContain(`CLANG_OTHER_PREFIX_MAPPINGS=${tmp}=/^src ${workspaceDerivedData(tmp)}=/^derived-data`);
@@ -961,7 +961,7 @@ describe('buildIos with a mocked executor', () => {
       cacheableTasks: 1520,
       hitRatePercent: 91.7,
     });
-    expect(notes).toEqual(['compilation cache 1394/1520 hits (91.7%)']);
+    expect(notes).toEqual(['  cache       compilation cache 1394/1520 hits (91.7%)']);
     expect(writer.records).toContainEqual(
       expect.objectContaining({
         event: 'compilation_cache',
@@ -1172,7 +1172,7 @@ describe('buildIos with a mocked executor', () => {
     child.stdout.emit('data', 'CompileC main.o\n');
     await new Promise((r) => setTimeout(r, 80));
     expect(beats.length).toBeGreaterThanOrEqual(1);
-    expect(beats[0]).toMatch(/^build {6} still running \(\d+s\): CompileC main\.o$/);
+    expect(beats[0]).toMatch(/^ {2}build {6} still running \(\d+s\): CompileC main\.o$/);
     makeProduct(dd);
     child.emit('close', 0, null);
     await promise;

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { readdirSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_FINGERPRINT_IGNORES } from '../build-cache.ts';
+import { OUTPUT_LABELS } from '../command-output.ts';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
@@ -28,6 +29,31 @@ test('the lifecycle topic separates an iOS install proof from dev-client prepara
   expect(body).toMatch(/install\s+unchanged \(stim-app already has this build\)/);
   expect(body).toMatch(/install\s+dev client prepared/);
   expect(body).toMatch(/slow simulator command is never charged\s+to an install that did not run/);
+});
+
+test('the lifecycle topic names every label the output vocabulary allows', () => {
+  const body = renderTopic('lifecycle');
+  assert(body);
+  const paragraph = body.slice(body.indexOf('The labels are a closed set'));
+  assert(paragraph);
+  for (const label of OUTPUT_LABELS) {
+    if (label === '') continue;
+    expect({ label, named: new RegExp(`\\b${label.replace('.', '\\.')}\\b`).test(paragraph) }).toEqual({
+      label,
+      named: true,
+    });
+  }
+  expect(paragraph).toMatch(/`app` and `compilation cache` join them in the stdout block/);
+});
+
+test('the errors topic names the two device fallbacks under the label that prints them', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  expect(body).toMatch(/both print a `cache` note and\s+build fresh/);
+  expect(body).toMatch(/cache\s+a cached Release device app carries its builder's JS/);
+  expect(body).not.toMatch(/^ *device app {2}/m);
+  const src = readFileSync(new URL('../commands/ios.ts', import.meta.url), 'utf-8');
+  expect(src.includes("'device app'")).toBe(false);
 });
 
 test('an unknown topic renders nothing rather than throwing', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -31,19 +31,24 @@ test('the lifecycle topic separates an iOS install proof from dev-client prepara
   expect(body).toMatch(/slow simulator command is never charged\s+to an install that did not run/);
 });
 
-test('the lifecycle topic names every label the output vocabulary allows', () => {
+const SUMMARY_ONLY_LABELS = ['app', 'compilation cache'];
+
+test('the lifecycle topic grids every label the output vocabulary allows, and no others', () => {
   const body = renderTopic('lifecycle');
   assert(body);
-  const paragraph = body.slice(body.indexOf('The labels are a closed set'));
-  assert(paragraph);
-  for (const label of OUTPUT_LABELS) {
-    if (label === '') continue;
-    expect({ label, named: new RegExp(`\\b${label.replace('.', '\\.')}\\b`).test(paragraph) }).toEqual({
-      label,
-      named: true,
-    });
-  }
-  expect(paragraph).toMatch(/`app` and `compilation cache` join them in the stdout block/);
+  const start = body.indexOf('The labels are a closed set');
+  expect(start).toBeGreaterThan(-1);
+  const grid = body.slice(body.indexOf('column:', start) + 'column:'.length, body.indexOf('`app` and', start));
+  expect(
+    grid
+      .trim()
+      .split('\n')
+      .filter((line) => line.trim() !== ''),
+  ).toHaveLength(6);
+  expect(grid.trim().split(/\s+/).toSorted()).toEqual(
+    OUTPUT_LABELS.filter((label) => label !== '' && !SUMMARY_ONLY_LABELS.includes(label)).toSorted(),
+  );
+  expect(body.slice(start)).toMatch(/`app` and `compilation cache` join them in the stdout block/);
 });
 
 test('the errors topic names the two device fallbacks under the label that prints them', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -25,8 +25,8 @@ test('the facts topic pins how an owned emulator gets its console port', () => {
 test('the lifecycle topic separates an iOS install proof from dev-client preparation', () => {
   const body = renderTopic('lifecycle');
   assert(body);
-  expect(body).toMatch(/install\s+unchanged; .*already holds this app; proof/);
-  expect(body).toMatch(/dev client\s+prepared/);
+  expect(body).toMatch(/install\s+unchanged \(stim-app already has this build\)/);
+  expect(body).toMatch(/install\s+dev client prepared/);
   expect(body).toMatch(/slow simulator command is never charged\s+to an install that did not run/);
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -610,7 +610,7 @@ describe('launch verification', () => {
     );
   });
 
-  test('a verified launch counts the OS log noise instead of printing it', async () => {
+  test('a verified launch counts the device log instead of printing it', async () => {
     reserve();
     const { errs } = await run(
       {},
@@ -619,9 +619,8 @@ describe('launch verification', () => {
           verified: true,
           waitedMs: 2500,
           errors: [
-            { src: 'device', proc: 'SpringBoard', msg: 'attention client lost event tag is not a number: (null)' },
-            { src: 'device', proc: 'amsengagementd', msg: 'Object decoding failed' },
-            { src: 'device', proc: 'Fixture', msg: 'the app itself complained' },
+            { src: 'device', proc: 'Fixture', msg: 'Failed to send CA Event for app launch measurements' },
+            { src: 'device', proc: 'Fixture', msg: 'NSBundle (null) initWithPath failed' },
             { src: 'client', msg: 'a redbox from the app' },
           ],
         }),
@@ -629,12 +628,11 @@ describe('launch verification', () => {
     );
     const text = errs.join('\n');
     expect(text).toMatch(
-      /^  launch {6}2 error-level OS log lines during launch, none from com\.example\.app \(logs --source device\)$/m,
+      /^  launch {6}2 error-level records in the device log during launch \(logs --errors --source device\)$/m,
     );
-    expect(text).toMatch(/^  launch {6}the app itself complained$/m);
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
-    expect(text).not.toMatch(/attention client lost/);
-    expect(text).not.toMatch(/Object decoding failed/);
+    expect(text).not.toMatch(/Failed to send CA Event/);
+    expect(text).not.toMatch(/NSBundle/);
   });
 
   test('a launch that does not verify still prints every error it collected', async () => {
@@ -3638,6 +3636,15 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(facts.udid).toBe(PHONE);
     expect(facts.launched).toBe(true);
     expect(facts.cacheKey).toBe(`${FINGERPRINT}-debug-device`);
+  });
+
+  test('the phone launch line is the shared shape plus the pid that proves it', async () => {
+    reserve();
+    const { errs } = await run({ device: true }, connected());
+    const text = errs.join('\n');
+    expect(text).toMatch(new RegExp(`^  launch {6}com\\.example\\.app pid ${DEVICE_PID} \\(\\d+m?s?\\)$`, 'm'));
+    expect(text).not.toMatch(/on the phone/);
+    expect(text).not.toMatch(/opened on the dev-client URL/);
   });
 
   test('the collector is the launch: it carries --physical and the run reads the device pid', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -610,6 +610,50 @@ describe('launch verification', () => {
     );
   });
 
+  test('a verified launch counts the OS log noise instead of printing it', async () => {
+    reserve();
+    const { errs } = await run(
+      {},
+      {
+        verifyLaunch: async () => ({
+          verified: true,
+          waitedMs: 2500,
+          errors: [
+            { src: 'device', proc: 'SpringBoard', msg: 'attention client lost event tag is not a number: (null)' },
+            { src: 'device', proc: 'amsengagementd', msg: 'Object decoding failed' },
+            { src: 'device', proc: 'Fixture', msg: 'the app itself complained' },
+            { src: 'client', msg: 'a redbox from the app' },
+          ],
+        }),
+      },
+    );
+    const text = errs.join('\n');
+    expect(text).toMatch(
+      /^  launch {6}2 error-level OS log lines during launch, none from com\.example\.app \(logs --source device\)$/m,
+    );
+    expect(text).toMatch(/^  launch {6}the app itself complained$/m);
+    expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
+    expect(text).not.toMatch(/attention client lost/);
+    expect(text).not.toMatch(/Object decoding failed/);
+  });
+
+  test('a launch that does not verify still prints every error it collected', async () => {
+    reserve();
+    const { errs, exitCode } = await run(
+      {},
+      {
+        verifyLaunch: async () => ({
+          fatal: true,
+          waitedMs: 2500,
+          processAlive: false,
+          errors: [{ src: 'device', proc: 'SpringBoard', msg: 'attention client lost event tag' }],
+        }),
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/attention client lost event tag/);
+  });
+
   test('the picker: an unverified launch is launched: "unverified", exit 0, and a loud warning', async () => {
     reserve();
     const { logs, errs, exitCode } = await run(
@@ -1642,7 +1686,7 @@ describe('success output', () => {
     expect(text).toMatch(/^  fingerprint a3f9b1\.\. miss \(\d+ms\)$/m);
     expect(text).toMatch(/^  build {7}compiling Debug with xcodebuild$/m);
     expect(text).toMatch(/^  build {7}ok \(2m41s\)$/m);
-    expect(text).toMatch(/^  install {5}-> stim-fixture \(BF2A\.\.\) \(\d+ms\)$/m);
+    expect(text).toMatch(/^  install {5}Fixture\.app -> stim-fixture \(BF2A\.\.\) \(\d+ms\)$/m);
     expect(text).toMatch(/^  launch {6}com\.example\.app \(\d+ms\)$/m);
   });
 
@@ -2725,7 +2769,7 @@ describe('the release cache key and the JS swap', () => {
     expect(calls.args.swapJsBundle.cachedAppPath).toBe(cached);
     expect(calls.args.installIosApp.appPath).toBe(join(root, 'js-swap', 'Fixture.app'));
     expect(calls.args.readBundleId).toBe(join(root, 'js-swap', 'Fixture.app'));
-    expect(errs.join('\n')).toMatch(/js swap/);
+    expect(errs.join('\n')).toMatch(/^  swap {8}/m);
   });
 
   test('a debug cache hit never swaps', async () => {
@@ -2746,7 +2790,7 @@ describe('the release cache key and the JS swap', () => {
       },
     );
     expect(exitCode).toBe(null);
-    expect(errs.join('\n')).toMatch(/js swap/);
+    expect(errs.join('\n')).toMatch(/^  swap {8}/m);
     expect(errs.join('\n')).toMatch(/building fresh instead/);
     expect(calls.order.includes('buildIos')).toBeTruthy();
     expect(calls.args.installIosApp.appPath).toBe(appPath);
@@ -2847,7 +2891,7 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
     const shift = errs.find((line) => /^  fingerprint\s+\S+ -> /.test(line));
     assert(shift, 'expected a fingerprint shift line on stderr');
     expect(shift).toMatch(/aaaaaa\.\. -> bbbbbb\.\./);
-    expect(shift).toMatch(/prebuild \+ pod install/);
+    expect(shift).toMatch(/\(after prebuild, pod install\)$/);
 
     const facts = parseFirst(logs);
     expect(facts.fingerprint).toBe(WARM);
@@ -2874,7 +2918,7 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
     expect(calls.order.includes('buildIos')).toBe(false);
     expect(calls.order.includes('storeBuild')).toBe(false);
     expect(calls.args.installIosApp.appPath).toBe(cachedApp);
-    expect(errs.join('\n')).toMatch(/hit under the post-prebuild key \(this tree was cold/);
+    expect(errs.join('\n')).toMatch(/^  cache {7}hit bbbbbb\.\. \(post-prebuild key\)$/m);
 
     const facts = parseFirst(logs);
     expect(facts.cacheHit).toBe('local');
@@ -3370,8 +3414,8 @@ describe('an app the simulator already holds', () => {
       },
     );
 
-    expect(stderr).toMatch(/install\s+unchanged; .*already holds this app; proof \(45\.6s\)/);
-    expect(stderr).toMatch(/dev client\s+prepared \(1\.2s\)/);
+    expect(stderr).toMatch(/^  install {5}unchanged \(stim-fixture already has this build\) \(45\.6s\)$/m);
+    expect(stderr).toMatch(/^  install {5}dev client prepared \(1\.2s\)$/m);
     expect(parseFirst(logs).installSkipped).toBe(true);
   });
 

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -41,3 +41,73 @@ export function shortHash(hash: unknown): string {
   const text = String(hash ?? '');
   return text.length > 8 ? `${text.slice(0, 6)}..` : text;
 }
+
+/**
+ * Every label Stim prints in the phase-line column. `''` is the continuation
+ * label for a wrapped fact. `app` and `compilation cache` appear only in the
+ * stdout summary block a successful run ends with.
+ */
+export const OUTPUT_LABELS: readonly string[] = [
+  '',
+  'app',
+  'branch',
+  'build',
+  'cache',
+  'carry',
+  'compilation cache',
+  'device',
+  'error',
+  'failed',
+  'fingerprint',
+  'gems',
+  'install',
+  'ip.txt',
+  'lan',
+  'launch',
+  'lease',
+  'log',
+  'logs',
+  'metro',
+  'pods',
+  'port',
+  'prebuild',
+  'ready',
+  'remedy',
+  'setting',
+  'state',
+  'stats',
+  'stop',
+  'swap',
+  'verify',
+];
+
+export function isOutputLabel(label: unknown): boolean {
+  return OUTPUT_LABELS.includes(String(label));
+}
+
+export interface LaunchErrorRecord {
+  src?: unknown;
+  proc?: unknown;
+  msg?: unknown;
+}
+
+/**
+ * Splits the error-level records a verified launch collected into the OS-log
+ * noise the run summarizes and the records it still prints one by one.
+ */
+export function launchErrorReport(
+  records: readonly LaunchErrorRecord[],
+  { appId, fromApp }: { appId: string; fromApp: (record: LaunchErrorRecord) => boolean },
+): { summary: string | null; lines: string[] } {
+  const noise = records.filter((record) => record.src === 'device' && !fromApp(record));
+  const lines = records
+    .filter((record) => !noise.includes(record))
+    .map((record) => (record.msg === undefined || record.msg === null ? '' : String(record.msg)))
+    .filter((msg) => msg !== '');
+  const noun = noise.length === 1 ? 'line' : 'lines';
+  const summary =
+    noise.length === 0
+      ? null
+      : `${noise.length} error-level OS log ${noun} during launch, none from ${appId} (logs --source device)`;
+  return { summary, lines };
+}

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -85,29 +85,27 @@ export function isOutputLabel(label: unknown): boolean {
   return OUTPUT_LABELS.includes(String(label));
 }
 
+/** The two fields a launch report reads off a collector's NDJSON record. */
 export interface LaunchErrorRecord {
   src?: unknown;
-  proc?: unknown;
   msg?: unknown;
+  [key: string]: unknown;
 }
 
 /**
- * Splits the error-level records a verified launch collected into the OS-log
- * noise the run summarizes and the records it still prints one by one.
+ * Splits the error-level records a verified launch collected into the device
+ * log the run counts and the records it still prints one by one.
  */
-export function launchErrorReport(
-  records: readonly LaunchErrorRecord[],
-  { appId, fromApp }: { appId: string; fromApp: (record: LaunchErrorRecord) => boolean },
-): { summary: string | null; lines: string[] } {
-  const noise = records.filter((record) => record.src === 'device' && !fromApp(record));
+export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summary: string | null; lines: string[] } {
+  const fromDevice = records.filter((record) => record.src === 'device');
   const lines = records
-    .filter((record) => !noise.includes(record))
+    .filter((record) => record.src !== 'device')
     .map((record) => (record.msg === undefined || record.msg === null ? '' : String(record.msg)))
     .filter((msg) => msg !== '');
-  const noun = noise.length === 1 ? 'line' : 'lines';
+  const noun = fromDevice.length === 1 ? 'record' : 'records';
   const summary =
-    noise.length === 0
+    fromDevice.length === 0
       ? null
-      : `${noise.length} error-level OS log ${noun} during launch, none from ${appId} (logs --source device)`;
+      : `${fromDevice.length} error-level ${noun} in the device log during launch (logs --errors --source device)`;
   return { summary, lines };
 }

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -13,7 +13,7 @@ import {
   type ProviderCallResult,
 } from '@stim-cli/cache';
 import type { AndroidFacts, RemoteDeviceBackend, SettingsObject, WaitedForBuild } from '../types.ts';
-import { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+import { formatDuration, launchErrorReport, phaseLine, shortHash, type LaunchErrorRecord } from '../command-output.ts';
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import { getExecutor } from '../exec.ts';
@@ -131,6 +131,7 @@ import { selectFromPool } from '../engine/device-pool.ts';
 import {
   DEBUG_VERIFY_STEP_MS,
   acquireRunLease,
+  leaseExpiryText,
   lostLine,
   lostRefusal,
   parseDeviceWait,
@@ -297,7 +298,7 @@ interface VerifyLaunchResultLike {
   requested?: boolean;
   fatal?: boolean;
   processAlive?: boolean | null;
-  errors?: Array<{ msg?: unknown }>;
+  errors?: LaunchErrorRecord[];
   waitedMs?: number;
 }
 
@@ -945,9 +946,9 @@ async function verifyAndroidRun({
         `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    for (const record of verification.errors ?? []) {
-      if (record.msg) phase('launch err', chalk.yellow(String(record.msg)));
-    }
+    const report = launchErrorReport(verification.errors ?? [], { appId: androidPackage, fromApp: () => true });
+    if (report.summary) phase('launch', chalk.dim(report.summary));
+    for (const line of report.lines) phase('launch', chalk.yellow(line));
     return true;
   }
   if (verification?.skipped) {
@@ -1292,8 +1293,8 @@ async function finishAndroidRun({
   phase(
     'install',
     installSkipped
-      ? `skipped; ${serial} already holds this APK ${installTimer()}`
-      : `${record.cacheHit ? `from ${record.cacheHit} cache` : basename(apkPath!)} ${installTimer()}`,
+      ? `unchanged (${serial} already has this build) ${installTimer()}`
+      : `${basename(apkPath!)} -> ${serial} ${installTimer()}`,
   );
   if (installed.note) {
     phase('install', chalk.yellow(installed.note));
@@ -1348,15 +1349,14 @@ async function finishAndroidRun({
       ? `launched ${androidPackage} on ${serial} (${variant}, embedded JS bundle, no Metro)`
       : `launched ${androidPackage} on ${serial} against Metro port ${metroPort}`,
   });
-  const launchMode = launched.mode === 'deep-link' ? 'expo-dev-client deep link' : launched.mode;
-  phase('launch', `${launchMode ? `${androidPackage} (${launchMode})` : androidPackage} ${launchTimer()}`);
+  phase('launch', `${androidPackage} ${launchTimer()}`);
 
   const reversedSummary = (launched.reversed ?? []).join(', ') || `tcp:${metroPort}->tcp:${metroPort}`;
   if (!release && launched.debugHttpHost) {
-    phase('wired', `debug_http_host ${launched.debugHttpHost} + adb reverse ${reversedSummary}`);
+    phase('metro', `debug_http_host ${launched.debugHttpHost} + adb reverse ${reversedSummary}`);
   } else if (!release) {
     phase(
-      'wired',
+      'metro',
       chalk.yellow(`adb reverse ${reversedSummary}; ${launched.debugHttpHostNote || 'debug_http_host not written'}`),
     );
     writer.write({
@@ -1367,7 +1367,7 @@ async function finishAndroidRun({
     });
   }
   if (launched.devClientNote) {
-    phase('wired', chalk.yellow(launched.devClientNote));
+    phase('metro', chalk.yellow(launched.devClientNote));
     writer.write({ src: 'build', level: 'warn', event: 'dev_client_link_failed', msg: launched.devClientNote });
   }
 
@@ -2085,8 +2085,11 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       });
     }
     const prepareMs = prepare();
-    if (prepareMs >= SLOW_STEP_MS) {
-      phase('device', `${device.avdName || device.deviceName || label} prepared (${formatDuration(prepareMs)})`);
+    if (device.created || prepareMs >= SLOW_STEP_MS) {
+      phase(
+        'device',
+        `${device.avdName || device.deviceName || label} ${device.created ? 'created' : 'prepared'} (${formatDuration(prepareMs)})`,
+      );
     }
 
     const bootTimer = stepTimer(now);
@@ -2357,7 +2360,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     let swapFellBack = false;
     const installableCachedApk = async (key: string, cachedPath: string): Promise<string | null> => {
       if (!release) return cachedPath;
-      phase('apk swap', `regenerating this workspace's JS for the cached ${variant} APK`);
+      phase('swap', `regenerating this workspace's JS for the cached ${variant} APK`);
       const swap = await swapApk({
         root,
         isExpo,
@@ -2367,17 +2370,17 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         storedAssets: storedAssets(PLATFORM, key),
       });
       if (swap?.ok && swap.apkPath) {
-        if (swap.note) phase('apk swap', chalk.yellow(swap.note));
+        if (swap.note) phase('swap', chalk.yellow(swap.note));
         swapDir = swap.tmpDir ?? null;
         phase(
-          'apk swap',
+          'swap',
           `${swap.hermes ? 'hermes bytecode' : 'plain JS'} repacked (store), zipaligned and re-signed (${formatDuration(swap.durationMs)})`,
         );
         return swap.apkPath;
       }
       if (swap?.assetMismatch) {
         phase(
-          'apk swap',
+          'swap',
           chalk.yellow(
             `${swap.reason} -- building fresh instead` +
               (swap.assetDiff ? ' (an APK cannot be made to carry an asset AAPT did not package)' : ''),
@@ -2385,7 +2388,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         );
       } else {
         phase(
-          'apk swap',
+          'swap',
           chalk.yellow(
             `failed at ${swap?.step || 'unknown step'}: ${swap?.reason || 'unknown reason'} -- ` +
               `building fresh instead (a cached ${variant} APK carries its builder's JS; it is never installed after a failed swap)`,
@@ -2448,13 +2451,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
               storeKey = buildCacheKey(PLATFORM, after.hash, variant ? { variant } : {});
               record.fingerprint = storeHash;
               record.cacheKey = storeKey;
-              phase(
-                'fingerprint',
-                chalk.dim(
-                  `${shortHash(hash)} -> ${shortHash(storeHash)} after prebuild; ` +
-                    'storing under the new key, which is the one the next run looks up',
-                ),
-              );
+              phase('fingerprint', chalk.dim(`${shortHash(hash)} -> ${shortHash(storeHash)} (after prebuild)`));
 
               const late = useBuildCache ? resolveCached(PLATFORM, storeKey) : null;
               if (late) {
@@ -2462,10 +2459,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
                 if (prepared) {
                   apkPath = prepared;
                   record.cacheHit = 'local';
-                  phase(
-                    'cache',
-                    'hit under the post-prebuild key (this tree was cold, so the first lookup could not find it)',
-                  );
+                  phase('cache', `hit ${shortHash(storeHash)} (post-prebuild key)`);
                 }
               }
             }
@@ -2497,7 +2491,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
               return false;
             }
             apkPath = built.apkPath ?? null;
-            phase('build', `${basename(apkPath!)} (${formatDuration(built.durationMs)})`);
+            phase('build', `ok (${formatDuration(built.durationMs)})`);
             if (built.apkNote) phase('build', chalk.yellow(built.apkNote));
 
             const beforeBuildHash = storeHash;
@@ -2523,10 +2517,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
                 record.cacheKey = storeKey;
                 phase(
                   'fingerprint',
-                  chalk.dim(
-                    `${shortHash(beforeBuildHash)} -> ${shortHash(storeHash)} after Gradle; ` +
-                      'storing under the new key, which is the one the next run looks up',
-                  ),
+                  chalk.dim(`${shortHash(beforeBuildHash)} -> ${shortHash(storeHash)} (after Gradle)`),
                 );
               }
 
@@ -2618,7 +2609,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       });
       if (acquired.status === 'leased') {
         stopLeaseSignals = onLeaseSignal(releaseLease);
-        phase('lease', `${acquired.kind} lease on ${device.serial} until ${acquired.expiresAt}`);
+        phase(
+          'lease',
+          `${acquired.kind} lease on ${device.serial} until ${leaseExpiryText(acquired.expiresAt, now())}`,
+        );
       }
     }
 

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -946,7 +946,7 @@ async function verifyAndroidRun({
         `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    const report = launchErrorReport(verification.errors ?? [], { appId: androidPackage, fromApp: () => true });
+    const report = launchErrorReport(verification.errors ?? []);
     if (report.summary) phase('launch', chalk.dim(report.summary));
     for (const line of report.lines) phase('launch', chalk.yellow(line));
     return true;

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -55,7 +55,7 @@ line by design (see \`guide logs\`), not this single-payload contract.
                   is printed on stderr as one dim line naming both short
                   hashes. A prebuild shift is RE-LOOKED-UP before anything
                   compiles (\`cache
-                  hit under the post-prebuild key\`), so a cold tree -- a
+                  hit 6564e2.. (post-prebuild key)\`), so a cold tree -- a
                   fresh worktree or clone of a CNG app -- installs an entry
                   another workspace already built instead of compiling
                   beside it. Android also fingerprints after Gradle because
@@ -109,8 +109,14 @@ line by design (see \`guide logs\`), not this single-payload contract.
                                  alive through a three-second stability window.
                                  The command checks process liveness when the
                                  platform exposes it. Errors from that window
-                                 are printed even when the app stays alive; the
-                                 agent decides whether a nonfatal error matters.
+                                 are printed even when the app stays alive,
+                                 EXCEPT the error-level device-log records that
+                                 did not come from the app's own process: those
+                                 are counted into one \`launch\` line pointing at
+                                 \`logs --source device\` (see \`guide logs\`),
+                                 because on iOS every Apple framework in the
+                                 app's process logs there. The agent decides
+                                 whether a nonfatal error matters.
                                  IT IS NOT A PAINTED SCREEN. Stim observes the
                                  bundle and the process, never a frame, and a
                                  cold app can keep rendering for a minute or
@@ -575,12 +581,21 @@ WHAT WRITES WHAT
                        the app's process also logs. The proven noise sources
                        are recorded at info rather than error; the rest is why
                        --errors leaves this source out unless asked. A VERIFIED
-                       LAUNCH also drops one iOS device record from the RUN
-                       SUMMARY: the connection refusal \`TCP Conn ... Failed :
-                       error 0:61 [61]\` (61 is ECONNREFUSED). The app got its
-                       bundle over this workspace's Metro and outlived the
-                       stability window, so it recovered. A refusal before the
-                       launch verifies still prints, and the record stays an
+                       LAUNCH prints NONE of these records one by one. It counts
+                       the error-level device records that did not come from the
+                       app's own process and prints one line instead:
+
+                         launch      12 error-level OS log lines during launch,
+                                     none from com.example.app
+                                     (logs --source device)
+
+                       The connection refusal \`TCP Conn ... Failed :
+                       error 0:61 [61]\` (61 is ECONNREFUSED) is not even
+                       counted. The app got its bundle over this workspace's
+                       Metro and outlived the stability window, so it
+                       recovered. A refusal before the
+                       launch verifies still prints, as does every record on a
+                       launch that does not verify, and the record stays an
                        error in device.ndjson either way; read it with
                        \`logs --errors --source device\`.
 
@@ -729,7 +744,7 @@ FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
   copy of the APK. When any step of that swap fails (the bundle command,
   hermesc, the re-sign, zipalign, apksigner), the run does NOT install the
   cached artifact -- its baked-in JS is the builder's, not yours -- and does
-  NOT fail: it prints a \`js swap\` / \`apk swap  failed at <step>: ... --
+  NOT fail: it prints a \`swap        failed at <step>: ... --
   building fresh instead\` note on stderr and falls back to a full build. If
   the run then fails, the code is the build's own (STIM_BUILD_FAILED etc.);
   the swap note above it says why the cache hit was not used. A swap that
@@ -741,7 +756,7 @@ FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
   against the assets the cached APK carries. Any added, removed or changed
   asset prints
 
-    apk swap    this workspace's asset set differs from the cached APK's
+    swap        this workspace's asset set differs from the cached APK's
                 (1 added, 0 changed, 0 removed; e.g. added
                 res/drawable-mdpi/new_logo.png) -- building fresh instead
 
@@ -1484,14 +1499,28 @@ Repeat step 3 whenever a NATIVE input changes. A JS-only edit needs nothing --
 that is what Fast Refresh over the running dev server is for.
 
 PROGRESS ON A LONG RUN
-  The whole summary is stderr; stdout carries only the \`--json\` payload. A
-  step that costs real time is named and timed, including the step that
+  The whole summary is stderr; stdout carries only the \`--json\` payload. Every
+  progress line has the same shape -- two spaces, a label padded to eleven
+  columns, the FACT, and the time the step cost:
+
+    <label>     <fact> (<duration>)
+
+  The labels are a closed set: device, metro, lan, lease, fingerprint,
+  prebuild, pods, gems, cache, build, swap, ip.txt, install, launch, verify,
+  logs, branch, carry, ready, stop, port, plus error / remedy / log / failed
+  on a failure. A line states a fact; the reason a fact matters lives in this
+  guide, not in the run output. Both platforms use the same words, so
+  \`build       ok (51.8s)\` and \`launch      com.example.app (2s)\` read the
+  same on iOS and Android; the artifact name is in the \`--json\` payload.
+
+  A step that costs real time is named and timed, including the step that
   creates or reconciles the owned device before anything is fingerprinted:
 
     device      stim-app-412 (BF2A..) created (2m14s)
 
   A step that is still running heartbeats every 30 seconds, on the 30-second
-  grid, so the values read 30s, 1m00s, 1m30s and never repeat:
+  grid, so the values read 30s, 1m00s, 1m30s and never repeat. A heartbeat
+  reuses its phase's label and column:
 
     build       still running (1m30s): > Task :app:compileDebugKotlin
     build       waiting on /w/app-411 (pid 41233, 1m30s elapsed)
@@ -1510,14 +1539,14 @@ AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
   is skipped. The phase still reports the cost of proving that identity, but
   avoids the ~43s a 400MB APK can cost to copy and install over USB.
 
-    install     skipped; emulator-5584 already holds this APK (0.4s)
+    install     unchanged (emulator-5584 already has this build) (0.4s)
 
   On iOS the install line names the identity proof separately from the Expo
   dev-client preference writes, so a slow simulator command is never charged
   to an install that did not run:
 
-    install     unchanged; stim-app (BF2A..) already holds this app; proof (0.4s)
-    dev client  prepared (0.9s)
+    install     unchanged (stim-app already has this build) (0.4s)
+    install     dev client prepared (0.9s)
 
   The skip needs PROOF. A package that is not installed, a split install, an
   image without \`sha256sum\`, and any adb or simctl failure all read as
@@ -1610,6 +1639,22 @@ THE BUILD CACHE HAS THREE LEVELS
   stored its fingerprint sources beside the cache entry, the fingerprint line
   gains " -- N sources changed: <up to three paths>", and the full list
   (capped at 20 names) lands in the build log as a fingerprint_diff record.
+
+  THE KEY CAN MOVE MID-RUN, and the run says so in two facts rather than two
+  explanations. \`expo prebuild\` and \`pod install\` rewrite fingerprinted
+  files while they work, so the run fingerprints again afterwards:
+
+    fingerprint dcbd8d.. -> 6564e2.. (after prebuild, pod install)
+    cache       hit 6564e2.. (post-prebuild/pod install key)
+
+  The first line means the artifact, the \`lastBuild\` record and any remote
+  upload are stored under the SECOND hash -- the one the next run in this tree
+  computes, and therefore the one it looks up. The second line only appears on
+  a tree that was COLD: the first lookup ran on the pre-prebuild hash and
+  could not find an entry another workspace had already stored under the
+  post-prebuild one, so re-resolving under the moved key installs it instead
+  of compiling beside it. No second line means nothing was found there and the
+  run compiles.
 
 WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   Every entry is keyed on what the tree hashes, so two workspaces share an

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -589,14 +589,18 @@ WHAT WRITES WHAT
                        point. Both collectors already narrow the stream to the
                        app: the simulator's \`log stream\` runs under a
                        processImagePath predicate, and \`adb logcat\` is filtered
-                       to the app's pid. So every record left is inside the
-                       app's own process, and the error-level ones are the Apple
-                       frameworks running there -- "Failed to send CA Event for
-                       app launch measurements", "NSBundle (null) initWithPath
-                       failed", the TCP refusal. Nothing about the record says
-                       which of them wrote it, so the run does not guess; a
-                       count plus the command that shows the records is the
-                       honest report. The app's OWN errors are not in this
+                       to the app's pid. So every record left is MEANT to be
+                       inside the app's own process, and the error-level ones
+                       are the Apple frameworks running there -- "Failed to send
+                       CA Event for app launch measurements", "NSBundle (null)
+                       initWithPath failed", the TCP refusal. Nothing about the
+                       record says which of them wrote it, so the run does not
+                       guess; a count plus the command that shows the records is
+                       the honest report. The iOS predicate matches on a
+                       substring of the process path today, which a short app
+                       name can widen past the app -- appandflow/stim#264
+                       anchors it. Until it lands, read the records rather than
+                       trusting the count to be the app's alone. The app's OWN errors are not in this
                        number: a redbox or a console.error arrives on the client
                        or metro source and still prints line by line.
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -110,13 +110,10 @@ line by design (see \`guide logs\`), not this single-payload contract.
                                  The command checks process liveness when the
                                  platform exposes it. Errors from that window
                                  are printed even when the app stays alive,
-                                 EXCEPT the error-level device-log records that
-                                 did not come from the app's own process: those
-                                 are counted into one \`launch\` line pointing at
-                                 \`logs --source device\` (see \`guide logs\`),
-                                 because on iOS every Apple framework in the
-                                 app's process logs there. The agent decides
-                                 whether a nonfatal error matters.
+                                 EXCEPT the device log's, which is COUNTED into
+                                 one \`launch\` line instead (see
+                                 \`guide logs\`). The agent decides whether a
+                                 nonfatal error matters.
                                  IT IS NOT A PAINTED SCREEN. Stim observes the
                                  bundle and the process, never a frame, and a
                                  cold app can keep rendering for a minute or
@@ -582,12 +579,26 @@ WHAT WRITES WHAT
                        are recorded at info rather than error; the rest is why
                        --errors leaves this source out unless asked. A VERIFIED
                        LAUNCH prints NONE of these records one by one. It counts
-                       the error-level device records that did not come from the
-                       app's own process and prints one line instead:
+                       them and prints one line instead:
 
-                         launch      12 error-level OS log lines during launch,
-                                     none from com.example.app
-                                     (logs --source device)
+                         launch      9 error-level records in the device log
+                                     during launch
+                                     (logs --errors --source device)
+
+                       THE COUNT IS NOT ATTRIBUTED TO ANYTHING, and that is the
+                       point. Both collectors already narrow the stream to the
+                       app: the simulator's \`log stream\` runs under a
+                       processImagePath predicate, and \`adb logcat\` is filtered
+                       to the app's pid. So every record left is inside the
+                       app's own process, and the error-level ones are the Apple
+                       frameworks running there -- "Failed to send CA Event for
+                       app launch measurements", "NSBundle (null) initWithPath
+                       failed", the TCP refusal. Nothing about the record says
+                       which of them wrote it, so the run does not guess; a
+                       count plus the command that shows the records is the
+                       honest report. The app's OWN errors are not in this
+                       number: a redbox or a console.error arrives on the client
+                       or metro source and still prints line by line.
 
                        The connection refusal \`TCP Conn ... Failed :
                        error 0:61 [61]\` (61 is ECONNREFUSED) is not even
@@ -790,10 +801,10 @@ FALLBACK NOTES THAT ARE NOT CODES (release cache hits)
   until someone taps Trust again. The retry is one uninstall and one install --
   it is not a way around a tap that has no API.
 
-  THE DEVICE FALLBACKS are the fourth, and both print a \`device app\` note and
+  THE DEVICE FALLBACKS are the fourth, and both print a \`cache\` note and
   build fresh rather than failing:
 
-    device app  a cached Release device app carries its builder's JS, and the
+    cache       a cached Release device app carries its builder's JS, and the
                 device JS swap lands with phase 6 of appandflow/stim#178 --
                 building fresh instead, which bakes in this workspace's JS
 
@@ -1505,13 +1516,22 @@ PROGRESS ON A LONG RUN
 
     <label>     <fact> (<duration>)
 
-  The labels are a closed set: device, metro, lan, lease, fingerprint,
-  prebuild, pods, gems, cache, build, swap, ip.txt, install, launch, verify,
-  logs, branch, carry, ready, stop, port, plus error / remedy / log / failed
-  on a failure. A line states a fact; the reason a fact matters lives in this
-  guide, not in the run output. Both platforms use the same words, so
-  \`build       ok (51.8s)\` and \`launch      com.example.app (2s)\` read the
-  same on iOS and Android; the artifact name is in the \`--json\` payload.
+  The labels are a closed set, and nothing else is ever printed in that
+  column:
+
+    device      metro       lan         lease       fingerprint
+    prebuild    pods        gems        cache       build
+    swap        ip.txt      install     launch      verify
+    logs        branch      carry       ready       stop
+    port        setting     state       stats       error
+    remedy      log         failed
+
+  \`app\` and \`compilation cache\` join them in the stdout block a successful
+  run ends with, and nowhere else. A line states a fact; the reason a fact
+  matters lives in this guide, not in the run output. Both platforms use the
+  same words, so \`build       ok (51.8s)\` and
+  \`launch      com.example.app (2s)\` read the same on iOS and Android; the
+  artifact name is in the \`--json\` payload.
 
   A step that costs real time is named and timed, including the step that
   creates or reconciles the owned device before anything is fingerprinted:

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -29,7 +29,7 @@ import {
   untrackedNativeFiles,
 } from '../build-cache.ts';
 import type { FingerprintSource } from '@expo/fingerprint';
-import { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+import { formatDuration, launchErrorReport, phaseLine, shortHash, type LaunchErrorRecord } from '../command-output.ts';
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import {
@@ -90,6 +90,7 @@ import { selectFromPool } from '../engine/device-pool.ts';
 import {
   DEBUG_VERIFY_STEP_MS,
   acquireRunLease,
+  leaseExpiryText,
   lostLine,
   lostRefusal,
   parseDeviceWait,
@@ -243,7 +244,7 @@ interface VerifyLaunchResultLike {
   requested?: boolean;
   fatal?: boolean;
   processAlive?: boolean | null;
-  errors?: Array<{ msg?: unknown }>;
+  errors?: LaunchErrorRecord[];
   waitedMs?: number;
 }
 
@@ -323,6 +324,10 @@ export function shortUdid(udid: unknown): string {
 export function deviceLabel(device: DeviceLike | null | undefined, udid: unknown): string {
   const name = device?.deviceName || device?.name || null;
   return name ? `${name} (${shortUdid(udid)})` : shortUdid(udid);
+}
+
+export function deviceShortName(device: DeviceLike | null | undefined, udid: unknown): string {
+  return device?.deviceName || device?.name || shortUdid(udid);
 }
 
 export function appNameFromPath(appPath: unknown): string | null {
@@ -1155,9 +1160,7 @@ async function verifyIosRun({
         `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    for (const record of verification.errors ?? []) {
-      if (record.msg) note(chalk.yellow(phaseLine('launch err', String(record.msg))));
-    }
+    reportLaunchErrors(verification.errors ?? [], { note, appId: bundleId, appProcess: appName ?? null });
     return true;
   }
   if (verification?.skipped) {
@@ -1202,6 +1205,18 @@ async function verifyIosRun({
   }))
     note(chalk.yellow(phaseLine('', line)));
   return LAUNCH_UNVERIFIED;
+}
+
+function reportLaunchErrors(
+  errors: LaunchErrorRecord[],
+  { note, appId, appProcess }: { note: (line: string) => void; appId: string; appProcess: string | null },
+): void {
+  const report = launchErrorReport(errors, {
+    appId,
+    fromApp: (record) => appProcess !== null && record.proc === appProcess,
+  });
+  if (report.summary) note(chalk.dim(phaseLine('launch', report.summary)));
+  for (const line of report.lines) note(chalk.yellow(phaseLine('launch', line)));
 }
 
 async function finishIosUpload(
@@ -1532,7 +1547,7 @@ async function finishIosRun({
         build: { ...buildFailure, appPath, bundleId },
       });
     }
-    phase('install', `-> ${deviceLabel(device, udid)} ${installTimer()}`);
+    phase('install', `${basename(appPath!)} -> ${deviceLabel(device, udid)} ${installTimer()}`);
     if (installed?.note) {
       note(chalk.yellow(phaseLine('install', installed.note)));
       logWriter().write({ src: 'build', level: 'warn', event: 'install_uninstalled_first', msg: installed.note });
@@ -1584,12 +1599,7 @@ async function finishIosRun({
       ...(payloadUrl ? { url: payloadUrl } : {}),
       ...(lanOriginUrl ? { jsLocation: lanOriginUrl } : {}),
     };
-    phase(
-      'launch',
-      `${bundleId!} pid ${started.pid} on the phone` +
-        (payloadUrl ? ', opened on the dev-client URL' : '') +
-        ` ${launchTimer()}`,
-    );
+    phase('launch', `${bundleId!} pid ${started.pid} ${launchTimer()}`);
   } else {
     const installTimer = stepTimer(d.now);
     const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme }, { now: d.now });
@@ -1609,11 +1619,11 @@ async function finishIosRun({
     phase(
       'install',
       installSkipped
-        ? `unchanged; ${deviceLabel(device, udid)} already holds this app; proof ${artifactDuration}`
-        : `-> ${deviceLabel(device, udid)} ${artifactDuration}`,
+        ? `unchanged (${deviceShortName(device, udid)} already has this build) ${artifactDuration}`
+        : `${basename(appPath!)} -> ${deviceLabel(device, udid)} ${artifactDuration}`,
     );
     if (!remoteDevice && installed?.devClientPreparationDurationMs !== undefined) {
-      phase('dev client', `prepared (${formatDuration(installed.devClientPreparationDurationMs)})`);
+      phase('install', `dev client prepared (${formatDuration(installed.devClientPreparationDurationMs)})`);
     }
 
     dropSwapDir();
@@ -2441,7 +2451,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         fail({ code, message: reason, remedy, build: { ...buildFailure, appPath: path } });
         return null;
       }
-      note(chalk.yellow(phaseLine('device app', `${reason} -- building fresh instead`)));
+      note(chalk.yellow(phaseLine('cache', `${reason} -- building fresh instead`)));
       note(chalk.dim(phaseLine('', remedy)));
       swapFellBack = true;
       return null;
@@ -2456,7 +2466,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         note(
           chalk.yellow(
             phaseLine(
-              'device app',
+              'cache',
               `a cached ${configuration} device app carries its builder's JS, and the device JS swap lands with ` +
                 "phase 6 of appandflow/stim#178 -- building fresh instead, which bakes in this workspace's JS",
             ),
@@ -2513,13 +2523,13 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   const installableCachedApp = async (cachedPath: string): Promise<string | null> => {
     if (physical) return prepareDeviceApp(cachedPath, { fresh: false });
     if (!release) return cachedPath;
-    phase('js swap', `regenerating this workspace's JS for the cached ${configuration} app`);
+    phase('swap', `regenerating this workspace's JS for the cached ${configuration} app`);
     const swap = await d.swapJsBundle({ root, isExpo, cachedAppPath: cachedPath, logWriter: logWriter() });
     if (swap?.ok && swap.appPath) {
-      if (swap.note) note(chalk.yellow(phaseLine('js swap', swap.note)));
+      if (swap.note) note(chalk.yellow(phaseLine('swap', swap.note)));
       swapDir = swap.tmpDir ?? null;
       phase(
-        'js swap',
+        'swap',
         `${swap.hermes ? 'hermes bytecode' : 'plain JS'} + assets replaced, re-signed (${formatDuration(swap.durationMs ?? 0)})`,
       );
       return swap.appPath;
@@ -2527,7 +2537,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     note(
       chalk.yellow(
         phaseLine(
-          'js swap',
+          'swap',
           `failed at ${swap?.step || 'unknown step'}: ${swap?.reason || 'unknown reason'} -- ` +
             `building fresh instead (a cached ${configuration} app carries its builder's JS; it is never installed after a failed swap)`,
         ),
@@ -2627,8 +2637,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
               chalk.dim(
                 phaseLine(
                   'fingerprint',
-                  `${shortHash(fingerprint)} -> ${shortHash(storeHash)} after ${mutatingSteps.join(' + ')}; ` +
-                    'storing under the new key, which is the one the next run looks up',
+                  `${shortHash(fingerprint)} -> ${shortHash(storeHash)} (after ${mutatingSteps.join(', ')})`,
                 ),
               ),
             );
@@ -2639,10 +2648,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
               if (prepared) {
                 appPath = prepared;
                 cacheHit = 'local';
-                phase(
-                  'cache',
-                  `hit under the post-${mutatingSteps.join('/')} key (this tree was cold, so the first lookup could not find it)`,
-                );
+                phase('cache', `hit ${shortHash(storeHash)} (post-${mutatingSteps.join('/')} key)`);
               }
             }
           }
@@ -2755,7 +2761,10 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       });
       if (acquired.status === 'leased') {
         stopLeaseSignals = d.releaseLeaseOnSignal(releaseLease);
-        phase('lease', `${acquired.kind} lease on ${physicalDevice.udid} until ${acquired.expiresAt}`);
+        phase(
+          'lease',
+          `${acquired.kind} lease on ${physicalDevice.udid} until ${leaseExpiryText(acquired.expiresAt, d.now())}`,
+        );
       }
     }
 

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1160,7 +1160,7 @@ async function verifyIosRun({
         `, stable for 3s -- the first screen may still be rendering` +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    reportLaunchErrors(verification.errors ?? [], { note, appId: bundleId, appProcess: appName ?? null });
+    reportLaunchErrors(verification.errors ?? [], note);
     return true;
   }
   if (verification?.skipped) {
@@ -1207,14 +1207,8 @@ async function verifyIosRun({
   return LAUNCH_UNVERIFIED;
 }
 
-function reportLaunchErrors(
-  errors: LaunchErrorRecord[],
-  { note, appId, appProcess }: { note: (line: string) => void; appId: string; appProcess: string | null },
-): void {
-  const report = launchErrorReport(errors, {
-    appId,
-    fromApp: (record) => appProcess !== null && record.proc === appProcess,
-  });
+function reportLaunchErrors(errors: LaunchErrorRecord[], note: (line: string) => void): void {
+  const report = launchErrorReport(errors);
   if (report.summary) note(chalk.dim(phaseLine('launch', report.summary)));
   for (const line of report.lines) note(chalk.yellow(phaseLine('launch', line)));
 }
@@ -1872,7 +1866,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
   }
   const cacheProviderConfig = d.resolveCacheProviderConfig(settingsContext);
   for (const key of unknownSettingKeys(settings)) {
-    note(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
+    note(phaseLine('setting', chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`)));
   }
   const cacheProviderError = cacheProviderSettingError(settings);
   if (cacheProviderError) note(chalk.yellow(phaseLine('cache', `${cacheProviderError} Using the local cache.`)));

--- a/packages/stim-cli/src/engine/apk-swap.ts
+++ b/packages/stim-cli/src/engine/apk-swap.ts
@@ -302,7 +302,7 @@ export async function swapApkBundle({
     elapsed,
     lastLine: () => transcript.at(-1) ?? '',
     emit: onHeartbeat,
-    label: 'apk swap',
+    label: 'swap',
   });
   let outcome: Awaited<ReturnType<typeof waitForChild>>;
   try {

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { phaseLine } from '../command-output.ts';
 import {
   allConsolePortsAndSerials,
   clearDevice,
@@ -193,7 +194,7 @@ async function ensureOwnedIosDevice({
           );
         }
         if (sim.state !== 'Booted') {
-          out(chalk.dim(`Booting owned sim ${sim.name} (${sim.udid})...`));
+          out(chalk.dim(phaseLine('device', `booting ${sim.name} (${sim.udid})`)));
           bootIosSim(sim.udid);
         }
         const updated = {
@@ -238,7 +239,6 @@ async function ensureOwnedIosDevice({
     deviceType: flags.deviceType || settings.ios?.deviceType,
     runtime: flags.runtime || settings.ios?.runtime,
   });
-  out(chalk.dim(`Created owned sim ${created.name} (${created.udid})`));
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
   setDevice(projectPath, 'ios', newRecord);
   bootIosSim(created.udid);
@@ -265,8 +265,9 @@ async function configureOwnedIosSim({
   out: Notify;
   reconcileIosSimulator: typeof reconcileSimSlim;
 }): Promise<OwnedDeviceRecord> {
-  if (profile) out(chalk.dim(`Applying the configured SimSlim profile to ${record.deviceUdid}...`));
-  else if (record.simslimManaged) out(chalk.dim(`Restoring stock simulator services on ${record.deviceUdid}...`));
+  if (profile) out(chalk.dim(phaseLine('device', `applying the SimSlim profile to ${record.deviceUdid}`)));
+  else if (record.simslimManaged)
+    out(chalk.dim(phaseLine('device', `restoring stock simulator services on ${record.deviceUdid}`)));
 
   const previouslyManaged = Boolean(record.simslimManaged);
   if (profile && !record.simslimManaged) {
@@ -423,7 +424,7 @@ async function ensureOwnedAndroidDevice({
         );
       }
       created = { avdName, systemImage: ownedAvdSystemImage(avdName) };
-      out(chalk.dim(`Recovered existing owned AVD ${avdName} (unrecorded from a prior run)`));
+      out(chalk.dim(phaseLine('device', `recovered ${avdName} (unrecorded from a prior run)`)));
     } else {
       throw e;
     }
@@ -453,7 +454,6 @@ async function ensureOwnedAndroidDevice({
       );
     }
   }
-  out(chalk.dim(`Created owned AVD ${created.avdName}`));
   return {
     ...(await bootOwnedAvdOnFreshPort({
       avdName: created.avdName,
@@ -463,6 +463,7 @@ async function ensureOwnedAndroidDevice({
       logFile,
       alive,
     })),
+    created: true,
     systemImage: created.systemImage,
   };
 }
@@ -535,7 +536,7 @@ async function bootOwnedAvdOnFreshPort({
   const serial = `emulator-${claim.consolePort}`;
   try {
     const pid = bootAndroidEmulator(avdName, claim.consolePort, { logFile });
-    out(chalk.dim(`Waiting for ${serial} to finish booting...`));
+    out(chalk.dim(phaseLine('device', `waiting for ${serial} to finish booting`)));
     const result = await waitForBoot(serial, 120000, { aborted: emulatorGone(pid, alive) });
     if (!result.ok) {
       throw new Error(
@@ -807,7 +808,7 @@ async function ensureIosBooted({
   const sim = resolved.sim as SimRecord;
   if (sim.state === 'Booted') return { ok: true, udid };
 
-  out(chalk.dim(`Booting sim ${sim.name} (${udid})...`));
+  out(chalk.dim(phaseLine('device', `booting ${sim.name} (${udid})`)));
   const bootDeadline = Date.now() + timeoutMs;
   try {
     bootIosSim(udid, { timeoutMs });
@@ -882,7 +883,7 @@ async function ensureAndroidBooted({
   }
 
   const serial = `emulator-${pickConsolePort(device.consolePort)}`;
-  out(chalk.dim(`Booting owned AVD ${device.avdName} as ${serial}...`));
+  out(chalk.dim(phaseLine('device', `booting ${device.avdName} as ${serial}`)));
   let pid: number | null = null;
   try {
     pid = bootAndroidEmulator(device.avdName, Number(serial.replace(/^emulator-/, '')), { logFile });

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import chalk from 'chalk';
+import { phaseLine } from '../command-output.ts';
 import { getExecutor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
@@ -462,11 +463,7 @@ export async function buildAndroid(
   const task = assembleTaskFor(variant);
   const args = gradleArgs(task, { buildCache });
   if (buildCache) {
-    onNote(
-      chalk.dim(
-        'gradle build cache on for this build: --build-cache (shared under the Gradle user home; gradle.properties is not touched)',
-      ),
-    );
+    onNote(chalk.dim(phaseLine('cache', 'gradle build cache on (--build-cache, shared under the Gradle user home)')));
   }
 
   logWriter?.write?.({

--- a/packages/stim-cli/src/engine/js-swap.ts
+++ b/packages/stim-cli/src/engine/js-swap.ts
@@ -219,7 +219,7 @@ export async function swapJsBundle({
     elapsed,
     lastLine: () => transcript.at(-1) ?? '',
     emit: onHeartbeat,
-    label: 'js swap',
+    label: 'swap',
   });
   let outcome: Awaited<ReturnType<typeof waitForChild>>;
   try {

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -6,7 +6,7 @@ import { register } from '../cache-manifest.ts';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { sharedCompilationCache, workspaceDerivedData } from '../paths.ts';
-import { formatElapsed } from '../command-output.ts';
+import { formatElapsed, phaseLine } from '../command-output.ts';
 import { createLineReader } from '../process-output.ts';
 import { capDiagnostics, describeDiagnostic, type Diagnostic, extractXcodeDiagnostics } from './errors-xcode.ts';
 import { cleanLine } from '../supervisor/server-expo.ts';
@@ -254,11 +254,7 @@ function resolveCompilationCacheSettings({
       prune: 'atomic',
       note: 'shared Xcode compilation cache',
     });
-    onNote(
-      chalk.dim(
-        `compilation cache on for this build: CAS at ${casPath} (Stim sets it on its own xcodebuild; the Podfile is not touched)`,
-      ),
-    );
+    onNote(chalk.dim(phaseLine('cache', `compilation cache on (CAS at ${casPath})`)));
   }
   return settings;
 }
@@ -376,7 +372,7 @@ export function heartbeatLine(elapsedMs: number, lastLine: string, label = 'buil
   const hint =
     lastLine.length > HEARTBEAT_HINT_LENGTH ? `${lastLine.slice(0, HEARTBEAT_HINT_LENGTH - 3)}...` : lastLine;
   const activity = hint.trim() === '' ? '' : `: ${hint}`;
-  return `${label.padEnd(11)} still running (${formatElapsed(elapsedMs)})${activity}`;
+  return phaseLine(label, `still running (${formatElapsed(elapsedMs)})${activity}`);
 }
 
 export type HeartbeatSchedule = (run: () => void, delayMs: number) => () => void;
@@ -633,7 +629,7 @@ export async function buildIos({
         cacheableTasks: activity.cacheableTasks,
         hitRatePercent: activity.hitRatePercent,
       });
-      onNote(`compilation cache ${compilationCacheActivityLine(activity)}`);
+      onNote(phaseLine('cache', `compilation cache ${compilationCacheActivityLine(activity)}`));
     }
   };
 


### PR DESCRIPTION
## Description

Run output mixed three formats — indented phase lines, unindented heartbeats (`pods        still running`), free text (`compilation cache 0/171 hits`, `Created owned sim ...`) — worded the same fact differently per platform, and ended a passing simulator launch with a dozen `launch err` lines of OS noise. This collapses it to one vocabulary. Warm `stim ios` on a real app, from this branch:

```
  fingerprint ab703f.. hit (2.4s)
  device      stim-issue-260 (C5F8..) booted (80ms)
  install     unchanged (stim-issue-260 already has this build) (399ms)
  install     dev client prepared (718ms)
  launch      com.appandflow.trailhead (333ms)
  verify      bundle loaded, process alive, stable for 3s -- the first screen may still be rendering (3.4s total)
```

Line 3 is the one the maintainer flagged: `install     skipped; ... already holds this app (45.6s)` read as a fault when it is the cheapest possible outcome.

PR 1 of two for #260: `ios` and `android` run output. PR 2 (#262) applies the same vocabulary to `worktree create`, `start` and `stop`.

## Solution

Every progress line is `  <label padded to 11> <fact> (<duration>)` on stderr, and the label set is a closed, exported list (`OUTPUT_LABELS` in `command-output.ts`) that a contract test enforces by scraping every `phase(`/`phaseLine(` label literal out of `ios.ts` and `android.ts` — the two files this PR touches. A second test checks the guide spells out the same set, including `setting`, `state`, `stats` and the two (`app`, `compilation cache`) that appear only in the stdout summary block. `js swap`/`apk swap` collapse to `swap`, `wired` to `metro`, `dev client` and `device app` to `install` and `cache`; `launch err` is gone. Heartbeats go through `phaseLine` so they land in their phase's column, and the compilation-cache, Gradle-cache and device sentences that were free text are now `cache` and `device` lines. Lines state facts: `fingerprint dcbd8d.. -> 6564e2.. (after prebuild, pod install)` and `cache hit 6564e2.. (post-prebuild key)` replace the two that explained inline what a moved key means, and `guide lifecycle` now says it once, at length.

**The verified-launch rule is the one behavior change.** After a launch verifies, the error-level records the device collector wrote are counted into one line instead of printed:

```
  launch      9 error-level records in the device log during launch (logs --errors --source device)
```

only when there were any, with the records untouched in `device.ndjson`.

**The count is deliberately not attributed to anything.** Both collectors already narrow the device stream to the app — the simulator's `log stream` runs under a `processImagePath CONTAINS[c] "<appName>"` predicate, `adb logcat` under the app's pid — so every error-level record left is an Apple framework running *inside the app's own process*, and nothing in the record distinguishes them. A real run bears this out: the nine error records in a `stim ios` timeline are all `proc: "Trailhead"` and all framework noise (`Failed to send CA Event for app launch measurements`, `NSBundle (null) initWithPath failed`, the TCP refusal). An earlier revision of this branch filtered on `proc`, which would have printed every one of those nine. The SpringBoard/`amsengagementd` lines in the issue's transcript came from a fixture named `app.app` making that case-insensitive predicate leak — a separate bug, filed on its own.

The app's own errors are unaffected: a redbox or a `console.error` arrives on the client or metro source and still prints line by line. A launch that does not verify, or that is fatal, still prints every record, and #220's TCP-refusal filter inside `verifyLaunch` is untouched.

Platform parity for the rest: `build ok (<time>)` and `launch <bundle id> (<time>)` on both, `install <artifact> -> <device> (<time>)`, `install unchanged (<device> already has this build)`, and `device <name> created|booted|prepared`.

- The phone launch line is `launch      com.example.app pid 964 (1.5s)` — `pid` only where the pid is the launch proof. **Dropping #204's `, opened on the dev-client URL` clause is deliberate**: the launch line reports the launch, and the dev-client fact survives where it is actionable — the build log's launch marker records `(expo-dev-client)`, and an unverified launch still prints the deep link verbatim as a pasteable command (#204's remedy, unchanged). Note it is *not* in the iOS `--json` payload, which has no `devClientUrl` field; adding one would change the payload, which this PR does not do.
- **#220's `prepared` gate is preserved**: the device line prints only when the device was created or the reconcile took at least `SLOW_STEP_MS` (2 s), so a fast no-op stays silent. Android's `created` case is new — `ensureOwnedAndroidDevice` returns `created: true` rather than printing `Created owned AVD ...` as free text, which is what lets the emulator report creation the way the simulator already did. It has no serial yet at that point, so unlike the iOS line it carries the name only. Both levels of the gate are pinned.
- The run lease prints `until 02:54:18 (60s from now)` through the existing `leaseExpiryText` instead of an ISO timestamp.

The `OK:`/`failed` summary block on stdout, the `verify` ready sentence, the `launched` states and the `--json` payloads are unchanged (invariants 7 and 11), as is everything the physical-device remedies print as commands.

**Risk.** Output-only apart from the launch count. Its worst case is that a device-log error an agent would have wanted gets summarized instead of shown; the line names the exact command that shows them and the records stay at error level in `device.ndjson`, so nothing is lost, and the counted records are by construction from the app's process rather than the app's code.

## Test plan

`pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (3284 pass), `pnpm run knip`, `pnpm run test:e2e` (20 pass).

Every test that pinned a changed line was updated, not deleted: the heartbeat column in `engine-xcode`/`engine-gradle`/`engine-deps`, the cache notes in `engine-xcode`/`engine-gradle`, the install/build/launch/wired/swap/fingerprint pins in `ios-command`/`android-command`, and the lifecycle sample lines in `guide.test.ts`. New: the label-set contract test, the guide-lists-every-label test, `launchErrorReport` unit tests modelled on the real record shape (`{ src: 'device', proc: 'Trailhead', msg: 'Failed to send CA Event ...' }`) including one that asserts the count is identical with and without `proc`, an iOS and an Android test that a verified launch counts the device records and still prints the redbox, an iOS test that a fatal launch prints everything, the Android `device created` / `prepared`-gate pins, the phone `launch <bundle> pid <n>` pin, and the guide pin for the `cache` device-fallback quote.

**The counting path's real-record evidence** is `~/.stim/workspaces/issue-245-measure--f38d5dd7962959a4/logs/device.ndjson` from an earlier real `stim ios`: nine error-level records, every one `src: "device"`, `proc: "Trailhead"`. That file is what the unit tests are modelled on and what makes the "cannot be attributed by process" claim above checkable.

Real-tool check (invariant 9), in a scratch worktree of a real Expo app with the CLI built from this branch: `start --json`, `ios` twice, `stop`, `worktree remove --force`. No `--device`, no phone, zero `stim-*` simulators left behind. The warm transcript is above; cold for this workspace (the shared artifact cache answered, so no compile):

```
  device      stim-issue-260 (C5F8..) created (23.5s)
  fingerprint ab703f.. hit (17.2s)
  device      stim-issue-260 (C5F8..) booted (1.7s)
  install     Trailhead.app -> stim-issue-260 (C5F8..) (5.1s)
  install     dev client prepared (1.4s)
  launch      com.appandflow.trailhead (552ms)
  verify      bundle loaded, process alive, stable for 3s -- the first screen may still be rendering (8s total)
```

That run's device log held one error-level record (the TCP refusal, which #220's filter drops before this code sees it), so it printed no count line — the correct output for that run.

Fixes #260 (run output; lifecycle output follows in #262, which is stacked on this branch).
