### PR TITLE
fix: anchor the iOS simulator log predicate to the app's executable path

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -124,8 +124,8 @@ describe('ios: log stream ndjson', () => {
     expect(parseLogStreamLine('{"eventType":"logEvent","messageType":"Default","eventMessage":"   "}')).toBe(null);
   });
 
-  test('logStreamArgs is the exact argv, with the predicate quoted for the device', () => {
-    expect(logStreamArgs('U1', 'MyApp')).toEqual([
+  test('logStreamArgs is the exact argv, anchored to the app executable path', () => {
+    expect(logStreamArgs('U1', 'MyApp', 'MyApp')).toEqual([
       'simctl',
       'spawn',
       'U1',
@@ -134,8 +134,32 @@ describe('ios: log stream ndjson', () => {
       '--style',
       'ndjson',
       '--predicate',
-      'processImagePath CONTAINS[c] "MyApp"',
+      'processImagePath ENDSWITH "/MyApp.app/MyApp"',
     ]);
+  });
+
+  test('logStreamArgs anchors to CFBundleExecutable when it differs from the .app basename', () => {
+    const args = logStreamArgs('U1', 'MyAppDev', 'MyApp');
+    expect(args[args.length - 1]).toBe('processImagePath ENDSWITH "/MyAppDev.app/MyApp"');
+  });
+
+  test('logStreamArgs falls back to the .app basename as the executable when none is given', () => {
+    expect(logStreamArgs('U1', 'MyApp')).toEqual(logStreamArgs('U1', 'MyApp', null));
+    expect(logStreamArgs('U1', 'MyApp')[8]).toBe('processImagePath ENDSWITH "/MyApp.app/MyApp"');
+  });
+
+  test('a short app name no longer admits an unrelated system process such as SpringBoard', () => {
+    const predicate = logStreamArgs('U1', 'app')[8];
+    assert(predicate);
+    const suffix = predicate.match(/ENDSWITH "(.+)"$/)?.[1];
+    assert(suffix);
+    const appsOwnPath =
+      '/Users/x/Library/Developer/CoreSimulator/Devices/U/data/Containers/Bundle/Application/ABC/app.app/app';
+    const springBoardPath = '/System/Library/CoreServices/SpringBoard.app/SpringBoard';
+    const amsengagementdPath = '/usr/libexec/amsengagementd';
+    expect(appsOwnPath.endsWith(suffix)).toBe(true);
+    expect(springBoardPath.endsWith(suffix)).toBe(false);
+    expect(amsengagementdPath.endsWith(suffix)).toBe(false);
   });
 
   test('appNameFromBundleId is the last segment, as a fallback for a caller with only a bundle id', () => {

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -326,6 +326,48 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
     expect(deviceLog().some((r) => r.event === 'collector_stopped')).toBeTruthy();
   });
 
+  test('a distinct --app-executable anchors the predicate to it, not to --app-name', async () => {
+    // #264: the shim only accepts the anchor built from --app-executable, not --app-name.
+    writeShim(
+      'xcrun',
+      [
+        `case "$*" in`,
+        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyAppDev.app/MyApp"') ;;`,
+        `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
+        `esac`,
+        ...iosShimLines()
+          .slice(0, 1)
+          .map((l) => `cat <<'LINE'\n${l}\nLINE`),
+        'exec sleep 30',
+      ].join('\n'),
+    );
+
+    const child = spawnCollector([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      'UDID-1',
+      '--bundle',
+      'com.example.app',
+      '--app-name',
+      'MyAppDev',
+      '--app-executable',
+      'MyApp',
+    ]);
+
+    const registered = await until(() => readCollectors(root).ios as CollectorEntry, {
+      label: 'the collector registration',
+    });
+    expect(registered.pid).toBe(child.pid);
+    expect(deviceLog().some((r) => r.event === 'collector_failed')).toBe(false);
+
+    process.kill(childPid(child), 'SIGTERM');
+    const result = await exited(child);
+    expect(result).toEqual({ code: 0, signal: null });
+  });
+
   test('survives the stream ending: a record, and exit 0', async () => {
     writeShim(
       'xcrun',

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -106,6 +106,7 @@ describe('parseArgs', () => {
         udid: 'U1',
         bundleId: 'com.example.MyApp',
         appName: 'MyApp',
+        appExecutable: null,
         serial: null,
         packageName: null,
         physical: false,
@@ -135,6 +136,7 @@ describe('parseArgs', () => {
       udid: 'U1',
       bundleId: 'com.example.MyApp',
       appName: 'MyApp',
+      appExecutable: null,
       serial: null,
       packageName: null,
       physical: true,
@@ -169,6 +171,25 @@ describe('parseArgs', () => {
         '--app-name',
         'MyApp',
       ]).appName,
+    ).toBe('MyApp');
+  });
+
+  test('--app-executable carries CFBundleExecutable separately from the .app basename', () => {
+    expect(
+      parseArgs([
+        '--platform',
+        'ios',
+        '--root',
+        '/abs',
+        '--udid',
+        'U1',
+        '--bundle',
+        'com.example.app',
+        '--app-name',
+        'MyAppDev',
+        '--app-executable',
+        'MyApp',
+      ]).appExecutable,
     ).toBe('MyApp');
   });
 
@@ -250,12 +271,12 @@ function iosShimLines() {
 
 describe('the ios collector, spawned for real against a fake xcrun', () => {
   test('registers its own pid, writes records, and clears the registration on SIGTERM', async () => {
-    const banner = 'Filtering the log data using "processImagePath CONTAINS[c] \\"MyApp\\""';
+    const banner = 'Filtering the log data using "processImagePath ENDSWITH \\"/MyApp.app/MyApp\\""';
     writeShim(
       'xcrun',
       [
         `case "$*" in`,
-        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath CONTAINS[c] "MyApp"') ;;`,
+        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyApp.app/MyApp"') ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
         `esac`,
         `echo "${banner}" >&2`,

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -327,7 +327,6 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
   });
 
   test('a distinct --app-executable anchors the predicate to it, not to --app-name', async () => {
-    // #264: the shim only accepts the anchor built from --app-executable, not --app-name.
     writeShim(
       'xcrun',
       [
@@ -335,9 +334,7 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
         `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyAppDev.app/MyApp"') ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
         `esac`,
-        ...iosShimLines()
-          .slice(0, 1)
-          .map((l) => `cat <<'LINE'\n${l}\nLINE`),
+        ...iosShimLines().map((l) => `cat <<'LINE'\n${l}\nLINE`),
         'exec sleep 30',
       ].join('\n'),
     );
@@ -361,7 +358,13 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
       label: 'the collector registration',
     });
     expect(registered.pid).toBe(child.pid);
-    expect(deviceLog().some((r) => r.event === 'collector_failed')).toBe(false);
+
+    await until(() => deviceLog().find((r) => r.src === 'device' && r.proc === 'locationd') ?? null, {
+      label: 'a parsed device record',
+    });
+    expect(
+      deviceLog().some((r) => r.event === 'collector_stderr' && /unexpected argv/.test(String(r.msg))),
+    ).toBe(false);
 
     process.kill(childPid(child), 'SIGTERM');
     const result = await exited(child);

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -362,9 +362,9 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
     await until(() => deviceLog().find((r) => r.src === 'device' && r.proc === 'locationd') ?? null, {
       label: 'a parsed device record',
     });
-    expect(
-      deviceLog().some((r) => r.event === 'collector_stderr' && /unexpected argv/.test(String(r.msg))),
-    ).toBe(false);
+    expect(deviceLog().some((r) => r.event === 'collector_stderr' && /unexpected argv/.test(String(r.msg)))).toBe(
+      false,
+    );
 
     process.kill(childPid(child), 'SIGTERM');
     const result = await exited(child);

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -18,6 +18,7 @@ import {
   discoverXcodeProject,
   findAppBundle,
   listSchemes,
+  parseBundleExecutable,
   parseBundleId,
   parseCompilationCacheActivity,
   parseSchemeList,
@@ -27,6 +28,7 @@ import {
   pickScheme,
   pickXcodeProject,
   productsDir,
+  readBundleExecutable,
   readBundleId,
   heartbeatLine,
   startBuildHeartbeat,
@@ -624,6 +626,63 @@ describe('reading the bundle id', () => {
       },
     });
     expect(readBundleId('/dd/App.app')).toBe(null);
+  });
+});
+
+describe('reading the bundle executable', () => {
+  test('parseBundleExecutable takes CFBundleExecutable out of plutil JSON', () => {
+    expect(parseBundleExecutable('{"CFBundleExecutable":"App","CFBundleIdentifier":"com.example.app"}')).toBe('App');
+  });
+
+  test('anything else is null, so the caller falls back to the .app basename', () => {
+    expect(parseBundleExecutable('{"CFBundleIdentifier":"com.example.app"}')).toBe(null);
+    expect(parseBundleExecutable('{"CFBundleExecutable":""}')).toBe(null);
+    expect(parseBundleExecutable('{"CFBundleExecutable":42}')).toBe(null);
+    expect(parseBundleExecutable('not json')).toBe(null);
+    expect(parseBundleExecutable(null)).toBe(null);
+  });
+
+  test('readBundleExecutable asks plutil first, with the .plist path', () => {
+    const calls: [string, string[] | undefined][] = [];
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: (file, args) => {
+        calls.push([file, args]);
+        return '{"CFBundleExecutable":"App"}';
+      },
+    });
+    expect(readBundleExecutable('/dd/App.app')).toBe('App');
+    expect(calls).toEqual([['plutil', ['-convert', 'json', '-o', '-', '/dd/App.app/Info.plist']]]);
+  });
+
+  test('falls back to `defaults read`, which takes the path WITHOUT the extension', () => {
+    const calls: string[] = [];
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: (file, _args) => {
+        calls.push(file);
+        if (file === 'plutil') throw new Error('plutil missing');
+        return 'App\n';
+      },
+    });
+    expect(readBundleExecutable('/dd/App.app')).toBe('App');
+    expect(calls).toEqual(['plutil', 'defaults']);
+  });
+
+  test('both failing is null rather than a throw out of a build', () => {
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: () => {
+        throw new Error('nope');
+      },
+    });
+    expect(readBundleExecutable('/dd/App.app')).toBe(null);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1982,7 +1982,7 @@ describe('the collector', () => {
   test('the command hands the collector CFBundleExecutable, so the log predicate can anchor to it', async () => {
     reserve();
     let seenAppPath: unknown;
-    const { calls } = await run(
+    const { calls, stderr } = await run(
       {},
       {
         buildIos: async () => ({
@@ -1999,11 +1999,12 @@ describe('the collector', () => {
     expect(seenAppPath).toBe('/tmp/dd/Build/Products/Debug-iphonesimulator/FixtureDev.app');
     expect(calls.args.replaceCollector.appExecutable).toBe('Fixture');
     expect(calls.args.replaceCollector.appName).toBe('FixtureDev');
+    expect(stderr).not.toMatch(/Could not read CFBundleExecutable/);
   });
 
   test('a missing CFBundleExecutable leaves the collector to fall back to the .app basename', async () => {
     reserve();
-    const { calls } = await run(
+    const { calls, stderr } = await run(
       {},
       {
         buildIos: async () => ({
@@ -2014,6 +2015,8 @@ describe('the collector', () => {
       },
     );
     expect(calls.args.replaceCollector.appExecutable).toBe(null);
+    expect(stderr).toMatch(/Could not read CFBundleExecutable/);
+    expect(stderr).toMatch(/FixtureDev\.app/);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -160,12 +160,13 @@ interface RecordedArgs {
   swapJsBundle: { cachedAppPath?: unknown; isExpo?: unknown; root?: unknown };
   verifyReleaseLaunch: { pid?: unknown };
   readBundleId: unknown;
+  readBundleExecutable: unknown;
   storeBuild: { options?: unknown; platform?: unknown; path?: unknown; key?: unknown };
   resolveBuild: { key?: unknown };
   verifyLaunch: { since?: unknown; logsDir?: unknown; platform?: unknown };
   uploadRemote: { fingerprintHash?: unknown; buildPath?: unknown };
   resolveRemote: { projectRoot?: unknown; platform?: unknown; fingerprintHash?: unknown };
-  replaceCollector: { udid?: unknown; bundleId?: unknown; appName?: unknown };
+  replaceCollector: { udid?: unknown; bundleId?: unknown; appName?: unknown; appExecutable?: unknown };
   loadProjectProvider: { isExpo?: unknown };
   acquireBuildLock: { root?: unknown; platform?: unknown; logFile?: unknown; key?: unknown };
   untrackedNativeFiles: { projectRoot?: unknown };
@@ -262,6 +263,10 @@ function harness(overrides: LooseDeps = {}) {
     readBundleId: (path) => {
       record('readBundleId', path);
       return 'com.example.app';
+    },
+    readBundleExecutable: (path) => {
+      record('readBundleExecutable', path);
+      return null;
     },
     installIosApp: (args) => {
       record('installIosApp', args);
@@ -1935,6 +1940,28 @@ describe('the collector', () => {
     expect(opts.cwd).toBe(root);
   });
 
+  test('an --app-executable is appended when the caller supplies CFBundleExecutable', async () => {
+    const h = collectorHarness();
+    h.opts.appExecutable = 'Fixture';
+    await replaceCollector(h.opts);
+    const firstSpawn = h.spawns[0];
+    assert(firstSpawn);
+    expect(firstSpawn.args.slice(1)).toEqual([
+      '--platform',
+      'ios',
+      '--root',
+      root,
+      '--udid',
+      UDID,
+      '--bundle',
+      'com.example.app',
+      '--app-name',
+      'FixtureDev',
+      '--app-executable',
+      'Fixture',
+    ]);
+  });
+
   test('the command hands it the app name derived from the .app basename', async () => {
     reserve();
     const { calls } = await run(
@@ -1950,6 +1977,43 @@ describe('the collector', () => {
     expect(calls.args.replaceCollector.appName).toBe('FixtureDev');
     expect(calls.args.replaceCollector.bundleId).toBe('com.example.app');
     expect(calls.args.replaceCollector.udid).toBe(UDID);
+  });
+
+  test('the command hands the collector CFBundleExecutable, so the log predicate can anchor to it', async () => {
+    reserve();
+    let seenAppPath: unknown;
+    const { calls } = await run(
+      {},
+      {
+        buildIos: async () => ({
+          appPath: '/tmp/dd/Build/Products/Debug-iphonesimulator/FixtureDev.app',
+          bundleId: 'com.example.app',
+          durationMs: 1000,
+        }),
+        readBundleExecutable: (path) => {
+          seenAppPath = path;
+          return 'Fixture';
+        },
+      },
+    );
+    expect(seenAppPath).toBe('/tmp/dd/Build/Products/Debug-iphonesimulator/FixtureDev.app');
+    expect(calls.args.replaceCollector.appExecutable).toBe('Fixture');
+    expect(calls.args.replaceCollector.appName).toBe('FixtureDev');
+  });
+
+  test('a missing CFBundleExecutable leaves the collector to fall back to the .app basename', async () => {
+    reserve();
+    const { calls } = await run(
+      {},
+      {
+        buildIos: async () => ({
+          appPath: '/tmp/dd/Build/Products/Debug-iphonesimulator/FixtureDev.app',
+          bundleId: 'com.example.app',
+          durationMs: 1000,
+        }),
+      },
+    );
+    expect(calls.args.replaceCollector.appExecutable).toBe(null);
   });
 });
 

--- a/packages/stim-cli/src/collector/ios.ts
+++ b/packages/stim-cli/src/collector/ios.ts
@@ -142,7 +142,8 @@ export function parseLogStreamLine(line: string, { now = Date.now }: { now?: () 
   return recordFromLogEvent(event, { now });
 }
 
-export function logStreamArgs(udid: string, appName: string): string[] {
+export function logStreamArgs(udid: string, appName: string, executableName?: string | null): string[] {
+  const exe = executableName && executableName.trim() !== '' ? executableName.trim() : appName;
   return [
     'simctl',
     'spawn',
@@ -152,7 +153,7 @@ export function logStreamArgs(udid: string, appName: string): string[] {
     '--style',
     'ndjson',
     '--predicate',
-    `processImagePath CONTAINS[c] "${appName}"`,
+    `processImagePath ENDSWITH "/${appName}.app/${exe}"`,
   ];
 }
 
@@ -164,14 +165,16 @@ export function appNameFromBundleId(bundleId: string | null | undefined): string
 export function startIosLogStream({
   udid,
   appName,
+  executableName = null,
   spawnFn = null,
 }: {
   udid: string;
   appName: string;
+  executableName?: string | null;
   spawnFn?: ((cmd: string, args: string[], opts: SpawnOptions) => ChildProcess) | null;
 }): ChildProcess {
   const spawn = spawnFn || ((cmd: string, args: string[], opts: SpawnOptions) => getExecutor().spawn(cmd, args, opts));
-  return spawn('xcrun', logStreamArgs(udid, appName), {
+  return spawn('xcrun', logStreamArgs(udid, appName, executableName), {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
   });

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -26,6 +26,7 @@ export interface ParsedCollectorArgs {
   udid?: string;
   bundleId?: string;
   appName?: string;
+  appExecutable?: string | null;
   serial?: string | null;
   packageName?: string | null;
   physical?: boolean;
@@ -39,6 +40,7 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
   let udid: string | undefined;
   let bundleId: string | undefined;
   let appName: string | undefined;
+  let appExecutable: string | null = null;
   let serial: string | null = null;
   let packageName: string | null = null;
   let physical = false;
@@ -63,6 +65,10 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
     }
     if (arg === '--app-name') {
       appName = argv[++i];
+      continue;
+    }
+    if (arg === '--app-executable') {
+      appExecutable = argv[++i] ?? null;
       continue;
     }
     if (arg === '--serial') {
@@ -102,7 +108,7 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
   if (payloadUrl && !physical) {
     return { error: '--payload-url only applies to --physical, which launches the app itself.' };
   }
-  return { platform, root, udid, bundleId, appName, serial, packageName, physical, payloadUrl };
+  return { platform, root, udid, bundleId, appName, appExecutable, serial, packageName, physical, payloadUrl };
 }
 
 import { readCollectors, registerCollector, unregisterCollector } from './state.ts';
@@ -113,6 +119,7 @@ export interface RunCollectorOptions {
   root: string;
   udid?: string | null;
   appName?: string | null;
+  appExecutable?: string | null;
   bundleId?: string | null;
   serial?: string | null;
   packageName?: string | null;
@@ -123,6 +130,7 @@ export interface RunCollectorOptions {
         platform: string;
         udid?: string | null;
         appName?: string | null;
+        appExecutable?: string | null;
         bundleId?: string | null;
         serial?: string | null;
         physical?: boolean;
@@ -186,6 +194,7 @@ export async function runCollector({
   root,
   udid = null,
   appName = null,
+  appExecutable = null,
   bundleId = null,
   serial = null,
   packageName = null,
@@ -292,11 +301,11 @@ export async function runCollector({
 
   const attach = (streamPid: number | null): ChildProcess => {
     const spawned = startStream
-      ? startStream({ platform, udid, appName, bundleId, serial, physical, payloadUrl, pid: streamPid })
+      ? startStream({ platform, udid, appName, appExecutable, bundleId, serial, physical, payloadUrl, pid: streamPid })
       : platform === 'ios'
         ? physical
           ? startIosDeviceConsole({ udid: udid as string, bundleId: bundleId as string, payloadUrl })
-          : startIosLogStream({ udid: udid as string, appName: appName as string })
+          : startIosLogStream({ udid: udid as string, appName: appName as string, executableName: appExecutable })
         : startAndroidLogcat({ serial: serial as string, pid: streamPid as number });
     const outReader = createLineReader(onLine);
     // devicectl --console connects the app's stderr to its own, and the os_log

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -128,6 +128,7 @@ import {
   compilationCacheActivityLine,
   COMPILATION_CACHE_NOT_RUN,
   COMPILATION_CACHE_UNAVAILABLE,
+  readBundleExecutable,
   readBundleId,
 } from '../engine/xcode.ts';
 import { getExecutor } from '../exec.ts';
@@ -723,6 +724,7 @@ interface ReplaceCollectorArgs {
   udid: string;
   bundleId: string;
   appName?: string | null;
+  appExecutable?: string | null;
   physical?: boolean;
   payloadUrl?: string | null;
   spawn?: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => ChildProcess;
@@ -794,6 +796,7 @@ export async function replaceCollector({
   udid,
   bundleId,
   appName,
+  appExecutable,
   physical = false,
   payloadUrl = null,
   spawn = (cmd, args, opts) => getExecutor().spawn(cmd, args, opts),
@@ -808,6 +811,7 @@ export async function replaceCollector({
 
   const args = [collectorEntry(), '--platform', PLATFORM, '--root', root, '--udid', udid, '--bundle', bundleId];
   if (appName) args.push('--app-name', appName);
+  if (appExecutable) args.push('--app-executable', appExecutable);
   if (physical) args.push('--physical');
   if (payloadUrl) args.push('--payload-url', payloadUrl);
 
@@ -895,6 +899,7 @@ interface IosDeps {
   iosDeviceProcess: typeof iosDeviceProcess;
   verifyIosDeviceReleaseLaunch: typeof verifyIosDeviceReleaseLaunch;
   readBundleId: typeof readBundleId;
+  readBundleExecutable: typeof readBundleExecutable;
   swapJsBundle: typeof swapJsBundle;
   installIosApp: typeof installIosApp;
   launchIosApp: typeof launchIosApp;
@@ -970,6 +975,7 @@ const DEFAULT_DEPS: IosDeps = {
   iosDeviceProcess,
   verifyIosDeviceReleaseLaunch,
   readBundleId,
+  readBundleExecutable,
   swapJsBundle,
   installIosApp,
   launchIosApp,
@@ -1516,6 +1522,7 @@ async function finishIosRun({
 
   const scheme = release ? undefined : d.devClientScheme(root, appPath);
   const appName = appNameFromPath(appPath);
+  const appExecutable = appPath ? d.readBundleExecutable(appPath) : null;
   const dropSwapDir = () => {
     if (!swapDir) return;
     try {
@@ -1647,7 +1654,7 @@ async function finishIosRun({
         (launched?.mode === 'openurl' || launched?.mode === 'payload-url' ? ' (expo-dev-client)' : ''),
   });
 
-  if (!physical) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, note });
+  if (!physical) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const launchState = await verifyIosRun({

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1523,6 +1523,13 @@ async function finishIosRun({
   const scheme = release ? undefined : d.devClientScheme(root, appPath);
   const appName = appNameFromPath(appPath);
   const appExecutable = appPath ? d.readBundleExecutable(appPath) : null;
+  if (appPath && !appExecutable) {
+    note(
+      chalk.dim(
+        `Could not read CFBundleExecutable from ${appPath}; the device log predicate falls back to the .app basename.`,
+      ),
+    );
+  }
   const dropSwapDir = () => {
     if (!swapDir) return;
     try {

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -359,6 +359,35 @@ export function readBundleId(appPath: string, { exec = null }: { exec?: Executor
   }
 }
 
+export function parseBundleExecutable(plistJson: unknown): string | null {
+  if (typeof plistJson !== 'string') return null;
+  let data: unknown;
+  try {
+    data = JSON.parse(plistJson);
+  } catch {
+    return null;
+  }
+  if (!data || typeof data !== 'object') return null;
+  const name = (data as { CFBundleExecutable?: unknown }).CFBundleExecutable;
+  return typeof name === 'string' && name.trim() !== '' ? name.trim() : null;
+}
+
+export function readBundleExecutable(appPath: string, { exec = null }: { exec?: Executor | null } = {}): string | null {
+  const executor = exec || getExecutor();
+  try {
+    const json = executor.runFile('plutil', ['-convert', 'json', '-o', '-', join(appPath, 'Info.plist')]);
+    const name = parseBundleExecutable(json);
+    if (name) return name;
+  } catch {}
+  try {
+    const value = executor.runFile('defaults', ['read', join(appPath, 'Info'), 'CFBundleExecutable']);
+    const trimmed = String(value).trim();
+    return trimmed === '' ? null : trimmed;
+  } catch {
+    return null;
+  }
+}
+
 export function tailLines(lines: unknown, count = 5): string[] {
   const nonEmpty = (Array.isArray(lines) ? lines : []).filter((l) => typeof l === 'string' && l.trim() !== '');
   return nonEmpty.slice(-count);


### PR DESCRIPTION
## Description

The device-log collector filtered `xcrun simctl spawn <udid> log stream` with `processImagePath CONTAINS[c] "<app basename>"` (`collector/ios.ts` `logStreamArgs`). That admits any process whose image path merely *contains* the app name — for a short or common app name (the native e2e fixture's `app`, or names like `mobile`/`ios`) this pulled SpringBoard, `amsengagementd`, and other unrelated system processes into `device.ndjson`, and (before #260) into the run's error summary.

PR #261 also touched `commands/ios.ts` around the `replaceCollector` call site and has since merged; this branch is rebased onto it. My hunk there stays small — one new local (`appExecutable`), passed to the simulator's `replaceCollector` call only (the physical-device call site doesn't need it; hardware streams the devicectl console, not `log stream`).

## Solution

Anchor the predicate to the app's own executable path instead: `processImagePath ENDSWITH "/<AppName>.app/<CFBundleExecutable>"`, falling back to the `.app` basename when `CFBundleExecutable` can't be read (that's what Xcode uses as the executable name by default anyway).

`CFBundleExecutable` comes from a new `readBundleExecutable` in `engine/xcode.ts`, parsed from the built app's `Info.plist` the same way `readBundleId` already reads `CFBundleIdentifier`. `commands/ios.ts` reads it once and threads it through `replaceCollector` -> the collector subprocess (`--app-executable`) -> `startIosLogStream`. `procFromImagePath` needed no change: it already takes the last path segment, which is the executable name. When `CFBundleExecutable` can't be read, `commands/ios.ts` now also emits a dim stderr note naming the app path, so an unexpectedly empty device log is diagnosable instead of silently falling back.

## Test plan

- Unit tests: `logStreamArgs`/`startIosLogStream` (`collector-parsers.test.ts`) cover the anchored predicate, the CFBundleExecutable-vs-basename case, the fallback, and directly assert that a short app name (`app`) no longer matches `/SpringBoard.app/SpringBoard` or `/usr/libexec/amsengagementd` while it does match the app's own installed path. `readBundleExecutable`/`parseBundleExecutable` (`engine-xcode.test.ts`) mirror the existing `readBundleId` coverage. `ios-command.test.ts` and `collector-run.test.ts` cover the plumbing (`--app-executable` on the spawned collector argv and its parsing), the diagnostic note when `CFBundleExecutable` can't be read, and the real-subprocess fake-`xcrun` test now expects the anchored predicate string. A second real-subprocess test uses `--app-name MyAppDev --app-executable MyApp` (deliberately distinct) against a shim that only accepts the exact anchored argv, `processImagePath ENDSWITH "/MyAppDev.app/MyApp"`, then asserts on a parsed device record (mirroring the sibling test) and the absence of an `unexpected argv` stderr line -- closing the gap where a same-named fixture couldn't catch a bug that dropped `--app-executable` on its way to `startIosLogStream`. I confirmed this by ablating that line locally (removed `executableName: appExecutable` from the `startIosLogStream` call in `collector/run.ts`): the test timed out waiting for the parsed record; restoring the line made it pass again.
- Real-tool check (invariant 9): built this branch's CLI, then from `trailhead-bench` ran `worktree create qa-264 --carry-ignored`, and from the new worktree `start --json` and `ios --json` (fingerprint cache hit). After the launch settled, every record in `device.ndjson` carried `proc: "Trailhead"` (642/642 records with a `proc` field; the other two are the collector's own `collector_started`/`collector_stderr` events). `ps -ef | grep 'log stream'` showed the actual spawned command:
  ```
  simctl spawn <udid> log stream --style ndjson --predicate processImagePath ENDSWITH "/Trailhead.app/Trailhead"
  ```
  Then `stop --json` and, from `trailhead-bench`, `worktree remove <path> --force`; no `stim-*` simulators left behind (`stim-issue-245-measure` belongs to another session and was left alone).

Fixes #264
