### PR TITLE
feat: heartbeats name the phase and size it from this project's last cold build

### DIFF
--- a/docs/specs/2026-09-02-stats-design.md
+++ b/docs/specs/2026-09-02-stats-design.md
@@ -118,10 +118,17 @@ sides and cancels in the mean; no second definition of duration exists.
    `lastPodsMs`; a run that did neither leaves both exactly as they were. The
    machine bucket takes them in lockstep, like every other field. Both are
    written by the same recorder, in the same call, under the same lock.
+6. A run that compiled and then failed -- an install, a boot, or a launch that
+   went wrong after the compile -- still sets `lastColdBuildMs`. Rule 3's
+   "nothing else" governs the COUNTERS: a failed run is not a cold run and
+   adds nothing to `coldRunMs`, so it changes no mean and no credit. The
+   compile itself was a real cold build of this project, and it is the best
+   estimate the next run has. A phase that did not finish never supplies a
+   duration at all.
 
 Reading them is not part of the update rule: before its build, and before
 `pod install`, a run reads the PROJECT bucket for its platform (the same key
-rule) with a plain read and no lock. A file that is missing, unreadable, from
+rule) with a plain read and no lock, once per run and reused by both phases. A file that is missing, unreadable, from
 a newer version, or has no entry for this project yields no estimate and no
 message; a statistics read never affects the run.
 

--- a/docs/specs/2026-09-02-stats-design.md
+++ b/docs/specs/2026-09-02-stats-design.md
@@ -60,6 +60,21 @@ is never a placeholder):
       "lastRunAt": "..."
     }
 
+### Amendment, 2026-09-02 (issue #265)
+
+Two optional fields join a bucket:
+
+    "lastColdBuildMs": 190000,
+    "lastPodsMs": 100000
+
+`lastColdBuildMs` is the duration of the BUILD PHASE of the last cache miss
+that compiled, and `lastPodsMs` the duration of the last `pod install`. Each
+is absent until the project has done that thing once. This is still
+aggregate-only: two numbers per bucket, the last value each, not a log. They
+size the heartbeat of the next run (`build       still compiling (1m00s of
+~3m10s)`), which is why the last value beats the mean -- a project's build
+time drifts with its size, so the most recent one is the best single guess.
+
 Milliseconds are integers. Durations come from the run's injected clock
 (`d.now` on iOS, the `now` option on Android) and timestamps from
 `new Date(now()).toISOString()`, so the pure update function and its tests
@@ -95,6 +110,20 @@ sides and cancels in the mean; no second definition of duration exists.
    With no cold run recorded for the project and platform, a hit credits
    nothing, even when the machine bucket has cold runs: compile times differ
    per project.
+
+### Amendment, 2026-09-02 (issue #265)
+
+5. A run that supplies a build-phase duration (a miss that compiled) sets
+   `lastColdBuildMs`, and one that supplies a `pod install` duration sets
+   `lastPodsMs`; a run that did neither leaves both exactly as they were. The
+   machine bucket takes them in lockstep, like every other field. Both are
+   written by the same recorder, in the same call, under the same lock.
+
+Reading them is not part of the update rule: before its build, and before
+`pod install`, a run reads the PROJECT bucket for its platform (the same key
+rule) with a plain read and no lock. A file that is missing, unreadable, from
+a newer version, or has no entry for this project yields no estimate and no
+message; a statistics read never affects the run.
 
 The machine bucket receives every increment and the same credit, so
 `machine.timeSavedMs` is the sum of per-project credits and is not derivable

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -4447,9 +4447,51 @@ describe('run statistics', () => {
       cacheHit: false,
       waitedForBuild: false,
       durationMs: expect.any(Number),
+      coldBuildMs: 161000,
     });
     expect((runs[0]?.run.durationMs as number) > 0).toBe(true);
     expect(runs[0]?.now).toBe(clock);
