### PR TITLE
docs: add stacked pull requests guidance for dependent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ the branch limited to that issue, run the required checks, and open a pull
 request that links the issue, with a description following
 `.github/PULL_REQUEST_TEMPLATE.md`.
 
+A change that depends on an unmerged pull request branches from that pull
+request's branch and links the two as a GitHub stack with `gh stack link
+<lower> <upper>` (bottom to top), so the diff shown is against the parent, not
+`main`. The pull request body names the dependency, and every member still gets
+its own review and CI. Merge the stack bottom-up with `gh stack merge` once
+every member is clear and green. Independent issues stay separate pull
+requests; do not stack to skip a review.
+
 As soon as the pull request is open, assign a fresh agent that did not implement
 the change to review the issue, diff, tests, and user-facing guidance. Address
 every actionable finding and rerun the affected checks. Mark the pull request


### PR DESCRIPTION
## Description

The "Issue and pull request workflow" section in AGENTS.md has no guidance
for a change that depends on another unmerged pull request. The only
documented option is a branch based on the dependent branch opened as a
normal pull request against `main`, which shows the reviewer the combined
diff of both changes rather than just the new one.

`gh` 2.99.0 ships the `gh stack` command, which links existing pull requests
into a GitHub stack so each one diffs against its parent and can be reviewed
and merged independently, confirmed by running `gh stack link` on this repo.

## Solution

Added one paragraph after "Implement each valid issue in its own git
worktree..." describing when and how to use stacking:

- base the dependent branch on the parent pull request's branch
- link them with `gh stack link <lower> <upper>` (bottom to top)
- name the dependency in the pull request body
- keep per-member review and CI as usual
- merge bottom-up with `gh stack merge` once every member is clear and green

It also states that independent issues stay as separate pull requests rather
than being stacked to skip review. The website docs under `website/docs/`
only cover Stim's own `worktree` CLI command, a different feature, so nothing
there needed updating.

## Test plan

- `pnpm run format:check` — passes
- `pnpm run lint` — passes

Closes #277
