### PR TITLE
fix: pin uuid, serialize-javascript, and qs to patched versions in website's dependency tree

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: ^11.1.1
+  serialize-javascript: '>=7.0.5'
+  qs: '>=6.16.0'
+
 importers:
 
   .:
@@ -5836,8 +5841,8 @@ packages:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -5849,9 +5854,6 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -6147,8 +6149,9 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.1.1:
+    resolution: {integrity: sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -6665,9 +6668,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   value-equal@1.0.1:
@@ -10711,7 +10713,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -10997,7 +10999,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.1.1
       webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   core-js-compat@3.50.0:
@@ -11064,7 +11066,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.26
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.1.1
       webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
       clean-css: 5.3.3
@@ -11478,7 +11480,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -13672,7 +13674,7 @@ snapshots:
 
   pvutils@1.2.0: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -13682,10 +13684,6 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   range-parser@1.2.0: {}
 
@@ -14073,9 +14071,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.1.1: {}
 
   serve-handler@6.1.7:
     dependencies:
@@ -14198,7 +14194,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 8.3.2
+      uuid: 11.1.1
       websocket-driver: 0.7.5
 
   sort-css-media-queries@2.2.0: {}
@@ -14588,7 +14584,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   value-equal@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,11 @@ minimumReleaseAgeExclude:
 allowBuilds:
   '@swc/core': false
   core-js: false
+
+# website's Docusaurus toolchain pulls these transitively at vulnerable
+# versions; the published packages under packages/ do not depend on them
+# (see issue #267).
+overrides:
+  uuid: ^11.1.1
+  serialize-javascript: '>=7.0.5'
+  qs: '>=6.16.0'


### PR DESCRIPTION
## Description

`pnpm audit` reported 7 vulnerabilities (4 moderate, 3 high) in `uuid`, `serialize-javascript`, and `qs`, all resolved through `website` -> `@docusaurus/core` -> `webpack-dev-server` -> `sockjs`/`express`. None of the five published packages under `packages/` depend on any of them (`pnpm --filter <pkg> why <dep>` is empty for each). This is website build tooling only; it does not affect anything shipped to npm.

The issue's suggested fix (`uuid@^14.0.0`) is wrong:

- uuid 11.1.1 is already the patched version -- the advisory covers `<11.1.1`, not `<14.0.0`.
- `sockjs` requires uuid as CommonJS, and uuid 11 is the last major line that still ships a CJS build (per the deprecation notice on `uuid@11`), so `^14.0.0` would break resolution for that consumer.

`image-size` also has two open high-severity advisories (`<=2.0.2`, ICNS/JXL/HEIF parser infinite loops) with no patched version yet, so it is left as-is.

## Solution

Added `overrides` for `uuid` (`^11.1.1`), `serialize-javascript` (`>=7.0.5`), and `qs` (`>=6.16.0`) to `pnpm-workspace.yaml`.

**Aside:** this repo's `package.json` already had a top-level `"overrides"` block (the existing `vite` -> `rolldown-vite` swap). That field is a no-op under pnpm 12 -- it only reads `overrides` from `pnpm-workspace.yaml` -- so the `vite` override was never actually applied; `vite@8.2.2` was resolving before this change too. Pre-existing and unrelated to this issue, so I left it alone and put the new overrides where pnpm 12 actually honors them. Worth a follow-up issue for the dead `vite` entry.

## Test plan

- `pnpm install` to regenerate the lockfile, then `pnpm audit`:
  - Before: 7 vulnerabilities (4 moderate, 3 high) -- uuid, serialize-javascript (x2), qs (x2), image-size (x2)
  - After: 2 vulnerabilities (2 high) -- only the unpatched image-size advisories remain
- `pnpm why uuid` / `pnpm why serialize-javascript` / `pnpm why qs` each show a single resolved version (11.1.1, 7.1.1, 6.16.0 respectively), all under the `website` importer.
- `pnpm --filter website build` -- Docusaurus production build succeeds (sockjs/webpack-dev-server still load fine with uuid 11).
- Full repo checklist: `format:check`, `lint`, `build`, `typecheck`, `test` (83 files, 3329 tests) all pass.

Fixes #267