+  });
+
+  test('a cache hit compiles nothing, so it carries no build duration', async () => {
+    const { runs, recordStats } = recorder();
+    const h = harness({ recordStats, resolveCached: () => fakeApk(), build: never('the build') });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(runs[0]?.run).not.toHaveProperty('coldBuildMs');
+    expect(runs[0]?.run).not.toHaveProperty('podsMs');
+  });
+
+  test("the heartbeat is sized by this project's last cold build", async () => {
+    const seen: unknown[] = [];
+    const h = harness({
+      readEstimates: () => ({ coldBuildMs: 190_000, podsMs: null }),
+      build: async (_args: BuildArgs = {}, options: { estimateMs?: number | null } = {}) => {
+        seen.push(options.estimateMs);
+        return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      },
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(seen).toEqual([190_000]);
+  });
+
+  test('a stats file this Stim cannot read costs the run nothing: it builds with no estimate', async () => {
+    writeFileSync(join(home, 'stats.json'), 'not json at all');
+    const { recordStats } = recorder();
+    const seen: unknown[] = [];
+    const h = harness({
+      recordStats,
+      build: async (_args: BuildArgs = {}, options: { estimateMs?: number | null } = {}) => {
+        seen.push(options.estimateMs);
+        return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      },
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(seen).toEqual([null]);
+    expect(h.stderr.some((line) => /stats/i.test(line))).toBe(false);
+    expect(readFileSync(join(home, 'stats.json'), 'utf-8')).toBe('not json at all');
   });
 
   test('a cache hit is recorded as a hit', async () => {

--- a/packages/stim-cli/src/__tests__/engine-deps.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-deps.test.ts
@@ -192,8 +192,25 @@ describe('runPodInstall', () => {
     });
     expect(result.ok).toBe(true);
     expect(beats.length >= 1).toBe(true);
-    expect(beats[0]).toMatch(/^ {2}pods\s+still running \(/);
-    expect(beats[0]).toMatch(/Installing FlipperKit/);
+    expect(beats[0]).toMatch(/^ {2}pods\s+still installing \(/);
+    expect(beats[0]).not.toMatch(/Installing FlipperKit/);
+  });
+
+  test("a `pods` heartbeat carries this project's last pod install when stats have one", async () => {
+    mkdirSync(join(root, 'ios'), { recursive: true });
+    const beats: string[] = [];
+    const child = makeChildProcess({ pid: 4243 });
+    const result = await runPodInstall(root, collectingWriter(), {
+      spawnFn: () => {
+        setTimeout(() => child.emit('exit', 0, null), 120);
+        return child;
+      },
+      heartbeatMs: 25,
+      estimateMs: 100_000,
+      onHeartbeat: (l: string) => beats.push(l),
+    });
+    expect(result.ok).toBe(true);
+    expect(beats[0]).toMatch(/^ {2}pods\s+still installing \(\d+s of ~1m40s\)$/);
   });
 
   test('a non-zero exit comes back as {failed, lastLines}, never a throw', async () => {
@@ -391,7 +408,7 @@ describe('runPodInstall through bundler (#137)', () => {
     expect(result.ok).toBe(true);
     expect(calls[1]?.opts.cwd).toBe(root);
     expect(beats[0]).toMatch(/^ {2}gems\s+still running \(/);
-    expect(beats[0]).toMatch(/Fetching cocoapods/);
+    expect(beats[0]).not.toMatch(/Fetching cocoapods/);
   });
 
   test('a Gemfile with no Gemfile.lock stays on plain `pod install`, so nothing writes a lockfile', async () => {

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -682,7 +682,7 @@ describe('buildAndroid', () => {
     child.stdout.emit('data', '> Task :app:compileDebugKotlin\n');
     await new Promise((r) => setTimeout(r, 80));
     expect(beats.length).toBeGreaterThanOrEqual(1);
-    expect(beats[0]).toMatch(/^ {2}build {6} still running \(\d+s\): > Task :app:compileDebugKotlin$/);
+    expect(beats[0]).toMatch(/^ {2}build {6} still compiling \(\d+s\)$/);
     writeApk();
     child.emit('exit', 0, null);
     const result = await promise;

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -628,16 +628,25 @@ describe('reading the bundle id', () => {
 });
 
 describe('the heartbeat line', () => {
-  test('carries the activity hint, truncated to one readable line', () => {
-    expect(heartbeatLine(30_000, 'CompileC App.o')).toBe('  build       still running (30s): CompileC App.o');
-    const long = 'x'.repeat(200);
-    const line = heartbeatLine(30_000, long);
-    expect(line.endsWith('...')).toBe(true);
-    expect(line.length).toBeLessThan(120);
+  test("names what the phase is doing and never the tool's own last line", () => {
+    expect(heartbeatLine(30_000)).toBe('  build       still compiling (30s)');
+    expect(heartbeatLine(90_000, 'pods')).toBe('  pods        still installing (1m30s)');
+    expect(heartbeatLine(30_000, 'swap')).toBe('  swap        still running (30s)');
   });
 
-  test('omits the hint before the child has printed anything', () => {
-    expect(heartbeatLine(30_000, '')).toBe('  build       still running (30s)');
+  test("sizes the elapsed against this project's last comparable phase", () => {
+    expect(heartbeatLine(60_000, 'build', 190_000)).toBe('  build       still compiling (1m00s of ~3m10s)');
+    expect(heartbeatLine(90_000, 'pods', 100_000)).toBe('  pods        still installing (1m30s of ~1m40s)');
+  });
+
+  test('past the estimate the line says usually, so a slow machine does not read as a hang', () => {
+    expect(heartbeatLine(240_000, 'build', 190_000)).toBe('  build       still compiling (4m00s, usually ~3m10s)');
+    expect(heartbeatLine(190_000, 'build', 190_000)).toBe('  build       still compiling (3m10s of ~3m10s)');
+  });
+
+  test('with no record for this project the line is the elapsed alone', () => {
+    expect(heartbeatLine(60_000, 'build', null)).toBe('  build       still compiling (1m00s)');
+    expect(heartbeatLine(60_000, 'build', 0)).toBe('  build       still compiling (1m00s)');
   });
 });
 
@@ -675,12 +684,17 @@ describe('the heartbeat cadence', () => {
     };
   }
 
-  function heartbeat(scheduler: ReturnType<typeof fakeScheduler>, beats: string[], intervalMs = 30_000) {
+  function heartbeat(
+    scheduler: ReturnType<typeof fakeScheduler>,
+    beats: string[],
+    intervalMs = 30_000,
+    estimateMs: number | null = null,
+  ) {
     return startBuildHeartbeat({
       intervalMs,
       elapsed: scheduler.now,
-      lastLine: () => '',
       emit: (line) => beats.push(line),
+      estimateMs,
       schedule: scheduler.schedule,
     });
   }
@@ -694,9 +708,9 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     stop();
     expect(beats).toEqual([
-      '  build       still running (30s)',
-      '  build       still running (1m00s)',
-      '  build       still running (1m30s)',
+      '  build       still compiling (30s)',
+      '  build       still compiling (1m00s)',
+      '  build       still compiling (1m30s)',
     ]);
     expect(scheduler.idle()).toBe(true);
   });
@@ -711,10 +725,10 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     stop();
     expect(beats).toEqual([
-      '  build       still running (30s)',
-      '  build       still running (5m30s)',
-      '  build       still running (6m00s)',
-      '  build       still running (6m30s)',
+      '  build       still compiling (30s)',
+      '  build       still compiling (5m30s)',
+      '  build       still compiling (6m00s)',
+      '  build       still compiling (6m30s)',
     ]);
   });
 
@@ -725,10 +739,25 @@ describe('the heartbeat cadence', () => {
     scheduler.advance(30_000);
     scheduler.jump(29_999);
     scheduler.fire();
-    expect(beats).toEqual(['  build       still running (30s)']);
+    expect(beats).toEqual(['  build       still compiling (30s)']);
     scheduler.advance(1);
     stop();
-    expect(beats).toEqual(['  build       still running (30s)', '  build       still running (1m00s)']);
+    expect(beats).toEqual(['  build       still compiling (30s)', '  build       still compiling (1m00s)']);
+  });
+
+  test('the estimate rides every beat and flips to usually once it is passed', () => {
+    const scheduler = fakeScheduler();
+    const beats: string[] = [];
+    const stop = heartbeat(scheduler, beats, 30_000, 70_000);
+    scheduler.advance(30_000);
+    scheduler.advance(30_000);
+    scheduler.advance(30_000);
+    stop();
+    expect(beats).toEqual([
+      '  build       still compiling (30s of ~1m10s)',
+      '  build       still compiling (1m00s of ~1m10s)',
+      '  build       still compiling (1m30s, usually ~1m10s)',
+    ]);
   });
 
   test('a non-positive interval schedules nothing at all', () => {
@@ -1172,7 +1201,7 @@ describe('buildIos with a mocked executor', () => {
     child.stdout.emit('data', 'CompileC main.o\n');
     await new Promise((r) => setTimeout(r, 80));
     expect(beats.length).toBeGreaterThanOrEqual(1);
-    expect(beats[0]).toMatch(/^ {2}build {6} still running \(\d+s\): CompileC main\.o$/);
+    expect(beats[0]).toMatch(/^ {2}build {6} still compiling \(\d+s\)$/);
     makeProduct(dd);
     child.emit('close', 0, null);
     await promise;

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -639,6 +639,14 @@ describe('the heartbeat line', () => {
     expect(heartbeatLine(90_000, 'pods', 100_000)).toBe('  pods        still installing (1m30s of ~1m40s)');
   });
 
+  test('both numbers are the same clock, so a whole minute and an hour read alike', () => {
+    expect(heartbeatLine(60_000, 'build', 240_000)).toBe('  build       still compiling (1m00s of ~4m00s)');
+    expect(heartbeatLine(3_600_000, 'build', 3_900_000)).toBe('  build       still compiling (60m00s of ~65m00s)');
+    expect(heartbeatLine(4_200_000, 'build', 3_900_000)).toBe(
+      '  build       still compiling (70m00s, usually ~65m00s)',
+    );
+  });
+
   test('past the estimate the line says usually, so a slow machine does not read as a hang', () => {
     expect(heartbeatLine(240_000, 'build', 190_000)).toBe('  build       still compiling (4m00s, usually ~3m10s)');
     expect(heartbeatLine(190_000, 'build', 190_000)).toBe('  build       still compiling (3m10s of ~3m10s)');

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -7,7 +7,7 @@ import { topicNames, renderTopic, renderIndex } from '../commands/guide.ts';
 import { carriedChangesLine, carryConflictWarning } from '../commands/worktree.ts';
 import { ANDROID_AVD_CONFIG_HELP } from '../settings.ts';
 import { CONSOLE_ENV, deviceConsoleArgs } from '../collector/ios-device.ts';
-import { HEARTBEAT_INTERVAL_MS } from '../engine/xcode.ts';
+import { HEARTBEAT_INTERVAL_MS, heartbeatLine } from '../engine/xcode.ts';
 
 test('every advertised topic renders non-empty content', () => {
   for (const name of topicNames()) {
@@ -313,13 +313,36 @@ test('the guide documents the progress cadence the heartbeat actually uses', () 
   expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
   expect(lifecycle).toMatch(/PROGRESS ON A LONG RUN/);
   expect(lifecycle).toMatch(/every 30 seconds, on the 30-second\s+grid/);
-  expect(lifecycle).toMatch(/still running \(1m30s\)/);
+  expect(lifecycle).toMatch(/build {7}still compiling \(1m00s of ~3m10s\)/);
+  expect(lifecycle).toMatch(/build {7}still compiling \(4m00s, usually ~3m10s\)/);
+  expect(lifecycle).toMatch(/build {7}still compiling \(1m00s\)/);
+  expect(lifecycle).toMatch(/pods {8}still installing \(1m30s of ~1m40s\)/);
+  expect(lifecycle).not.toMatch(/still (?:compiling|running|installing) \([^)]*\):/);
+  expect(heartbeatLine(60_000, 'build', 190_000)).toBe('  build       still compiling (1m00s of ~3m10s)');
+  expect(heartbeatLine(240_000, 'build', 190_000)).toBe('  build       still compiling (4m00s, usually ~3m10s)');
+  expect(heartbeatLine(60_000, 'build')).toBe('  build       still compiling (1m00s)');
+  expect(heartbeatLine(90_000, 'pods', 100_000)).toBe('  pods        still installing (1m30s of ~1m40s)');
   expect(lifecycle).toMatch(/GAP BETWEEN HEARTBEATS IS NOT A HANG/);
   expect(lifecycle).toMatch(/device\s+stim-app-412 \(BF2A\.\.\) created \(2m14s\)/);
   for (const command of ['ios', 'android']) {
     const src = readFileSync(new URL(`../commands/${command}.ts`, import.meta.url), 'utf-8');
     expect(src.includes('SLOW_STEP_MS')).toBeTruthy();
   }
+});
+
+test('the guide states once where the heartbeat estimate comes from', () => {
+  const facts = renderTopic('facts');
+  assert(facts);
+  expect(facts).toMatch(/lastColdBuildMs/);
+  expect(facts).toMatch(/lastPodsMs/);
+  expect(facts).toMatch(/THAT IS\s+WHERE THE HEARTBEAT ESTIMATE COMES FROM/);
+  expect(facts).toMatch(/THIS PROJECT'S LAST COLD BUILD/);
+  expect(facts).toMatch(/never a mean/);
+  expect(facts).toMatch(/read takes no lock/);
+  expect(facts).toMatch(/build {7}still compiling \(1m00s of ~3m10s\)/);
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+  expect(lifecycle).toMatch(/`guide facts` says where the\s+number comes from/);
 });
 
 test('the guide documents scoped iOS dev-client preapproval', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -4620,9 +4620,84 @@ describe('run statistics', () => {
       cacheHit: false,
       waitedForBuild: false,
       durationMs: expect.any(Number),
+      coldBuildMs: 161000,
     });
     expect((runs[0]?.run.durationMs as number) > 0).toBe(true);
     expect(runs[0]?.now).toBe(clock);
+  });
+
+  test('the build phase and the pod install reach the record', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    await run({}, { recordStats, readPodState: () => ({ hasPodfile: true, lockText: 'A', manifestText: 'B' }) });
+
+    expect(runs[0]?.run.coldBuildMs).toBe(161000);
+    expect(runs[0]?.run.podsMs).toBe(18000);
+  });
+
+  test('a cache hit compiles nothing, so it carries no build duration', async () => {
+    reserve();
+    const { runs, recordStats } = recorder();
+    await run({}, { recordStats, resolveBuild: (_platform, _key) => join(root, 'cached', 'Fixture.app') });
+
+    expect(runs[0]?.run).not.toHaveProperty('coldBuildMs');
+    expect(runs[0]?.run).not.toHaveProperty('podsMs');
+  });
+
+  test("the heartbeat is sized by this project's last cold build and last pod install", async () => {
+    reserve();
+    const seen: { build: unknown; pods: unknown } = { build: null, pods: null };
+    const { exitCode } = await run(
+      {},
+      {
+        readEstimates: () => ({ coldBuildMs: 190_000, podsMs: 100_000 }),
+        readPodState: () => ({ hasPodfile: true, lockText: 'A', manifestText: 'B' }),
+        runPodInstall: async (_root, _writer, options) => {
+          seen.pods = options?.estimateMs;
+          return { ok: true, durationMs: 18000 };
+        },
+        buildIos: async (args) => {
+          seen.build = (args as { estimateMs?: number | null }).estimateMs;
+          return {
+            appPath: join(root, 'build', 'Fixture.app'),
+            bundleId: 'com.example.app',
+            durationMs: 161000,
+            scheme: 'Fixture',
+          };
+        },
+      },
+    );
+
+    expect(exitCode).toBe(null);
+    expect(seen.build).toBe(190_000);
+    expect(seen.pods).toBe(100_000);
+  });
+
+  test('a stats file this Stim cannot read costs the run nothing: it builds with no estimate', async () => {
+    reserve();
+    writeFileSync(join(tmpHome, 'stats.json'), 'not json at all');
+    const { recordStats } = recorder();
+    const seen: unknown[] = [];
+    const { exitCode, stderr } = await run(
+      {},
+      {
+        recordStats,
+        buildIos: async (args) => {
+          seen.push((args as { estimateMs?: number | null }).estimateMs);
+          return {
+            appPath: join(root, 'build', 'Fixture.app'),
+            bundleId: 'com.example.app',
+            durationMs: 161000,
+            scheme: 'Fixture',
+          };
+        },
+      },
+    );
+
+    expect(exitCode).toBe(null);
+    expect(seen).toEqual([null]);
+    expect(stderr).not.toMatch(/stats/i);
+    expect(readFileSync(join(tmpHome, 'stats.json'), 'utf-8')).toBe('not json at all');
   });
 
   test('a cache hit is recorded as a hit', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -4647,10 +4647,14 @@ describe('run statistics', () => {
   test("the heartbeat is sized by this project's last cold build and last pod install", async () => {
     reserve();
     const seen: { build: unknown; pods: unknown } = { build: null, pods: null };
+    let reads = 0;
     const { exitCode } = await run(
       {},
       {
-        readEstimates: () => ({ coldBuildMs: 190_000, podsMs: 100_000 }),
+        readEstimates: () => {
+          reads += 1;
+          return { coldBuildMs: 190_000, podsMs: 100_000 };
+        },
         readPodState: () => ({ hasPodfile: true, lockText: 'A', manifestText: 'B' }),
         runPodInstall: async (_root, _writer, options) => {
           seen.pods = options?.estimateMs;
@@ -4671,6 +4675,7 @@ describe('run statistics', () => {
     expect(exitCode).toBe(null);
     expect(seen.build).toBe(190_000);
     expect(seen.pods).toBe(100_000);
+    expect(reads).toBe(1);
   });
 
   test('a stats file this Stim cannot read costs the run nothing: it builds with no estimate', async () => {

--- a/packages/stim-cli/src/__tests__/stats.test.ts
+++ b/packages/stim-cli/src/__tests__/stats.test.ts
@@ -6,7 +6,9 @@ import { Command } from 'commander';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import statsCommand from '../commands/stats.ts';
 import {
+  createRunRecorder,
   emptyStats,
+  readRunEstimates,
   readStats,
   recordRunStats,
   statsFile,
@@ -194,6 +196,47 @@ describe('the update rule', () => {
     expect(Number.isInteger(bucket.timeSavedMs)).toBe(true);
   });
 
+  test('a miss that compiled records the build phase, in both buckets', () => {
+    const record = updateStats(emptyStats(), run({ durationMs: 240_000, coldBuildMs: 190_000 }), T0);
+
+    expect(bucketOf(record, '/repo/app').lastColdBuildMs).toBe(190_000);
+    expect(record.machine.ios?.lastColdBuildMs).toBe(190_000);
+  });
+
+  test('a pod install records its own duration, in both buckets', () => {
+    const record = updateStats(emptyStats(), run({ durationMs: 240_000, podsMs: 100_000 }), T0);
+
+    expect(bucketOf(record, '/repo/app').lastPodsMs).toBe(100_000);
+    expect(record.machine.ios?.lastPodsMs).toBe(100_000);
+  });
+
+  test('the last value wins: a later cold build replaces the one before it', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000, coldBuildMs: 190_000, podsMs: 100_000 }), T0);
+    record = updateStats(record, run({ durationMs: 300_000, coldBuildMs: 250_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.lastColdBuildMs).toBe(250_000);
+    expect(bucket.lastPodsMs).toBe(100_000);
+  });
+
+  test('a run with no long phase leaves both fields exactly as they were', () => {
+    let record = updateStats(emptyStats(), run({ durationMs: 240_000, coldBuildMs: 190_000, podsMs: 100_000 }), T0);
+    record = updateStats(record, run({ cacheHit: 'local', durationMs: 30_000 }), T1);
+    record = updateStats(record, run({ failed: true, durationMs: 5_000 }), T1);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.lastColdBuildMs).toBe(190_000);
+    expect(bucket.lastPodsMs).toBe(100_000);
+  });
+
+  test('a bucket that never compiled carries neither field, so the payload is unchanged', () => {
+    const record = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect('lastColdBuildMs' in bucket).toBe(false);
+    expect('lastPodsMs' in bucket).toBe(false);
+  });
+
   test('the input record is not mutated', () => {
     const before = updateStats(emptyStats(), run({ durationMs: 240_000 }), T0);
     const snapshot = JSON.stringify(before);
@@ -264,6 +307,88 @@ describe('the stats file', () => {
     expect(statsProjectKey({ root, commonDir: join(repo, 'bare.git'), repoRoot: repo })).toBe(root);
 
     rmSync(repo, { recursive: true, force: true });
+  });
+});
+
+describe('the run recorder', () => {
+  function recorderFor(writes: { run: StatsRun; now: number }[]) {
+    const recorder = createRunRecorder({
+      platform: 'ios',
+      write: (statsRun, at) => {
+        writes.push({ run: statsRun, now: at });
+        return { recorded: true, note: null };
+      },
+      now: () => T0,
+      note: () => {},
+    });
+    recorder.setProject('/repo/app');
+    recorder.setCacheKey('ios-abc');
+    return recorder;
+  }
+
+  test('the build and pod install durations reach the record', () => {
+    const writes: { run: StatsRun; now: number }[] = [];
+    const recorder = recorderFor(writes);
+    recorder.setPodsMs(100_000);
+    recorder.setBuildMs(190_000);
+    recorder.record({ failed: false, cacheHit: false, durationMs: 300_000 });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.run.coldBuildMs).toBe(190_000);
+    expect(writes[0]?.run.podsMs).toBe(100_000);
+  });
+
+  test('a run with neither phase sends neither field', () => {
+    const writes: { run: StatsRun; now: number }[] = [];
+    recorderFor(writes).record({ failed: false, cacheHit: 'local', durationMs: 30_000 });
+
+    expect(writes[0]?.run).not.toHaveProperty('coldBuildMs');
+    expect(writes[0]?.run).not.toHaveProperty('podsMs');
+  });
+});
+
+describe('the estimates a run reads back', () => {
+  test('the project bucket supplies the last cold build and the last pod install', () => {
+    const record = updateStats(emptyStats(), run({ projectKey: root, coldBuildMs: 190_000, podsMs: 100_000 }), T0);
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    expect(readRunEstimates({ projectKey: root, platform: 'ios' })).toEqual({
+      coldBuildMs: 190_000,
+      podsMs: 100_000,
+    });
+  });
+
+  test('another project, another platform, and no file at all all read as no record', () => {
+    const record = updateStats(emptyStats(), run({ projectKey: root, coldBuildMs: 190_000 }), T0);
+    writeFileSync(statsFile(), JSON.stringify(record));
+
+    expect(readRunEstimates({ projectKey: '/elsewhere', platform: 'ios' })).toEqual({
+      coldBuildMs: null,
+      podsMs: null,
+    });
+    expect(readRunEstimates({ projectKey: root, platform: 'android' })).toEqual({
+      coldBuildMs: null,
+      podsMs: null,
+    });
+    rmSync(statsFile(), { force: true });
+    expect(readRunEstimates({ projectKey: root, platform: 'ios' })).toEqual({ coldBuildMs: null, podsMs: null });
+    expect(readRunEstimates({ projectKey: null, platform: 'ios' })).toEqual({ coldBuildMs: null, podsMs: null });
+  });
+
+  test('a corrupt file and a throwing read are silent: the run gets no estimate and no note', () => {
+    writeFileSync(statsFile(), 'not json at all');
+
+    expect(readRunEstimates({ projectKey: root, platform: 'ios' })).toEqual({ coldBuildMs: null, podsMs: null });
+    expect(
+      readRunEstimates({
+        projectKey: root,
+        platform: 'ios',
+        read: () => {
+          throw new Error('nope');
+        },
+      }),
+    ).toEqual({ coldBuildMs: null, podsMs: null });
+    expect(readFileSync(statsFile(), 'utf-8')).toBe('not json at all');
   });
 });
 

--- a/packages/stim-cli/src/__tests__/stats.test.ts
+++ b/packages/stim-cli/src/__tests__/stats.test.ts
@@ -210,6 +210,18 @@ describe('the update rule', () => {
     expect(record.machine.ios?.lastPodsMs).toBe(100_000);
   });
 
+  test('a run that compiled and then failed still records the cold build it paid for', () => {
+    const record = updateStats(emptyStats(), run({ failed: true, durationMs: 200_000, coldBuildMs: 190_000 }), T0);
+    const bucket = bucketOf(record, '/repo/app');
+
+    expect(bucket.lastColdBuildMs).toBe(190_000);
+    expect(record.machine.ios?.lastColdBuildMs).toBe(190_000);
+    expect(bucket.failed).toBe(1);
+    expect(bucket.coldRuns).toBe(0);
+    expect(bucket.coldRunMs).toBe(0);
+    expect(bucket.misses).toBe(0);
+  });
+
   test('the last value wins: a later cold build replaces the one before it', () => {
     let record = updateStats(emptyStats(), run({ durationMs: 240_000, coldBuildMs: 190_000, podsMs: 100_000 }), T0);
     record = updateStats(record, run({ durationMs: 300_000, coldBuildMs: 250_000 }), T1);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -75,7 +75,14 @@ import {
   tunnelModeSetting,
   unknownSettingKeys,
 } from '../settings.ts';
-import { createRunRecorder, recordRunStats, statsProjectKey, type RunRecorder } from '../engine/stats.ts';
+import {
+  createRunRecorder,
+  readRunEstimates,
+  recordRunStats,
+  statsProjectKey,
+  type RunEstimates,
+  type RunRecorder,
+} from '../engine/stats.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
 import { readCollectors } from '../collector/state.ts';
 import { MODE_BARE, MODE_EXPO, readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
@@ -828,6 +835,7 @@ interface RunAndroidOptions {
   createWriter?: typeof createNdjsonWriter;
   writeState?: typeof writeWorkspaceState;
   recordStats?: typeof recordRunStats;
+  readEstimates?: typeof readRunEstimates;
   now?: () => number;
   out?: (line: string) => void;
   emit?: (line: string) => void;
@@ -1573,6 +1581,7 @@ function resolveRunAndroidOptions(
     createWriter = createNdjsonWriter,
     writeState = writeWorkspaceState,
     recordStats = recordRunStats,
+    readEstimates = readRunEstimates,
     now = Date.now,
     out = (line) => console.error(line),
     emit = (line) => console.log(line),
@@ -1647,6 +1656,7 @@ function resolveRunAndroidOptions(
     createWriter,
     writeState,
     recordStats,
+    readEstimates,
     now,
     out,
     emit,
@@ -1723,6 +1733,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     createWriter,
     writeState,
     recordStats,
+    readEstimates,
     now,
     out,
     emit,
@@ -1832,7 +1843,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     gitCommonDir: gitCommonDir(root),
     repoRoot: settingsRepoRoot,
   };
-  stats.setProject(statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot }));
+  const projectKey = statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot });
+  stats.setProject(projectKey);
+  let estimatesRead: RunEstimates | null = null;
+  const estimates = (): RunEstimates => (estimatesRead ??= readEstimates({ projectKey, platform: PLATFORM }));
   const settings = resolveSettingsFor(settingsContext);
   const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
   if (shapeError) {
@@ -2467,7 +2481,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
 
           if (!apkPath) {
             phase('build', `compiling ${variant || 'debug'} with Gradle`);
-            const built: BuildAndroidResultLike = await build({ root, logWriter: writer, variant });
+            const built: BuildAndroidResultLike = await build(
+              { root, logWriter: writer, variant },
+              { estimateMs: estimates().coldBuildMs },
+            );
             if (built.failed) {
               const diagnostics = built.diagnostics || [];
               for (const diag of diagnostics) {
@@ -2491,6 +2508,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
               return false;
             }
             apkPath = built.apkPath ?? null;
+            stats.setBuildMs(built.durationMs ?? 0);
             phase('build', `ok (${formatDuration(built.durationMs)})`);
             if (built.apkNote) phase('build', chalk.yellow(built.apkNote));
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -299,7 +299,9 @@ line by design (see \`guide logs\`), not this single-payload contract.
 
   \`project\` is null outside a project; a platform with no run yet is null.
   A bucket carries runs, failed, hits, misses, coldRuns, coldRunMs, hitRuns,
-  hitRunMs, timeSavedMs, firstRunAt and lastRunAt. Milliseconds are integers.
+  hitRunMs, timeSavedMs, firstRunAt and lastRunAt, plus lastColdBuildMs and
+  lastPodsMs once the project has compiled or installed pods. Milliseconds are
+  integers.
 
 HOW A RUN IS COUNTED (\`stats\`)
   Every \`ios\` or \`android\` invocation that got as far as computing a
@@ -319,6 +321,24 @@ HOW A RUN IS COUNTED (\`stats\`)
   nothing to compare against, so it credits nothing either. The saved figure
   is therefore an ESTIMATE and is printed as one. Nothing per run is stored;
   the file is $STIM_HOME/stats.json (see \`guide lifecycle\`).
+
+  A run also keeps the duration of its own two long phases in that bucket:
+  the build phase of a miss that compiled (lastColdBuildMs) and the last
+  \`pod install\` (lastPodsMs). The last value only, not a series. THAT IS
+  WHERE THE HEARTBEAT ESTIMATE COMES FROM. A later run reads this project's
+  bucket before it compiles, and prints:
+
+    build       still compiling (1m00s of ~3m10s)
+    pods        still installing (1m30s of ~1m40s)
+
+  The \`~\` value is THIS PROJECT'S LAST COLD BUILD, or its last
+  \`pod install\`, and never a mean: a project's build time drifts with its
+  size, so the most recent run is the best single guess. Past the estimate
+  the line reads \`(4m00s, usually ~3m10s)\`, because a slower machine is not
+  a hang. A project with no record yet gets \`(1m00s)\`, the elapsed alone,
+  and a warm run has no long phase to size. That read takes no lock and
+  ignores what it cannot read, so nothing about statistics can change a
+  run's outcome.
 
 ON FAILURE
   \`start\`, \`ios\` and \`android\` all print the error contract instead,
@@ -1551,10 +1571,19 @@ PROGRESS ON A LONG RUN
 
   A step that is still running heartbeats every 30 seconds, on the 30-second
   grid, so the values read 30s, 1m00s, 1m30s and never repeat. A heartbeat
-  reuses its phase's label and column:
+  reuses its phase's label and column and names what the phase is doing, never
+  the build tool's own last line -- that transcript is in the build log
+  (\`logs --source build\`):
 
-    build       still running (1m30s): > Task :app:compileDebugKotlin
+    build       still compiling (1m00s of ~3m10s)
+    build       still compiling (4m00s, usually ~3m10s)
+    build       still compiling (1m00s)
+    pods        still installing (1m30s of ~1m40s)
     build       waiting on /w/app-411 (pid 41233, 1m30s elapsed)
+
+  The \`~\` value is an estimate, never a countdown; the third line is a
+  project with no record to estimate from yet. \`guide facts\` says where the
+  number comes from.
 
   The lifecycle commands use the same column. \`worktree create\` keeps the
   created path alone on stdout and reports itself on stderr:

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -121,7 +121,14 @@ import {
   uploadRemote,
   type LoadProjectProviderResult,
 } from '../engine/remote-cache.ts';
-import { createRunRecorder, recordRunStats, statsProjectKey, type RunRecorder } from '../engine/stats.ts';
+import {
+  createRunRecorder,
+  readRunEstimates,
+  recordRunStats,
+  statsProjectKey,
+  type RunEstimates,
+  type RunRecorder,
+} from '../engine/stats.ts';
 import { swapJsBundle } from '../engine/js-swap.ts';
 import {
   buildIos,
@@ -906,6 +913,7 @@ interface IosDeps {
   writeWorkspaceState: typeof writeWorkspaceState;
   createWriter: typeof createNdjsonWriter;
   recordStats: typeof recordRunStats;
+  readEstimates: typeof readRunEstimates;
   now: () => number;
 }
 
@@ -981,6 +989,7 @@ const DEFAULT_DEPS: IosDeps = {
   writeWorkspaceState,
   createWriter: createNdjsonWriter,
   recordStats: recordRunStats,
+  readEstimates: readRunEstimates,
   now: () => Date.now(),
 };
 
@@ -1853,7 +1862,10 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     gitCommonDir: d.gitCommonDir(root),
     repoRoot: settingsRepoRoot,
   };
-  stats.setProject(statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot }));
+  const projectKey = statsProjectKey({ root, commonDir: settingsContext.gitCommonDir, repoRoot: settingsRepoRoot });
+  stats.setProject(projectKey);
+  let estimatesRead: RunEstimates | null = null;
+  const estimates = (): RunEstimates => (estimatesRead ??= d.readEstimates({ projectKey, platform: PLATFORM }));
   const settings = d.resolveSettings(settingsContext);
   const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
   if (shapeError) {
@@ -2592,7 +2604,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
         const verdict = d.podsAreStale(podState.lockText, podState.manifestText);
         const action = podAction(podState, verdict);
         if (action.install) {
-          const result = await d.runPodInstall(root, logWriter());
+          const result = await d.runPodInstall(root, logWriter(), { estimateMs: estimates().podsMs });
           const podCommand = result?.command || 'pod install';
           for (const line of result?.notes || []) note(chalk.dim(phaseLine('pods', line)));
           if (result?.failed) {
@@ -2606,6 +2618,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             });
             return false;
           }
+          stats.setPodsMs(result?.durationMs ?? 0);
           phase(
             'pods',
             `${action.reason} -> installed with \`${podCommand}\` (${formatDuration(result?.durationMs ?? 0)})`,
@@ -2657,6 +2670,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             ...(physical ? { sdk: IPHONEOS_SDK } : {}),
             logWriter: logWriter(),
             ...(configuration ? { configuration } : {}),
+            estimateMs: estimates().coldBuildMs,
           });
           if (result?.failed) {
             phase('build', `FAILED after ${formatDuration(result.durationMs)}`);
@@ -2672,6 +2686,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
             return false;
           }
           compilationCache = result.compilationCache ?? COMPILATION_CACHE_UNAVAILABLE;
+          stats.setBuildMs(result.durationMs ?? 0);
           phase('build', `ok (${formatDuration(result.durationMs)})`);
           appPath = result.appPath ?? null;
           bundleId = result.bundleId ?? null;

--- a/packages/stim-cli/src/engine/apk-swap.ts
+++ b/packages/stim-cli/src/engine/apk-swap.ts
@@ -300,7 +300,6 @@ export async function swapApkBundle({
   const stopHeartbeat = startBuildHeartbeat({
     intervalMs: heartbeatMs,
     elapsed,
-    lastLine: () => transcript.at(-1) ?? '',
     emit: onHeartbeat,
     label: 'swap',
   });

--- a/packages/stim-cli/src/engine/deps.ts
+++ b/packages/stim-cli/src/engine/deps.ts
@@ -260,6 +260,7 @@ async function runCaptured(
     env: NodeJS.ProcessEnv;
     event: string;
     label?: string | null;
+    estimateMs?: number | null;
   },
 ): Promise<CapturedRun> {
   const startedAt = ctx.now();
@@ -292,9 +293,9 @@ async function runCaptured(
     ? startBuildHeartbeat({
         intervalMs: ctx.heartbeatMs,
         elapsed: () => ctx.now() - startedAt,
-        lastLine: () => transcript.at(-1) ?? '',
         emit: ctx.onHeartbeat,
         label: ctx.label,
+        estimateMs: ctx.estimateMs ?? null,
       })
     : () => {};
 
@@ -428,11 +429,13 @@ export async function runPodInstall(
     spawnFn = null,
     now = Date.now,
     heartbeatMs = HEARTBEAT_INTERVAL_MS,
+    estimateMs = null,
     onHeartbeat = (line: string) => console.error(line),
   }: {
     spawnFn?: SpawnFn | null;
     now?: () => number;
     heartbeatMs?: number;
+    estimateMs?: number | null;
     onHeartbeat?: (line: string) => void;
   } = {},
 ): Promise<PodInstallResult> {
@@ -475,6 +478,7 @@ export async function runPodInstall(
     env: bundler && pin ? bundlerEnv(root, pin.gemfile) : podEnv(root),
     event: 'pod_install',
     label: 'pods',
+    estimateMs,
   });
 
   if (run.error) {

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -435,6 +435,7 @@ export async function buildAndroid(
     env = process.env,
     buildCache = true,
     heartbeatMs = HEARTBEAT_INTERVAL_MS,
+    estimateMs = null,
     onHeartbeat = (line: string) => console.error(line),
     onNote = (line: string) => console.error(line),
   }: {
@@ -443,6 +444,7 @@ export async function buildAndroid(
     env?: NodeJS.ProcessEnv;
     buildCache?: boolean;
     heartbeatMs?: number;
+    estimateMs?: number | null;
     onHeartbeat?: (line: string) => void;
     onNote?: (line: string) => void;
   } = {},
@@ -476,11 +478,9 @@ export async function buildAndroid(
   const startedAt = now();
   const tail: string[] = [];
   const window: string[] = [];
-  let lastTranscriptLine = '';
   const push = (line: unknown) => {
     const msg = stripAnsi(String(line)).trimEnd();
     if (!msg.trim()) return;
-    lastTranscriptLine = msg;
     tail.push(msg);
     if (tail.length > LAST_LINES) tail.shift();
     window.push(msg);
@@ -509,8 +509,8 @@ export async function buildAndroid(
   const stopHeartbeat = startBuildHeartbeat({
     intervalMs: heartbeatMs,
     elapsed: () => now() - startedAt,
-    lastLine: () => lastTranscriptLine,
     emit: onHeartbeat,
+    estimateMs,
   });
 
   const result = await waitForChild(child);

--- a/packages/stim-cli/src/engine/js-swap.ts
+++ b/packages/stim-cli/src/engine/js-swap.ts
@@ -217,7 +217,6 @@ export async function swapJsBundle({
   const stopHeartbeat = startBuildHeartbeat({
     intervalMs: heartbeatMs,
     elapsed,
-    lastLine: () => transcript.at(-1) ?? '',
     emit: onHeartbeat,
     label: 'swap',
   });

--- a/packages/stim-cli/src/engine/stats.ts
+++ b/packages/stim-cli/src/engine/stats.ts
@@ -19,6 +19,8 @@ export interface StatsBucket {
   timeSavedMs: number;
   firstRunAt: string;
   lastRunAt: string;
+  lastColdBuildMs?: number;
+  lastPodsMs?: number;
 }
 
 export type StatsScope = Partial<Record<StatsPlatform, StatsBucket>>;
@@ -36,6 +38,17 @@ export interface StatsRun {
   cacheHit: CacheHitLevel;
   waitedForBuild: boolean;
   durationMs: number;
+  coldBuildMs?: number;
+  podsMs?: number;
+}
+
+/**
+ * The two phase durations a run reads back to size its own heartbeat: the
+ * project's last cold build and its last `pod install`, in milliseconds.
+ */
+export interface RunEstimates {
+  coldBuildMs: number | null;
+  podsMs: number | null;
 }
 
 export interface RecordStatsResult {
@@ -58,6 +71,8 @@ interface RunOutcome {
 export interface RunRecorder {
   setProject(key: string): void;
   setCacheKey(key: string): void;
+  setBuildMs(ms: number): void;
+  setPodsMs(ms: number): void;
   record(outcome: RunOutcome): void;
 }
 
@@ -89,15 +104,16 @@ export function statsProjectKey({
 export function updateStats(record: StatsRecord, run: StatsRun, now: number): StatsRecord {
   const at = new Date(now).toISOString();
   const durationMs = wholeMs(run.durationMs);
+  const phases = { coldBuildMs: wholeMs(run.coldBuildMs), podsMs: wholeMs(run.podsMs) };
   const projects: Record<string, StatsScope> = { ...record.projects };
   const scope: StatsScope = { ...projects[run.projectKey] };
   const machine: StatsScope = { ...record.machine };
   const before = scope[run.platform] ?? null;
   const credit = creditMs(before, run, durationMs);
 
-  scope[run.platform] = applyRun(before, run, { at, durationMs, credit });
+  scope[run.platform] = applyRun(before, run, { at, durationMs, credit, phases });
   projects[run.projectKey] = scope;
-  machine[run.platform] = applyRun(machine[run.platform] ?? null, run, { at, durationMs, credit });
+  machine[run.platform] = applyRun(machine[run.platform] ?? null, run, { at, durationMs, credit, phases });
 
   return { version: STATS_VERSION, machine, projects };
 }
@@ -124,6 +140,31 @@ export function readStats(): ReadStatsResult {
     };
   }
   return { record: normalize(parsed), note: null };
+}
+
+function projectEstimates(record: StatsRecord | null, projectKey: string, platform: StatsPlatform): RunEstimates {
+  const bucket = record?.projects?.[projectKey]?.[platform] ?? null;
+  return {
+    coldBuildMs: positive(bucket?.lastColdBuildMs),
+    podsMs: positive(bucket?.lastPodsMs),
+  };
+}
+
+export function readRunEstimates({
+  projectKey,
+  platform,
+  read = readStats,
+}: {
+  projectKey: string | null;
+  platform: StatsPlatform;
+  read?: () => ReadStatsResult;
+}): RunEstimates {
+  if (!projectKey) return { coldBuildMs: null, podsMs: null };
+  try {
+    return projectEstimates(read().record, projectKey, platform);
+  } catch {
+    return { coldBuildMs: null, podsMs: null };
+  }
 }
 
 export function recordRunStats(run: StatsRun, now: number): RecordStatsResult {
@@ -156,6 +197,8 @@ export function createRunRecorder({
 }): RunRecorder {
   let projectKey: string | null = null;
   let cacheKey: string | null = null;
+  let coldBuildMs = 0;
+  let podsMs = 0;
   let recorded = false;
   return {
     setProject(key: string): void {
@@ -164,12 +207,27 @@ export function createRunRecorder({
     setCacheKey(key: string): void {
       cacheKey = key;
     },
+    setBuildMs(ms: number): void {
+      coldBuildMs = wholeMs(ms);
+    },
+    setPodsMs(ms: number): void {
+      podsMs = wholeMs(ms);
+    },
     record({ failed, cacheHit = false, waited = null, durationMs }: RunOutcome): void {
       if (!projectKey || !cacheKey || recorded) return;
       recorded = true;
       try {
         const outcome = write(
-          { platform, projectKey, failed, cacheHit, waitedForBuild: Boolean(waited), durationMs },
+          {
+            platform,
+            projectKey,
+            failed,
+            cacheHit,
+            waitedForBuild: Boolean(waited),
+            durationMs,
+            ...(coldBuildMs > 0 ? { coldBuildMs } : {}),
+            ...(podsMs > 0 ? { podsMs } : {}),
+          },
           now(),
         );
         if (outcome?.note) note(outcome.note);
@@ -264,13 +322,20 @@ function normalizeBucket(bucket: Record<string, unknown>): StatsBucket {
     timeSavedMs: count(bucket.timeSavedMs),
     firstRunAt: timestamp(bucket.firstRunAt),
     lastRunAt: timestamp(bucket.lastRunAt),
+    ...(count(bucket.lastColdBuildMs) > 0 ? { lastColdBuildMs: count(bucket.lastColdBuildMs) } : {}),
+    ...(count(bucket.lastPodsMs) > 0 ? { lastPodsMs: count(bucket.lastPodsMs) } : {}),
   };
 }
 
 function applyRun(
   bucket: StatsBucket | null,
   run: StatsRun,
-  { at, durationMs, credit }: { at: string; durationMs: number; credit: number },
+  {
+    at,
+    durationMs,
+    credit,
+    phases,
+  }: { at: string; durationMs: number; credit: number; phases: { coldBuildMs: number; podsMs: number } },
 ): StatsBucket {
   const next: StatsBucket = bucket
     ? { ...bucket }
@@ -289,6 +354,8 @@ function applyRun(
       };
   next.runs += 1;
   next.lastRunAt = at;
+  if (phases.coldBuildMs > 0) next.lastColdBuildMs = phases.coldBuildMs;
+  if (phases.podsMs > 0) next.lastPodsMs = phases.podsMs;
   if (run.failed) {
     next.failed += 1;
     return next;
@@ -316,6 +383,11 @@ function creditMs(bucket: StatsBucket | null, run: StatsRun, durationMs: number)
 
 function isHit(cacheHit: CacheHitLevel): boolean {
   return cacheHit === 'local' || cacheHit === 'remote';
+}
+
+function positive(value: unknown): number | null {
+  const ms = wholeMs(value);
+  return ms > 0 ? ms : null;
 }
 
 function wholeMs(value: unknown): number {

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -6,7 +6,7 @@ import { register } from '../cache-manifest.ts';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { sharedCompilationCache, workspaceDerivedData } from '../paths.ts';
-import { formatElapsed, phaseLine } from '../command-output.ts';
+import { formatElapsed, formatLongDuration, phaseLine } from '../command-output.ts';
 import { createLineReader } from '../process-output.ts';
 import { capDiagnostics, describeDiagnostic, type Diagnostic, extractXcodeDiagnostics } from './errors-xcode.ts';
 import { cleanLine } from '../supervisor/server-expo.ts';
@@ -366,13 +366,18 @@ export function tailLines(lines: unknown, count = 5): string[] {
 
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 
-const HEARTBEAT_HINT_LENGTH = 80;
+const HEARTBEAT_ACTIVITY: Record<string, string> = { build: 'compiling', pods: 'installing' };
 
-export function heartbeatLine(elapsedMs: number, lastLine: string, label = 'build'): string {
-  const hint =
-    lastLine.length > HEARTBEAT_HINT_LENGTH ? `${lastLine.slice(0, HEARTBEAT_HINT_LENGTH - 3)}...` : lastLine;
-  const activity = hint.trim() === '' ? '' : `: ${hint}`;
-  return phaseLine(label, `still running (${formatElapsed(elapsedMs)})${activity}`);
+export function heartbeatLine(elapsedMs: number, label = 'build', estimateMs: number | null = null): string {
+  const activity = HEARTBEAT_ACTIVITY[label] ?? 'running';
+  const elapsed = formatElapsed(elapsedMs);
+  const inside =
+    estimateMs && estimateMs > 0
+      ? elapsedMs > estimateMs
+        ? `${elapsed}, usually ~${formatLongDuration(estimateMs)}`
+        : `${elapsed} of ~${formatLongDuration(estimateMs)}`
+      : elapsed;
+  return phaseLine(label, `still ${activity} (${inside})`);
 }
 
 export type HeartbeatSchedule = (run: () => void, delayMs: number) => () => void;
@@ -386,16 +391,16 @@ const defaultSchedule: HeartbeatSchedule = (run, delayMs) => {
 export function startBuildHeartbeat({
   intervalMs,
   elapsed,
-  lastLine,
   emit,
   label = 'build',
+  estimateMs = null,
   schedule = defaultSchedule,
 }: {
   intervalMs: number;
   elapsed: () => number;
-  lastLine: () => string;
   emit: (line: string) => void;
   label?: string;
+  estimateMs?: number | null;
   schedule?: HeartbeatSchedule;
 }): () => void {
   if (!(intervalMs > 0)) return () => {};
@@ -408,7 +413,7 @@ export function startBuildHeartbeat({
     const beat = Math.floor(ms / intervalMs) * intervalMs;
     if (beat > lastBeat) {
       lastBeat = beat;
-      emit(heartbeatLine(beat, lastLine(), label));
+      emit(heartbeatLine(beat, label, estimateMs));
     }
     cancel = schedule(tick, intervalMs - (ms % intervalMs));
   }
@@ -514,6 +519,7 @@ export async function buildIos({
   now = () => Date.now(),
   exec = null,
   heartbeatMs = HEARTBEAT_INTERVAL_MS,
+  estimateMs = null,
   onHeartbeat = (line: string) => console.error(line),
   onNote = (line: string) => console.error(line),
 }: {
@@ -531,6 +537,7 @@ export async function buildIos({
   now?: () => number;
   exec?: Executor | null;
   heartbeatMs?: number;
+  estimateMs?: number | null;
   onHeartbeat?: (line: string) => void;
   onNote?: (line: string) => void;
 }): Promise<BuildIosResult> {
@@ -610,12 +617,10 @@ export async function buildIos({
 
   const transcript: string[] = [];
   let compilationCacheActivity: CompilationCacheActivity = COMPILATION_CACHE_UNAVAILABLE;
-  let lastTranscriptLine = '';
   const onLine = (line: unknown) => {
     const msg = cleanLine(line);
     transcript.push(msg);
     if (msg.trim() === '') return;
-    lastTranscriptLine = msg;
     logWriter.write({ src: 'build', level: 'debug', msg });
     const activity = parseCompilationCacheActivity(msg);
     if (activity) {
@@ -664,8 +669,8 @@ export async function buildIos({
   const stopHeartbeat = startBuildHeartbeat({
     intervalMs: heartbeatMs,
     elapsed,
-    lastLine: () => lastTranscriptLine,
     emit: onHeartbeat,
+    estimateMs,
   });
 
   const outcome = await new Promise<{ code?: number | null; signal?: NodeJS.Signals | null; error?: Error }>(

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -6,7 +6,7 @@ import { register } from '../cache-manifest.ts';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { sharedCompilationCache, workspaceDerivedData } from '../paths.ts';
-import { formatElapsed, formatLongDuration, phaseLine } from '../command-output.ts';
+import { formatElapsed, phaseLine } from '../command-output.ts';
 import { createLineReader } from '../process-output.ts';
 import { capDiagnostics, describeDiagnostic, type Diagnostic, extractXcodeDiagnostics } from './errors-xcode.ts';
 import { cleanLine } from '../supervisor/server-expo.ts';
@@ -374,8 +374,8 @@ export function heartbeatLine(elapsedMs: number, label = 'build', estimateMs: nu
   const inside =
     estimateMs && estimateMs > 0
       ? elapsedMs > estimateMs
-        ? `${elapsed}, usually ~${formatLongDuration(estimateMs)}`
-        : `${elapsed} of ~${formatLongDuration(estimateMs)}`
+        ? `${elapsed}, usually ~${formatElapsed(estimateMs)}`
+        : `${elapsed} of ~${formatElapsed(estimateMs)}`
       : elapsed;
   return phaseLine(label, `still ${activity} (${inside})`);
 }

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -240,9 +240,11 @@ machine section prints. There is no reset flag: delete that file to start over.
 `project` is `null` outside a project, and a platform with no run yet is
 `null`. A bucket carries `runs`, `failed`, `hits`, `misses`, `coldRuns`,
 `coldRunMs`, `hitRuns`, `hitRunMs`, `timeSavedMs`, `firstRunAt` and
-`lastRunAt`. The saved figure is an estimate: each cache hit is credited this
-project's mean cold run at that moment, minus its own duration, floored at
-zero.
+`lastRunAt`, plus `lastColdBuildMs` and `lastPodsMs` once the project has
+compiled or installed pods; those two size the progress line a long build
+prints (`build       still compiling (1m00s of ~3m10s)`). The saved figure is
+an estimate: each cache hit is credited this project's mean cold run at that
+moment, minus its own duration, floored at zero.
 
 ## `worktree create`
 


### PR DESCRIPTION
## Description

While a compile runs, the heartbeat appended the build tool's last output line,
truncated: `build       still running (30s): > Task :app:configureCMakeDebug[armeabi-v7a]`.
That is whatever Gradle or xcodebuild happened to print, not progress, and it
reads as random noise (rc.8 gate transcripts, `qa-loop-expo-ios.log` 46-52).
What an agent wants from a heartbeat is how much longer, and `stats` now holds
the numbers to answer that.

The estimate has to come from THIS project: build times differ by an order of
magnitude between projects, so a machine-wide figure would be worse than none.
The project bucket keyed by the app's path in the main working tree is already
that scope, and a worktree pools into the checkout that filled the cache.

## Solution

Every heartbeat drops the `lastLine()` argument and names its own phase
instead: `build` compiles, `pods` installs, everything else (`gems`, `swap`)
still runs. The build transcript did not move -- it is still in
`logs --source build` and in the path the summary prints -- so a genuinely
hung build stays diagnosable. The 30-second grid from #220 and the `phaseLine`
format from #260 are untouched.

The stats bucket gains two optional fields, `lastColdBuildMs` (the build
phase's duration on a cache miss that compiled) and `lastPodsMs` (the last
`pod install`), written by the same recorder in the same call under the same
lock, machine bucket in lockstep. They are optional, so a bucket that has never
compiled serializes exactly as it does today and `stats --json` is unchanged
for existing data. This is still aggregate-only: two numbers per bucket, the
last value each, not a log. `docs/specs/2026-09-02-stats-design.md` carries the
decision as a dated amendment in its record and update-rule sections rather
than a rewrite.

The last value, not the mean, is deliberate: a project's build time drifts with
its size, so the most recent cold build is the best single guess, and the line
is never phrased as a countdown. Per the maintainer's wording decision on the
issue, no provenance rides on the line:

```text
  build       still compiling (1m00s of ~3m10s)
  build       still compiling (4m00s, usually ~3m10s)
  build       still compiling (1m00s)
  pods        still installing (1m30s of ~1m40s)
```

Where the number comes from is stated once, in `guide facts`; `guide lifecycle`
shows the shapes and routes there.

Reading is the first time a run reads `stats.json`, so it is deliberately
inert: a plain read with no lock, memoized once per run, and every failure mode
-- missing file, unparseable file, newer version, no entry for this project --
yields no estimate, no note, and no change to the run. A corrupt file is left
exactly as found (only the recorder's write path renames one aside).

One deviation from the issue's letter: both numbers use `formatElapsed`, not
`formatLongDuration`. The two formatters agree on the maintainer's four lines
but diverge everywhere the seconds are zero or the value passes an hour --
`formatLongDuration` renders 4m00s as `4m` and 65m as `1h05m`. Mixing them puts
two different clocks inside one pair of parentheses (`(1m00s of ~4m)`,
`(60m00s of ~1h05m)`), and the elapsed side cannot move: the 30-second grid
must print `1m00s`, which `formatLongDuration` cannot produce. So the estimate
follows the elapsed.

Blast radius is the stderr progress lines of `ios` and `android` plus two new
optional JSON fields. `--json` run payloads are byte-identical. Worst case is a
misleading estimate on a project whose last cold build was atypical, which
costs a reader nothing and self-corrects on the next miss.

## Test plan

- `heartbeatLine` unit tests pin all four mandated shapes, the boundary
  (elapsed exactly equal to the estimate still reads `of ~`), the
  no-record/zero cases, and the two places the formatters used to diverge:
  `(1m00s of ~4m00s)` and `(60m00s of ~65m00s)`. A fake-clock cadence test
  walks a run across the estimate and shows the flip to `usually ~` on the
  30-second grid.
- `runPodInstall` and `buildAndroid` heartbeat tests assert the tool's line is
  gone from the beat, and a `pods` beat carries `(Ns of ~1m40s)`.
- `updateStats`: both fields set on a miss that compiled and on a pods install,
  machine bucket in lockstep, last value wins, untouched by a run with no long
  phase, and absent entirely from a bucket that never compiled. A run that
  compiled and then failed keeps its `lastColdBuildMs` while adding nothing to
  `misses`, `coldRuns`, or `coldRunMs` -- that compile was a real cold build of
  this project, and rule 3's "nothing else" is about the counters. The spec
  amendment states this as rule 6.
- Recorder threading: `ios` sends `coldBuildMs: 161000` and `podsMs: 18000`
  from its build and pods phases, `android` sends the Gradle duration, and a
  cache hit sends neither. Both commands pass the estimate they read into
  `buildIos` / `buildAndroid` / `runPodInstall`, and the iOS test counts the
  reads: one per run, memoized across the pods and build phases.
- A `stats.json` this Stim cannot parse: `ios` and `android` still exit 0,
  build with `estimateMs: null`, print nothing about statistics, and leave the
  file untouched.
- `guide` contract tests pin the four shapes in `lifecycle`, the provenance
  paragraph in `facts`, and the new bucket fields.
- Full suite from the repo root: `pnpm run format:check`, `pnpm run lint`,
  `pnpm run build`, `pnpm run typecheck`, `pnpm test` (83 files, 3315 tests
  passing), `pnpm run knip` (clean; the `pod` ignoreBinaries hint is
  pre-existing on `origin/main`).
- No changed tool call: no argument list to `xcodebuild`, Gradle, or `pod`
  changed, so invariant 9 needs no new real-tool exercise. Not run on a device.

Fixes #265

