### PR TITLE
fix: skip the redundant simulator list after a boot this run performed

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -198,6 +198,63 @@ describe('ensureBooted: ios', () => {
     setExecutor({ run: () => '', runQuiet: () => '', runFile: () => '', spawn: () => null });
     expect((await ensureBooted({ platform: 'ios', device: {} })).reason).toMatch(/No iOS simulator is recorded/);
   });
+
+  test('does not list simulators again when this run already booted the sim', async () => {
+    const commands: string[] = [];
+    setExecutor({
+      run: (cmd: string) => {
+        commands.push(cmd);
+        throw new Error(`unexpected run: ${cmd}`);
+      },
+      runQuiet: (cmd: string) => {
+        commands.push(cmd);
+        return '';
+      },
+      runFile: () => '',
+      spawn: () => null,
+    });
+    const result = await ensureBooted({
+      platform: 'ios',
+      device: { deviceUdid: 'U1', owned: true, bootedUdid: 'U1' },
+    });
+    expect(result).toEqual({ ok: true, udid: 'U1' });
+    expect(commands).toEqual([]);
+  });
+
+  test('still lists a reused sim, which can have been shut down since it was resolved', async () => {
+    const commands: string[] = [];
+    setExecutor({
+      run: (cmd: string) => {
+        commands.push(cmd);
+        return simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]);
+      },
+      runQuiet: () => '',
+      runFile: () => '',
+      spawn: () => null,
+    });
+    const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1', owned: true } });
+    expect(result).toEqual({ ok: true, udid: 'U1' });
+    expect(commands.filter((c) => c.includes('list devices')).length).toBe(1);
+  });
+
+  test('a boot recorded for another sim does not vouch for this one', async () => {
+    const commands: string[] = [];
+    setExecutor({
+      run: (cmd: string) => {
+        commands.push(cmd);
+        return simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]);
+      },
+      runQuiet: () => '',
+      runFile: () => '',
+      spawn: () => null,
+    });
+    const result = await ensureBooted({
+      platform: 'ios',
+      device: { deviceUdid: 'U1', owned: true, bootedUdid: 'U2' },
+    });
+    expect(result).toEqual({ ok: true, udid: 'U1' });
+    expect(commands.filter((c) => c.includes('list devices')).length).toBe(1);
+  });
 });
 
 describe('ensureBooted: android', () => {
@@ -665,6 +722,58 @@ describe('ensureOwnedDevice: ios', () => {
       expect(notes.some((n) => /not Stim-owned by name/i.test(n))).toBeTruthy();
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a created sim reports the boot it just performed', async () => {
+    const root = projectDir();
+    try {
+      const { run, exec } = iosExecutor([]);
+      setExecutor(exec);
+      const result = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(result.created).toBe(true);
+      expect(result.bootedUdid).toBe('NEW-UDID');
+      expect(run.filter((c) => c === 'xcrun simctl bootstatus NEW-UDID -b').length).toBe(1);
+      expect(getProject(root)?.platforms?.ios).toEqual({ deviceUdid: 'NEW-UDID', owned: true, deviceName: 'stim-app' });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a reused sim reports a boot only when it had to perform one', async () => {
+    const shutdown = projectDir();
+    const booted = projectDir();
+    try {
+      setDevice(shutdown, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-app' });
+      setExecutor(iosExecutor([{ udid: 'U1', name: 'stim-app', state: 'Shutdown', isAvailable: true }]).exec);
+      const afterBoot = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(shutdown),
+        projectPath: shutdown,
+        label: 'app',
+        settings: {},
+      });
+      expect(afterBoot.bootedUdid).toBe('U1');
+
+      setDevice(booted, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-app' });
+      setExecutor(iosExecutor([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]).exec);
+      const alreadyBooted = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(booted),
+        projectPath: booted,
+        label: 'app',
+        settings: {},
+      });
+      expect(alreadyBooted.bootedUdid).toBeUndefined();
+    } finally {
+      rmSync(shutdown, { recursive: true, force: true });
+      rmSync(booted, { recursive: true, force: true });
     }
   });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -40,6 +40,8 @@ import {
   writeLastBuild,
 } from '../commands/ios.ts';
 import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroResolution } from './_factories.ts';
