### PR TITLE
fix: one output vocabulary for `worktree create`, `start`, and `stop`

### DIFF
--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -68,12 +68,12 @@ test('the label set is closed, sorted, and free of duplicates', () => {
   expect(isOutputLabel('wired')).toBe(false);
 });
 
-test('every label ios.ts and android.ts print comes from that one set', () => {
-  for (const command of ['ios', 'android']) {
+test('every label the run and lifecycle commands print comes from that one set', () => {
+  for (const command of ['ios', 'android', 'worktree', 'start', 'stop']) {
     const src = readFileSync(new URL(`../commands/${command}.ts`, import.meta.url), 'utf-8');
     const labels = new Set<string>();
     for (const match of src.matchAll(/\bphase(?:Line)?\(\s*'((?:[^'\\]|\\.)*)'/g)) labels.add(match[1]!);
-    expect(labels.size).toBeGreaterThan(10);
+    expect(labels.size).toBeGreaterThan(1);
     for (const label of labels) {
       expect({ command, label, known: isOutputLabel(label) }).toEqual({ command, label, known: true });
     }

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { DEFAULT_FINGERPRINT_IGNORES } from '../build-cache.ts';
 import { OUTPUT_LABELS } from '../command-output.ts';
 import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
+import { carriedChangesLine, carryConflictWarning } from '../commands/worktree.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
 import { HEARTBEAT_INTERVAL_MS } from '../engine/xcode.ts';
@@ -70,6 +71,27 @@ test('the errors topic names the two device fallbacks under the label that print
   expect(body).not.toMatch(/^ *device app {2}/m);
   const src = readFileSync(new URL('../commands/ios.ts', import.meta.url), 'utf-8');
   expect(src.includes("'device app'")).toBe(false);
+});
+
+test('the errors topic quotes the stop refusals in the column stop actually prints', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  expect(body).toMatch(/"metro {7}refusing to kill port <n>/);
+  expect(body).toMatch(/"stop {8}refusing to signal supervisor pid <n>/);
+  expect(body).not.toMatch(/"metro: refusing/);
+  expect(body).not.toMatch(/"supervisor: refusing/);
+  const src = readFileSync(new URL('../commands/stop.ts', import.meta.url), 'utf-8');
+  expect(src).toContain("phaseLine('metro', `refusing to kill port ${port}");
+  expect(src).toContain("phaseLine('stop', `refusing to signal supervisor pid ${target.pid}");
+});
+
+test('the errors topic quotes the carry lines exactly as worktree create writes them', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  expect(body).toMatch(/"carry {7}carried 2 uncommitted changes from the source/);
+  expect(body).toMatch(/"carry {7}could not carry the source's uncommitted changes/);
+  expect(carriedChangesLine(['a', 'b'])).toMatch(/^carried 2 uncommitted changes from the source/);
+  expect(carryConflictWarning(['a'])).toMatch(/^could not carry the source's uncommitted changes/);
 });
 
 test('the errors topic states that the stale-carry line only prints on a real difference', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -51,6 +51,17 @@ test('the lifecycle topic grids every label the output vocabulary allows, and no
   expect(body.slice(start)).toMatch(/`app` and `compilation cache` join them in the stdout block/);
 });
 
+test('the lifecycle topic shows the lifecycle commands in the same label column', () => {
+  const body = renderTopic('lifecycle');
+  assert(body);
+  expect(body).toMatch(/branch\s+worktree-e2e-1 from HEAD \(9d0ebc4\)/);
+  expect(body).toMatch(/carry\s+node_modules \(APFS clone\); no Pods; no native build output/);
+  expect(body).toMatch(/ready\s+\/w\/worktree-e2e-1/);
+  expect(body).toMatch(/metro\s+starting on port 8083 \(expo-child, supervisor pid 13724\)/);
+  expect(body).toMatch(/stop\s+collector ios pid 45268/);
+  expect(body).toMatch(/port\s+released 8084/);
+});
+
 test('the errors topic names the two device fallbacks under the label that prints them', () => {
   const body = renderTopic('errors');
   assert(body);
@@ -59,6 +70,13 @@ test('the errors topic names the two device fallbacks under the label that print
   expect(body).not.toMatch(/^ *device app {2}/m);
   const src = readFileSync(new URL('../commands/ios.ts', import.meta.url), 'utf-8');
   expect(src.includes("'device app'")).toBe(false);
+});
+
+test('the errors topic states that the stale-carry line only prints on a real difference', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  expect(body).toMatch(/carry\s+carried dependencies may be stale/);
+  expect(body).toMatch(/a carry whose lockfile matches is\s+silent/);
 });
 
 test('an unknown topic renders nothing rather than throwing', () => {

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -197,6 +197,35 @@ test('a live supervisor is SIGTERMed as a group and its Metro is left to it', as
   expect(calls.stateCleared).toBe(1);
 });
 
+test('the headline stop lines land in the label column, not as colon sentences', async () => {
+  const { opts } = seams({
+    state: { pid: 4242, port: 8083, mode: 'expo-child' },
+    collectors: { ios: { pid: 111 } },
+    project: { metroPort: 8083, platforms: { ios: { deviceUdid: 'U1', owned: true } } },
+    isAlive: () => true,
+  });
+  const reported: string[] = [];
+  const r = await runStop({ ...opts, report: (line: string) => reported.push(line) });
+  expect(r.ok).toBe(true);
+  const text = reported.join('\n');
+  expect(text).toMatch(/^  stop {8}supervisor pid 4242$/m);
+  expect(text).toMatch(/^  stop {8}collector ios pid 111$/m);
+  expect(text).toMatch(/^  device {6}shut down stim-a$/m);
+  expect(text).toMatch(/^  port {8}released 8083$/m);
+  expect(text).not.toMatch(/^(supervisor|collectors|metro|ios|android|port|leases):/m);
+});
+
+test('a metro stopped without a supervisor reports itself in the same column', async () => {
+  const { opts } = seams({
+    project: { metroPort: 8083, platforms: {} },
+    resolveMetro: async () => makeMetroResolution.identified({ metro: { pid: 90, leader: 88, cwd: '/proj/a' } }),
+  });
+  const reported: string[] = [];
+  const r = await runStop({ ...opts, report: (line: string) => reported.push(line) });
+  expect(r.outcomes.metro.status).toBe('stopped');
+  expect(reported.join('\n')).toMatch(/^  metro {7}stopped pid 90 on port 8083$/m);
+});
+
 test('a supervisor that outlives the wait is reported, never SIGKILLed', async () => {
   const { calls, opts } = seams({
     state: { pid: 4242, port: 8083 },

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Command } from 'commander';
+import { clockTime } from '../command-output.ts';
 import { saveConfig, getProject } from '../config.ts';
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { ensureWorkspaceStorage, supervisorPidFile, workspaceStateFile } from '../paths.ts';
@@ -618,7 +619,7 @@ test('stop refuses to signal a collector pid it cannot prove, and keeps the reco
     { platform: 'android', pid: 222, status: 'stopped' },
   ]);
   expect(r.summary).toMatch(/1 collector left unsignalled/);
-  expect(reported.join('\n')).toMatch(/refusing to signal ios pid 111/);
+  expect(reported.join('\n')).toMatch(/^  stop {8}refusing to signal collector ios pid 111/m);
 
   const payload = JSON.parse(JSON.stringify({ root: '/proj/a', ok: r.ok, ...r.outcomes }));
   expect(payload.collectors).toEqual({
@@ -802,7 +803,7 @@ test('a stopped session with an unreconciled claim is reported and keeps its ret
   });
 
   expect(result.ok).toBe(false);
-  expect(lines.join('\n')).toMatch(/stopped session drs_8/i);
+  expect(lines.join('\n')).toMatch(/^  device {6}stopped remote session drs_8/m);
   expect(lines.join('\n')).toMatch(/ownership claim.*could not be removed/i);
   const state = JSON.parse(readFileSync(workspaceStateFile(tmpRoot), 'utf-8'));
   expect(state.remoteDevice.sessionId).toBe('drs_8');
@@ -1142,7 +1143,10 @@ test('stop releases the leases this workspace holds and lists them', async () =>
   ]);
   expect(r.summary).toMatch(/ios lease on UDID-1 released/);
   expect(reported.join('\n')).toMatch(
-    new RegExp(`released the ios lease on UDID-1 \\(it ran until ${taken.lease.expiresAt}\\)`),
+    new RegExp(
+      `^  lease {7}released the ios lease on UDID-1 \\(it ran until ${clockTime(taken.lease.expiresAt)}\\)$`,
+      'm',
+    ),
   );
   expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
 

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -285,7 +285,7 @@ test('create action: --base takes any ref this repo resolves, and branches from 
       expect(logs).toEqual([target]);
       expect(process.exitCode).not.toBe(1);
       expect(execSync('git rev-parse HEAD', { cwd: target, encoding: 'utf-8' }).trim()).toBe(releaseSha);
-      const branchedFrom = errs.filter((e) => String(e).startsWith('Branched '));
+      const branchedFrom = errs.filter((e) => /^  branch {6}worktree-/.test(String(e)));
       expect(branchedFrom.length).toBe(1);
       expect(String(branchedFrom[0])).toMatch(new RegExp(`from ${ref.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')} \\(`));
       expect(String(branchedFrom[0])).toMatch(new RegExp(releaseSha.slice(0, 7)));
@@ -496,8 +496,8 @@ test('create action: an existing branch is reported as attached, not as branched
       worktreeBranchOwned: false,
       worktreeMainRoot: repo,
     });
-    expect(errs.some((e) => /Attached to the existing branch worktree-feat-again/.test(String(e)))).toBeTruthy();
-    expect(!errs.some((e) => String(e).startsWith('Branched '))).toBeTruthy();
+    expect(errs.some((e) => /^  branch {6}attached to the existing worktree-feat-again/.test(String(e)))).toBeTruthy();
+    expect(!errs.some((e) => /^  branch {6}worktree-feat-again from /.test(String(e)))).toBeTruthy();
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
@@ -908,8 +908,11 @@ test('warmCarryCategories recognizes dependency, CocoaPods, and native output pa
       'apps/mobile/android/app/build',
     ]),
   ).toEqual({ dependencies: true, pods: true, nativeOutput: true });
-  expect(warmCarrySummary(['node_modules'])).toBe(
-    'Carried warm state: dependencies=yes, CocoaPods=no, native build output=no.',
+  expect(warmCarrySummary(['node_modules'], undefined, true)).toBe(
+    'node_modules (APFS clone); no Pods; no native build output',
+  );
+  expect(warmCarrySummary(['node_modules', 'ios/Pods', 'ios/build'], undefined, false)).toBe(
+    'node_modules, Pods, native build output (byte copy)',
   );
 });
 
@@ -981,9 +984,9 @@ test('create action: a plain create reports the exact warm-worktree command when
 
     const { errs } = await runCreateInRepo(repo, 'feat-warm-hint', { base: 'head' });
 
-    expect(errs.some((e) => /Warm source not carried: dependencies, CocoaPods, native build output/.test(e))).toBe(
-      true,
-    );
+    expect(
+      errs.some((e) => /^  carry {7}warm source not carried: dependencies, CocoaPods, native build output/.test(e)),
+    ).toBe(true);
     expect(errs.some((e) => /stim worktree create <name> --carry-ignored/.test(e))).toBe(true);
   } finally {
     process.exitCode = 0;
@@ -1037,7 +1040,7 @@ test('create action: pods that disagree with the Podfile.lock on disk still get 
 
     const { errs } = await runCreateInRepo(repo, 'feat-pods-stale', { base: 'head', carryIgnored: true });
 
-    const warning = errs.find((e) => /Carried ios\/Pods does not match/.test(e));
+    const warning = errs.find((e) => /^  carry {7}carried ios\/Pods does not match/.test(e));
     expect(warning).toContain('the ios/Podfile.lock on disk here');
     expect(warning).toContain('pod install');
   } finally {
@@ -1066,13 +1069,51 @@ test('create action: --carry-ignored reports warm categories and the copy mode',
     const { errs } = await runCreateInRepo(repo, 'feat-warm-summary', { base: 'head', carryIgnored: true });
 
     expect(
-      errs.some((e) => /Carried warm state: dependencies=yes, CocoaPods=yes, native build output=yes/.test(e)),
+      errs.some((e) => /^  carry {7}node_modules, Pods, native build output \((APFS clone|byte copy)\)$/.test(e)),
     ).toBe(true);
-    expect(errs.some((e) => /Worktree ready\. Cloned dependencies may be stale/.test(e))).toBe(true);
-    expect(errs.some((e) => /Copy mode: (APFS copy-on-write clone|full byte copy)/.test(e))).toBe(true);
+    expect(errs.some((e) => /Cloned dependencies may be stale/.test(e))).toBe(false);
+    expect(errs.some((e) => /^  ready {7}\//.test(e))).toBe(true);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('create action: the stale-carry line prints only when the branch lockfile differs', async () => {
+  for (const [label, useOldBase] of [
+    ['a branch whose lockfile matches the source', false],
+    ['a branch pinned before the lockfile changed', true],
+  ] as const) {
+    resetExecutor();
+    const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-stale-')));
+    const repo = join(base, 'repo');
+    try {
+      const git = initScratchRepo(repo);
+      writeFileSync(join(repo, '.gitignore'), 'node_modules/\n');
+      writeFileSync(join(repo, 'package.json'), '{"name":"app"}\n');
+      writeFileSync(join(repo, 'package-lock.json'), '{"lockfileVersion":3,"packages":{}}\n');
+      git('git add .gitignore package.json package-lock.json');
+      git('git commit -q -m lockfile');
+      const first = git('git rev-parse HEAD').trim();
+      writeFileSync(join(repo, 'package-lock.json'), '{"lockfileVersion":3,"packages":{"node_modules/pkg":{}}}\n');
+      git('git add package-lock.json');
+      git('git commit -q -m bump');
+      mkdirSync(join(repo, 'node_modules', 'pkg'), { recursive: true });
+      writeFileSync(join(repo, 'node_modules', 'pkg', 'index.js'), 'dep');
+
+      const { errs } = await runCreateInRepo(repo, `feat-stale-${useOldBase ? 'yes' : 'no'}`, {
+        base: useOldBase ? first : 'head',
+        carryIgnored: true,
+      });
+
+      expect({
+        label,
+        stale: errs.some((e) => /^  carry {7}carried dependencies may be stale/.test(e)),
+      }).toEqual({ label, stale: useOldBase });
+    } finally {
+      process.exitCode = 0;
+      rmSync(base, { recursive: true, force: true });
+    }
   }
 });
 
@@ -1104,10 +1145,10 @@ test('create action: a cold --carry-ignored create prints one exact dependency r
 
     const { errs } = await runCreateInRepo(repo, 'feat-cold-carry', { base: 'head', carryIgnored: true });
 
-    const remedies = errs.filter((e) => /Dependencies were not carried/.test(e));
+    const remedies = errs.filter((e) => /^  carry {7}no dependencies carried/.test(e));
     expect(remedies).toHaveLength(1);
     expect(remedies[0]).toContain('npm ci');
-    expect(errs.some((e) => /Worktree ready\. Install dependencies yourself/.test(e))).toBe(true);
+    expect(errs.some((e) => /^  ready {7}\//.test(e))).toBe(true);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -571,7 +571,7 @@ test('create action: a leftover branch already AT the base is refused too, since
     expect(text).toContain('STIM_WORKTREE_BRANCH_EXISTS');
     expect(text).toMatch(/coincidence, not the guarantee/);
     expect(text).toMatch(/branch -D worktree-feat-same/);
-    expect(text).not.toMatch(/Attached to the existing branch/);
+    expect(text).not.toMatch(/attached to the existing/);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
@@ -805,8 +805,9 @@ test('create action: a same-named tag does not stand in for the branch in the --
 
 test('carriedChangesLine and carryConflictWarning cap at three files and count the rest', () => {
   expect(carriedChangesLine(['app.json'])).toBe(
-    'Carried 1 uncommitted change(s) from the source (app.json) -- uncommitted here too; commit deliberately.',
+    'carried 1 uncommitted change from the source (app.json) -- uncommitted here too; commit deliberately',
   );
+  expect(carriedChangesLine(['a', 'b'])).toContain('carried 2 uncommitted changes from the source');
   expect(carriedChangesLine(['a', 'b', 'c', 'd', 'e'])).toContain('(a, b, c, +2)');
   const warning = carryConflictWarning(['a', 'b', 'c', 'd']);
   expect(warning).toContain('(a, b, c, +1)');
@@ -836,7 +837,9 @@ test('create action: --carry-ignored applies the source uncommitted changes when
     expect(readFileSync(join(wt, 'app.json'), 'utf-8')).toContain('dirty-scheme');
     const status = execSync('git status --porcelain -- app.json', { cwd: wt, encoding: 'utf-8' }).trim();
     expect(status).toBe('M app.json');
-    expect(errs.some((e) => /Carried 1 uncommitted change\(s\) from the source \(app\.json\)/.test(e))).toBeTruthy();
+    expect(
+      errs.some((e) => /^  carry {7}carried 1 uncommitted change from the source \(app\.json\)/.test(e)),
+    ).toBeTruthy();
     expect(errs.some((e) => /uncommitted here too; commit deliberately/.test(e))).toBeTruthy();
     expect(process.exitCode).not.toBe(1);
   } finally {
@@ -866,7 +869,9 @@ test('create action: --carry-ignored warns and applies NOTHING when the base div
     expect(logs).toEqual([wt]);
     expect(readFileSync(join(wt, 'app.json'), 'utf-8')).toBe('first version\n');
     expect(execSync('git status --porcelain', { cwd: wt, encoding: 'utf-8' }).trim()).toBe('');
-    expect(errs.some((e) => /Could not carry the source's uncommitted changes \(app\.json\)/.test(e))).toBeTruthy();
+    expect(
+      errs.some((e) => /^  carry {7}could not carry the source's uncommitted changes \(app\.json\)/.test(e)),
+    ).toBeTruthy();
     expect(errs.some((e) => /base diverges from the source HEAD/.test(e))).toBeTruthy();
     expect(errs.some((e) => /fingerprints and cache keys/.test(e))).toBeTruthy();
     expect(process.exitCode).not.toBe(1);
@@ -892,7 +897,7 @@ test('create action: a plain create (no --carry-ignored) is pure HEAD -- no diff
     const wt = join(defaultWorktreeDir(repo), 'feat-plain');
     expect(readFileSync(join(wt, 'app.json'), 'utf-8')).toBe('{"expo":{}}\n');
     expect(execSync('git status --porcelain', { cwd: wt, encoding: 'utf-8' }).trim()).toBe('');
-    expect(errs.some((e) => /Carried .* uncommitted|Could not carry/.test(e))).toBe(false);
+    expect(errs.some((e) => /carried .* uncommitted|could not carry/.test(e))).toBe(false);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });
@@ -1022,8 +1027,8 @@ test('create action: pods installed against an uncommitted Podfile.lock carried 
     expect(readFileSync(join(wt, 'ios', 'Podfile.lock'), 'utf-8')).toBe(
       readFileSync(join(wt, 'ios', 'Pods', 'Manifest.lock'), 'utf-8'),
     );
-    expect(errs.some((e) => /Carried ios\/Pods does not match/.test(e))).toBe(false);
-    expect(errs.some((e) => /Carried 1 uncommitted change\(s\)/.test(e))).toBe(true);
+    expect(errs.some((e) => /carried ios\/Pods does not match/.test(e))).toBe(false);
+    expect(errs.some((e) => /^  carry {7}carried 1 uncommitted change /.test(e))).toBe(true);
   } finally {
     process.exitCode = 0;
     rmSync(base, { recursive: true, force: true });

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -33,6 +33,12 @@ export function formatElapsed(ms: unknown): string {
   return minutes > 0 ? `${minutes}m${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
 }
 
+export function clockTime(iso: string): string {
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return iso;
+  return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
+}
+
 export function phaseLine(label: unknown, text: string): string {
   return `  ${String(label).padEnd(LABEL_WIDTH)} ${text}`;
 }

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -33,6 +33,10 @@ export function formatElapsed(ms: unknown): string {
   return minutes > 0 ? `${minutes}m${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
 }
 
+export function plural(count: number, singular: string, many = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : many}`;
+}
+
 export function clockTime(iso: string): string {
   const at = new Date(iso);
   if (Number.isNaN(at.getTime())) return iso;
@@ -108,10 +112,9 @@ export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summ
     .filter((record) => record.src !== 'device')
     .map((record) => (record.msg === undefined || record.msg === null ? '' : String(record.msg)))
     .filter((msg) => msg !== '');
-  const noun = fromDevice.length === 1 ? 'record' : 'records';
   const summary =
     fromDevice.length === 0
       ? null
-      : `${fromDevice.length} error-level ${noun} in the device log during launch (logs --errors --source device)`;
+      : `${plural(fromDevice.length, 'error-level record')} in the device log during launch (logs --errors --source device)`;
   return { summary, lines };
 }

--- a/packages/stim-cli/src/commands/device.ts
+++ b/packages/stim-cli/src/commands/device.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
+import { clockTime } from '../command-output.ts';
 import {
   fileLeaseIo,
   parseLeaseDuration,
@@ -90,12 +91,6 @@ export interface LockFacts {
   grantedAt: string | null;
   expiresAt: string;
   leaseSeconds: number;
-}
-
-function clockTime(iso: string): string {
-  const at = new Date(iso);
-  if (Number.isNaN(at.getTime())) return iso;
-  return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
 }
 
 export function grantLine(facts: LockFacts, durationText: string): string {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1251,13 +1251,14 @@ STIM_LOCK_TIMEOUT
 
 --- TEARDOWN AND WORKSPACE REFUSALS ---
 
-"metro: refusing to kill port <n>: ... runs from <dir>, outside <project>"
-  (stop) Stim will not kill a process it cannot attribute to you.
+"metro       refusing to kill port <n>: ... runs from <dir>, outside
+<project>"  (stop)
+  Stim will not kill a process it cannot attribute to you.
   \`stim stop --force\` kills it without proving whose it is -- ask the user
   first. That flag is reachable only when no supervisor is recorded for this
   workspace, and it never deletes anything.
 
-"supervisor: refusing to signal pid <n>: ..."  (stop)
+"stop        refusing to signal supervisor pid <n>: ..."  (stop)
   The two records describing that supervisor disagree, or it records a port
   this project did not reserve. A pid is a number the OS reuses, so it is not
   signalled. The port reservation is KEPT -- it is the only handle a retry
@@ -1368,15 +1369,15 @@ worktree create <name> --carry-ignored"  (worktree create)
   BRANCH has. Nothing else prints this: a carry whose lockfile matches is
   silent, so the line always means a real difference. Run the printed command.
 
-"carry       carried N uncommitted change(s) from the source (...) --
-uncommitted here too; commit deliberately."  (worktree create --carry-ignored)
+"carry       carried 2 uncommitted changes from the source (...) --
+uncommitted here too; commit deliberately"  (worktree create --carry-ignored)
   The source tree had uncommitted tracked changes, and the cloned artifacts
   were installed against that working tree -- so the same changes were applied
   to the new worktree as a patch, still uncommitted. Whether they belong in a
   commit is your call; the tool never commits for you.
 
-"Could not carry the source's uncommitted changes (...)"  (worktree create
---carry-ignored)
+"carry       could not carry the source's uncommitted changes (...)"
+(worktree create --carry-ignored)
   The worktree's --base diverges from the source HEAD, so that patch does not
   apply and NOTHING was changed here. Until those changes are reconciled, this
   worktree fingerprints differently from the source and misses the cache

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1333,8 +1333,8 @@ STIM_WORKTREE_BRANCH_EXISTS  (worktree create)
   \`gc --delete --cache "compilation cache"\`, then build again. The next
   build is a cold one.
 
-"Carried <dir>/Pods does not match the <dir>/Podfile.lock on disk here"
-(worktree create)
+"carry       carried <dir>/Pods does not match the <dir>/Podfile.lock on
+disk here"  (worktree create)
   \`ios/Pods\` is gitignored, so --carry-ignored clones it; \`ios/Podfile.lock\`
   is tracked. The check compares the cloned
   \`Pods/Manifest.lock\` with the \`Podfile.lock\` that is on disk in the new
@@ -1348,22 +1348,28 @@ STIM_WORKTREE_BRANCH_EXISTS  (worktree create)
   source's uncommitted changes"); the branch lockfile then stands, and this
   note is about that lockfile.
 
-"Warm source not carried: ... For the next worktree, use: stim worktree create
-<name> --carry-ignored"  (worktree create)
+"carry       warm source not carried: ... For the next worktree, use: stim
+worktree create <name> --carry-ignored"  (worktree create)
   A plain create found installed dependencies, CocoaPods, or native build output
   in the source. The new worktree stays clean. Use the printed command for the
   next worktree to clone that warm state.
 
-"Carried warm state: dependencies=..., CocoaPods=..., native build output=..."
-  The line reports each useful warm category. The following copy-mode line says
-  whether APFS used a copy-on-write clone or Stim made a full byte copy.
+"carry       node_modules (APFS clone); no Pods; no native build output"
+  One line names every useful warm category, carried or not, and the copy mode
+  APFS gave the carried ones: a copy-on-write clone, or a full byte copy when
+  the clone was unavailable.
 
-"Dependencies were not carried. Run ... before building."
-  The source has no node_modules to clone. Run the printed package-manager
-  command in the new worktree.
+"carry       no dependencies carried. Run ... before building."
+  There was no node_modules to clone, or --carry-ignored was not passed. Run
+  the printed package-manager command in the new worktree.
 
-"Carried N uncommitted change(s) from the source (...) -- uncommitted here
-too; commit deliberately."  (worktree create --carry-ignored)
+"carry       carried dependencies may be stale: they do not match ..."
+  The lockfile that came with the cloned node_modules is not the lockfile this
+  BRANCH has. Nothing else prints this: a carry whose lockfile matches is
+  silent, so the line always means a real difference. Run the printed command.
+
+"carry       carried N uncommitted change(s) from the source (...) --
+uncommitted here too; commit deliberately."  (worktree create --carry-ignored)
   The source tree had uncommitted tracked changes, and the cloned artifacts
   were installed against that working tree -- so the same changes were applied
   to the new worktree as a patch, still uncommitted. Whether they belong in a
@@ -1548,6 +1554,22 @@ PROGRESS ON A LONG RUN
 
     build       still running (1m30s): > Task :app:compileDebugKotlin
     build       waiting on /w/app-411 (pid 41233, 1m30s elapsed)
+
+  The lifecycle commands use the same column. \`worktree create\` keeps the
+  created path alone on stdout and reports itself on stderr:
+
+    branch      worktree-e2e-1 from HEAD (9d0ebc4)
+    carry       node_modules (APFS clone); no Pods; no native build output
+    ready       /w/worktree-e2e-1
+
+  \`start\` names the port, the supervisor mode and its pid on one line
+  (\`metro       starting on port 8083 (expo-child, supervisor pid 13724)\`),
+  and \`stop\` reports what it released:
+
+    stop        supervisor pid 34856
+    stop        collector ios pid 45268
+    device      shut down stim-e2e-2
+    port        released 8084
 
   A GAP BETWEEN HEARTBEATS IS NOT A HANG. Stim runs device tools
   synchronously, so a long \`simctl\`, \`adb\` or copy call holds the timer

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import type { ChildProcess } from 'node:child_process';
 import { mkdirSync, openSync, readFileSync } from 'node:fs';
 import type { Command } from 'commander';
+import { phaseLine } from '../command-output.ts';
 import type { StartError, StartFacts, SupervisorRecord } from '../types.ts';
 import { getProject, upsertProject } from '../config.ts';
 import { getExecutor } from '../exec.ts';
@@ -424,7 +425,14 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           child.on?.('error', (err) => {
             childExit = { code: null, signal: null, error: err };
           });
-          out(chalk.dim(`Supervisor pid ${child.pid} starting the dev server on port ${port}...`));
+          out(
+            chalk.dim(
+              phaseLine(
+                'metro',
+                `starting on port ${port} (${isExpo ? 'expo-child' : 'bare-inproc'}, supervisor pid ${child.pid})`,
+              ),
+            ),
+          );
           spawnedChild = child;
           return child;
         };
@@ -984,6 +992,6 @@ function report({
     ? `supervisor pid ${facts.supervisorPid}${facts.mode ? ` (${facts.mode})` : ''}`
     : 'started outside Stim';
   out(chalk.green(`OK: dev server on port ${port}, ${who}${alreadyRunning ? ' (already running)' : ''} ${waited}`));
-  out(chalk.dim(`Logs: ${logsDir}`));
+  out(chalk.dim(phaseLine('logs', logsDir)));
   return facts;
 }

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { rmSync } from 'fs';
 import type { Command } from 'commander';
+import { clockTime, phaseLine } from '../command-output.ts';
 import { clearSupervisor, getProject, upsertProject } from '../config.ts';
 import type { ProjectRecord, SupervisorRecord } from '../config.ts';
 import { findProjectRoot } from '../project.ts';
@@ -359,17 +360,17 @@ export async function runStop({
 
   const target = resolveSupervisorTarget({ state: sup, record: proj?.supervisor ?? null, reservedPort, isAlive });
   if (target.status === 'none') {
-    report(chalk.dim('supervisor: none recorded'));
+    report(chalk.dim(phaseLine('stop', 'no supervisor recorded')));
   } else if (target.status === 'stale') {
     outcomes.supervisor = {
       status: 'already-stopped',
       pid: target.pid,
       reason: `recorded pid ${target.pid} is not running`,
     };
-    report(chalk.dim(`supervisor: pid ${target.pid} is already gone (stale record)`));
+    report(chalk.dim(phaseLine('stop', `supervisor pid ${target.pid} is already gone (stale record)`)));
   } else if (target.status === 'unverified') {
     outcomes.supervisor = { status: 'unverified', pid: target.pid, reason: target.reason };
-    report(chalk.yellow(`supervisor: refusing to signal pid ${target.pid}: ${target.reason}`));
+    report(chalk.yellow(phaseLine('stop', `refusing to signal supervisor pid ${target.pid}: ${target.reason}`)));
     ok = false;
     stillHolding = `supervisor pid ${target.pid} could not be verified`;
   } else {
@@ -390,7 +391,10 @@ export async function runStop({
   if (unverifiedCollectors.length) {
     report(
       chalk.dim(
-        `collectors: keeping the records; ${unverifiedCollectors.length} pid(s) could not be verified, and a later \`ios\` / \`android\` run replaces them`,
+        phaseLine(
+          'stop',
+          `keeping the collector records; ${unverifiedCollectors.length} pid(s) could not be verified, and a later \`ios\` / \`android\` run replaces them`,
+        ),
       ),
     );
   } else if (outcomes.collectors.entries.length) clearCollectors(root);
@@ -403,7 +407,7 @@ export async function runStop({
   if (supervisorHandled) {
     outcomes.metro = { status: 'skipped', reason: 'the supervisor owns the dev server on this port' };
   } else if (reservedPort === null) {
-    report(chalk.dim('metro: no port reserved'));
+    report(chalk.dim(phaseLine('metro', 'no port reserved')));
   } else {
     outcomes.metro = await stopMetro(reservedPort, root, { force, resolveMetro, killMetro, findListener, report });
     if (outcomes.metro.status === 'refused' || outcomes.metro.status === 'failed') {
@@ -413,7 +417,7 @@ export async function runStop({
   }
 
   if (stillHolding) {
-    report(chalk.dim('device: left alone (something is still running)'));
+    report(chalk.dim(phaseLine('device', 'left alone (something is still running)')));
   } else {
     outcomes.device = shutDownDevices(proj, { teardownIos, teardownAvd, report });
     if (outcomes.device.ios?.status === 'failed' || outcomes.device.android?.status === 'failed') ok = false;
@@ -426,12 +430,12 @@ export async function runStop({
     outcomes.device.remote = { status: result.status, label: sessionId, reason: result.reason };
     if (result.status === 'failed') {
       ok = false;
-      report(chalk.red(`remote: ${result.reason ?? `could not stop session ${sessionId}`}`));
+      report(chalk.red(phaseLine('device', result.reason ?? `could not stop remote session ${sessionId}`)));
     } else {
-      report(chalk.dim(`remote: stopped session ${sessionId}`));
+      report(chalk.dim(phaseLine('device', `stopped remote session ${sessionId}`)));
       if (result.reason) {
         ok = false;
-        report(chalk.yellow(`remote: ${result.reason}`));
+        report(chalk.yellow(phaseLine('device', result.reason)));
       } else {
         clearRemoteSession(root, sessionId);
       }
@@ -447,18 +451,21 @@ export async function runStop({
       ok = false;
       tunnelHolding = result.reason ?? `could not stop the ${tunnel.provider} tunnel`;
       if (!stillHolding) stillHolding = tunnelHolding;
-      report(chalk.red(`tunnel: ${tunnelHolding}`));
+      report(chalk.red(phaseLine('lan', tunnelHolding)));
     } else {
       if (!clearManagedMetroTunnel(root, tunnel)) {
         tunnelHolding = 'a replacement managed tunnel record appeared during cleanup and remains active';
         stillHolding = stillHolding ?? tunnelHolding;
         ok = false;
         outcomes.metroTunnel = { status: 'failed', provider: tunnel.provider, reason: tunnelHolding };
-        report(chalk.red(`tunnel: ${tunnelHolding}`));
+        report(chalk.red(phaseLine('lan', tunnelHolding)));
       } else {
         report(
           chalk.dim(
-            result.status === 'missing' ? 'tunnel: already gone' : `tunnel: stopped the ${tunnel.provider} tunnel`,
+            phaseLine(
+              'lan',
+              result.status === 'missing' ? 'tunnel already gone' : `stopped the ${tunnel.provider} tunnel`,
+            ),
           ),
         );
       }
@@ -469,12 +476,19 @@ export async function runStop({
 
   outcomes.releasedLeases = releaseLeases(root);
   for (const lease of outcomes.releasedLeases) {
-    report(chalk.dim(`leases: released the ${lease.platform} lease on ${lease.id} (it ran until ${lease.expiresAt})`));
+    report(
+      chalk.dim(
+        phaseLine(
+          'lease',
+          `released the ${lease.platform} lease on ${lease.id} (it ran until ${clockTime(lease.expiresAt)})`,
+        ),
+      ),
+    );
   }
 
   if (stillHolding) {
     outcomes.port = { status: 'kept', port: reservedPort, reason: stillHolding };
-    report(chalk.yellow(`port: keeping reservation ${reservedPort ?? '(none)'} -- ${stillHolding}`));
+    report(chalk.yellow(phaseLine('port', `keeping reservation ${reservedPort ?? '(none)'} -- ${stillHolding}`)));
     const supervisorIsDown =
       outcomes.supervisor.status === 'none' ||
       outcomes.supervisor.status === 'already-stopped' ||
@@ -487,7 +501,7 @@ export async function runStop({
     if (reservedPort !== null) {
       freePort(root, reservedPort);
       outcomes.port = { status: 'freed', port: reservedPort };
-      report(chalk.dim(`port: released ${reservedPort}`));
+      report(chalk.dim(phaseLine('port', `released ${reservedPort}`)));
     }
     clearState(root);
     await clearRegistration(root);
@@ -517,30 +531,38 @@ function reapCollectors(
   for (const target of targets) {
     if (target.status === 'invalid') {
       entries.push({ platform: target.platform, pid: target.pid, status: 'invalid' });
-      report(chalk.dim(`collectors: ignoring an unusable ${target.platform} record`));
+      report(chalk.dim(phaseLine('stop', `ignoring an unusable ${target.platform} collector record`)));
       continue;
     }
     if (target.status === 'stale') {
       entries.push({ platform: target.platform, pid: target.pid, status: 'already-stopped' });
-      report(chalk.dim(`collectors: ${target.platform} pid ${target.pid} is already gone`));
+      report(chalk.dim(phaseLine('stop', `collector ${target.platform} pid ${target.pid} is already gone`)));
       continue;
     }
     if (target.status === 'unverified') {
       entries.push({ platform: target.platform, pid: target.pid, status: 'unverified', reason: target.reason });
-      report(chalk.yellow(`collectors: refusing to signal ${target.platform} pid ${target.pid}: ${target.reason}`));
+      report(
+        chalk.yellow(
+          phaseLine('stop', `refusing to signal collector ${target.platform} pid ${target.pid}: ${target.reason}`),
+        ),
+      );
       continue;
     }
     try {
       signal(target.pid as number);
       entries.push({ platform: target.platform, pid: target.pid, status: 'stopped' });
-      report(chalk.green(`collectors: stopped ${target.platform} pid ${target.pid}`));
+      report(chalk.green(phaseLine('stop', `collector ${target.platform} pid ${target.pid}`)));
     } catch {
       entries.push({ platform: target.platform, pid: target.pid, status: 'already-stopped' });
-      report(chalk.dim(`collectors: ${target.platform} pid ${target.pid} exited before it could be signalled`));
+      report(
+        chalk.dim(
+          phaseLine('stop', `collector ${target.platform} pid ${target.pid} exited before it could be signalled`),
+        ),
+      );
     }
   }
   if (entries.length === 0) {
-    report(chalk.dim('collectors: none recorded'));
+    report(chalk.dim(phaseLine('stop', 'no collectors recorded')));
     return { status: 'none', entries };
   }
   return { status: 'stopped', entries };
@@ -558,27 +580,33 @@ async function stopSupervisor(
     report: (line: string) => void;
   },
 ): Promise<SupervisorOutcome> {
-  report(chalk.dim(`supervisor: sending SIGTERM to process group ${target.pid}`));
+  report(chalk.dim(phaseLine('stop', `sending SIGTERM to supervisor process group ${target.pid}`)));
   let signalled = false;
   try {
     signalled = killGroup(target.pid);
   } catch (e) {
     signalled = false;
-    report(chalk.red(`supervisor: could not signal pid ${target.pid}: ${String((e as Error)?.message || e)}`));
+    report(
+      chalk.red(
+        phaseLine('stop', `could not signal supervisor pid ${target.pid}: ${String((e as Error)?.message || e)}`),
+      ),
+    );
   }
   if (!signalled) {
     const reason = `could not signal supervisor pid ${target.pid}`;
-    report(chalk.red(`supervisor: ${reason}`));
+    report(chalk.red(phaseLine('stop', reason)));
     return { status: 'failed', pid: target.pid, port: target.port ?? null, reason };
   }
   const died = await waiter(target.pid as number);
   if (died) {
-    report(chalk.green(`supervisor: stopped (pid ${target.pid})`));
+    report(chalk.green(phaseLine('stop', `supervisor pid ${target.pid}`)));
     return { status: 'stopped', pid: target.pid, port: target.port ?? null, mode: target.mode ?? null };
   }
   const reason = `supervisor pid ${target.pid} did not exit within ${Math.round(DEFAULT_WAIT_MS / 1000)}s of SIGTERM`;
-  report(chalk.red(`supervisor: ${reason}`));
-  report(chalk.dim(`  inspect it with \`ps -p ${target.pid}\`, or signal it yourself: kill -9 -${target.pid}`));
+  report(chalk.red(phaseLine('stop', reason)));
+  report(
+    chalk.dim(phaseLine('', `inspect it with \`ps -p ${target.pid}\`, or signal it yourself: kill -9 -${target.pid}`)),
+  );
   return { status: 'timeout', pid: target.pid, port: target.port ?? null, reason };
 }
 
@@ -601,31 +629,31 @@ async function stopMetro(
 ): Promise<MetroOutcome> {
   const resolution = await resolveMetro(port, root);
   if (resolution.missing) {
-    report(chalk.dim(`metro: nothing listening on port ${port}`));
+    report(chalk.dim(phaseLine('metro', `nothing listening on port ${port}`)));
     return { status: 'missing', port };
   }
   if (resolution.notOurs && !force) {
-    report(chalk.yellow(`metro: refusing to kill port ${port}: ${resolution.notOurs}`));
-    report(chalk.dim('  pass --force to kill it anyway'));
+    report(chalk.yellow(phaseLine('metro', `refusing to kill port ${port}: ${resolution.notOurs}`)));
+    report(chalk.dim(phaseLine('', 'pass --force to kill it anyway')));
     return { status: 'refused', port, reason: resolution.notOurs };
   }
   const identified = Boolean(resolution.metro);
   const pid = identified ? resolution.metro!.pid : findListener(port);
   const leader = identified ? (resolution.metro!.leader ?? pid) : pid;
   if (!leader) {
-    report(chalk.dim(`metro: nothing listening on port ${port}`));
+    report(chalk.dim(phaseLine('metro', `nothing listening on port ${port}`)));
     return { status: 'missing', port };
   }
   if (!killMetro(leader, pid)) {
     const reason = `could not kill the process on port ${port}`;
-    report(chalk.red(`metro: ${reason}`));
+    report(chalk.red(phaseLine('metro', reason)));
     return { status: 'failed', port, pid, reason };
   }
   if (identified) {
-    report(chalk.green(`metro: stopped (pid ${pid} on port ${port})`));
+    report(chalk.green(phaseLine('metro', `stopped pid ${pid} on port ${port}`)));
     return { status: 'stopped', port, pid };
   }
-  report(chalk.yellow(`metro: killed pid ${pid} on port ${port} (forced, identity unverified)`));
+  report(chalk.yellow(phaseLine('metro', `killed pid ${pid} on port ${port} (forced, identity unverified)`)));
   return { status: 'forced', port, pid };
 }
 
@@ -661,9 +689,9 @@ function shutDownDevices(
         label: iosUdid,
         reason: 'Stim does not own this device',
       };
-      report(chalk.dim(`ios: ${iosUdid} is not Stim-owned, leaving it running`));
+      report(chalk.dim(phaseLine('device', `${iosUdid} is not Stim-owned, leaving it running`)));
     } else {
-      device.ios = reportDevice('ios', iosUdid, teardownIos(iosUdid, { del: false, label: iosName }), report);
+      device.ios = reportDevice(iosUdid, teardownIos(iosUdid, { del: false, label: iosName }), report);
     }
   }
 
@@ -676,35 +704,30 @@ function shutDownDevices(
         label: android.avdName,
         reason: 'Stim does not own this device',
       };
-      report(chalk.dim(`android: ${android.avdName} is not Stim-owned, leaving it running`));
+      report(chalk.dim(phaseLine('device', `${android.avdName} is not Stim-owned, leaving it running`)));
     } else {
-      device.android = reportDevice('android', android.avdName, teardownAvd(android.avdName, { del: false }), report);
+      device.android = reportDevice(android.avdName, teardownAvd(android.avdName, { del: false }), report);
     }
   }
 
   return device;
 }
 
-function reportDevice(
-  platform: string,
-  label: string,
-  r: TeardownResult,
-  report: (line: string) => void,
-): DeviceOutcomeEntry {
+function reportDevice(label: string, r: TeardownResult, report: (line: string) => void): DeviceOutcomeEntry {
   if (r.status === 'torn-down') {
-    report(chalk.green(`${platform}: shut down ${r.label ?? label}`));
+    report(chalk.green(phaseLine('device', `shut down ${r.label ?? label}`)));
     return { status: 'shut-down', label: r.label ?? label };
   }
   if (r.status === 'missing') {
-    report(chalk.dim(`${platform}: ${label} is already gone`));
+    report(chalk.dim(phaseLine('device', `${label} is already gone`)));
     return { status: 'missing', label };
   }
   if (r.status === 'skipped') {
     const reason = r.kind === 'occupied' ? occupiedSkipReason(r.reason as string, r.holders) : r.reason;
-    report(chalk.yellow(`${platform}: skipped ${label}: ${reason}`));
+    report(chalk.yellow(phaseLine('device', `skipped ${label}: ${reason}`)));
     return { status: 'skipped', kind: r.kind ?? null, label, reason };
   }
-  report(chalk.red(`${platform}: failed to shut down ${label}: ${r.reason}`));
+  report(chalk.red(phaseLine('device', `failed to shut down ${label}: ${r.reason}`)));
   return { status: 'failed', label, reason: r.reason };
 }
 

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { rmSync } from 'fs';
 import type { Command } from 'commander';
-import { clockTime, phaseLine } from '../command-output.ts';
+import { clockTime, phaseLine, plural } from '../command-output.ts';
 import { clearSupervisor, getProject, upsertProject } from '../config.ts';
 import type { ProjectRecord, SupervisorRecord } from '../config.ts';
 import { findProjectRoot } from '../project.ts';
@@ -393,7 +393,7 @@ export async function runStop({
       chalk.dim(
         phaseLine(
           'stop',
-          `keeping the collector records; ${unverifiedCollectors.length} pid(s) could not be verified, and a later \`ios\` / \`android\` run replaces them`,
+          `keeping the collector records; ${plural(unverifiedCollectors.length, 'pid')} could not be verified, and a later \`ios\` / \`android\` run replaces them`,
         ),
       ),
     );

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
+import { phaseLine } from '../command-output.ts';
 import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
@@ -100,9 +101,20 @@ function warmCategoryNames(categories: WarmCarryCategories): string[] {
   return names;
 }
 
-export function warmCarrySummary(entries: string[], root?: string): string {
+export function warmCarrySummary(entries: string[], root: string | undefined, cloned: boolean): string {
   const categories = warmCarryCategories(entries, root);
-  return `Carried warm state: dependencies=${categories.dependencies ? 'yes' : 'no'}, CocoaPods=${categories.pods ? 'yes' : 'no'}, native build output=${categories.nativeOutput ? 'yes' : 'no'}.`;
+  const carried: string[] = [];
+  const absent: string[] = [];
+  for (const [name, present] of [
+    ['node_modules', categories.dependencies],
+    ['Pods', categories.pods],
+    ['native build output', categories.nativeOutput],
+  ] as const) {
+    (present ? carried : absent).push(name);
+  }
+  const mode = cloned ? 'APFS clone' : 'byte copy';
+  const parts = carried.length ? [`${carried.join(', ')} (${mode})`] : [];
+  return [...parts, ...absent.map((name) => `no ${name}`)].join('; ');
 }
 
 export function dependencyInstallCommand(target: string, dir = '.'): string {
@@ -296,16 +308,22 @@ export function registerCreate(worktree: Command): void {
 
       console.error(
         chalk.dim(
-          reusedBranch
-            ? `Attached to the existing branch ${branch}${branchSha ? ` (${branchSha})` : ''}; its tip is the base, and ${baseRef} was not applied.`
-            : `Branched ${branch} from ${baseRef} (${baseSha}).`,
+          phaseLine(
+            'branch',
+            reusedBranch
+              ? `attached to the existing ${branch}${branchSha ? ` (${branchSha})` : ''}; its tip is the base, ${baseRef} was not applied`
+              : `${branch} from ${baseRef} (${baseSha})`,
+          ),
         ),
       );
       if (!reusedBranch && base === 'fresh') {
         console.error(
           chalk.dim(
-            `  ${baseRef} is a local ref, current as of the last \`git fetch\`. If you need the very latest, ` +
-              `run \`git -C ${root} fetch\` first.`,
+            phaseLine(
+              '',
+              `${baseRef} is a local ref, current as of the last \`git fetch\`. If you need the very latest, ` +
+                `run \`git -C ${root} fetch\` first.`,
+            ),
           ),
         );
       }
@@ -313,9 +331,9 @@ export function registerCreate(worktree: Command): void {
       const included = readWorktreeInclude(root);
       const patterns = included && included.length ? included : settings?.worktree?.include || [];
       const { copied, failed } = carryOverFiles({ root, target, patterns });
-      if (copied.length) console.error(chalk.dim(`Carried over ${copied.length} file(s).`));
+      if (copied.length) console.error(chalk.dim(phaseLine('carry', `${copied.length} configured file(s)`)));
       for (const f of failed) {
-        console.error(chalk.yellow(`Failed to carry over ${f.file}: ${f.error}`));
+        console.error(chalk.yellow(phaseLine('carry', `could not carry ${f.file}: ${f.error}`)));
       }
 
       let carriedDeps = false;
@@ -326,32 +344,16 @@ export function registerCreate(worktree: Command): void {
         const res = cloneIgnoredEntries({ root, target, patterns: skip });
         carriedDeps = warmCarryCategories(res.copied, target).dependencies;
         if (res.copied.length) {
-          console.error(chalk.dim(`Cloned ${res.copied.length} gitignored path(s).`));
-          console.error(chalk.dim(warmCarrySummary(res.copied, target)));
-          console.error(
-            chalk.dim(
-              res.cloned
-                ? 'Copy mode: APFS copy-on-write clone.'
-                : 'Copy mode: full byte copy. APFS copy-on-write clone was unavailable.',
-            ),
-          );
-        }
-        if (!carriedDeps) {
-          const remedies = dependencyInstallCommands(target);
-          console.error(
-            chalk.yellow(
-              `Dependencies were not carried. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
-            ),
-          );
+          console.error(chalk.dim(phaseLine('carry', warmCarrySummary(res.copied, target, res.cloned))));
         }
         for (const f of res.failed) {
-          console.error(chalk.yellow(`Failed to clone ${f.file}: ${f.error}`));
+          console.error(chalk.yellow(phaseLine('carry', `could not clone ${f.file}: ${f.error}`)));
         }
         const changes = carryUncommittedChanges({ root, target });
         if (changes?.applied) {
-          console.error(chalk.dim(carriedChangesLine(changes.files)));
+          console.error(chalk.dim(phaseLine('carry', carriedChangesLine(changes.files))));
         } else if (changes?.conflicted) {
-          console.error(chalk.yellow(carryConflictWarning(changes.files)));
+          console.error(chalk.yellow(phaseLine('carry', carryConflictWarning(changes.files))));
         }
         const staleDeps = depsOutOfSync(root, target, res.copied);
         if (staleDeps.length) {
@@ -361,7 +363,10 @@ export function registerCreate(worktree: Command): void {
           ];
           console.error(
             chalk.yellow(
-              `Carried dependencies do not match ${manifests}. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
+              phaseLine(
+                'carry',
+                `carried dependencies may be stale: they do not match ${manifests}. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
+              ),
             ),
           );
         }
@@ -370,9 +375,12 @@ export function registerCreate(worktree: Command): void {
           const pod = podInstallCommand(p.dir === '.' ? target : resolve(target, p.dir, '..'));
           console.error(
             chalk.yellow(
-              p.reason === 'missing'
-                ? `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
-                : `Carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match the ${where} on disk here. Pods are gitignored and cloned; Podfile.lock is tracked, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
+              phaseLine(
+                'carry',
+                p.reason === 'missing'
+                  ? `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
+                  : `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match the ${where} on disk here. Pods are gitignored and cloned; Podfile.lock is tracked, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
+              ),
             ),
           );
         }
@@ -391,20 +399,28 @@ export function registerCreate(worktree: Command): void {
         worktreeMainRoot: mainRoot,
       });
 
-      console.error(
-        chalk.dim(
-          carriedDeps
-            ? 'Worktree ready. Cloned dependencies may be stale; reinstall if this branch changes them.'
-            : 'Worktree ready. Install dependencies yourself before building.',
-        ),
-      );
-      if (warmSource.length) {
+      if (!carriedDeps) {
+        const remedies = dependencyInstallCommands(target);
         console.error(
           chalk.yellow(
-            `Warm source not carried: ${warmSource.join(', ')}. For the next worktree, use: stim worktree create <name> --carry-ignored`,
+            phaseLine(
+              'carry',
+              `no dependencies carried. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
+            ),
           ),
         );
       }
+      if (warmSource.length) {
+        console.error(
+          chalk.yellow(
+            phaseLine(
+              'carry',
+              `warm source not carried: ${warmSource.join(', ')}. For the next worktree, use: stim worktree create <name> --carry-ignored`,
+            ),
+          ),
+        );
+      }
+      console.error(chalk.dim(phaseLine('ready', target)));
 
       console.log(target);
     });

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { phaseLine } from '../command-output.ts';
+import { phaseLine, plural } from '../command-output.ts';
 import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
@@ -331,7 +331,7 @@ export function registerCreate(worktree: Command): void {
       const included = readWorktreeInclude(root);
       const patterns = included && included.length ? included : settings?.worktree?.include || [];
       const { copied, failed } = carryOverFiles({ root, target, patterns });
-      if (copied.length) console.error(chalk.dim(phaseLine('carry', `${copied.length} configured file(s)`)));
+      if (copied.length) console.error(chalk.dim(phaseLine('carry', plural(copied.length, 'configured file'))));
       for (const f of failed) {
         console.error(chalk.yellow(phaseLine('carry', `could not carry ${f.file}: ${f.error}`)));
       }
@@ -432,12 +432,12 @@ function carriedFileList(files: string[]): string {
 }
 
 export function carriedChangesLine(files: string[]): string {
-  return `Carried ${files.length} uncommitted change(s) from the source (${carriedFileList(files)}) -- uncommitted here too; commit deliberately.`;
+  return `carried ${plural(files.length, 'uncommitted change')} from the source (${carriedFileList(files)}) -- uncommitted here too; commit deliberately`;
 }
 
 export function carryConflictWarning(files: string[]): string {
   return (
-    `Could not carry the source's uncommitted changes (${carriedFileList(files)}): this worktree's base diverges from the source HEAD, so the patch does not apply and nothing was changed here. ` +
+    `could not carry the source's uncommitted changes (${carriedFileList(files)}): this worktree's base diverges from the source HEAD, so the patch does not apply and nothing was changed here. ` +
     "The carried artifacts were installed for the source's uncommitted state, so fingerprints and cache keys in this worktree will differ from the source's until those changes are reconciled."
   );
 }

--- a/packages/stim-cli/src/engine/device-lease-run.ts
+++ b/packages/stim-cli/src/engine/device-lease-run.ts
@@ -1,4 +1,4 @@
-import { formatElapsed } from '../command-output.ts';
+import { clockTime, formatElapsed } from '../command-output.ts';
 import { STABILITY_WINDOW_MS, VERIFY_TIMEOUT_MS } from './app-install.ts';
 import {
   deviceLeasePath,
@@ -54,12 +54,6 @@ export interface RunLeaseRefusal {
   message: string;
   remedy: string;
   lease: LeaseFacts | null;
-}
-
-function clockTime(iso: string): string {
-  const at = new Date(iso);
-  if (Number.isNaN(at.getTime())) return iso;
-  return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
 }
 
 export function leaseExpiryText(expiresAt: string, now: number): string {

--- a/packages/stim-cli/src/status.ts
+++ b/packages/stim-cli/src/status.ts
@@ -1,4 +1,4 @@
-import { formatElapsed } from './command-output.ts';
+import { clockTime, formatElapsed } from './command-output.ts';
 import type { ProjectRecord } from './config.ts';
 import type { LeaseFileEntry } from './engine/device-lease.ts';
 
@@ -231,12 +231,6 @@ export function deviceLeaseStates(
       parsed: Boolean(lease),
     };
   });
-}
-
-function clockTime(iso: string): string {
-  const at = new Date(iso);
-  if (Number.isNaN(at.getTime())) return iso;
-  return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
 }
 
 export function deviceLeaseLines(states: readonly DeviceLeaseState[], now: number): string[] {

--- a/test/e2e/worktree-warm.e2e.js
+++ b/test/e2e/worktree-warm.e2e.js
@@ -45,13 +45,16 @@ test('cold and warm worktree creation report different guidance', () => {
 
   const plainWarm = create('plain-warm');
   assert.equal(plainWarm.status, 0, plainWarm.stderr);
-  assert.match(plainWarm.stderr, /Warm source not carried: dependencies, CocoaPods, native build output/);
+  assert.match(
+    plainWarm.stderr,
+    /^ {2}carry {7}warm source not carried: dependencies, CocoaPods, native build output/m,
+  );
   assert.match(plainWarm.stderr, /stim worktree create <name> --carry-ignored/);
 
   const carried = create('carried', ['--carry-ignored']);
   assert.equal(carried.status, 0, carried.stderr);
-  assert.match(carried.stderr, /Carried warm state: dependencies=yes, CocoaPods=yes, native build output=yes/);
-  assert.match(carried.stderr, /Copy mode: (APFS copy-on-write clone|full byte copy)/);
+  assert.match(carried.stderr, /^ {2}carry {7}node_modules, Pods, native build output \((APFS clone|byte copy)\)$/m);
+  assert.match(carried.stderr, /^ {2}ready {7}\//m);
   const carriedPath = carried.stdout.trim();
   assert.ok(existsSync(join(carriedPath, 'node_modules', 'pkg', 'index.js')));
   assert.ok(existsSync(join(carriedPath, 'ios', 'Pods', 'Manifest.lock')));
@@ -89,7 +92,7 @@ test('carried pods are judged against the Podfile.lock the new worktree ends up 
   const created = carried.stdout.trim();
   assert.equal(readFileSync(join(created, 'ios', 'Podfile.lock'), 'utf-8'), workingLock);
   assert.equal(readFileSync(join(created, 'ios', 'Pods', 'Manifest.lock'), 'utf-8'), workingLock);
-  assert.doesNotMatch(carried.stderr, /Carried ios\/Pods does not match/);
+  assert.doesNotMatch(carried.stderr, /carried ios\/Pods does not match/);
 });
 
 function create(name, extra = []) {


### PR DESCRIPTION
## Description

Stacked on #261 (`--base fix/run-output-vocabulary`); review that one first. It gave `ios` and `android` one output vocabulary — this applies the same one to `worktree create`, `start` and `stop`, which were the remaining commands printing free text and colon-labelled sentences.

`worktree create`, before and after, on a repo with a carried `node_modules`:

```
Branched worktree-warm from HEAD (94107b6).          |    branch      worktree-warm from HEAD (94107b6)
Cloned 1 gitignored path(s).                         |    carry       node_modules (APFS clone); no Pods; no native build output
Carried warm state: dependencies=yes, CocoaPods=no,  |    ready       /w/warm
  native build output=no.                            |
Copy mode: APFS copy-on-write clone.                 |
Worktree ready. Cloned dependencies may be stale;    |
  reinstall if this branch changes them.             |
```

The path is still alone on stdout (invariant 7). `stop` gets the same treatment: `stop        supervisor pid 34856`, `stop        collector ios pid 45268`, `device      shut down stim-e2e-2`, `port        released 8084`. `start`'s spawn line becomes `metro       starting on port 8083 (expo-child, supervisor pid 13724)`.

## Solution

The mechanical part is the label column: `supervisor:` and `collectors:` become `stop`, `metro:` stays `metro`, `ios:`/`android:` become `device`, `remote:` becomes `device`, `tunnel:` becomes `lan`, `leases:` becomes `lease`, `port:` becomes `port`. The `Stopped:` and `OK:` summary lines are untouched, as are the `--json` payloads. The two `guide errors` entries that quoted `metro:` / `supervisor:` refusals now quote the column the code prints, and a test reads both `stop.ts` and the guide so the quote and the code cannot drift apart again.

**The one behavior change is that "may be stale" is now conditional.** It printed on every `--carry-ignored` create, so an agent read it as a problem even when nothing had changed. There is already a check that answers the question properly — `depsOutOfSync` (#201) compares the source's lockfile against the one the new worktree ends up with, *after* the uncommitted changes are carried — and it prints `carry       carried dependencies may be stale: they do not match <lockfile>. Run <command> ...`. Deleting the unconditional sentence leaves that as the only stale line, so the line now always means a real difference. A new test drives both sides: a worktree based on HEAD is silent, one pinned to a commit before the lockfile changed prints it.

The generic `Worktree ready. Install dependencies yourself before building.` is replaced by `ready       <path>` plus the `carry       no dependencies carried. Run <exact command> ...` line, which was previously only printed on the `--carry-ignored` path — so a cold plain create now gets the real package-manager command instead of a sentence telling it to figure one out.

The facts in the column are lowercase, so `carriedChangesLine` and `carryConflictWarning` no longer return a capitalized first word (they used to read `carry       Carried 1 uncommitted change(s) ...`), and a `plural` helper replaces the `(s)` and ternary hacks at every count site — the line says "1 configured file" / "3 configured files", not "N file(s)".

`clockTime` had three identical copies (`status.ts`, `commands/device.ts`, `engine/device-lease-run.ts`); it moves to `command-output.ts`, leaving one definition, and `stop.ts` uses it for the released-lease line, which was the last ISO timestamp in the output.

**Risk.** Output-only apart from the conditional stale line. The worst case there is a stale carried `node_modules` going unmentioned, which needs `depsOutOfSync` to be wrong about two lockfiles being equal — it is a byte comparison of the two files.

## How this lands

#261 squash-merges into `main` first. Then this branch rebases onto the new `main` (the two `worktree create`/`start`/`stop` commits replay cleanly on top of the squashed commit) and the PR retargets to `main`. Do not merge this one while its base branch still exists.

## Test plan

`pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (3291 pass), `pnpm run knip`, `pnpm run test:e2e` (20 pass). The e2e worktree suite pins these lines directly, so it is the load-bearing check here.

Tests updated deliberately rather than dropped: the branch/attach/warm-summary/stale-pods/cold-remedy/uncommitted-changes assertions in `worktree-create.test.ts`, the collector/remote/lease lines in `stop.test.ts`, `warmCarrySummary`'s and `carriedChangesLine`'s unit tests, and the two `worktree-warm.e2e.js` assertions. One negative assertion that had gone vacuous against the new wording (`not.toMatch(/Attached to the existing branch/)`) was repointed at the text the code now prints.

The label contract test from #261 now scrapes `worktree.ts`, `start.ts` and `stop.ts` as well as `ios.ts`/`android.ts`, so a new lifecycle label has to be added to `OUTPUT_LABELS` or the test fails. New tests pin `stop`'s headline lines (`stop supervisor pid`, `stop collector`, `device shut down`, `port released`, `metro stopped`) and assert no line still starts with a colon-labelled prefix; new guide tests pin the lifecycle sample block, the two refusal quotes, the two carry quotes, and the sentence saying the stale line only prints on a real difference.

Smoke run with the CLI built from this branch, in a scratch git repo with a gitignored `node_modules` (no simulator, no emulator):

```
$ stim worktree create plain --base head
  branch      worktree-plain from HEAD (94107b6)
  carry       no dependencies carried. Run `cd '/tmp/repo-worktrees/plain' && npm ci` before building.
  carry       warm source not carried: dependencies. For the next worktree, use: stim worktree create <name> --carry-ignored
  ready       /tmp/repo-worktrees/plain

$ stim worktree create warm --base head --carry-ignored
  branch      worktree-warm from HEAD (94107b6)
  carry       node_modules (APFS clone); no Pods; no native build output
  ready       /tmp/repo-worktrees/warm

$ stim stop
  stop        no supervisor recorded
  stop        no collectors recorded
  metro       no port reserved
Stopped: nothing was running (/tmp/repo-worktrees/warm)
```

stdout from a create was exactly the one path. `start` on a real Expo app is covered by #261's real-tool transcript, which was run before this branch's `start` change; the change is the one spawn line and is covered by `start.test.ts`.

`worktree remove`'s output is deliberately left alone here and gets its own issue.

Fixes #260 (lifecycle output). Related: #261 covers the `ios`/`android` run output and is this PR's base.
