### PR TITLE
fix: one output vocabulary for `worktree remove`

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -621,6 +621,7 @@ test('action: on success, prints only the label-column vocabulary on stderr and 
   });
   ensureWorkspaceStorage(wtDir);
   writeFileSync(join(workspaceDir(wtDir), 'state.json'), '{}');
+  expect(takeLease({ root: wtDir, platform: 'android', id: 'R5CT', kind: 'run' }).status).toBe('taken');
   const exec = makeExecutor({
     worktrees: porcelain([
       { path: mainDir, branch: 'main' },
@@ -650,6 +651,9 @@ test('action: on success, prints only the label-column vocabulary on stderr and 
   expect(errs.some((line) => /^\s*device\s+deleted stim-x$/.test(line))).toBe(true);
   expect(errs.some((line) => /^\s*workspace\s+removed /.test(line))).toBe(true);
   expect(errs.some((line) => /^\s*branch\s+deleted worktree-feat-x$/.test(line))).toBe(true);
+  expect(
+    errs.some((line) => /^\s*lease\s+released the android lease on R5CT \(it ran until \d{2}:\d{2}:\d{2}\)/.test(line)),
+  ).toBe(true);
   expect(errs.some((line) => new RegExp(`^\\s*removed\\s+${wtDir}$`).test(line))).toBe(true);
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -487,7 +487,7 @@ test('action: main-checkout artifact deletion blocks a concurrent replacement tu
   let competingStart: Promise<'started' | 'refused'> | null = null;
   const original = console.error;
   console.error = (message) => {
-    if (String(message).includes("this workspace's own output")) {
+    if (/^\s*workspace\s+removed\s/.test(String(message))) {
       competingStart = withManagedRemoteWorktreeLock(mainDir, async () => {
         ensureWorkspaceStorage(mainDir);
         writeFileSync(workspaceStateFile(mainDir), JSON.stringify({ metroTunnel: { pid: 5252 } }));
@@ -611,6 +611,48 @@ test('action: removes the branch that Stim created when it has no unique commits
   expect(exec.calls.run.some((call) => /update-ref -d refs\/heads\/worktree-feat-x abc123/.test(call))).toBe(true);
 });
 
+test('action: on success, prints only the label-column vocabulary on stderr and nothing on stdout', async () => {
+  upsertProject(wtDir, {
+    worktreeRoot: true,
+    worktreeBranch: 'worktree-feat-x',
+    worktreeBranchOwned: true,
+    worktreeMainRoot: mainDir,
+    platforms: { ios: { deviceUdid: 'U1', owned: true, deviceName: 'stim-x' } },
+  });
+  ensureWorkspaceStorage(wtDir);
+  writeFileSync(join(workspaceDir(wtDir), 'state.json'), '{}');
+  const exec = makeExecutor({
+    worktrees: porcelain([
+      { path: mainDir, branch: 'main' },
+      { path: wtDir, branch: 'worktree-feat-x' },
+    ]),
+    mainTrees: [mainDir],
+    simctlList: simctlJson([{ udid: 'U1', name: 'stim-x', state: 'Shutdown', isAvailable: true }]),
+  });
+  setExecutor(exec);
+
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (m) => logs.push(String(m));
+  console.error = (m) => errs.push(String(m));
+  try {
+    const run = captureAction(registerRemove);
+    await run(wtDir, {});
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  expect(process.exitCode).not.toBe(1);
+  expect(logs).toEqual([]);
+  expect(errs.some((line) => /^\s*device\s+deleted stim-x$/.test(line))).toBe(true);
+  expect(errs.some((line) => /^\s*workspace\s+removed /.test(line))).toBe(true);
+  expect(errs.some((line) => /^\s*branch\s+deleted worktree-feat-x$/.test(line))).toBe(true);
+  expect(errs.some((line) => new RegExp(`^\\s*removed\\s+${wtDir}$`).test(line))).toBe(true);
+});
+
 test('action: keeps a branch that existed before Stim attached the worktree', async () => {
   upsertProject(wtDir, {
     worktreeRoot: true,
@@ -626,19 +668,19 @@ test('action: keeps a branch that existed before Stim attached the worktree', as
   });
   setExecutor(exec);
 
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (message) => logs.push(String(message));
+  const errs: string[] = [];
+  const original = console.error;
+  console.error = (message) => errs.push(String(message));
   try {
     const run = captureAction(registerRemove);
     await run(wtDir, {});
   } finally {
-    console.log = originalLog;
+    console.error = original;
   }
 
   expect(process.exitCode).not.toBe(1);
   expect(exec.calls.run.some((call) => /branch -D/.test(call))).toBe(false);
-  expect(logs.some((line) => /kept branch worktree-feat-x: Stim did not create it/.test(line))).toBe(true);
+  expect(errs.some((line) => /branch\s+kept worktree-feat-x \(Stim did not create it\)/.test(line))).toBe(true);
 });
 
 test('action: force removal keeps an owned branch that has unique commits', async () => {
@@ -657,20 +699,20 @@ test('action: force removal keeps an owned branch that has unique commits', asyn
   });
   setExecutor(exec);
 
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (message) => logs.push(String(message));
+  const errs: string[] = [];
+  const original = console.error;
+  console.error = (message) => errs.push(String(message));
   try {
     const run = captureAction(registerRemove);
     await run(wtDir, { force: true });
   } finally {
-    console.log = originalLog;
+    console.error = original;
   }
 
   expect(process.exitCode).not.toBe(1);
   expect(exec.calls.run.some((call) => /worktree remove --force/.test(call))).toBe(true);
   expect(exec.calls.run.some((call) => /branch -D/.test(call))).toBe(false);
-  expect(logs.some((line) => /kept branch worktree-feat-x: it has 1 unique commit/.test(line))).toBe(true);
+  expect(errs.some((line) => /branch\s+kept worktree-feat-x \(it has 1 unique commit/.test(line))).toBe(true);
 });
 
 test('action: a branch deletion failure keeps ownership state and exits unsuccessfully', async () => {
@@ -972,14 +1014,14 @@ test('action: an occupied owned sim is deleted with the rest -- the environment 
   });
   setExecutor(exec);
 
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (msg) => logs.push(msg);
+  const errs: string[] = [];
+  const original = console.error;
+  console.error = (msg) => errs.push(String(msg));
   const run = captureAction(registerRemove);
   try {
     await run(wtDir, {});
   } finally {
-    console.log = originalLog;
+    console.error = original;
   }
 
   expect(process.exitCode).not.toBe(1);
@@ -991,7 +1033,7 @@ test('action: an occupied owned sim is deleted with the rest -- the environment 
   expect(getProject(nestedDir1)).toBe(null);
   expect(getProject(nestedDir2)).toBe(null);
 
-  expect(!logs.some((l) => /kept .*device|kept .*sim/i.test(l))).toBeTruthy();
+  expect(!errs.some((l) => /kept .*device|kept .*sim/i.test(l))).toBeTruthy();
 });
 
 test('action: a project-local .stim directory is ordinary dirt and refuses removal', async () => {
@@ -1497,4 +1539,9 @@ test('action: removal releases this workspace lease and leaves another workspace
 
   expect(process.exitCode).not.toBe(1);
   expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['R5CT']);
+  expect(
+    errs.some((line) =>
+      /^\s*lease\s+released the ios lease on UDID-MINE \(it ran until \d{2}:\d{2}:\d{2}\)/.test(line),
+    ),
+  ).toBe(true);
 });

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -43,6 +43,17 @@ export function clockTime(iso: string): string {
   return [at.getHours(), at.getMinutes(), at.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
 }
 
+/** The fields `stop` and `worktree remove` need to report a released device lease. */
+export interface ReleasedLeaseFact {
+  platform: string;
+  id: string;
+  expiresAt: string;
+}
+
+export function releasedLeaseFact(lease: ReleasedLeaseFact): string {
+  return `released the ${lease.platform} lease on ${lease.id} (it ran until ${clockTime(lease.expiresAt)})`;
+}
+
 export function phaseLine(label: unknown, text: string): string {
   return `  ${String(label).padEnd(LABEL_WIDTH)} ${text}`;
 }

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -83,12 +83,14 @@ export const OUTPUT_LABELS: readonly string[] = [
   'prebuild',
   'ready',
   'remedy',
+  'removed',
   'setting',
   'state',
   'stats',
   'stop',
   'swap',
   'verify',
+  'workspace',
 ];
 
 export function isOutputLabel(label: unknown): boolean {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1609,13 +1609,13 @@ PROGRESS ON A LONG RUN
 
     branch      deleted worktree-e2e-1
     device      deleted stim-e2e-1
-    lease       released the ios lease on iPhone-15 Pro (F6D2..) (it ran until 14:32:10)
+    lease       released the ios lease on 00008101-000A10913C89001E (it ran until 14:32:10)
     workspace   removed /w/.stim/workspaces/3f9c2a
     removed     /w/worktree-e2e-1
 
   A branch \`worktree remove\` did not create, or one with unique commits, is
   kept and named instead: \`branch      kept worktree-e2e-1 (it has 2 unique
-  commit(s))\`. On the main checkout, \`worktree remove\` reclaims only the
+  commits)\`. On the main checkout, \`worktree remove\` reclaims only the
   environment -- the same \`device\`, \`lease\` and \`workspace\` lines, ending
   with a sentence instead of a \`removed\` line, because the checkout itself
   is never touched: \`Reclaimed the environment; the working tree stays (it

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1555,7 +1555,7 @@ PROGRESS ON A LONG RUN
     swap        ip.txt      install     launch      verify
     logs        branch      carry       ready       stop
     port        setting     state       stats       error
-    remedy      log         failed
+    remedy      log         failed      removed     workspace
 
   \`app\` and \`compilation cache\` join them in the stdout block a successful
   run ends with, and nowhere else. A line states a fact; the reason a fact
@@ -1600,6 +1600,26 @@ PROGRESS ON A LONG RUN
     stop        collector ios pid 45268
     device      shut down stim-e2e-2
     port        released 8084
+
+  \`worktree remove\` reports itself the same way: the branch decision, the
+  owned device, any released device lease, and this workspace's own state
+  directory, each on its own line. Nothing prints on stdout; even the removed
+  path is on stderr. \`worktree create\` prints its path on stdout because a
+  caller needs it to \`cd\` into; a removed path has no such use:
+
+    branch      deleted worktree-e2e-1
+    device      deleted stim-e2e-1
+    lease       released the ios lease on iPhone-15 Pro (F6D2..) (it ran until 14:32:10)
+    workspace   removed /w/.stim/workspaces/3f9c2a
+    removed     /w/worktree-e2e-1
+
+  A branch \`worktree remove\` did not create, or one with unique commits, is
+  kept and named instead: \`branch      kept worktree-e2e-1 (it has 2 unique
+  commit(s))\`. On the main checkout, \`worktree remove\` reclaims only the
+  environment -- the same \`device\`, \`lease\` and \`workspace\` lines, ending
+  with a sentence instead of a \`removed\` line, because the checkout itself
+  is never touched: \`Reclaimed the environment; the working tree stays (it
+  is the main checkout).\`
 
   A GAP BETWEEN HEARTBEATS IS NOT A HANG. Stim runs device tools
   synchronously, so a long \`simctl\`, \`adb\` or copy call holds the timer

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { rmSync } from 'fs';
 import type { Command } from 'commander';
-import { clockTime, phaseLine, plural } from '../command-output.ts';
+import { phaseLine, plural, releasedLeaseFact } from '../command-output.ts';
 import { clearSupervisor, getProject, upsertProject } from '../config.ts';
 import type { ProjectRecord, SupervisorRecord } from '../config.ts';
 import { findProjectRoot } from '../project.ts';
@@ -476,14 +476,7 @@ export async function runStop({
 
   outcomes.releasedLeases = releaseLeases(root);
   for (const lease of outcomes.releasedLeases) {
-    report(
-      chalk.dim(
-        phaseLine(
-          'lease',
-          `released the ${lease.platform} lease on ${lease.id} (it ran until ${clockTime(lease.expiresAt)})`,
-        ),
-      ),
-    );
+    report(chalk.dim(phaseLine('lease', releasedLeaseFact(lease))));
   }
 
   if (stillHolding) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { clockTime, phaseLine, plural } from '../command-output.ts';
+import { phaseLine, plural, releasedLeaseFact } from '../command-output.ts';
 import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import type { ReleasedLease } from '../engine/device-lease.ts';
@@ -531,7 +531,7 @@ export function removalBlockers({ dirty, unpushed }: { dirty: boolean | null; un
   }
   if (dirty) blockers.push('uncommitted changes or untracked files');
   if (unpushed && unpushed.length) {
-    blockers.push(`${unpushed.length} commit(s) not on any remote or any other local branch`);
+    blockers.push(`${plural(unpushed.length, 'commit')} not on any remote or any other local branch`);
   }
   return blockers;
 }
@@ -549,11 +549,6 @@ interface RetainedResource extends SkippedDevice {
 
 function describeKeptDevice(s: SkippedDevice): string {
   return s.udid && s.udid !== s.name ? `${s.name} (${s.udid})` : s.name;
-}
-
-function releasedLeaseFact(lease: ReleasedLease): string {
-  const device = lease.deviceName ? `${lease.deviceName} (${lease.id})` : lease.id;
-  return `released the ${lease.platform} lease on ${device} (it ran until ${clockTime(lease.expiresAt)})`;
 }
 
 interface ReclaimAllResult {
@@ -714,7 +709,7 @@ async function reclaimEnvironment(root: string, why: string): Promise<void> {
         return;
       }
       for (const s of result.skippedDevices) {
-        console.error(chalk.yellow(phaseLine('device', `kept ${describeKeptDevice(s)}: ${s.reason}`)));
+        console.error(chalk.yellow(phaseLine('device', `kept ${describeKeptDevice(s)} (${s.reason})`)));
       }
       console.error(chalk.green(`Reclaimed the environment; the working tree stays (${why}).`));
     }),
@@ -815,17 +810,7 @@ function printRemovalCleanup(result: ReclaimAllResult, failed: boolean): void {
   for (const skipped of result.skippedDevices) {
     console.error(
       (failed ? chalk.dim : chalk.yellow)(
-        phaseLine('device', `kept ${describeKeptDevice(skipped)}: ${skipped.reason}`),
-      ),
-    );
-  }
-  for (const kept of result.keptEntries) {
-    console.error(
-      (failed ? chalk.dim : chalk.yellow)(
-        phaseLine(
-          'workspace',
-          `${kept} still tracked -- environment cleanup failed; re-run \`stim gc --delete\` once the cause is fixed`,
-        ),
+        phaseLine('device', `kept ${describeKeptDevice(skipped)} (${skipped.reason})`),
       ),
     );
   }
@@ -939,7 +924,7 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
       : inspection.unpushed === null
         ? 'Stim could not verify whether it has unique commits'
         : inspection.unpushed.length > 0
-          ? `it has ${inspection.unpushed.length} unique commit(s)`
+          ? `it has ${plural(inspection.unpushed.length, 'unique commit')}`
           : null;
   const branchDeleteCwd = worktrees.find((candidate) => isMainWorkingTree(candidate.path))?.path;
 

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,9 +2,10 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { phaseLine, plural } from '../command-output.ts';
+import { clockTime, phaseLine, plural } from '../command-output.ts';
 import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
+import type { ReleasedLease } from '../engine/device-lease.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
 import { reclaimProject } from '../reclaim.ts';
 import { withManagedRemoteWorktreeRemovalLock, withManagedTunnelRemovalLock } from '../engine/tunnel.ts';
@@ -550,6 +551,11 @@ function describeKeptDevice(s: SkippedDevice): string {
   return s.udid && s.udid !== s.name ? `${s.name} (${s.udid})` : s.name;
 }
 
+function releasedLeaseFact(lease: ReleasedLease): string {
+  const device = lease.deviceName ? `${lease.deviceName} (${lease.id})` : lease.id;
+  return `released the ${lease.platform} lease on ${device} (it ran until ${clockTime(lease.expiresAt)})`;
+}
+
 interface ReclaimAllResult {
   dereferenced: string[];
   killedPids: number[];
@@ -560,6 +566,7 @@ interface ReclaimAllResult {
   reclaimedKeys: string[];
   stoppedSessions: string[];
   stoppedTunnels: string[];
+  releasedLeases: ReleasedLease[];
   removedWorkspaceDirs: string[];
   failedWorkspaceDirs: string[];
 }
@@ -595,6 +602,7 @@ async function reclaimAll(
   const retainedResources: RetainedResource[] = [];
   const stoppedSessions: string[] = [];
   const stoppedTunnels: string[] = [];
+  const releasedLeases: ReleasedLease[] = [];
   const removedWorkspaceDirs: string[] = [];
   const failedWorkspaceDirs: string[] = [];
   for (const key of keys) {
@@ -608,6 +616,7 @@ async function reclaimAll(
     skippedDevices.push(...r.skippedDevices);
     if (r.stoppedSession) stoppedSessions.push(r.stoppedSession);
     if (r.stoppedTunnel) stoppedTunnels.push(r.stoppedTunnel);
+    releasedLeases.push(...r.releasedLeases);
     removedWorkspaceDirs.push(...r.removedWorkspaceDirs);
     failedWorkspaceDirs.push(...r.failedWorkspaceDirs);
     if (r.keptEntry) {
@@ -649,6 +658,7 @@ async function reclaimAll(
     reclaimedKeys: [...keys],
     stoppedSessions,
     stoppedTunnels,
+    releasedLeases,
     removedWorkspaceDirs,
     failedWorkspaceDirs,
   };
@@ -677,21 +687,34 @@ async function reclaimEnvironment(root: string, why: string): Promise<void> {
   await withManagedRemoteWorktreeRemovalLock(root, () =>
     withReclaimLocks(root, async (lockedKeys) => {
       const result = await reclaimAll(root, lockedKeys);
-      for (const dir of result.removedWorkspaceDirs) {
-        console.error(chalk.dim(`  removed ${dir} (this workspace's own output)`));
+      for (const device of result.deletedDevices) {
+        console.error(chalk.dim(phaseLine('device', `deleted ${device}`)));
       }
-      for (const dir of result.failedWorkspaceDirs) console.error(chalk.yellow(`  could not remove ${dir}`));
-      if (result.dereferenced.length)
-        console.error(chalk.dim(`  no longer referenced: ${result.dereferenced.join(', ')}`));
-      for (const pid of result.killedPids) console.error(chalk.dim(`  killed Metro pid ${pid}`));
-      if (result.deletedDevices.length)
-        console.error(chalk.dim(`  deleted device(s): ${result.deletedDevices.join(', ')}`));
+      for (const session of result.stoppedSessions) {
+        console.error(chalk.dim(phaseLine('device', `stopped remote session ${session}`)));
+      }
+      for (const tunnel of result.stoppedTunnels) {
+        console.error(chalk.dim(phaseLine('lan', `stopped the ${tunnel} tunnel`)));
+      }
+      for (const lease of result.releasedLeases) {
+        console.error(chalk.dim(phaseLine('lease', releasedLeaseFact(lease))));
+      }
+      for (const pid of result.killedPids) console.error(chalk.dim(phaseLine('metro', `killed pid ${pid}`)));
+      for (const dir of result.removedWorkspaceDirs) {
+        console.error(chalk.dim(phaseLine('workspace', `removed ${dir}`)));
+      }
+      for (const dir of result.failedWorkspaceDirs) {
+        console.error(chalk.yellow(phaseLine('workspace', `could not remove ${dir}`)));
+      }
+      if (result.dereferenced.length) {
+        console.error(chalk.dim(phaseLine('workspace', `no longer referenced: ${result.dereferenced.join(', ')}`)));
+      }
       if (result.keptEntries.length) {
         reportRetainedResources(root, result);
         return;
       }
       for (const s of result.skippedDevices) {
-        console.error(chalk.yellow(`  kept ${describeKeptDevice(s)}: ${s.reason}`));
+        console.error(chalk.yellow(phaseLine('device', `kept ${describeKeptDevice(s)}: ${s.reason}`)));
       }
       console.error(chalk.green(`Reclaimed the environment; the working tree stays (${why}).`));
     }),
@@ -770,23 +793,39 @@ function restorePodChurn(path: string, files: string[]): void {
 }
 
 function printRemovalCleanup(result: ReclaimAllResult, failed: boolean): void {
-  const print = failed ? console.error : console.log;
-  if (!failed) {
-    for (const dir of result.removedWorkspaceDirs) print(chalk.dim(`  removed workspace output ${dir}`));
+  for (const device of result.deletedDevices) {
+    console.error(chalk.dim(phaseLine('device', `deleted ${device}`)));
   }
-  if (result.dereferenced.length) print(chalk.dim(`  no longer referenced: ${result.dereferenced.join(', ')}`));
-  for (const pid of result.killedPids) print(chalk.dim(`  killed Metro pid ${pid}`));
-  if (result.deletedDevices.length) print(chalk.dim(`  deleted device(s): ${result.deletedDevices.join(', ')}`));
-  if (result.stoppedSessions.length)
-    print(chalk.dim(`  stopped remote session(s): ${result.stoppedSessions.join(', ')}`));
-  if (result.stoppedTunnels.length) print(chalk.dim(`  stopped tunnel(s): ${result.stoppedTunnels.join(', ')}`));
+  for (const session of result.stoppedSessions) {
+    console.error(chalk.dim(phaseLine('device', `stopped remote session ${session}`)));
+  }
+  for (const tunnel of result.stoppedTunnels) {
+    console.error(chalk.dim(phaseLine('lan', `stopped the ${tunnel} tunnel`)));
+  }
+  for (const lease of result.releasedLeases) {
+    console.error(chalk.dim(phaseLine('lease', releasedLeaseFact(lease))));
+  }
+  for (const pid of result.killedPids) console.error(chalk.dim(phaseLine('metro', `killed pid ${pid}`)));
+  if (!failed) {
+    for (const dir of result.removedWorkspaceDirs) console.error(chalk.dim(phaseLine('workspace', `removed ${dir}`)));
+  }
+  if (result.dereferenced.length) {
+    console.error(chalk.dim(phaseLine('workspace', `no longer referenced: ${result.dereferenced.join(', ')}`)));
+  }
   for (const skipped of result.skippedDevices) {
-    print((failed ? chalk.dim : chalk.yellow)(`  kept ${describeKeptDevice(skipped)}: ${skipped.reason}`));
+    console.error(
+      (failed ? chalk.dim : chalk.yellow)(
+        phaseLine('device', `kept ${describeKeptDevice(skipped)}: ${skipped.reason}`),
+      ),
+    );
   }
   for (const kept of result.keptEntries) {
-    print(
+    console.error(
       (failed ? chalk.dim : chalk.yellow)(
-        `  Stim still tracks ${kept} because environment cleanup failed; re-run \`stim gc --delete\` once the cause is fixed.`,
+        phaseLine(
+          'workspace',
+          `${kept} still tracked -- environment cleanup failed; re-run \`stim gc --delete\` once the cause is fixed`,
+        ),
       ),
     );
   }
@@ -813,7 +852,9 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
       }
       if (!branchExists(mainRoot, branch)) {
         removeProject(path);
-        console.log(chalk.green(`Branch ${branch} is already absent; cleared its pending cleanup record.`));
+        console.error(
+          chalk.dim(phaseLine('branch', `${branch} is already absent; cleared its pending cleanup record`)),
+        );
         return;
       }
       const checkedOutAt = listWorktrees(mainRoot).find(
@@ -839,7 +880,7 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
       try {
         deleteBranch(mainRoot, branch, pending.worktreePendingBranchSha);
         removeProject(path);
-        console.log(chalk.green(`Deleted branch ${branch} and cleared its pending cleanup record.`));
+        console.error(chalk.dim(phaseLine('branch', `deleted ${branch}; cleared its pending cleanup record`)));
       } catch (error) {
         console.error(chalk.red(`Could not delete branch ${branch}: ${String((error as Error)?.message || error)}`));
         console.error(chalk.dim(`Retry with: stim worktree remove ${path}`));
@@ -919,49 +960,56 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
         process.exitCode = 1;
         return;
       }
-      console.log(chalk.green(`Removed worktree ${path}`));
+      const finish = (): void => {
+        printRemovalCleanup(result, false);
+        console.error(chalk.dim(phaseLine('removed', path)));
+      };
       if (deleteOwnedBranch && branch) {
         if (!approvedBranchSha) {
-          console.error(chalk.yellow(`  kept branch ${branch}: Stim could not record its commit before removal`));
+          console.error(
+            chalk.yellow(phaseLine('branch', `kept ${branch} (Stim could not record its commit before removal)`)),
+          );
           process.exitCode = 1;
-          printRemovalCleanup(result, false);
+          finish();
           return;
         }
         upsertProject(path, { worktreeRemovalComplete: true, worktreePendingBranchSha: approvedBranchSha });
         if (!branchDeleteCwd) {
-          console.error(chalk.yellow(`  kept branch ${branch}: Stim could not find the main worktree`));
+          console.error(chalk.yellow(phaseLine('branch', `kept ${branch} (Stim could not find the main worktree)`)));
           console.error(chalk.dim(`  Retry with: stim worktree remove ${path}`));
           process.exitCode = 1;
-          printRemovalCleanup(result, false);
+          finish();
           return;
         }
         const checkedOutAt = listWorktrees(branchDeleteCwd).find(
           (candidate) => candidate.branch === branch && resolve(candidate.path) !== resolve(path),
         )?.path;
         if (checkedOutAt) {
-          console.error(chalk.yellow(`  kept branch ${branch}: it is checked out at ${checkedOutAt}`));
+          console.error(chalk.yellow(phaseLine('branch', `kept ${branch} (it is checked out at ${checkedOutAt})`)));
           console.error(
             chalk.dim(`  Switch that worktree to another branch, then retry: stim worktree remove ${path}`),
           );
           process.exitCode = 1;
-          printRemovalCleanup(result, false);
+          finish();
           return;
         }
         try {
           deleteBranch(branchDeleteCwd, branch, approvedBranchSha);
-          console.log(chalk.dim(`  deleted branch ${branch}`));
+          console.error(chalk.dim(phaseLine('branch', `deleted ${branch}`)));
         } catch (error) {
-          console.error(chalk.yellow(`  kept branch ${branch}: ${String((error as Error)?.message || error)}`));
+          console.error(
+            chalk.yellow(phaseLine('branch', `kept ${branch} (${String((error as Error)?.message || error)})`)),
+          );
           console.error(chalk.dim(`  Retry with: git -C ${branchDeleteCwd} branch -D -- ${branch}`));
           process.exitCode = 1;
-          printRemovalCleanup(result, false);
+          finish();
           return;
         }
       } else if (branch && retainedBranchReason) {
-        console.log(chalk.dim(`  kept branch ${branch}: ${retainedBranchReason}`));
+        console.error(chalk.dim(phaseLine('branch', `kept ${branch} (${retainedBranchReason})`)));
       }
       removeProject(path);
-      printRemovalCleanup(result, false);
+      finish();
     }),
   );
 }


### PR DESCRIPTION
## Description

After #260/#262, `worktree create`, `start`, `stop`, `ios`, and `android` all print the `  <label> <fact> (<duration>)` shape on stderr. `worktree remove` was the one lifecycle command left outside it: it printed `Removed worktree <path>` and every branch/device/workspace-cleanup line as green/dim two-space colon sentences, mostly on **stdout**, not stderr.

Also fixed a separate bug found while doing this: `reclaimAll` (what `worktree remove` uses to release a workspace's resources) collected everything `reclaimProject` returns except `releasedLeases`. A workspace's device lease was released correctly, just never reported.

## Solution

Converts every progress line to `phaseLine`/`plural`:

- `branch deleted <name>` / `branch kept <name> (<reason>)`
- `device deleted <name>` / `device stopped remote session <id>` / `device kept <name> (<reason>)`
- `lease released <fact>` (same wording `stop` already uses -- this is the line the dropped `releasedLeases` used to suppress)
- `workspace removed <dir>` / `workspace no longer referenced: <...>`
- a trailing `removed <path>`

Same treatment for the main-checkout reclaim path (`worktree remove` run from the main checkout only reclaims the environment).

Nothing reads `worktree remove`'s stdout today -- no skill, guide text, or e2e test parses it, unlike `worktree create`'s printed path, which a caller `cd`s into. So the whole report moves to stderr; stdout is empty on success.

Added `removed` and `workspace` to `OUTPUT_LABELS` and the guide's label grid (still 6 rows of 5), and documented the new shape, including the main-checkout variant, in the `lifecycle` guide topic.

## Test plan

- `pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (3292 tests), `pnpm run knip` (one pre-existing, unrelated config hint), `pnpm run test:e2e` (20 tests) -- all pass.
- Updated the unit tests that pinned the old sentence wording, and added two: `worktree remove` prints only the vocabulary on stderr and nothing on stdout, and the released-lease line actually appears.
- Real-tool check (invariant 9), scratch git repo, `STIM_HOME` redirected, built CLI:

```
$ STIM_HOME=$SCRATCH/home node dist/cli.mjs worktree create demo-feature --base head
# stdout:
/private/tmp/stim-manual-check-2/repo-worktrees/demo-feature
# stderr:
  branch      worktree-demo-feature from HEAD (5b4eb6d)
  carry       no dependencies carried. Run `cd '/private/tmp/stim-manual-check-2/repo-worktrees/demo-feature' && npm install` before building.
  ready       /private/tmp/stim-manual-check-2/repo-worktrees/demo-feature

$ STIM_HOME=$SCRATCH/home node dist/cli.mjs worktree remove /private/tmp/stim-manual-check-2/repo-worktrees/demo-feature
# stdout: (empty, 0 bytes)
# stderr:
  branch      deleted worktree-demo-feature
  removed     /private/tmp/stim-manual-check-2/repo-worktrees/demo-feature
```

Fixes #263
