### PR TITLE
feat: fingerprint the tree while the simulator boots

### DIFF
--- a/packages/stim-cli/src/__tests__/_factories.ts
+++ b/packages/stim-cli/src/__tests__/_factories.ts
@@ -156,6 +156,15 @@ export function makeChildProcess(overrides: Partial<ChildProcess> = {}): ChildPr
   return Object.assign(stub, overrides) as unknown as ChildProcess;
 }
 
+export function makeExitingChild(code = 0, stderr = ''): ChildProcess {
+  const child = makeChildProcess();
+  setImmediate(() => {
+    if (stderr) child.stderr?.emit('data', Buffer.from(stderr));
+    child.emit('exit', code, null);
+  });
+  return child;
+}
+
 export function asRequire(fn: (id: string) => unknown): NodeJS.Require {
   return fn as unknown as NodeJS.Require;
 }

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -15,7 +15,7 @@ import {
 import { allConsolePortsAndSerials, getProject, setDevice, upsertProject } from '../config.ts';
 import type { DeviceRecord } from '../types.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
-import { makeAdbDevices, makeConfig, makeIosSim } from './_factories.ts';
+import { makeAdbDevices, makeChildProcess, makeConfig, makeExitingChild, makeIosSim } from './_factories.ts';
 
 type SimEntry = {
   udid: string;
@@ -70,7 +70,10 @@ describe('ensureBooted: ios', () => {
         return '';
       },
       runFile: () => '',
-      spawn: () => null,
+      spawn: (cmd: string, args: readonly string[] = []) => {
+        commands.push([cmd, ...args].join(' '));
+        return makeExitingChild();
+      },
     });
     expect(await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1', owned: true } })).toEqual({
       ok: true,
@@ -95,7 +98,10 @@ describe('ensureBooted: ios', () => {
       },
       runQuiet: () => '',
       runFile: () => '',
-      spawn: () => null,
+      spawn: (cmd: string, args: readonly string[] = []) => {
+        commands.push([cmd, ...args].join(' '));
+        return makeExitingChild();
+      },
     });
     const result = await ensureBooted({
       platform: 'ios',
@@ -114,17 +120,11 @@ describe('ensureBooted: ios', () => {
         if (cmd.includes('list devices')) {
           return simList([{ udid: 'U1', name: 'stim-app', state: 'Booting', isAvailable: true }]);
         }
-        if (cmd.includes('bootstatus')) {
-          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
-          const e = new Error('spawnSync /bin/sh ETIMEDOUT') as Error & { code?: string };
-          e.code = 'ETIMEDOUT';
-          throw e;
-        }
         return '';
       },
       runQuiet: () => '',
       runFile: () => '',
-      spawn: () => null,
+      spawn: () => makeChildProcess(),
     });
 
     const result = await ensureBooted({
@@ -144,12 +144,11 @@ describe('ensureBooted: ios', () => {
         if (cmd.includes('list devices')) {
           return simList([{ udid: 'U1', name: 'stim-app', state: 'Shutdown', isAvailable: true }]);
         }
-        if (cmd.includes('bootstatus')) throw new Error('CoreLocationMigrator failed');
         return '';
       },
       runQuiet: () => '',
       runFile: () => '',
-      spawn: () => null,
+      spawn: () => makeExitingChild(1, 'CoreLocationMigrator failed'),
     });
 
     const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1', owned: true } });
@@ -188,7 +187,7 @@ describe('ensureBooted: ios', () => {
           : '',
       runQuiet: () => '',
       runFile: () => '',
-      spawn: () => null,
+      spawn: () => makeExitingChild(),
     });
     const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1' }, timeoutMs: 60, pollMs: 5 });
     expect(result.reason).toMatch(/did not reach the Booted state/);
@@ -199,7 +198,7 @@ describe('ensureBooted: ios', () => {
     expect((await ensureBooted({ platform: 'ios', device: {} })).reason).toMatch(/No iOS simulator is recorded/);
   });
 
-  test('does not list simulators again when this run already booted the sim', async () => {
+  test('joins the boot this run started instead of listing simulators again', async () => {
     const commands: string[] = [];
     setExecutor({
       run: (cmd: string) => {
@@ -213,12 +212,37 @@ describe('ensureBooted: ios', () => {
       runFile: () => '',
       spawn: () => null,
     });
+    let finished = false;
+    const done = new Promise<void>((resolve) =>
+      setTimeout(() => {
+        finished = true;
+        resolve();
+      }, 5),
+    );
     const result = await ensureBooted({
       platform: 'ios',
-      device: { deviceUdid: 'U1', owned: true, bootedUdid: 'U1' },
+      device: { deviceUdid: 'U1', owned: true, booting: { udid: 'U1', done } },
     });
     expect(result).toEqual({ ok: true, udid: 'U1' });
+    expect(finished).toBe(true);
     expect(commands).toEqual([]);
+  });
+
+  test('reports the failure of the boot this run started, before anything is installed', async () => {
+    setExecutor({
+      run: () => simList([{ udid: 'U1', name: 'stim-app', state: 'Shutdown', isAvailable: true }]),
+      runQuiet: () => '',
+      runFile: () => '',
+      spawn: () => null,
+    });
+    const done = Promise.reject(new Error('CoreLocationMigrator failed'));
+    const result = await ensureBooted({
+      platform: 'ios',
+      device: { deviceUdid: 'U1', owned: true, booting: { udid: 'U1', done } },
+    });
+    expect(result.ok).toBeUndefined();
+    expect(result.reason).toMatch(/Could not boot simulator U1/);
+    expect(result.reason).toMatch(/CoreLocationMigrator failed/);
   });
 
   test('still lists a reused sim, which can have been shut down since it was resolved', async () => {
@@ -250,7 +274,7 @@ describe('ensureBooted: ios', () => {
     });
     const result = await ensureBooted({
       platform: 'ios',
-      device: { deviceUdid: 'U1', owned: true, bootedUdid: 'U2' },
+      device: { deviceUdid: 'U1', owned: true, booting: { udid: 'U2', done: Promise.resolve() } },
     });
     expect(result).toEqual({ ok: true, udid: 'U1' });
     expect(commands.filter((c) => c.includes('list devices')).length).toBe(1);
@@ -552,8 +576,10 @@ function projectDir() {
 
 function iosExecutor(devices: SimEntry[]) {
   const run: string[] = [];
+  const spawned: string[] = [];
   return {
     run,
+    spawned,
     exec: {
       run(cmd: string) {
         run.push(cmd);
@@ -574,8 +600,9 @@ function iosExecutor(devices: SimEntry[]) {
       runFile() {
         return '';
       },
-      spawn() {
-        return { pid: 1, unref() {} };
+      spawn(cmd: string, args: readonly string[] = []) {
+        spawned.push([cmd, ...args].join(' '));
+        return makeExitingChild();
       },
     },
   };
@@ -725,10 +752,10 @@ describe('ensureOwnedDevice: ios', () => {
     }
   });
 
-  test('a created sim reports the boot it just performed', async () => {
+  test('a created sim is registered and its boot handed back, not waited out', async () => {
     const root = projectDir();
     try {
-      const { run, exec } = iosExecutor([]);
+      const { run, spawned, exec } = iosExecutor([]);
       setExecutor(exec);
       const result = await ensureOwnedDevice({
         platform: 'ios',
@@ -738,15 +765,46 @@ describe('ensureOwnedDevice: ios', () => {
         settings: {},
       });
       expect(result.created).toBe(true);
-      expect(result.bootedUdid).toBe('NEW-UDID');
-      expect(run.filter((c) => c === 'xcrun simctl bootstatus NEW-UDID -b').length).toBe(1);
+      expect(result.booting?.udid).toBe('NEW-UDID');
+      expect(run).toContain('xcrun simctl boot NEW-UDID');
       expect(getProject(root)?.platforms?.ios).toEqual({ deviceUdid: 'NEW-UDID', owned: true, deviceName: 'stim-app' });
+      await result.booting?.done;
+      expect(spawned).toEqual(['xcrun simctl bootstatus NEW-UDID -b']);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });
 
-  test('a reused sim reports a boot only when it had to perform one', async () => {
+  test('the SimSlim reconcile rides on the deferred boot, so nothing installs before it', async () => {
+    const root = projectDir();
+    try {
+      const profilePath = join(root, 'simslim.json');
+      writeFileSync(profilePath, '{}\n');
+      const profile = realpathSync(profilePath);
+      const { exec } = iosExecutor([]);
+      setExecutor(exec);
+      const calls: unknown[] = [];
+      const result = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: { ios: { simslimProfile: 'simslim.json' } },
+        reconcileIosSimulator: async (args) => {
+          calls.push(args);
+          return { managed: true, profile };
+        },
+      });
+      expect(calls).toEqual([]);
+      await result.booting?.done;
+      expect(calls).toMatchObject([{ udid: 'NEW-UDID', profile, previouslyManaged: false }]);
+      expect(getProject(root)?.platforms?.ios?.simslimManaged).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a reused sim hands back a boot only when it had to start one', async () => {
     const shutdown = projectDir();
     const booted = projectDir();
     try {
@@ -759,7 +817,8 @@ describe('ensureOwnedDevice: ios', () => {
         label: 'app',
         settings: {},
       });
-      expect(afterBoot.bootedUdid).toBe('U1');
+      expect(afterBoot.booting?.udid).toBe('U1');
+      await afterBoot.booting?.done;
 
       setDevice(booted, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-app' });
       setExecutor(iosExecutor([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]).exec);
@@ -770,7 +829,7 @@ describe('ensureOwnedDevice: ios', () => {
         label: 'app',
         settings: {},
       });
-      expect(alreadyBooted.bootedUdid).toBeUndefined();
+      expect(alreadyBooted.booting).toBeUndefined();
     } finally {
       rmSync(shutdown, { recursive: true, force: true });
       rmSync(booted, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -439,11 +439,57 @@ describe('the Metro gate', () => {
   });
 });
 
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('the simulator boot gate', () => {
-  test('waits for a new simulator to boot before fingerprinting and building', async () => {
+  test('the fingerprint starts with the boot, and each line reports its own wall time', async () => {
     reserve();
-    let booted = false;
-    const { exitCode, calls } = await run(
+    let clock = 1_000_000;
+    const events: string[] = [];
+    let bootStartedAt = 0;
+    let fingerprintStartedAt = 0;
+    const { exitCode, errs } = await run(
+      {},
+      {
+        now: () => clock,
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture',
+          owned: true,
+          created: true,
+        }),
+        ensureBooted: async () => {
+          bootStartedAt = clock;
+          events.push('boot start');
+          await tick();
+          await tick();
+          clock += 30_000;
+          events.push('boot end');
+          return { ok: true, udid: UDID };
+        },
+        fingerprintProject: async () => {
+          fingerprintStartedAt = clock;
+          events.push('fingerprint start');
+          await tick();
+          clock += 3_000;
+          events.push('fingerprint end');
+          return { hash: FINGERPRINT, sources: [] };
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(events).toEqual(['boot start', 'fingerprint start', 'fingerprint end', 'boot end']);
+    expect(bootStartedAt).toBe(fingerprintStartedAt);
+    const out = errs.join('\n');
+    expect(out).toMatch(/fingerprint a3f9b1\.\. miss \(3s\)/);
+    expect(out).toMatch(/booted \(33s\)/);
+  });
+
+  test('a created sim that fails to boot refuses before the install, not after it', async () => {
+    reserve();
+    const { exitCode, errs, calls } = await run(
       {},
       {
         ensureOwnedDevice: async () => ({
@@ -452,19 +498,27 @@ describe('the simulator boot gate', () => {
           owned: true,
           created: true,
         }),
-        ensureBooted: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          booted = true;
-          return { ok: true, udid: UDID };
-        },
-        fingerprintProject: async () => {
-          expect(booted).toBe(true);
-          return { hash: FINGERPRINT, sources: [] };
-        },
+        ensureBooted: async () => ({
+          failed: true,
+          reason: 'Could not boot simulator BF2A: CoreLocationMigrator failed',
+        }),
       },
     );
-    expect(exitCode).toBe(null);
-    expect(calls.order.includes('buildIos')).toBe(true);
+    expect(exitCode).toBe(1);
+    expect(calls.order.includes('installIosApp')).toBe(false);
+    expect(calls.order.includes('launchIosApp')).toBe(false);
+    const out = errs.join('\n');
+    expect(out).toMatch(/STIM_NO_DEVICE/);
+    expect(out).toMatch(/CoreLocationMigrator failed/);
+  });
+
+  test('a fingerprint that cannot be computed still refuses before the device is used', async () => {
+    reserve();
+    const { exitCode, errs, calls } = await run({}, { fingerprintProject: async () => null });
+    expect(exitCode).toBe(1);
+    expect(calls.order.includes('buildIos')).toBe(false);
+    expect(calls.order.includes('installIosApp')).toBe(false);
+    expect(errs.join('\n')).toMatch(/STIM_NO_FINGERPRINT/);
   });
 });
 
@@ -502,7 +556,7 @@ describe('the boot this run performed', () => {
           deviceName: 'stim-fixture',
           owned: true,
           created: true,
-          bootedUdid: UDID,
+          booting: { udid: UDID, done: Promise.resolve() },
         }),
       },
     );

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -15,6 +15,7 @@ import {
   bootIosSim,
 } from '../sim/ios.ts';
 import assert from 'node:assert';
+import { makeChildProcess, makeExitingChild } from './_factories.ts';
 
 let tmpHome: string;
 
@@ -345,12 +346,6 @@ test('ownedSimName does not double the ownership prefix', () => {
   expect(ownedSimName('Stim').startsWith('stim-')).toBeTruthy();
 });
 
-function timedOut(): Error {
-  const e = new Error('spawnSync /bin/sh ETIMEDOUT') as Error & { code?: string };
-  e.code = 'ETIMEDOUT';
-  return e;
-}
-
 function bootSimList(state: string) {
   return JSON.stringify({
     devices: {
@@ -359,126 +354,81 @@ function bootSimList(state: string) {
   });
 }
 
-test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is still Booting', () => {
+type BootstatusOutcome = 'hang' | { exitCode: number; stderr?: string };
+
+function bootstatusExecutor(outcomes: BootstatusOutcome[], list: () => string) {
+  const spawned: string[] = [];
   const quiet: string[] = [];
-  let bootstatusCalls = 0;
   setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) {
-        bootstatusCalls += 1;
-        if (bootstatusCalls === 1) throw timedOut();
-        return '';
-      }
-      if (cmd.includes('list devices')) return bootSimList('Booting');
+    run: (cmd: string) => {
+      if (cmd.includes('list devices')) return list();
       return '';
     },
-    runQuiet: (cmd) => {
+    runQuiet: (cmd: string) => {
       quiet.push(cmd);
       return '';
     },
     runFile: () => '',
-    spawn: () => null,
+    spawn: (cmd: string, args: readonly string[] = []) => {
+      spawned.push([cmd, ...args].join(' '));
+      const outcome = outcomes[spawned.length - 1] ?? outcomes[outcomes.length - 1] ?? 'hang';
+      if (outcome === 'hang') return makeChildProcess();
+      return makeExitingChild(outcome.exitCode, outcome.stderr);
+    },
   });
-  bootIosSim('UDID-A');
-  expect(bootstatusCalls).toBe(2);
+  return { spawned, quiet };
+}
+
+test('bootIosSim waits on `simctl bootstatus -b` as a child process, so the caller can work meanwhile', async () => {
+  const { spawned, quiet } = bootstatusExecutor([{ exitCode: 0 }], () => bootSimList('Booted'));
+  await bootIosSim('UDID-A');
+  expect(spawned).toEqual(['xcrun simctl bootstatus UDID-A -b']);
   expect(quiet).toContain('open -a Simulator');
 });
 
-test('bootIosSim treats a timed-out attempt as success when the sim reports Booted', () => {
-  let bootstatusCalls = 0;
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) {
-        bootstatusCalls += 1;
-        throw timedOut();
-      }
-      if (cmd.includes('list devices')) return bootSimList('Booted');
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
-  });
-  bootIosSim('UDID-A');
-  expect(bootstatusCalls).toBe(1);
+test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is still Booting', async () => {
+  const { spawned, quiet } = bootstatusExecutor(['hang', { exitCode: 0 }], () => bootSimList('Booting'));
+  await bootIosSim('UDID-A', { attemptMs: 20 });
+  expect(spawned.length).toBe(2);
+  expect(quiet).toContain('open -a Simulator');
 });
 
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-test('bootIosSim names the udid and the wait when the deadline expires while Booting', () => {
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) {
-        sleepSync(300);
-        throw timedOut();
-      }
-      if (cmd.includes('list devices')) return bootSimList('Booting');
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
-  });
-  expect(() => bootIosSim('UDID-A', { timeoutMs: 1200 })).toThrow(/UDID-A did not finish booting within 1s/);
+test('bootIosSim treats a timed-out attempt as success when the sim reports Booted', async () => {
+  const { spawned } = bootstatusExecutor(['hang'], () => bootSimList('Booted'));
+  await bootIosSim('UDID-A', { attemptMs: 20 });
+  expect(spawned.length).toBe(1);
 });
 
-test('bootIosSim reports a sim that vanished from the device list', () => {
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) throw timedOut();
-      if (cmd.includes('list devices')) return JSON.stringify({ devices: {} });
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
-  });
-  expect(() => bootIosSim('UDID-A')).toThrow(/UDID-A reports "missing"/);
+test('bootIosSim names the udid and the wait when the deadline expires while Booting', async () => {
+  bootstatusExecutor(['hang'], () => bootSimList('Booting'));
+  await expect(bootIosSim('UDID-A', { timeoutMs: 1200, attemptMs: 300 })).rejects.toThrow(
+    /UDID-A did not finish booting within 1s/,
+  );
 });
 
-test('bootIosSim keeps waiting through a failing device list and still hits the deadline', () => {
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) {
-        sleepSync(300);
-        throw timedOut();
-      }
-      if (cmd.includes('list devices')) throw new Error('CoreSimulatorService connection interrupted');
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
-  });
-  expect(() => bootIosSim('UDID-A', { timeoutMs: 1200 })).toThrow(/UDID-A did not finish booting within 1s/);
+test('bootIosSim reports a sim that vanished from the device list', async () => {
+  bootstatusExecutor(['hang'], () => JSON.stringify({ devices: {} }));
+  await expect(bootIosSim('UDID-A', { attemptMs: 20 })).rejects.toThrow(/UDID-A reports "missing"/);
 });
 
-test('bootIosSim reports a sim that left the boot path instead of retrying forever', () => {
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) throw timedOut();
-      if (cmd.includes('list devices')) return bootSimList('Shutdown');
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
+test('bootIosSim keeps waiting through a failing device list and still hits the deadline', async () => {
+  bootstatusExecutor(['hang'], () => {
+    throw new Error('CoreSimulatorService connection interrupted');
   });
-  expect(() => bootIosSim('UDID-A')).toThrow(/UDID-A reports "Shutdown"/);
+  await expect(bootIosSim('UDID-A', { timeoutMs: 1200, attemptMs: 300 })).rejects.toThrow(
+    /UDID-A did not finish booting within 1s/,
+  );
 });
 
-test('bootIosSim rethrows a bootstatus failure that is not a timeout', () => {
-  setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('bootstatus')) throw new Error('CoreLocationMigrator failed');
-      if (cmd.includes('list devices')) return bootSimList('Booting');
-      return '';
-    },
-    runQuiet: () => '',
-    runFile: () => '',
-    spawn: () => null,
-  });
-  expect(() => bootIosSim('UDID-A')).toThrow(/CoreLocationMigrator failed/);
+test('bootIosSim reports a sim that left the boot path instead of retrying forever', async () => {
+  bootstatusExecutor(['hang'], () => bootSimList('Shutdown'));
+  await expect(bootIosSim('UDID-A', { attemptMs: 20 })).rejects.toThrow(/UDID-A reports "Shutdown"/);
+});
+
+test('bootIosSim rethrows a bootstatus failure that is not a timeout', async () => {
+  const { spawned } = bootstatusExecutor([{ exitCode: 1, stderr: 'CoreLocationMigrator failed' }], () =>
+    bootSimList('Booting'),
+  );
+  await expect(bootIosSim('UDID-A')).rejects.toThrow(/CoreLocationMigrator failed/);
+  expect(spawned.length).toBe(1);
 });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1565,9 +1565,17 @@ PROGRESS ON A LONG RUN
   artifact name is in the \`--json\` payload.
 
   A step that costs real time is named and timed, including the step that
-  creates or reconciles the owned device before anything is fingerprinted:
+  creates or reconciles the owned device:
 
     device      stim-app-412 (BF2A..) created (2m14s)
+
+  On iOS that step does not wait the boot out. It creates the simulator, asks
+  it to boot, and hands the wait back, so the run fingerprints the native
+  inputs and resolves the build cache while \`simctl bootstatus\` is still
+  running; it joins the boot before it installs anything. The
+  \`device ... booted\` and \`fingerprint ...\` lines each report their own
+  elapsed time, and those two overlap -- adding every line up overstates the
+  run.
 
   A step that is still running heartbeats every 30 seconds, on the 30-second
   grid, so the values read 30s, 1m00s, 1m30s and never repeat. A heartbeat

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -2260,12 +2260,7 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       bootDuration = bootTimer();
       return result;
     });
-    if (!remoteDevice && device.created) {
-      const booted = await bootPromise;
-      udid = (device.deviceUdid as string | undefined) ?? booted?.udid ?? '';
-    } else {
-      udid = (device.deviceUdid as string | undefined) ?? (await bootPromise)?.udid ?? '';
-    }
+    udid = (device.deviceUdid as string | undefined) ?? (await bootPromise)?.udid ?? '';
 
     const fingerprintTimer = stepTimer(d.now);
     let computedFingerprint: string | null;

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -54,10 +54,28 @@ export interface OwnedDeviceRecord {
   runtime?: string | null;
   systemImage?: string | null;
   /**
-   * The simulator this call booted during this run. `ensureBooted` trusts it
-   * instead of listing simulators again; it is never persisted.
+   * The boot this call started, and the promise that finishes it: the wait on
+   * `simctl bootstatus -b` and the SimSlim reconcile that follows it.
+   * `ensureBooted` joins it instead of listing simulators again. It is never
+   * persisted.
    */
-  bootedUdid?: string;
+  booting?: IosBoot;
+}
+
+interface IosBoot {
+  udid: string;
+  done: Promise<void>;
+}
+
+function startIosBoot(udid: string, configure: () => Promise<unknown>): IosBoot {
+  const done = (async () => {
+    await bootIosSim(udid);
+    await configure();
+  })();
+  // Node ends the process on an unhandled rejection, and `ensureBooted` -- the
+  // real handler -- does not run when an earlier step of the run refuses first.
+  done.catch(() => {});
+  return { udid, done };
 }
 
 interface DeviceSettings {
@@ -198,29 +216,29 @@ async function ensureOwnedIosDevice({
               'Run `stim worktree remove` (or `stim gc --delete`) to reap the current sim, then `stim ios` again to create the requested one.',
           );
         }
-        const bootedHere = sim.state !== 'Booted';
-        if (bootedHere) {
-          out(chalk.dim(phaseLine('device', `booting ${sim.name} (${sim.udid})`)));
-          bootIosSim(sim.udid);
-        }
         const updated = {
           deviceUdid: sim.udid,
           owned: true,
           deviceName: record.deviceName ?? sim.name,
           ...(record.simslimManaged ? { simslimManaged: true } : {}),
         };
-        return {
-          ...(await configureOwnedIosSim({
+        const configure = () =>
+          configureOwnedIosSim({
             record: updated,
             projectPath,
             profile: simslimProfile,
             out,
             reconcileIosSimulator,
-          })),
-          ...(bootedHere ? { bootedUdid: sim.udid } : {}),
+          });
+        const model = {
           deviceType: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
           runtime: parseRuntimeVersion(sim.runtime),
         };
+        if (sim.state !== 'Booted') {
+          out(chalk.dim(phaseLine('device', `booting ${sim.name} (${sim.udid})`)));
+          return { ...updated, booting: startIosBoot(sim.udid, configure), ...model };
+        }
+        return { ...(await configure()), ...model };
       }
     } else {
       const sim = listAllIosSims().find((s) => s.udid === record.deviceUdid);
@@ -248,18 +266,19 @@ async function ensureOwnedIosDevice({
   });
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
   setDevice(projectPath, 'ios', newRecord);
-  bootIosSim(created.udid);
-  const configured = await configureOwnedIosSim({
-    record: newRecord,
-    projectPath,
-    profile: simslimProfile,
-    out,
-    reconcileIosSimulator,
-  });
+  const booting = startIosBoot(created.udid, () =>
+    configureOwnedIosSim({
+      record: newRecord,
+      projectPath,
+      profile: simslimProfile,
+      out,
+      reconcileIosSimulator,
+    }),
+  );
   return {
-    ...configured,
+    ...newRecord,
     created: true,
-    bootedUdid: created.udid,
+    booting,
     deviceType: created.deviceType,
     runtime: created.runtime,
   };
@@ -799,7 +818,15 @@ async function ensureIosBooted({
 }): Promise<BootResult> {
   const udid = device?.deviceUdid;
   if (!udid) return { failed: true, reason: 'No iOS simulator is recorded for this project.' };
-  if (device?.bootedUdid === udid) return { ok: true, udid };
+  const booting = device?.booting;
+  if (booting?.udid === udid) {
+    try {
+      await booting.done;
+    } catch (e) {
+      return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
+    }
+    return { ok: true, udid };
+  }
 
   let resolved;
   try {
@@ -825,7 +852,7 @@ async function ensureIosBooted({
   out(chalk.dim(phaseLine('device', `booting ${sim.name} (${udid})`)));
   const bootDeadline = Date.now() + timeoutMs;
   try {
-    bootIosSim(udid, { timeoutMs });
+    await bootIosSim(udid, { timeoutMs });
   } catch (e) {
     return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
   }

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -1,4 +1,5 @@
 import { getExecutor } from '../exec.ts';
+import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
 
 export interface IosSimRecord {
   udid: string;
@@ -106,7 +107,49 @@ const BOOTSTATUS_ATTEMPT_MS = 240000;
 const BOOTSTATUS_ATTEMPT_FLOOR_MS = 1000;
 const BOOT_STATE_LIST_TIMEOUT_MS = 30000;
 
-export function bootIosSim(udid: string, { timeoutMs = IOS_BOOT_TIMEOUT_MS }: { timeoutMs?: number } = {}): void {
+function bootstatusTimeout(udid: string): NodeJS.ErrnoException {
+  const e = new Error(`xcrun simctl bootstatus ${udid} -b timed out`) as NodeJS.ErrnoException;
+  e.code = 'ETIMEDOUT';
+  return e;
+}
+
+async function awaitBootstatus(udid: string, attemptMs: number): Promise<void> {
+  const lines: string[] = [];
+  const reader = createLineReader((raw) => {
+    const line = stripAnsi(raw).trim();
+    if (!line) return;
+    lines.push(line);
+    if (lines.length > 10) lines.shift();
+  });
+  const child = getExecutor().spawn('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout?.on('data', (chunk) => reader.push(chunk));
+  child.stderr?.on('data', (chunk) => reader.push(chunk));
+  let timer: NodeJS.Timeout | undefined;
+  const attempt = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), attemptMs);
+  });
+  const result = await Promise.race([waitForChild(child), attempt]);
+  clearTimeout(timer);
+  reader.flush();
+  if (result === 'timeout') {
+    child.kill('SIGKILL');
+    throw bootstatusTimeout(udid);
+  }
+  if (result.error) throw result.error;
+  if (result.code === 0) return;
+  const detail = lines.length ? `: ${lines.join(' | ')}` : '';
+  throw new Error(`xcrun simctl bootstatus ${udid} -b failed with exit code ${result.code ?? 'unknown'}${detail}`);
+}
+
+export async function bootIosSim(
+  udid: string,
+  {
+    timeoutMs = IOS_BOOT_TIMEOUT_MS,
+    attemptMs = BOOTSTATUS_ATTEMPT_MS,
+  }: { timeoutMs?: number; attemptMs?: number } = {},
+): Promise<void> {
   const exec = getExecutor();
   try {
     exec.run(`xcrun simctl boot ${udid}`);
@@ -121,9 +164,7 @@ export function bootIosSim(udid: string, { timeoutMs = IOS_BOOT_TIMEOUT_MS }: { 
     const remaining = deadline - Date.now();
     if (remaining > 0) {
       try {
-        exec.run(`xcrun simctl bootstatus ${udid} -b`, {
-          timeoutMs: Math.min(Math.max(remaining, BOOTSTATUS_ATTEMPT_FLOOR_MS), BOOTSTATUS_ATTEMPT_MS),
-        });
+        await awaitBootstatus(udid, Math.min(Math.max(remaining, BOOTSTATUS_ATTEMPT_FLOOR_MS), attemptMs));
         break;
       } catch (e) {
         if ((e as NodeJS.ErrnoException)?.code !== 'ETIMEDOUT') throw e;


### PR DESCRIPTION
## Description

Stacked on #272 (`fix/skip-redundant-sim-list`); this PR's base is that branch, and its diff is only the second commit. Read #272 first.

A cache-hit run in a fresh worktree spends ~30 s in the created simulator's first `simctl bootstatus -b` and then another 3-11 s walking the tree for the fingerprint, one after the other. The fingerprint never touches the simulator and the boot never touches the tree. Worse, the two fight when they do overlap by accident: the same walk measures 1.4-1.6 s on a quiet machine and 5.6-12.6 s while a sim boots (`investigations/2026-09-02-cache-hit-run-time.md`), which is where the "17-20 s first fingerprint" in the gate transcripts comes from -- it is contention, not a cold tree (`@expo/fingerprint` 0.20.10 keeps no on-disk cache).

Two things kept them serial, and both had to go:

- `commands/ios.ts` awaited `bootPromise` before the fingerprint on the `device.created` path only (the reuse path already skipped that await).
- `bootIosSim` waited on `bootstatus` through the synchronous `exec.run`, so even with the await deleted the boot would have blocked the event loop and the fingerprint could not have progressed. The reuse path's "overlap" was therefore never real either.

## Solution

`bootIosSim` is now async and waits on `bootstatus` through the executor's `spawn` (the same wrapper the collector and SimSlim use) instead of `execSync`. The argument list is byte-for-byte what it was -- `xcrun simctl bootstatus <udid> -b` -- only the invocation is a child process now, so the run's own thread is free while the simulator boots. The per-attempt bound that #128 added is preserved: a hung attempt is killed and retried against the deadline, with the same `ETIMEDOUT` -> re-list -> retry loop. The bound is now an `attemptMs` option so tests can exercise the retry in milliseconds instead of four minutes.

`ensureOwnedIosDevice` no longer waits the boot out. It creates (or resolves) the sim, issues `simctl boot`, and hands back `booting: { udid, done }` -- the promise that covers the `bootstatus` wait *and* the SimSlim reconcile that has to follow it, since a profile change can reboot the sim. `ensureBooted` joins that promise where #272 trusted its result, so the fingerprint and the tiered cache resolve run against a booting simulator and the run joins before it installs. A sim that was already booted is untouched: no promise, no deferral, `configureOwnedIosSim` still runs and still throws inline.

Invariant 10 is unaffected -- nothing about the keys moved. The initial lookup and the single-flight lock still use the pre-mutation key, `prebuild`/`pod install` still re-fingerprint, and the artifact is still stored only under the post-mutation key. Invariant 11 is unaffected: the launch happens after the join, and `launched` is untouched.

**What a boot failure now costs.** A dead simulator on the created path used to fail inside `ensureOwnedDevice`, before the build. It now fails where the reuse path has always failed it: at the join in `finishIosRun`, before the install but after a cache miss would have compiled. That is deliberate -- `ios-command.test.ts` has pinned "a device that will not boot is refused at install, after the build has been stored" since `612a447`, and the artifact is worth storing even when the device is gone. I tried joining the boot before `buildIos` instead and dropped it: it contradicts that contract for the sake of a failure mode that only bites on a miss. On a hit -- the case this PR is about -- nothing is installed or launched either way.

Blast radius: every iOS run, plus every caller of `bootIosSim`. Both callers are in `engine/device.ts` and both now await it. Nothing else in the codebase boots a simulator.

## Test plan

- Real tool (invariant 9, the `bootstatus` invocation changed): built this branch's CLI, then from `trailhead-bench` `worktree create qa-269 --carry-ignored`, `start --json` in the new worktree, and three `ios --json` runs. Cleaned up after: `stop`, `worktree remove --force`, no `stim-*` simulator of mine left (`stim-issue-245-measure` is another session's and was left alone), `/` back to 16 GB free. No `--device`, no physical device.

  **1. Fresh worktree, created sim (the baseline case). `durationMs: 61914`.**
  ```
    device      stim-qa-269 (16BE..) created (1.3s)
    fingerprint ab703f.. hit (11.1s)
    device      stim-qa-269 (16BE..) booted (34.2s)
    install     Trailhead.app -> stim-qa-269 (16BE..) (12.5s)
    install     dev client prepared (2.2s)
    launch      com.appandflow.trailhead (529ms)
    verify      bundle loaded, process alive, stable for 3s (11s total)
  ```
  `device ... created` is 1.3 s where the investigation's three baselines measured 24.8 / 28.3 / 54.2 s: the create and `simctl boot` are all that is left in it. The 11.1 s fingerprint ran inside the 34.2 s boot wait rather than after it. **61.9 s against the 72.6 s baseline mean** (range 61.2-83.8 s) on a machine with load average 5.5 and an `install` that came in at 12.5 s, itself twice the 4.9-7.1 s the baselines measured -- so the phase this PR targets improved while the run's noise floor was worse than the baseline's.

  **2. Same worktree, warm (sim booted, app installed). `durationMs: 8245`.**
  ```
    fingerprint ab703f.. hit (2.8s)
    device      stim-qa-269 (16BE..) booted (83ms)
    install     unchanged (stim-qa-269 already has this build) (373ms)
    install     dev client prepared (706ms)
    launch      com.appandflow.trailhead (330ms)
    verify      bundle loaded, process alive, stable for 3s (3.5s total)
  ```
  8.2 s against the investigation's 7.97 s warm reference -- unchanged, as expected: an already-booted sim takes neither the deferral nor #272's skip.

  **3. After `stop`, reuse of a shut-down sim** (the other path that now defers). `durationMs: 29035`, `fingerprint hit (15.4s)`, `device ... booted (7.2s)`: the boot finished 7.2 s in while the fingerprint was still walking, and the run joined it before installing. Comparable to the investigation's parked-shut-down runs (20.3 s / 32.5 s).

- `sim-ios.test.ts`: the `bootstatus` argv is asserted exactly (`xcrun simctl bootstatus UDID-A -b`), plus the retry after a hung attempt, the timed-out-but-Booted case, the deadline message, the vanished sim, the failing device list, and a non-timeout failure surfaced from the child's exit code and stderr.
- `engine-device.test.ts`: `ensureBooted` joins a pending `booting.done` without issuing any command, and turns its rejection into the refusal (no listing). `ensureOwnedDevice` registers the created sim and hands the boot back before it is awaited (`spawn` of `bootstatus` only happens once the caller awaits `done`), keeps the SimSlim reconcile on that promise, and hands back a boot on the reuse-after-shutdown path but not on the already-booted one.
- `ios-command.test.ts`: fake clock -- the boot and the fingerprint start at the same instant, interleave in the order `boot start, fingerprint start, fingerprint end, boot end`, and each phase line reports its own elapsed time. A created sim that fails to boot refuses with `STIM_NO_DEVICE` and never installs or launches; an uncomputable fingerprint still refuses with `STIM_NO_FINGERPRINT` before any of it. Ablation: restoring the `device.created` await fails the overlap test.
- `guide lifecycle` now says the iOS device step hands the boot back and that the `device ... booted` and `fingerprint` lines overlap, so their durations cannot be summed.
- `pnpm run format:check`, `lint`, `build`, `typecheck`, `pnpm test` (83 files, 3341 tests), `pnpm run knip` all pass.

Fixes #269