+import { ensureBooted } from '../engine/device.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
 import { RELEASE_VERIFY_WAIT_MS } from '../engine/app-install.ts';
 import { DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../engine/ios-device.ts';
 import type { RecordStatsResult, StatsRun } from '../engine/stats.ts';
@@ -109,6 +111,7 @@ afterEach(() => {
   rmSync(tmpHome, { recursive: true, force: true });
   rmSync(root, { recursive: true, force: true });
   delete process.env.STIM_HOME;
+  resetExecutor();
 });
 
 function captureAction(register: typeof registerIos, deps: LooseDeps) {
@@ -462,6 +465,66 @@ describe('the simulator boot gate', () => {
     );
     expect(exitCode).toBe(null);
     expect(calls.order.includes('buildIos')).toBe(true);
+  });
+});
+
+function simctlClock(step: number) {
+  const state = { now: 1_000_000 };
+  setExecutor(
+    makeExecutor({
+      run: (cmd: string) => {
+        if (!cmd.includes('simctl list devices')) return '';
+        state.now += step;
+        return JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+              { udid: UDID, name: 'stim-fixture', state: 'Booted', isAvailable: true },
+            ],
+          },
+        });
+      },
+    }),
+  );
+  return state;
+}
+
+describe('the boot this run performed', () => {
+  test('is trusted: the booted line does not pay for another simulator list', async () => {
+    reserve();
+    const clock = simctlClock(8000);
+    const { errs, exitCode } = await run(
+      {},
+      {
+        now: () => clock.now,
+        ensureBooted,
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture',
+          owned: true,
+          created: true,
+          bootedUdid: UDID,
+        }),
+      },
+    );
+    expect(exitCode).toBe(null);
+    const line = errs.find((l) => /booted \(/.test(l));
+    assert(line);
+    expect(Number(/booted \((\d+)ms\)/.exec(line)?.[1])).toBeLessThan(100);
+  });
+
+  test('a sim this run did not boot is still listed, and the line says what that cost', async () => {
+    reserve();
+    const clock = simctlClock(8000);
+    const { errs, exitCode } = await run(
+      {},
+      {
+        now: () => clock.now,
+        ensureBooted,
+        ensureOwnedDevice: async () => ({ deviceUdid: UDID, deviceName: 'stim-fixture', owned: true }),
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(errs.join('\n')).toMatch(/booted \(8s\)/);
   });
 });
 

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -53,6 +53,11 @@ export interface OwnedDeviceRecord {
   deviceType?: string | null;
   runtime?: string | null;
   systemImage?: string | null;
+  /**
+   * The simulator this call booted during this run. `ensureBooted` trusts it
+   * instead of listing simulators again; it is never persisted.
+   */
+  bootedUdid?: string;
 }
 
 interface DeviceSettings {
@@ -193,7 +198,8 @@ async function ensureOwnedIosDevice({
               'Run `stim worktree remove` (or `stim gc --delete`) to reap the current sim, then `stim ios` again to create the requested one.',
           );
         }
-        if (sim.state !== 'Booted') {
+        const bootedHere = sim.state !== 'Booted';
+        if (bootedHere) {
           out(chalk.dim(phaseLine('device', `booting ${sim.name} (${sim.udid})`)));
           bootIosSim(sim.udid);
         }
@@ -211,6 +217,7 @@ async function ensureOwnedIosDevice({
             out,
             reconcileIosSimulator,
           })),
+          ...(bootedHere ? { bootedUdid: sim.udid } : {}),
           deviceType: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
           runtime: parseRuntimeVersion(sim.runtime),
         };
@@ -249,7 +256,13 @@ async function ensureOwnedIosDevice({
     out,
     reconcileIosSimulator,
   });
-  return { ...configured, created: true, deviceType: created.deviceType, runtime: created.runtime };
+  return {
+    ...configured,
+    created: true,
+    bootedUdid: created.udid,
+    deviceType: created.deviceType,
+    runtime: created.runtime,
+  };
 }
 
 async function configureOwnedIosSim({
@@ -786,6 +799,7 @@ async function ensureIosBooted({
 }): Promise<BootResult> {
   const udid = device?.deviceUdid;
   if (!udid) return { failed: true, reason: 'No iOS simulator is recorded for this project.' };
+  if (device?.bootedUdid === udid) return { ok: true, udid };
 
   let resolved;
   try {


### PR DESCRIPTION
## Description

On a run that creates a simulator, `ensureOwnedIosDevice` boots it with a blocking `simctl bootstatus -b` and then `ensureIosBooted` opens with `resolveOwnedIosSim(udid)` -> `listAllIosSims()` -> `xcrun simctl list devices --json`, purely to learn a state it already knows. The sim is `Booted`, so the function returns on the next line -- but that list is the *first* simctl call after a boot, and CoreSimulator is still busy for several seconds after `bootstatus` claims the boot is done. Measured on this machine: `simctl list devices --json` costs 7.9 s right after a boot versus 0.06 s on a quiet one, and the `device ... booted` phase line reported 12.3 s / 8.7 s / 2.0 s across the three cache-hit baselines in `investigations/2026-09-02-cache-hit-run-time.md` (mean total 72.6 s).

Ownership is not weakened: `ensureOwnedIosDevice` already re-resolved the sim by name (`resolveOwnedIosSim`, or `createOwnedIosSim` for one it just made) earlier in the same call chain, so invariant 2 is satisfied before anything boots.

## Solution

`ensureOwnedIosDevice` now reports the udid it booted on the record it returns (`bootedUdid`), and `ensureIosBooted` returns `{ ok: true, udid }` immediately when that udid is the one it was asked about. It is deliberately narrow: the field is set only where this call actually ran `bootIosSim` -- the created path and the reuse path that found the sim shut down. A reused sim that was already `Booted` carries no `bootedUdid`, so it is still listed, because nothing in this process proves it did not shut down in between. A `bootedUdid` for a different sim does not vouch for this one either.

`bootedUdid` is attached after `configureOwnedIosSim` has written the registry, alongside `created`/`deviceType`/`runtime`, so it is never persisted -- it means "this process booted it", and it would be a lie in the next one.

I used the udid rather than the whole `IosSimRecord` the issue suggests: on the created path there is no `IosSimRecord` to return (`createOwnedIosSim` returns a name and a udid, not a `simctl list` row), and the udid match is the entire decision.

No tool call changes, so invariant 9 needs nothing new here; the argument lists are untouched and one `simctl list devices --json` is simply not issued.

## Test plan

- `engine-device.test.ts`: `ensureBooted` issues zero commands when the record carries a matching `bootedUdid`; it still lists for a reused sim with no `bootedUdid`, and for a `bootedUdid` that names another sim. `ensureOwnedDevice` reports the boot it performed on the created path and on the reuse-after-shutdown path, reports nothing on the already-booted path, and the persisted registry record is unchanged (`{ deviceUdid, owned, deviceName }`).
- `ios-command.test.ts`: an end-to-end run wired to the real `ensureBooted` with a fake clock that charges 8 s per `simctl list devices` -- the phase line reads `booted (0ms)` on the fresh-boot path and `booted (8s)` on the path that has to list. Ablation: dropping the new early return in `ensureIosBooted` fails both this test and the engine one.
- `pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (83 files, 3336 tests), `pnpm run knip` all pass on this branch.

Fixes #268

