### PR TITLE
feat: reuse parked iOS simulators across worktrees

### DIFF
--- a/.github/workflows/e2e-native.yml
+++ b/.github/workflows/e2e-native.yml
@@ -3,7 +3,7 @@
 #
 #     framework in {bare, expo}   x   platform in {ios, android}
 #
-# TWO SUITES RUN ON THIS MATRIX, selected by the `suite` dispatch input:
+# THREE SUITES RUN ON THIS MATRIX, selected by the `suite` dispatch input:
 #   loop    test/e2e/native/run-native-e2e.mjs -- docs/field-test-protocol.md as
 #           code: create -> start -> build -> second worktree hits the cache ->
 #           teardown. THE DEFAULT, and what the nightly has always run.
@@ -12,7 +12,9 @@
 #           directory gained files), and that a second workspace REUSED it. It
 #           costs two extra cold compiles per variant, so it is ON DEMAND ONLY:
 #           run it before a release, or after a change that touches caching.
-#   all     both, as separate parallel matrix jobs.
+#   pool    test/e2e/native/run-pool-e2e.mjs -- iOS only: park, evict, adopt,
+#           and empty the simulator pool on real CoreSimulator devices.
+#   all     every applicable suite, as separate parallel matrix jobs.
 #
 # The nightly and the PR label keep running `loop` exactly as before -- adding
 # the input changed nothing about them.
@@ -43,7 +45,7 @@ on:
         description: 'Which suite to run on the 2x2 matrix'
         type: choice
         default: loop
-        options: [loop, caches, all]
+        options: [loop, caches, pool, all]
   pull_request:
     # `labeled` is what makes "add the label to run it" work; the others let a
     # push to an already-labeled PR re-run. The `if:` on each job is the actual
@@ -74,7 +76,7 @@ jobs:
       matrix:
         framework: [bare, expo]
         # Schedule and pull_request events have no suite input and use loop.
-        suite: ${{ fromJSON(inputs.suite == 'all' && '["loop","caches"]' || inputs.suite == 'caches' && '["caches"]' || '["loop"]') }}
+        suite: ${{ fromJSON(inputs.suite == 'all' && '["loop","caches","pool"]' || inputs.suite == 'caches' && '["caches"]' || inputs.suite == 'pool' && '["pool"]' || '["loop"]') }}
     env:
       STIM_E2E_SUITE: ${{ matrix.suite }}
       # The registry stays throwaway per run (the driver makes its own temp home)
@@ -155,6 +157,10 @@ jobs:
           --framework ${{ matrix.framework }} --platform ios --keep --home "$TMPDIR/stim-cli-cache-home"
           --summary "$GITHUB_WORKSPACE/cache-summary-ios-${{ matrix.framework }}.json"
 
+      - name: Simulator pool suite (ios, ${{ matrix.framework }})
+        if: matrix.suite == 'pool'
+        run: node test/e2e/native/run-pool-e2e.mjs --framework ${{ matrix.framework }} --keep --home "$TMPDIR/stim-cli-pool-home"
+
       - name: Upload the cache-suite summary
         # `always()`: a FAILING cache run is exactly when the per-check evidence
         # is worth reading, and the summary carries it.
@@ -174,6 +180,7 @@ jobs:
           path: |
             ${{ env.TMPDIR }}/stim-cli-home/workspaces/**/logs/*
             ${{ env.TMPDIR }}/stim-cli-cache-home/workspaces/**/logs/*
+            ${{ env.TMPDIR }}/stim-cli-pool-home/workspaces/**/logs/*
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7
@@ -182,7 +189,7 @@ jobs:
     name: android ${{ matrix.framework }} (${{ matrix.suite }})
     if: >-
       github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && inputs.suite != 'pool') ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-native'))
     # A Linux host with KVM: the Android emulator needs hardware acceleration,
     # which the ubuntu-latest GitHub runners provide once /dev/kvm is exposed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,10 +149,11 @@ checks, and registry remedies, which cannot assume a global install.
 
 ### 2. Create, boot, and delete only owned devices
 
-Stim can create, boot, shut down, or delete only devices it created, named
-`stim-<label> (<model> <runtime>)` and recorded with `owned: true`. Never do any
-of those to a user-created emulator or simulator. Keep a device record when
-teardown fails so `gc` can find the device later.
+Stim can create, boot, shut down, or delete only devices it created. Owned iOS
+simulators are named `stim-<label> (<model> <runtime>)`; owned Android AVDs
+remain `stim-<label>`. Both are recorded with `owned: true`. Never do any of
+those actions to a user-created emulator or simulator. Keep a device record
+when teardown fails so `gc` can find the device later.
 
 Stim parks an owned simulator it no longer needs instead of deleting it, up to a
 configured maximum, and adopts a parked one before creating. Parked simulators

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,9 @@ when teardown fails so `gc` can find the device later.
 
 Stim parks an owned simulator it no longer needs instead of deleting it, up to a
 configured maximum, and adopts a parked one before creating. Parked simulators
-are Stim-owned, listed in the pool record, and deleted only by eviction or
-`gc --delete`.
+are Stim-owned and listed in the pool record. Delete them only by eviction,
+adoption-time reconciliation of a listed unavailable simulator, or `gc
+--delete`; every route uses centralized teardown and ownership revalidation.
 
 A physical device reached through `android --device` or `ios --device` is
 used but not owned. Hardware cannot be created or booted, so those paths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,14 @@ checks, and registry remedies, which cannot assume a global install.
 ### 2. Create, boot, and delete only owned devices
 
 Stim can create, boot, shut down, or delete only devices it created, named
-`stim-<label>` and recorded with `owned: true`. Never do any of those to a
-user-created emulator or simulator. Keep a device record when teardown fails so
-`gc` can find the device later.
+`stim-<label> (<model> <runtime>)` and recorded with `owned: true`. Never do any
+of those to a user-created emulator or simulator. Keep a device record when
+teardown fails so `gc` can find the device later.
+
+Stim parks an owned simulator it no longer needs instead of deleting it, up to a
+configured maximum, and adopts a parked one before creating. Parked simulators
+are Stim-owned, listed in the pool record, and deleted only by eviction or
+`gc --delete`.
 
 A physical device reached through `android --device` or `ios --device` is
 used but not owned. Hardware cannot be created or booted, so those paths
@@ -201,8 +206,9 @@ distribution remain out of scope.
 
 ### 4. Centralize device teardown
 
-All shutdown and deletion flows must use `src/teardown.ts`. Re-resolve ownership
-before each destructive command. Contain per-device failures so batch cleanup
+All shutdown and deletion flows must use `src/teardown.ts`, and so does park,
+which is the flow that gives a simulator up without deleting it. Re-resolve
+ownership before each destructive command. Contain per-device failures so batch cleanup
 can continue. `stop` shuts down devices; it never deletes them.
 
 ### 5. Redirect test state

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -45,15 +45,16 @@ The one non-real piece is the leaf hash function: the real CLI has a direct `@ex
 
 ## The native e2e
 
-There are TWO native suites, on one 2x2 matrix and one shared harness
+There are three native suites and one shared harness
 (`test/e2e/native/harness.mjs`, which owns the fixture creation, the process
-wrappers, the cleanup checks and the diagnostics dump so both drivers build and
+wrappers, the cleanup checks and the diagnostics dump so all drivers build and
 tear down the same app the same way):
 
-| suite      | driver               | proves                                               | when                        |
-| ---------- | -------------------- | ---------------------------------------------------- | --------------------------- |
-| **loop**   | `run-native-e2e.mjs` | the dev loop works end to end                        | nightly, PR label, dispatch |
-| **caches** | `run-cache-e2e.mjs`  | each individual cache is engaged, storing and reused | on demand                   |
+| suite      | driver               | proves                                                  | when                        |
+| ---------- | -------------------- | ------------------------------------------------------- | --------------------------- |
+| **loop**   | `run-native-e2e.mjs` | the dev loop works end to end                           | nightly, PR label, dispatch |
+| **caches** | `run-cache-e2e.mjs`  | each individual cache is engaged, storing and reused    | on demand                   |
+| **pool**   | `run-pool-e2e.mjs`   | iOS simulators are parked, evicted, adopted, and reaped | on demand                   |
 
 ### The loop suite
 
@@ -90,6 +91,18 @@ node test/e2e/native/run-native-e2e.mjs --framework bare --platform android --dr
 The fixture-creation commands are version-sensitive; each is overridable with an
 env var (`STIM_E2E_BARE_INIT`, `STIM_E2E_EXPO_INIT`) so a runner can adjust
 them without touching assertion logic.
+
+### The simulator pool suite
+
+`test/e2e/native/run-pool-e2e.mjs` runs on iOS. With a pool bound of one, it
+creates two workspace simulators, proves the first is parked and then evicted,
+proves a third workspace adopts the survivor, and finishes by proving
+`gc --delete` empties the pool. Run it by hand with:
+
+```bash
+node test/e2e/native/run-pool-e2e.mjs --framework expo
+node test/e2e/native/run-pool-e2e.mjs --framework bare --dry-run
+```
 
 ### The cache suite
 

--- a/docs/specs/2026-09-02-simulator-pool-design.md
+++ b/docs/specs/2026-09-02-simulator-pool-design.md
@@ -141,19 +141,23 @@ them.
    failure: there is nothing to clear.
 3. `simctl rename <udid> "stim-parked (<model> <runtime>) <4 hex>"`.
 4. Under the config lock: append the record, clear the workspace's
-   `platforms.ios` device record, and if the pool now exceeds the maximum
-   remove the oldest record by `parkedAt`; write once. `removeProject` still
-   removes the project entry at the end of the remove, as today.
-5. Outside the lock, `simctl delete` the evicted simulator through the
-   teardown delete path.
+   `platforms.ios` device record, and identify overflow by the oldest
+   `parkedAt`; write once without dropping the overflow records.
+   `removeProject` still removes the project entry at the end of the remove,
+   as today.
+5. For each overflow record, the teardown path reacquires the config lock and
+   verifies that the simulator is still parked before `simctl delete`. It
+   removes the record only after deletion succeeds. A failed deletion keeps
+   the record and can temporarily leave the pool above its bound.
 
 A crash between 3 and 4 leaves a workspace-owned simulator with a parked
-name, which the next `worktree remove` parks again; a crash between 4 and 5
-leaves a `stim-parked` simulator no record names, which is the orphan class
-`gc` reports and `--delete` removes. A step that fails falls back to
-deletion, as today, and prints the failed step. `stop` is unchanged: it shuts
-the owned simulator down and keeps it owned; parking is a consequence of
-giving the workspace up.
+name, which the next `worktree remove` parks again. A crash after step 4 keeps
+the pooled ownership record. If CoreSimulator deletion completed before a
+crash, the next successful `gc` listing proves the simulator absent and drops
+the record; otherwise `gc --delete` retries the claimed deletion. A park step
+that fails falls back to ownership-checked deletion, as today, and prints the
+failed step. `stop` is unchanged: it shuts the owned simulator down and keeps
+it owned; parking is a consequence of giving the workspace up.
 
 Park removes the previous workspace's app data, and adoption removes its
 privacy grants, the keychain, and its other apps. A parked simulator keeps

--- a/docs/specs/2026-09-02-simulator-pool-design.md
+++ b/docs/specs/2026-09-02-simulator-pool-design.md
@@ -1,6 +1,6 @@
 # Simulator pool
 
-Date: 2026-09-02. Status: proposed. Issue: #273.
+Date: 2026-09-02. Status: implemented. Issue: #273.
 
 ## Summary
 

--- a/docs/specs/2026-09-02-simulator-pool-design.md
+++ b/docs/specs/2026-09-02-simulator-pool-design.md
@@ -10,9 +10,11 @@ down, clear the app's data on disk while keeping the app installed, rename,
 record. When a workspace needs a simulator, Stim adopts a parked one of the
 same model and runtime before creating a new one, and finishes cleaning it
 after the boot it pays anyway: privacy grants, keychain, and every app that
-is not this workspace's. The pool holds at most a configured number of
-simulators (default 3); beyond that the oldest parked one is deleted. `gc`
-reports the pool and `gc --delete` empties it.
+is not this workspace's. The pool targets a configured number of simulators
+(default 3); beyond that the oldest parked one is deleted. A failed or
+unverifiable deletion keeps its ownership record and can temporarily leave
+the pool above that target. `gc` reports the pool, and `gc --delete` empties
+every entry it can re-verify and delete.
 
 ## Motivation
 
@@ -137,8 +139,10 @@ them.
    (`plutil -extract ... raw`), then empty the contents of `Documents`,
    `Library`, `tmp`, and `SystemData` (39 ms measured). This removes
    `NSUserDefaults`, AsyncStorage, SQLite, and the dev-menu keys stim wrote in
-   the app's domain. No bundle id recorded, or no container found, is not a
-   failure: there is nothing to clear.
+   the app's domain. No bundle id recorded, or a proven absent container root
+   or matching container, is not a failure: there is nothing to clear.
+   Unreadable directories, metadata, or container contents fail parking so
+   teardown falls back to ownership-checked deletion.
 3. `simctl rename <udid> "stim-parked (<model> <runtime>) <4 hex>"`.
 4. Under the config lock: append the record, clear the workspace's
    `platforms.ios` device record, and identify overflow by the oldest
@@ -231,8 +235,9 @@ normally when its workspace is removed.
       ios stim-parked (iPhone 17 26.5) a1f3 (A7A4..) iPhone 17 26.5 parked 3d ago 2.6 GB
 
 with the `--delete` effect line the other sections carry; size is the
-`dataPathSize` the same listing reports. `gc --delete` deletes every parked
-simulator and clears the list, even when `STIM_HOME` is set: the sweep for
+`dataPathSize` the same listing reports. `gc --delete` attempts every parked
+simulator, removes only records whose absence or deletion it can prove, and
+reports retained failures. This also works when `STIM_HOME` is set: the sweep for
 unlisted `stim-` devices stays refused under `STIM_HOME` as today, because a
 scoped config cannot prove an unlisted device stale, but a parked record in
 this config proves that simulator is Stim's and parked by this home. Orphaned `stim-parked` simulators
@@ -298,9 +303,10 @@ Android's "already exists" recovery (`engine/device.ts` line 409,
   boot time after the recipe goes in the PR (expected about 9 s; the probe
   measured 8.9 s).
 - Command tests with `STIM_HOME` redirected and the variable set explicitly:
-  `worktree remove` parks and evicts (delete outside the lock); `ios` adopts,
+  `worktree remove` parks and attempts overflow eviction; `ios` adopts,
   renames, and prints `adopted`; the idempotent rename on reuse; `gc` reports
-  and `--delete` empties, including under `STIM_HOME`; `status` lines;
+  and `--delete` removes verified entries while retaining failures, including
+  under `STIM_HOME`; `status` lines;
   parking disabled by `0` with a non-empty pool; `gc --delete` never parks;
   an adoption that crashes after the record write, where the next run
   finishes the resets and the uninstall and clears `adoptionPending`; an

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -100,7 +100,7 @@ emulator or simulator.
 
 `worktree remove` parks the workspace's simulator for a later one to adopt. A
 parked simulator is Stim-owned: never delete one by hand; `gc --delete` clears
-verified entries, keeps failures (`stim guide lifecycle`). A first launch on a physical iPhone can need
+verified entries, keeps failures (`stim guide lifecycle`). First launch on a physical iPhone can need
 one-time taps the remedy names.
 
 `stim android --device [serial]` and `stim ios --device [udid]` install on a

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -28,9 +28,8 @@ E404 in a repo with a private registry, use:
 npx --registry=https://registry.npmjs.org stim-cli <command>
 ```
 
-Prefer plain output: it streams each phase and ends with the device ID, app ID,
-Metro state, cache result, and log path. Use `--json` only when a script must
-parse a stable payload.
+Prefer plain output: it streams each phase and ends with the facts the next step
+needs. Use `--json` only when a script must parse a stable payload.
 
 ## Normal workflow
 
@@ -89,15 +88,20 @@ still building` means Metro has not finished the bundle; wait and query the
   `No matching log records` on stderr. JSON mode prints zero bytes when no
   records match. Do not read the NDJSON files directly.
 - Use `stim status` when resuming a workspace or recovering missing device,
-  port, server, or build facts. A normal `start` and platform run already print
-  what the next step needs. Use `stim doctor` when a build is
-  unexpectedly slow or the environment looks incomplete.
+  port, server, or build facts; a normal `start` and platform run already print
+  them. Use `stim doctor` when a build is unexpectedly slow or the environment
+  looks incomplete.
 
 ## Ownership and deletion
 
-Stim creates, boots, and deletes only devices it created. Owned devices use
-the `stim-<label>` name. Never point Stim at a user-created emulator or
-simulator.
+Stim creates, boots, and deletes only devices it created. Owned simulators use
+the `stim-<label> (<model> <runtime>)` name. Never point Stim at a user-created
+emulator or simulator.
+
+`worktree remove` parks the workspace's simulator for a later one to adopt. A
+parked simulator is Stim-owned: never delete one by hand; `gc --delete` empties
+the pool (`stim guide lifecycle`). A first launch on a physical iPhone can need
+one-time taps the remedy names.
 
 `stim android --device [serial]` and `stim ios --device [udid]` install on a
 connected physical device. Stim never creates, boots, or deletes hardware, and
@@ -108,17 +112,13 @@ A `--device` run leases that device for the run. `stim device lock ios --for
 (`stim guide lifecycle`). Never delete another workspace's lease file under
 `~/.stim/device-locks`; `gc --delete` removes the expired ones.
 
-A physical iPhone's first launch can need two one-time taps: developer
-trust, which only the user can grant, and Local Network, which a device tool
-accepts. The remedy names which; an uninstall clears both.
-
 Treat a refusal as an ownership or state mismatch: read its code and remedy.
 Never reach for `--force` first.
 
 Ask the user before these actions:
 
 - `worktree remove`, because it deletes the worktree, its Stim-created branch
-  when it has no unique commits, and its owned device.
+  when it has no unique commits, and gives up its owned device.
 - `worktree remove --force`, because it also discards uncommitted and untracked
   files.
 - `gc --delete`, because it deletes orphaned resources. `gc --delete --cache all`

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -99,8 +99,8 @@ the `stim-<label> (<model> <runtime>)` name. Never point Stim at a user-created
 emulator or simulator.
 
 `worktree remove` parks the workspace's simulator for a later one to adopt. A
-parked simulator is Stim-owned: never delete one by hand; `gc --delete` empties
-the pool (`stim guide lifecycle`). A first launch on a physical iPhone can need
+parked simulator is Stim-owned: never delete one by hand; `gc --delete` clears
+verified entries, keeps failures (`stim guide lifecycle`). A first launch on a physical iPhone can need
 one-time taps the remedy names.
 
 `stim android --device [serial]` and `stim ios --device [udid]` install on a

--- a/packages/stim-cli/src/__tests__/_factories.ts
+++ b/packages/stim-cli/src/__tests__/_factories.ts
@@ -40,6 +40,7 @@ export function makeIosSim(overrides: Partial<IosSimRecord> = {}): IosSimRecord 
     state: 'Booted',
     runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0',
     deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16',
+    available: true,
     ...overrides,
   };
 }

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -8,6 +8,7 @@ import {
   OUTPUT_LABELS,
   phaseLine,
   shortHash,
+  shortUdid,
 } from '../command-output.ts';
 
 test('formatDuration uses one format for every command', () => {
@@ -57,6 +58,12 @@ test('shortHash keeps short values and abbreviates long values', () => {
   expect(shortHash('12345678')).toBe('12345678');
   expect(shortHash('123456789')).toBe('123456..');
   expect(shortHash(null)).toBe('');
+});
+
+test('shortUdid keeps short values and abbreviates simulator ids', () => {
+  expect(shortUdid('A1F3')).toBe('A1F3');
+  expect(shortUdid('A1F3-0000')).toBe('A1F3..');
+  expect(shortUdid(null)).toBe('');
 });
 
 test('the label set is closed, sorted, and free of duplicates', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -42,6 +42,7 @@ import {
   verifyReleaseLaunch,
   reverseMetroPorts,
   writeDebugHttpHost,
+  clearOtherUserApps,
 } from '../engine/app-install.ts';
 import { hashFile } from '../engine/installed-artifact.ts';
 
@@ -145,6 +146,52 @@ describe('the two pure port-wiring shapes', () => {
 });
 
 describe('ios', () => {
+  test('clearOtherUserApps removes every user app except the adopting workspace app', () => {
+    const removed: string[] = [];
+    expect(
+      clearOtherUserApps(
+        { udid: 'U1', keep: 'com.example.keep' },
+        {
+          list: () => ['com.example.old', 'com.example.keep', 'com.example.other'],
+          uninstall: (_udid, bundleId) => removed.push(bundleId),
+        },
+      ),
+    ).toEqual({ listed: true, removed: ['com.example.old', 'com.example.other'], failed: [] });
+    expect(removed).toEqual(['com.example.old', 'com.example.other']);
+  });
+
+  test('clearOtherUserApps distinguishes a failed listing from an empty simulator', () => {
+    expect(clearOtherUserApps({ udid: 'U1' }, { list: () => [] })).toEqual({
+      listed: true,
+      removed: [],
+      failed: [],
+    });
+    expect(
+      clearOtherUserApps(
+        { udid: 'U1' },
+        {
+          list: () => {
+            throw new Error('simctl unavailable');
+          },
+        },
+      ),
+    ).toEqual({ listed: false, removed: [], failed: [] });
+  });
+
+  test('clearOtherUserApps reports each uninstall that must be retried', () => {
+    expect(
+      clearOtherUserApps(
+        { udid: 'U1' },
+        {
+          list: () => ['com.example.one', 'com.example.two'],
+          uninstall: (_udid, bundleId) => {
+            if (bundleId === 'com.example.two') throw new Error('busy');
+          },
+        },
+      ),
+    ).toEqual({ listed: true, removed: ['com.example.one'], failed: ['com.example.two'] });
+  });
+
   test('installIosApp passes the .app path as one literal argv element', () => {
     const exec = recordingExec();
     const appPath = '/tmp/Build Products/My App.app';

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -676,6 +676,56 @@ describe('ensureOwnedDevice: ios', () => {
     }
   });
 
+  test('keeps a parked record renamed away from Stim ownership and creates a fresh simulator', async () => {
+    const root = projectDir();
+    process.env.STIM_POOL_IOS_PARKED_MAX = '3';
+    const output: string[] = [];
+    try {
+      parkSim({
+        platform: 'ios',
+        projectPath: root,
+        max: 3,
+        record: {
+          udid: 'U1',
+          name: 'stim-parked (iPhone 17 Pro 26.2) u1',
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+          runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+          parkedAt: '2026-09-01T10:00:00.000Z',
+          simslimManaged: false,
+        },
+      });
+      const { files, exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'My iPhone',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+        },
+      ]);
+      setExecutor(exec);
+
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+        out: (line) => {
+          output.push(line);
+        },
+      });
+
+      expect(device).toMatchObject({ deviceUdid: 'NEW-UDID', created: true });
+      expect(readParked('ios')).toMatchObject([{ udid: 'U1' }]);
+      expect(files.some((call) => call.includes('U1'))).toBe(false);
+      expect(output.join('\n')).toMatch(/not Stim-owned/);
+    } finally {
+      delete process.env.STIM_POOL_IOS_PARKED_MAX;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('drops a gone parked record and creates a fresh simulator', async () => {
     const root = projectDir();
     process.env.STIM_POOL_IOS_PARKED_MAX = '3';

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import assert from 'node:assert';
 import {
   claimAndroidConsolePort,
+  clearIosAdoptionPending,
   deviceCapacityRefusal,
   deviceTypeMismatch,
   ensureBooted,
@@ -15,6 +16,7 @@ import {
 import { allConsolePortsAndSerials, getProject, setDevice, upsertProject } from '../config.ts';
 import type { DeviceRecord } from '../types.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
+import { parkSim, readParked } from '../sim-pool.ts';
 import { makeAdbDevices, makeChildProcess, makeConfig, makeExitingChild, makeIosSim } from './_factories.ts';
 
 type SimEntry = {
@@ -576,9 +578,11 @@ function projectDir() {
 
 function iosExecutor(devices: SimEntry[]) {
   const run: string[] = [];
+  const files: string[][] = [];
   const spawned: string[] = [];
   return {
     run,
+    files,
     spawned,
     exec: {
       run(cmd: string) {
@@ -597,7 +601,8 @@ function iosExecutor(devices: SimEntry[]) {
           return null;
         }
       },
-      runFile() {
+      runFile(file: string, args: string[] = []) {
+        files.push([file, ...args]);
         return '';
       },
       spawn(cmd: string, args: readonly string[] = []) {
@@ -609,6 +614,183 @@ function iosExecutor(devices: SimEntry[]) {
 }
 
 describe('ensureOwnedDevice: ios', () => {
+  test('adopts a matching parked simulator and resets it inside the deferred boot', async () => {
+    const root = projectDir();
+    process.env.STIM_POOL_IOS_PARKED_MAX = '3';
+    try {
+      parkSim({
+        platform: 'ios',
+        projectPath: root,
+        max: 3,
+        record: {
+          udid: 'U1',
+          name: 'stim-parked (iPhone 17 Pro 26.2) u1',
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+          runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+          parkedAt: '2026-09-01T10:00:00.000Z',
+          simslimManaged: false,
+          cacheKey: 'fingerprint-debug-sim',
+        },
+      });
+      const { run, files, exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'stim-parked (iPhone 17 Pro 26.2) u1',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+        },
+      ]);
+      setExecutor(exec);
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(device).toMatchObject({
+        deviceUdid: 'U1',
+        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+        adopted: true,
+        adoptionPending: true,
+        parkedCacheKey: 'fingerprint-debug-sim',
+      });
+      expect(readParked('ios')).toEqual([]);
+      expect(run).toContain('xcrun simctl boot U1');
+      expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', 'stim-app (iPhone 17 Pro 26.2)']);
+      expect(files.some((call) => call.includes('privacy'))).toBe(false);
+      await device.booting?.done;
+      expect(files).toContainEqual(['xcrun', 'simctl', 'privacy', 'U1', 'reset', 'all']);
+      expect(files).toContainEqual(['xcrun', 'simctl', 'keychain', 'U1', 'reset']);
+    } finally {
+      delete process.env.STIM_POOL_IOS_PARKED_MAX;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('drops a gone parked record and creates a fresh simulator', async () => {
+    const root = projectDir();
+    process.env.STIM_POOL_IOS_PARKED_MAX = '3';
+    try {
+      parkSim({
+        platform: 'ios',
+        projectPath: root,
+        max: 3,
+        record: {
+          udid: 'GONE',
+          name: 'stim-parked (iPhone 17 Pro 26.2) gone',
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+          runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+          parkedAt: '2026-09-01T10:00:00.000Z',
+          simslimManaged: false,
+        },
+      });
+      const { exec } = iosExecutor([]);
+      setExecutor(exec);
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(device).toMatchObject({ deviceUdid: 'NEW-UDID', created: true });
+      await device.booting?.done;
+      expect(readParked('ios')).toEqual([]);
+    } finally {
+      delete process.env.STIM_POOL_IOS_PARKED_MAX;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a pending adoption retries privacy and keychain cleanup on reuse', async () => {
+    const root = projectDir();
+    try {
+      setDevice(root, 'ios', {
+        deviceUdid: 'U1',
+        owned: true,
+        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+        adopted: true,
+        adoptionPending: true,
+      });
+      const { files, exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'stim-app (iPhone 17 Pro 26.2)',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+        },
+      ]);
+      setExecutor(exec);
+      await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(files).toContainEqual(['xcrun', 'simctl', 'privacy', 'U1', 'reset', 'all']);
+      expect(files).toContainEqual(['xcrun', 'simctl', 'keychain', 'U1', 'reset']);
+      expect(getProject(root)?.platforms?.ios?.adoptionPending).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('completing adoption clears both transient adoption fields', () => {
+    const root = projectDir();
+    try {
+      setDevice(root, 'ios', {
+        deviceUdid: 'U1',
+        owned: true,
+        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+        adopted: true,
+        adoptionPending: true,
+        parkedCacheKey: 'fingerprint-debug-sim',
+      });
+
+      clearIosAdoptionPending(root);
+
+      expect(getProject(root)?.platforms?.ios).toEqual({
+        deviceUdid: 'U1',
+        owned: true,
+        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('reuse heals a legacy simulator name before returning it', async () => {
+    const root = projectDir();
+    try {
+      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true, deviceName: 'stim-old' });
+      const { files, exec } = iosExecutor([
+        {
+          udid: 'U1',
+          name: 'stim-old',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+        },
+      ]);
+      setExecutor(exec);
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(device.deviceName).toBe('stim-app (iPhone 17 Pro 26.2)');
+      expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', 'stim-app (iPhone 17 Pro 26.2)']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('rejects an invalid SimSlim profile before creating or booting a simulator', async () => {
     const root = projectDir();
     try {
@@ -767,7 +949,11 @@ describe('ensureOwnedDevice: ios', () => {
       expect(result.created).toBe(true);
       expect(result.booting?.udid).toBe('NEW-UDID');
       expect(run).toContain('xcrun simctl boot NEW-UDID');
-      expect(getProject(root)?.platforms?.ios).toEqual({ deviceUdid: 'NEW-UDID', owned: true, deviceName: 'stim-app' });
+      expect(getProject(root)?.platforms?.ios).toEqual({
+        deviceUdid: 'NEW-UDID',
+        owned: true,
+        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+      });
       await result.booting?.done;
       expect(spawned).toEqual(['xcrun simctl bootstatus NEW-UDID -b']);
     } finally {
@@ -1572,7 +1758,9 @@ describe('ensureOwnedDevice: the requested model against the sim this workspace 
 
       expect(device.deviceType).toBe('iPhone 16');
       expect(device.runtime).toBe('26.2');
-      expect(run.some((cmd) => cmd.includes(`simctl create "stim-app" "${TYPE_16.identifier}"`))).toBe(true);
+      expect(run.some((cmd) => cmd.includes(`simctl create "stim-app (iPhone 16 26.2)" "${TYPE_16.identifier}"`))).toBe(
+        true,
+      );
       expect(getProject(root)?.platforms?.ios?.runtime).toBe(undefined);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -56,7 +56,14 @@ afterEach(() => {
 });
 
 function simList(devices: SimEntry[]) {
-  return JSON.stringify({ devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-26-2': devices } });
+  return JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-26-2': devices.map((device) => ({
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16',
+        ...device,
+      })),
+    },
+  });
 }
 
 describe('ensureBooted: ios', () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -176,7 +176,7 @@ test('reports parked simulators with model, runtime, age, size, and delete effec
   const lines = formatGcReport({ parkedSims: parked }, { now: Date.parse('2026-09-03T00:00:00.000Z') }).join('\n');
   expect(lines).toMatch(/Parked simulators \(1, 2M\)/);
   expect(lines).toMatch(/A1F3\.\.\).*iPhone 17 26\.5.*parked 48h ago.*2M/);
-  expect(lines).toMatch(/--delete deletes every parked simulator and empties the pool/);
+  expect(lines).toMatch(/--delete attempts verified deletions and keeps failures/);
   expect(lines).not.toMatch(/Nothing to reclaim/);
 });
 
@@ -238,7 +238,9 @@ test('parked deletion keeps ownership records when simulator listing was unavail
   expect(failures).toBe(1);
   expect(output).toMatch(/Could not verify.*record was kept/);
   expect(readParked('ios')).toEqual([record]);
-  expect(formatGcReport({ parkedSims: report.parkedSims }).join('\n')).toMatch(/keeps entries it cannot verify/);
+  expect(formatGcReport({ parkedSims: report.parkedSims }).join('\n')).toMatch(
+    /attempts verified deletions and keeps failures/,
+  );
 });
 
 test('parked deletion keeps ownership records after malformed simctl list output', async () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -1893,6 +1893,7 @@ function iosListJson(devices: DeviceSpec[]) {
         name: d.name,
         state: d.state || 'Shutdown',
         isAvailable: true,
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
       })),
     },
   });

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -241,6 +241,34 @@ test('parked deletion keeps ownership records when simulator listing was unavail
   expect(formatGcReport({ parkedSims: report.parkedSims }).join('\n')).toMatch(/keeps entries it cannot verify/);
 });
 
+test('parked deletion keeps ownership records after malformed simctl list output', async () => {
+  upsertProject('/tmp/source', { platforms: { ios: { deviceUdid: 'P1', deviceName: 'stim-source', owned: true } } });
+  const record = {
+    udid: 'P1',
+    name: 'stim-parked (iPhone 17 26.5) p1',
+    deviceTypeIdentifier: 'iphone-17',
+    runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+    parkedAt: '2026-09-01T00:00:00.000Z',
+    simslimManaged: false,
+  };
+  parkSim({ platform: 'ios', projectPath: '/tmp/source', record, max: 3 });
+  setExecutor({
+    run(cmd) {
+      if (cmd.includes('simctl list devices')) return '[]';
+      throw new Error(`unexpected run: ${cmd}`);
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+
+  const report = await collectGcReport();
+  const output = await captureLog(() => deleteParkedSims(report.parkedSims));
+
+  expect(report.parkedSims[0]?.listed).toBe(null);
+  expect(output).toMatch(/Could not verify.*record was kept/);
+  expect(readParked('ios')).toEqual([record]);
+});
+
 test('headline does not claim "nothing to reclaim" without flagging unchecked entries', () => {
   const lines = formatGcReport({
     skipped: [{ dir: '/Volumes/ExternalSSD/proj', reason: 'volume /Volumes/ExternalSSD is not mounted' }],

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -24,6 +24,7 @@ import { withEasProjectLock } from '../engine/eas-project-lock.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceStateFile } from '../paths.ts';
 import gcCommand, {
   collectGcReport,
+  describeParkedSims,
   describeUnverifiableDevices,
   findOrphanedDevices,
   findStaleDeviceRecords,
@@ -147,6 +148,36 @@ test('lists dead project entries', () => {
   expect(lines).toMatch(/Dead project entries/);
 });
 
+test('reports parked simulators with model, runtime, age, size, and delete effect', () => {
+  const parked = describeParkedSims(
+    [
+      {
+        udid: 'A1F3-0000',
+        name: 'stim-parked (iPhone 17 26.5) a1f3',
+        deviceTypeIdentifier: 'iphone-17',
+        runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+        parkedAt: '2026-09-01T00:00:00.000Z',
+        simslimManaged: false,
+      },
+    ],
+    [
+      makeIosSim({
+        udid: 'A1F3-0000',
+        name: 'stim-parked (iPhone 17 26.5) a1f3',
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+        deviceTypeIdentifier: 'iphone-17',
+        dataPathSize: 2 * 1024 * 1024,
+      }),
+    ],
+    [{ identifier: 'iphone-17', name: 'iPhone 17' }],
+  );
+  const lines = formatGcReport({ parkedSims: parked }, { now: Date.parse('2026-09-03T00:00:00.000Z') }).join('\n');
+  expect(lines).toMatch(/Parked simulators \(1, 2M\)/);
+  expect(lines).toMatch(/A1F3\.\.\).*iPhone 17 26\.5.*parked 48h ago.*2M/);
+  expect(lines).toMatch(/--delete deletes every parked simulator and empties the pool/);
+  expect(lines).not.toMatch(/Nothing to reclaim/);
+});
+
 test('headline does not claim "nothing to reclaim" without flagging unchecked entries', () => {
   const lines = formatGcReport({
     skipped: [{ dir: '/Volumes/ExternalSSD/proj', reason: 'volume /Volumes/ExternalSSD is not mounted' }],
@@ -203,6 +234,30 @@ test('findOrphanedDevices proposes only Stim devices absent from config', () => 
     isMounted: () => true,
   });
   expect(result.orphaned.map((o) => o.id).toSorted()).toEqual(['U1', 'stim-old']);
+});
+
+test('a simulator in the parked pool is referenced rather than orphaned', () => {
+  const result = findOrphanedDevices({
+    sims: [makeIosSim({ udid: 'P1', name: 'stim-parked (iPhone 17 26.5) p1' })],
+    config: makeConfig({
+      parked: {
+        ios: [
+          {
+            udid: 'P1',
+            name: 'stim-parked (iPhone 17 26.5) p1',
+            deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
+            runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+            parkedAt: '2026-09-03T00:00:00.000Z',
+            simslimManaged: false,
+          },
+        ],
+        android: [],
+      },
+    }),
+  });
+
+  expect(result.orphaned).toEqual([]);
+  expect(result.kept[0]?.reason).toBe('referenced by the simulator pool');
 });
 
 test('gc sizes only listed owned Android AVDs after ownership classification', async () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -16,7 +16,7 @@ import { dirname, join } from 'node:path';
 import { METRO_NAMED_CACHE_LAYOUT } from '@stim-cli/core';
 import { Command } from 'commander';
 import { setExecutor, resetExecutor } from '../exec.ts';
-import { saveConfig, loadConfig } from '../config.ts';
+import { getProject, saveConfig, loadConfig, upsertProject } from '../config.ts';
 import { register } from '../cache-manifest.ts';
 import { ensureRemoteBootOwned, withRemoteSessionLock } from '../engine/device-remote.ts';
 import { deviceLeasePath, deviceLocksDir } from '../engine/device-lease.ts';
@@ -24,6 +24,7 @@ import { withEasProjectLock } from '../engine/eas-project-lock.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceStateFile } from '../paths.ts';
 import gcCommand, {
   collectGcReport,
+  deleteParkedSims,
   describeParkedSims,
   describeUnverifiableDevices,
   findOrphanedDevices,
@@ -33,6 +34,7 @@ import gcCommand, {
   runGc,
   selectCaches,
 } from '../commands/gc.ts';
+import { adoptParked, parkSim, readParked } from '../sim-pool.ts';
 import { makeConfig, makeIosSim, makeCacheDescriptor, makeBuildLock, makeBuildSlot } from './_factories.ts';
 
 describe('selectCaches', () => {
@@ -176,6 +178,67 @@ test('reports parked simulators with model, runtime, age, size, and delete effec
   expect(lines).toMatch(/A1F3\.\.\).*iPhone 17 26\.5.*parked 48h ago.*2M/);
   expect(lines).toMatch(/--delete deletes every parked simulator and empties the pool/);
   expect(lines).not.toMatch(/Nothing to reclaim/);
+});
+
+test('parked deletion skips a simulator adopted after report collection', async () => {
+  upsertProject('/tmp/source', { platforms: { ios: { deviceUdid: 'P1', deviceName: 'stim-source', owned: true } } });
+  upsertProject('/tmp/adopter', { platforms: {} });
+  const record = {
+    udid: 'P1',
+    name: 'stim-parked (iPhone 17 26.5) p1',
+    deviceTypeIdentifier: 'iphone-17',
+    runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+    parkedAt: '2026-09-01T00:00:00.000Z',
+    simslimManaged: false,
+  };
+  parkSim({ platform: 'ios', projectPath: '/tmp/source', record, max: 3 });
+  const report = describeParkedSims([record], [makeIosSim({ udid: 'P1', name: record.name })], []);
+  const device = { deviceUdid: 'P1', deviceName: 'stim-adopter', owned: true };
+  adoptParked({ platform: 'ios', projectPath: '/tmp/adopter', udid: 'P1', device });
+  let deleted = false;
+
+  const output = await captureLog(() =>
+    deleteParkedSims(report, {
+      deleteParkedIosSim: () => {
+        deleted = true;
+      },
+    }),
+  );
+
+  expect(deleted).toBe(false);
+  expect(output).toMatch(/no longer parked/);
+  expect(getProject('/tmp/adopter')?.platforms?.ios).toEqual(device);
+});
+
+test('parked deletion keeps ownership records when simulator listing was unavailable', async () => {
+  upsertProject('/tmp/source', { platforms: { ios: { deviceUdid: 'P1', deviceName: 'stim-source', owned: true } } });
+  const record = {
+    udid: 'P1',
+    name: 'stim-parked (iPhone 17 26.5) p1',
+    deviceTypeIdentifier: 'iphone-17',
+    runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+    parkedAt: '2026-09-01T00:00:00.000Z',
+    simslimManaged: false,
+  };
+  parkSim({ platform: 'ios', projectPath: '/tmp/source', record, max: 3 });
+  const report = await collectGcReport(
+    { unsafeAllowScopedDeviceSweep: true },
+    {
+      listAllIosSims: () => {
+        throw new Error('simctl unavailable');
+      },
+    },
+  );
+
+  let failures = 0;
+  const output = await captureLog(() => {
+    failures = deleteParkedSims(report.parkedSims);
+  });
+
+  expect(failures).toBe(1);
+  expect(output).toMatch(/Could not verify.*record was kept/);
+  expect(readParked('ios')).toEqual([record]);
+  expect(formatGcReport({ parkedSims: report.parkedSims }).join('\n')).toMatch(/keeps entries it cannot verify/);
 });
 
 test('headline does not claim "nothing to reclaim" without flagging unchecked entries', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -157,7 +157,7 @@ function parseFirst(lines: string[]) {
 
 interface RecordedArgs {
   [key: string]: unknown;
-  installIosApp: { appPath?: unknown };
+  installIosApp: { appPath?: unknown; proveInstalled?: unknown };
   launchIosApp: { devClientScheme?: unknown; metroPort?: unknown; bundleId?: unknown };
   buildIos: { configuration?: unknown; root?: unknown };
   swapJsBundle: { cachedAppPath?: unknown; isExpo?: unknown; root?: unknown };
@@ -519,6 +519,73 @@ describe('the simulator boot gate', () => {
     expect(calls.order.includes('buildIos')).toBe(false);
     expect(calls.order.includes('installIosApp')).toBe(false);
     expect(errs.join('\n')).toMatch(/STIM_NO_FINGERPRINT/);
+  });
+});
+
+describe('parked simulator adoption', () => {
+  test('sweeps old apps before install, uses the parked cache key, and reports adopted', async () => {
+    reserve();
+    const events: string[] = [];
+    let installArgs: Record<string, unknown> = {};
+    const { exitCode, errs } = await run(
+      { metroCheck: false },
+      {
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture (iPhone 17 Pro 26.5)',
+          owned: true,
+          adopted: true,
+          adoptionPending: true,
+          parkedCacheKey: `${FINGERPRINT}-debug-sim`,
+        }),
+        clearOtherUserApps: () => {
+          events.push('sweep');
+          return { listed: true, removed: ['com.example.old'], failed: [] };
+        },
+        clearIosAdoptionPending: () => events.push('clear'),
+        installIosApp: (args) => {
+          events.push('install');
+          installArgs = args;
+          return { ok: true, skipped: true };
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(events).toEqual(['sweep', 'clear', 'install']);
+    expect(installArgs.proveInstalled).toBe(true);
+    expect(errs.join('\n')).toMatch(/device\s+stim-fixture .* adopted/);
+    expect(errs.join('\n')).toMatch(/removed com\.example\.old/);
+  });
+
+  test('a failed app listing leaves adoption pending for the next run', async () => {
+    reserve();
+    let cleared = false;
+    let proveInstalled: unknown;
+    const { exitCode, errs } = await run(
+      { metroCheck: false },
+      {
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture (iPhone 17 Pro 26.5)',
+          owned: true,
+          adopted: true,
+          adoptionPending: true,
+          parkedCacheKey: 'different-build',
+        }),
+        clearOtherUserApps: () => ({ listed: false, removed: [], failed: [] }),
+        clearIosAdoptionPending: () => {
+          cleared = true;
+        },
+        installIosApp: (args) => {
+          proveInstalled = args.proveInstalled;
+          return { ok: true };
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(cleared).toBe(false);
+    expect(errs.join('\n')).toMatch(/could not list apps .* cleanup will retry/);
+    expect(proveInstalled).toBe(false);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -557,7 +557,7 @@ describe('parked simulator adoption', () => {
     expect(errs.join('\n')).toMatch(/removed com\.example\.old/);
   });
 
-  test('a failed app listing leaves adoption pending for the next run', async () => {
+  test('a failed app listing refuses before install and leaves adoption pending', async () => {
     reserve();
     let cleared = false;
     let proveInstalled: unknown;
@@ -582,10 +582,40 @@ describe('parked simulator adoption', () => {
         },
       },
     );
-    expect(exitCode).toBe(null);
+    expect(exitCode).toBe(1);
     expect(cleared).toBe(false);
-    expect(errs.join('\n')).toMatch(/could not list apps .* cleanup will retry/);
-    expect(proveInstalled).toBe(false);
+    expect(errs.join('\n')).toMatch(/Could not list apps .* did not install or launch/);
+    expect(proveInstalled).toBe(undefined);
+  });
+
+  test('a failed old-app uninstall refuses before install and leaves adoption pending', async () => {
+    reserve();
+    let cleared = false;
+    let installed = false;
+    const { exitCode, errs } = await run(
+      { metroCheck: false },
+      {
+        ensureOwnedDevice: async () => ({
+          deviceUdid: UDID,
+          deviceName: 'stim-fixture (iPhone 17 Pro 26.5)',
+          owned: true,
+          adopted: true,
+          adoptionPending: true,
+        }),
+        clearOtherUserApps: () => ({ listed: true, removed: [], failed: ['com.example.old'] }),
+        clearIosAdoptionPending: () => {
+          cleared = true;
+        },
+        installIosApp: () => {
+          installed = true;
+          return { ok: true };
+        },
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(cleared).toBe(false);
+    expect(installed).toBe(false);
+    expect(errs.join('\n')).toMatch(/Could not remove com\.example\.old.*did not install or launch/);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -629,7 +629,13 @@ function simctlClock(step: number) {
         return JSON.stringify({
           devices: {
             'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
-              { udid: UDID, name: 'stim-fixture', state: 'Booted', isAvailable: true },
+              {
+                udid: UDID,
+                name: 'stim-fixture',
+                state: 'Booted',
+                isAvailable: true,
+                deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
+              },
             ],
           },
         });

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { setExecutor, resetExecutor } from '../exec.ts';
 import { upsertProject, setDevice, getProject } from '../config.ts';
-import { describeDereferenced, reclaimProject } from '../reclaim.ts';
+import { describeDereferenced, parkedIosCacheKey, reclaimProject } from '../reclaim.ts';
 import { endRecordedSession } from '../engine/device-remote.ts';
 import { ensureWorkspaceStorage, workspaceStateFile } from '../paths.ts';
 import { listLeaseFiles, takeLease } from '../engine/device-lease.ts';
@@ -36,6 +36,12 @@ test('describeDereferenced reports a physical android device when there is no av
 test('describeDereferenced returns an empty list when nothing is claimed', () => {
   expect(describeDereferenced({ platforms: {} })).toEqual([]);
   expect(describeDereferenced({})).toEqual([]);
+});
+
+test('only an iOS last build becomes a parked install hint', () => {
+  expect(parkedIosCacheKey({ platform: 'ios', cacheKey: 'ios-key' })).toBe('ios-key');
+  expect(parkedIosCacheKey({ platform: 'android', cacheKey: 'android-key' })).toBe(null);
+  expect(parkedIosCacheKey({ platform: 'ios', cacheKey: 42 })).toBe(null);
 });
 
 test('reclaimProject removes the config entry', async () => {

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -79,7 +79,13 @@ test('reclaimProject keeps the config entry when an owned device delete fails', 
   const listJson = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-17-4': [
-        { udid: 'U1', name: 'stim-proj', state: 'Shutdown', isAvailable: true },
+        {
+          udid: 'U1',
+          name: 'stim-proj',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-15',
+        },
       ],
     },
   });
@@ -106,7 +112,13 @@ test('reclaimProject removes the entry when the owned device really is deleted',
   const listJson = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-17-4': [
-        { udid: 'U1', name: 'stim-proj', state: 'Shutdown', isAvailable: true },
+        {
+          udid: 'U1',
+          name: 'stim-proj',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-15',
+        },
       ],
     },
   });

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -404,7 +404,8 @@ test('parseUserApps keeps only user applications', () => {
       }),
     ),
   ).toEqual(['com.example.one', 'com.example.two']);
-  expect(parseUserApps('not json')).toEqual([]);
+  expect(() => parseUserApps('not json')).toThrow(/JSON/);
+  expect(() => parseUserApps('[]')).toThrow(/JSON object/);
 });
 
 test('listUserApps passes the udid as one argv element and converts the property list', () => {

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -39,12 +39,36 @@ afterEach(() => {
 const SIMCTL_OUTPUT = JSON.stringify({
   devices: {
     'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
-      { udid: 'UDID-A', name: 'iPhone 15', state: 'Booted', isAvailable: true },
-      { udid: 'UDID-B', name: 'iPhone 15 Pro', state: 'Shutdown', isAvailable: true },
-      { udid: 'UDID-C', name: 'iPhone 14', state: 'Booted', isAvailable: true },
+      {
+        udid: 'UDID-A',
+        name: 'iPhone 15',
+        state: 'Booted',
+        isAvailable: true,
+        deviceTypeIdentifier: 'iphone-15',
+      },
+      {
+        udid: 'UDID-B',
+        name: 'iPhone 15 Pro',
+        state: 'Shutdown',
+        isAvailable: true,
+        deviceTypeIdentifier: 'iphone-15-pro',
+      },
+      {
+        udid: 'UDID-C',
+        name: 'iPhone 14',
+        state: 'Booted',
+        isAvailable: true,
+        deviceTypeIdentifier: 'iphone-14',
+      },
     ],
     'com.apple.CoreSimulator.SimRuntime.iOS-16-0': [
-      { udid: 'UDID-OLD', name: 'iPhone 13', state: 'Shutdown', isAvailable: false },
+      {
+        udid: 'UDID-OLD',
+        name: 'iPhone 13',
+        state: 'Shutdown',
+        isAvailable: false,
+        deviceTypeIdentifier: 'iphone-13',
+      },
     ],
   },
 });
@@ -60,6 +84,31 @@ test('parseSimctlList rejects structurally invalid successful output', () => {
     expect(() => parseSimctlList(output)).toThrow(/devices object/);
   }
   expect(() => parseSimctlList('{"devices":{"ios":{}}}')).toThrow(/to be an array/);
+});
+
+test('parseSimctlList rejects incomplete or mistyped iOS device records', () => {
+  const runtime = 'com.apple.CoreSimulator.SimRuntime.iOS-26-5';
+  const valid = {
+    udid: 'U1',
+    name: 'stim-app',
+    state: 'Shutdown',
+    isAvailable: true,
+    deviceTypeIdentifier: 'iphone-17',
+  };
+  for (const bad of [
+    { ...valid, udid: undefined },
+    { ...valid, name: 42 },
+    { ...valid, state: '' },
+    { ...valid, deviceTypeIdentifier: null },
+    { ...valid, isAvailable: 'yes' },
+    { ...valid, dataPath: 42 },
+    { ...valid, dataPathSize: Number.NaN },
+  ]) {
+    expect(() =>
+      parseSimctlList(JSON.stringify({ devices: { [runtime]: [bad] } }), { includeUnavailable: true }),
+    ).toThrow(/Expected simctl device field/);
+  }
+  expect(() => parseSimctlList(JSON.stringify({ devices: { [runtime]: ['corrupt'] } }))).toThrow(/every simctl device/);
 });
 
 test('parseSimctlList includes runtime in each entry', () => {
@@ -134,7 +183,13 @@ test('parseSimctlList drops non-iOS runtimes (watchOS, tvOS, visionOS)', () => {
   const out = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
-        { udid: 'IOS-1', name: 'iPhone 17', state: 'Booted', isAvailable: true },
+        {
+          udid: 'IOS-1',
+          name: 'iPhone 17',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-17',
+        },
       ],
       'com.apple.CoreSimulator.SimRuntime.watchOS-11-0': [
         { udid: 'WATCH-1', name: 'Apple Watch S10', state: 'Booted', isAvailable: true },
@@ -269,7 +324,13 @@ test('deleteIosSim refuses to delete a sim not owned by Stim', () => {
       JSON.stringify({
         devices: {
           'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
-            { udid: 'UDID-A', name: 'iPhone 15', state: 'Shutdown', isAvailable: true },
+            {
+              udid: 'UDID-A',
+              name: 'iPhone 15',
+              state: 'Shutdown',
+              isAvailable: true,
+              deviceTypeIdentifier: 'iphone-15',
+            },
           ],
         },
       }),
@@ -284,7 +345,13 @@ test('deleteIosSim refuses to delete a sim not owned by Stim', () => {
 const OWNED_SIM_LIST = JSON.stringify({
   devices: {
     'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
-      { udid: 'UDID-B', name: 'stim-my-project', state: 'Shutdown', isAvailable: true },
+      {
+        udid: 'UDID-B',
+        name: 'stim-my-project',
+        state: 'Shutdown',
+        isAvailable: true,
+        deviceTypeIdentifier: 'iphone-15',
+      },
     ],
   },
 });
@@ -351,7 +418,13 @@ test('occupyingApps reports a shut-down device free without probing', async () =
   const devices = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
-        { udid: 'UDID-X', name: 'stim-x', state: 'Shutdown', isAvailable: true },
+        {
+          udid: 'UDID-X',
+          name: 'stim-x',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-17',
+        },
       ],
     },
   });
@@ -373,7 +446,13 @@ test('occupyingApps still returns null (doubt) for a booted device whose probe c
   const devices = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
-        { udid: 'UDID-X', name: 'stim-x', state: 'Booted', isAvailable: true },
+        {
+          udid: 'UDID-X',
+          name: 'stim-x',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-17',
+        },
       ],
     },
   });
@@ -413,6 +492,11 @@ test('parseUserApps keeps only user applications', () => {
   ).toEqual(['com.example.one', 'com.example.two']);
   expect(() => parseUserApps('not json')).toThrow(/JSON/);
   expect(() => parseUserApps('[]')).toThrow(/JSON object/);
+  expect(() => parseUserApps(JSON.stringify({ 'com.example.old': 'corrupt' }))).toThrow(/to be an object/);
+  expect(() => parseUserApps(JSON.stringify({ 'com.example.old': {} }))).toThrow(/known ApplicationType/);
+  expect(() => parseUserApps(JSON.stringify({ 'com.example.old': { ApplicationType: 'Unknown' } }))).toThrow(
+    /known ApplicationType/,
+  );
 });
 
 test('listUserApps passes the udid as one argv element and converts the property list', () => {
@@ -460,6 +544,61 @@ test('the parked app data lookup reads metadata and clearing preserves the conta
   }
 });
 
+test('parked app data cleanup fails closed on unreadable metadata and invalid container directories', () => {
+  const dataPath = join(tmpHome, 'bad-device-data');
+  const app = join(dataPath, 'Containers', 'Data', 'Application', 'APP-UUID');
+  mkdirSync(app, { recursive: true });
+  setExecutor({
+    run: () => '',
+    runFile() {
+      throw new Error('metadata unreadable');
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+  expect(() => findAppDataContainer(dataPath, 'com.example.app')).toThrow(/metadata unreadable/);
+
+  const container = join(tmpHome, 'bad-container');
+  mkdirSync(container, { recursive: true });
+  writeFileSync(join(container, 'Library'), 'not a directory');
+  expect(() => clearAppDataContainer(container)).toThrow(/to be a directory/);
+});
+
+test('deleteParkedIosSim bounds ownership revalidation and deletion', () => {
+  const calls: Array<{ kind: 'run' | 'runFile'; timeoutMs?: number }> = [];
+  setExecutor({
+    run(_cmd, options) {
+      calls.push({ kind: 'run', timeoutMs: options?.timeoutMs });
+      return JSON.stringify({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+            {
+              udid: 'U1',
+              name: 'stim-parked (iPhone 17 26.5) u1',
+              state: 'Shutdown',
+              isAvailable: true,
+              deviceTypeIdentifier: 'iphone-17',
+            },
+          ],
+        },
+      });
+    },
+    runFile(_file, _args, options) {
+      calls.push({ kind: 'runFile', timeoutMs: options?.timeoutMs });
+      return '';
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+
+  deleteParkedIosSim('U1');
+
+  expect(calls).toEqual([
+    { kind: 'run', timeoutMs: 30000 },
+    { kind: 'runFile', timeoutMs: 30000 },
+  ]);
+});
+
 test('deleteParkedIosSim re-resolves the name before deletion', () => {
   const calls: string[][] = [];
   setExecutor({
@@ -491,7 +630,9 @@ test('deleteParkedIosSim re-resolves the name before deletion', () => {
 function bootSimList(state: string) {
   return JSON.stringify({
     devices: {
-      'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [{ udid: 'UDID-A', name: 'stim-app', state, isAvailable: true }],
+      'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
+        { udid: 'UDID-A', name: 'stim-app', state, isAvailable: true, deviceTypeIdentifier: 'iphone-15' },
+      ],
     },
   });
 }

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -55,6 +55,13 @@ test('parseSimctlList flattens devices and filters unavailable', () => {
   expect(sims.map((s) => s.udid).toSorted()).toEqual(['UDID-A', 'UDID-B', 'UDID-C']);
 });
 
+test('parseSimctlList rejects structurally invalid successful output', () => {
+  for (const output of ['[]', '{}', '"ok"', '{"devices":[]}']) {
+    expect(() => parseSimctlList(output)).toThrow(/devices object/);
+  }
+  expect(() => parseSimctlList('{"devices":{"ios":{}}}')).toThrow(/to be an array/);
+});
+
 test('parseSimctlList includes runtime in each entry', () => {
   const sims = parseSimctlList(SIMCTL_OUTPUT);
   const a = sims.find((s) => s.udid === 'UDID-A');

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -100,6 +100,7 @@ test('parseSimctlList rejects incomplete or mistyped iOS device records', () => 
     { ...valid, name: 42 },
     { ...valid, state: '' },
     { ...valid, deviceTypeIdentifier: null },
+    { ...valid, isAvailable: undefined },
     { ...valid, isAvailable: 'yes' },
     { ...valid, dataPath: 42 },
     { ...valid, dataPathSize: Number.NaN },

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { setExecutor, resetExecutor } from '../exec.ts';
@@ -13,6 +13,12 @@ import {
   deleteIosSim,
   occupyingApps,
   bootIosSim,
+  clearAppDataContainer,
+  deleteParkedIosSim,
+  findAppDataContainer,
+  listUserApps,
+  parkedSimName,
+  parseUserApps,
 } from '../sim/ios.ts';
 import assert from 'node:assert';
 import { makeChildProcess, makeExitingChild } from './_factories.ts';
@@ -54,6 +60,37 @@ test('parseSimctlList includes runtime in each entry', () => {
   const a = sims.find((s) => s.udid === 'UDID-A');
   assert(a);
   expect(a.runtime).toBe('com.apple.CoreSimulator.SimRuntime.iOS-17-2');
+});
+
+test('parseSimctlList can retain unavailable devices and their data sizes', () => {
+  const out = JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
+        {
+          udid: 'UDID-OLD',
+          name: 'stim-old',
+          state: 'Shutdown',
+          isAvailable: false,
+          dataPath: '/tmp/CoreSimulator/UDID-OLD/data',
+          dataPathSize: 1234,
+          deviceTypeIdentifier: 'iphone-15',
+        },
+      ],
+    },
+  });
+  expect(parseSimctlList(out)).toEqual([]);
+  expect(parseSimctlList(out, { includeUnavailable: true })).toEqual([
+    {
+      udid: 'UDID-OLD',
+      name: 'stim-old',
+      state: 'Shutdown',
+      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-2',
+      deviceTypeIdentifier: 'iphone-15',
+      dataPath: '/tmp/CoreSimulator/UDID-OLD/data',
+      dataPathSize: 1234,
+      available: false,
+    },
+  ]);
 });
 
 test('listAllIosSims uses simctl via executor', () => {
@@ -344,6 +381,103 @@ test('ownedSimName does not double the ownership prefix', () => {
   expect(ownedSimName('feat-a/tlon-mobile')).toBe('stim-feat-a-tlon-mobile');
   expect(ownedSimName('stim-x').startsWith('stim-')).toBeTruthy();
   expect(ownedSimName('Stim').startsWith('stim-')).toBeTruthy();
+});
+
+test('owned and parked simulator names show model and runtime and stay within 60 characters', () => {
+  expect(ownedSimName('feat-login', { model: 'iPhone 17', runtime: '26.5' })).toBe('stim-feat-login (iPhone 17 26.5)');
+  const long = parkedSimName('A1F3-0000', {
+    model: 'iPad Pro 13-inch (M4) with a deliberately very long qualifier',
+    runtime: '26.5',
+  });
+  expect(long.startsWith('stim-parked (')).toBe(true);
+  expect(long.endsWith(' 26.5) a1f3')).toBe(true);
+  expect(long.length).toBeLessThanOrEqual(60);
+});
+
+test('parseUserApps keeps only user applications', () => {
+  expect(
+    parseUserApps(
+      JSON.stringify({
+        'com.example.one': { ApplicationType: 'User' },
+        'com.apple.Preferences': { ApplicationType: 'System' },
+        'com.example.two': { ApplicationType: 'User' },
+      }),
+    ),
+  ).toEqual(['com.example.one', 'com.example.two']);
+  expect(parseUserApps('not json')).toEqual([]);
+});
+
+test('listUserApps passes the udid as one argv element and converts the property list', () => {
+  const calls: string[][] = [];
+  setExecutor({
+    run: () => {
+      throw new Error('must not invoke a shell');
+    },
+    runFile(file, args = []) {
+      calls.push([file, ...args]);
+      if (file === 'xcrun') return '{ "com.example.app" = { ApplicationType = User; }; }';
+      return JSON.stringify({ 'com.example.app': { ApplicationType: 'User' } });
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+  expect(listUserApps('UDID WITH SPACES')).toEqual(['com.example.app']);
+  expect(calls[0]).toEqual(['xcrun', 'simctl', 'listapps', 'UDID WITH SPACES']);
+  expect(calls[1]?.slice(0, 5)).toEqual(['plutil', '-convert', 'json', '-o', '-']);
+});
+
+test('the parked app data lookup reads metadata and clearing preserves the container directories', () => {
+  const dataPath = join(tmpHome, 'device-data');
+  const app = join(dataPath, 'Containers', 'Data', 'Application', 'APP-UUID');
+  for (const dir of ['Documents', 'Library', 'tmp', 'SystemData']) {
+    mkdirSync(join(app, dir), { recursive: true });
+    writeFileSync(join(app, dir, 'state.txt'), 'old');
+  }
+  writeFileSync(join(app, '.com.apple.mobile_container_manager.metadata.plist'), 'metadata');
+  setExecutor({
+    run: () => '',
+    runFile(file, args = []) {
+      expect(file).toBe('plutil');
+      expect(args.at(-1)).toBe(join(app, '.com.apple.mobile_container_manager.metadata.plist'));
+      return 'com.example.app';
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+  expect(findAppDataContainer(dataPath, 'com.example.app')).toBe(app);
+  clearAppDataContainer(app);
+  for (const dir of ['Documents', 'Library', 'tmp', 'SystemData']) {
+    expect(existsSync(join(app, dir))).toBe(true);
+    expect(existsSync(join(app, dir, 'state.txt'))).toBe(false);
+  }
+});
+
+test('deleteParkedIosSim re-resolves the name before deletion', () => {
+  const calls: string[][] = [];
+  setExecutor({
+    run: () =>
+      JSON.stringify({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+            {
+              udid: 'U1',
+              name: 'My renamed simulator',
+              state: 'Shutdown',
+              isAvailable: true,
+              deviceTypeIdentifier: 'iphone-17',
+            },
+          ],
+        },
+      }),
+    runFile(file, args = []) {
+      calls.push([file, ...args]);
+      return '';
+    },
+    runQuiet: () => null,
+    spawn: () => null,
+  });
+  expect(() => deleteParkedIosSim('U1')).toThrow(/not Stim-owned/);
+  expect(calls).toEqual([]);
 });
 
 function bootSimList(state: string) {

--- a/packages/stim-cli/src/__tests__/sim-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-pool.test.ts
@@ -9,6 +9,7 @@ import {
   parkSim,
   parkedMaxSetting,
   readParked,
+  removeParkedAfter,
   selectParked,
   type ParkedSim,
 } from '../sim-pool.ts';
@@ -100,6 +101,52 @@ test('parking moves a device claim into the pool in one persisted update', () =>
   expect(parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 3 })).toEqual([]);
   expect(getProject('/tmp/project')?.platforms?.ios).toBeUndefined();
   expect(readParked('ios').map((record) => record.udid)).toEqual(['FIRST']);
+});
+
+test('overflow records stay claimed until deletion succeeds', () => {
+  upsertProject('/tmp/project', {
+    platforms: { ios: { deviceUdid: first.udid, deviceName: 'stim-project', owned: true } },
+  });
+  parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 1 });
+  expect(parkSim({ platform: 'ios', projectPath: '/tmp/project', record: second, max: 1 })).toEqual([first]);
+  expect(
+    readParked('ios')
+      .map((record) => record.udid)
+      .toSorted(),
+  ).toEqual(['FIRST', 'SECOND']);
+
+  expect(() =>
+    removeParkedAfter('ios', first.udid, () => {
+      throw new Error('simctl busy');
+    }),
+  ).toThrow(/simctl busy/);
+  expect(
+    readParked('ios')
+      .map((record) => record.udid)
+      .toSorted(),
+  ).toEqual(['FIRST', 'SECOND']);
+
+  expect(removeParkedAfter('ios', first.udid, () => {})).toEqual(first);
+  expect(readParked('ios').map((record) => record.udid)).toEqual(['SECOND']);
+});
+
+test('a deletion claim skips a simulator that another workspace adopted', () => {
+  upsertProject('/tmp/source', {
+    platforms: { ios: { deviceUdid: first.udid, deviceName: 'stim-source', owned: true } },
+  });
+  upsertProject('/tmp/adopter', { platforms: {} });
+  parkSim({ platform: 'ios', projectPath: '/tmp/source', record: first, max: 3 });
+  const device = { deviceUdid: first.udid, deviceName: 'stim-adopter', owned: true };
+  adoptParked({ platform: 'ios', projectPath: '/tmp/adopter', udid: first.udid, device });
+  let deleted = false;
+
+  expect(
+    removeParkedAfter('ios', first.udid, () => {
+      deleted = true;
+    }),
+  ).toBe(null);
+  expect(deleted).toBe(false);
+  expect(getProject('/tmp/adopter')?.platforms?.ios).toEqual(device);
 });
 
 test('adoption takes a pool record and creates the owned project claim in one persisted update', () => {

--- a/packages/stim-cli/src/__tests__/sim-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-pool.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -148,6 +149,41 @@ test('a deletion claim skips a simulator that another workspace adopted', () => 
   expect(deleted).toBe(false);
   expect(getProject('/tmp/adopter')?.platforms?.ios).toEqual(device);
 });
+
+test('a live deletion claim blocks adoption beyond the ordinary lock stale window', () => {
+  upsertProject('/tmp/source', {
+    platforms: { ios: { deviceUdid: first.udid, deviceName: 'stim-source', owned: true } },
+  });
+  upsertProject('/tmp/adopter', { platforms: {} });
+  parkSim({ platform: 'ios', projectPath: '/tmp/source', record: first, max: 3 });
+  const device = { deviceUdid: first.udid, deviceName: 'stim-adopter', owned: true };
+  let childResult = '';
+
+  const removed = removeParkedAfter('ios', first.udid, () => {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_250);
+    const script = `
+        const { adoptParked } = await import(process.argv[1]);
+        const result = adoptParked(JSON.parse(process.argv[2]));
+        process.stdout.write(JSON.stringify(result));
+      `;
+    childResult = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        script,
+        new URL('../sim-pool.ts', import.meta.url).href,
+        JSON.stringify({ platform: 'ios', projectPath: '/tmp/adopter', udid: first.udid, device }),
+      ],
+      { encoding: 'utf8', env: { ...process.env, STIM_HOME: stimHome } },
+    );
+  });
+
+  expect(JSON.parse(childResult)).toBe(null);
+  expect(removed).toEqual(first);
+  expect(getProject('/tmp/adopter')?.platforms?.ios).toBeUndefined();
+  expect(readParked('ios')).toEqual([]);
+}, 20_000);
 
 test('adoption takes a pool record and creates the owned project claim in one persisted update', () => {
   upsertProject('/tmp/project', { platforms: {} });

--- a/packages/stim-cli/src/__tests__/sim-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-pool.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getProject, loadConfig, upsertProject } from '../config.ts';
+import {
+  DEFAULT_PARKED_MAX,
+  adoptParked,
+  evictOverflow,
+  parkSim,
+  parkedMaxSetting,
+  readParked,
+  selectParked,
+  type ParkedSim,
+} from '../sim-pool.ts';
+
+const first: ParkedSim = {
+  udid: 'FIRST',
+  name: 'stim-parked (iPhone 17 26.5) firs',
+  deviceTypeIdentifier: 'iphone-17',
+  runtimeIdentifier: 'ios-26-5',
+  parkedAt: '2026-09-01T10:00:00.000Z',
+  simslimManaged: false,
+};
+
+const second: ParkedSim = {
+  ...first,
+  udid: 'SECOND',
+  name: 'stim-parked (iPhone 17 26.5) seco',
+  parkedAt: '2026-09-01T11:00:00.000Z',
+};
+
+let stimHome: string;
+
+beforeEach(() => {
+  stimHome = mkdtempSync(join(tmpdir(), 'stim-pool-test-'));
+  process.env.STIM_HOME = stimHome;
+});
+
+afterEach(() => {
+  rmSync(stimHome, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+test('the machine pool defaults to three but redirected homes default to off', () => {
+  expect(parkedMaxSetting('ios', { config: null, env: {} })).toEqual({ max: DEFAULT_PARKED_MAX, error: null });
+  expect(parkedMaxSetting('ios', { config: null, env: { STIM_HOME: '/tmp/scoped' } })).toEqual({
+    max: 0,
+    error: null,
+  });
+});
+
+test('only the environment opts a redirected home into pooling', () => {
+  const config = { version: 2, projects: {}, repos: {}, pool: { iosParkedMax: 2 } };
+  expect(parkedMaxSetting('ios', { config, env: { STIM_HOME: '/tmp/scoped' } }).max).toBe(0);
+  expect(
+    parkedMaxSetting('ios', {
+      config,
+      env: { STIM_HOME: '/tmp/scoped', STIM_POOL_IOS_PARKED_MAX: '4' },
+    }),
+  ).toEqual({ max: 4, error: null });
+});
+
+test('invalid pool bounds fail closed', () => {
+  expect(
+    parkedMaxSetting('ios', {
+      config: { version: 2, projects: {}, repos: {} },
+      env: { STIM_POOL_IOS_PARKED_MAX: '-1' },
+    }),
+  ).toMatchObject({ max: 0, error: expect.stringContaining('Expected a whole number') });
+  expect(
+    parkedMaxSetting('ios', {
+      config: { version: 2, projects: {}, repos: {}, pool: { iosParkedMax: '3' } },
+      env: {},
+    }),
+  ).toMatchObject({ max: 0, error: expect.stringContaining('pool.iosParkedMax') });
+});
+
+test('selection is exact by model and runtime and oldest first', () => {
+  const wrongModel = { ...first, udid: 'OTHER-MODEL', deviceTypeIdentifier: 'ipad-pro' };
+  const wrongRuntime = { ...first, udid: 'OTHER-RUNTIME', runtimeIdentifier: 'ios-18-5' };
+  expect(
+    selectParked([second, wrongModel, first, wrongRuntime], {
+      deviceTypeIdentifier: 'iphone-17',
+      runtimeIdentifier: 'ios-26-5',
+    }).map((record) => record.udid),
+  ).toEqual(['FIRST', 'SECOND']);
+});
+
+test('overflow eviction removes the oldest records regardless of insertion order', () => {
+  const third = { ...second, udid: 'THIRD', parkedAt: '2026-09-01T12:00:00.000Z' };
+  const result = evictOverflow([third, first, second], 1);
+  expect(result.keep.map((record) => record.udid)).toEqual(['THIRD']);
+  expect(result.evicted.map((record) => record.udid)).toEqual(['FIRST', 'SECOND']);
+});
+
+test('parking moves a device claim into the pool in one persisted update', () => {
+  upsertProject('/tmp/project', {
+    platforms: { ios: { deviceUdid: first.udid, deviceName: 'stim-project', owned: true } },
+  });
+  expect(parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 3 })).toEqual([]);
+  expect(getProject('/tmp/project')?.platforms?.ios).toBeUndefined();
+  expect(readParked('ios').map((record) => record.udid)).toEqual(['FIRST']);
+});
+
+test('adoption takes a pool record and creates the owned project claim in one persisted update', () => {
+  upsertProject('/tmp/project', { platforms: {} });
+  parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 3 });
+  const device = {
+    deviceUdid: first.udid,
+    deviceName: 'stim-project (iPhone 17 26.5)',
+    owned: true,
+    adoptionPending: true,
+  };
+  expect(adoptParked({ platform: 'ios', projectPath: '/tmp/project', udid: first.udid, device })).toEqual(first);
+  expect(readParked('ios')).toEqual([]);
+  expect(loadConfig()?.projects['/tmp/project']?.platforms?.ios).toEqual(device);
+});
+
+test('malformed and non-Stim pool records are ignored', () => {
+  const config = {
+    version: 2,
+    projects: {},
+    repos: {},
+    parked: { ios: [{ ...first, name: 'My iPhone' }, { nope: true }, first] },
+  };
+  expect(readParked('ios', { config }).map((record) => record.udid)).toEqual(['FIRST']);
+});

--- a/packages/stim-cli/src/__tests__/status-state.test.ts
+++ b/packages/stim-cli/src/__tests__/status-state.test.ts
@@ -8,6 +8,7 @@ import {
   environmentState,
   formatSpace,
   parseDfFree,
+  poolLine,
   tightVolumes,
   unprovisionedWorktrees,
   type DeviceLeaseState,
@@ -86,6 +87,14 @@ test('capacity says nothing when the machine size is unknown', () => {
 test('unprovisioned worktrees are the ones with no registered environment', () => {
   const worktrees = [{ path: '/wt/a' }, { path: '/wt/b' }];
   expect(unprovisionedWorktrees(worktrees, ['/wt/a']).map((w) => w.path)).toEqual(['/wt/b']);
+});
+
+test('poolLine reports a bounded pool and a disabled pool that still has parked devices', () => {
+  expect(poolLine({ platform: 'ios', parked: 0, max: 3 })).toBe(null);
+  expect(poolLine({ platform: 'ios', parked: 2, max: 3 })).toBe('pool: 2 parked iOS simulators (max 3)');
+  expect(poolLine({ platform: 'ios', parked: 1, max: 0 })).toBe(
+    'pool: 1 parked iOS simulator (parking off; gc --delete removes them)',
+  );
 });
 
 test('parseDfFree reads the available and total columns from df -k', () => {

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -158,6 +158,34 @@ test('status still warns about a recorded sim missing from a readable listing', 
   expect(logs.some((l) => /recorded sim UDID-GONE no longer exists/.test(l))).toBeTruthy();
 });
 
+test('status reports a parked simulator when no projects remain', async () => {
+  process.env.STIM_POOL_IOS_PARKED_MAX = '3';
+  saveConfig(
+    makeConfig({
+      parked: {
+        ios: [
+          {
+            udid: 'PARKED-1',
+            name: 'stim-parked (iPhone 17 26.5) park',
+            deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
+            runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+            parkedAt: '2026-09-03T00:00:00.000Z',
+            simslimManaged: false,
+          },
+        ],
+        android: [],
+      },
+    }),
+  );
+
+  try {
+    const logs = await runStatus();
+    expect(logs).toContain('pool: 1 parked iOS simulator (max 3)');
+  } finally {
+    delete process.env.STIM_POOL_IOS_PARKED_MAX;
+  }
+});
+
 async function runStatusJson() {
   const program = new Command();
   statusCommand(program);

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -23,7 +23,13 @@ beforeEach(() => {
   const listJson = JSON.stringify({
     devices: {
       'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
-        { udid: 'UDID-ABC', name: 'stim-projA', state: 'Shutdown', isAvailable: true },
+        {
+          udid: 'UDID-ABC',
+          name: 'stim-projA',
+          state: 'Shutdown',
+          isAvailable: true,
+          deviceTypeIdentifier: 'iphone-17',
+        },
       ],
     },
   });

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { getProject, upsertProject } from '../config.ts';
 import { setExecutor, resetExecutor } from '../exec.ts';
-import { readParked } from '../sim-pool.ts';
+import { parkSim, readParked } from '../sim-pool.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 
 let savedAndroidHome: string | undefined;
@@ -194,6 +194,86 @@ test('teardownOwnedIosSim parks an owned simulator and clears its project claim'
   }
 });
 
+test('a failed overflow eviction retains its parked ownership record', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject('/tmp/old-project', {
+      platforms: { ios: { deviceUdid: 'U0', deviceName: 'stim-old', owned: true } },
+    });
+    parkSim({
+      platform: 'ios',
+      projectPath: '/tmp/old-project',
+      max: 1,
+      record: {
+        udid: 'U0',
+        name: 'stim-parked (iPhone 17 26.5) u0',
+        deviceTypeIdentifier: 'iphone-17',
+        runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+        parkedAt: '2026-09-01T00:00:00.000Z',
+        simslimManaged: false,
+      },
+    });
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    let shutdown = false;
+    setExecutor({
+      run(cmd) {
+        if (cmd.includes('list devicetypes')) {
+          return JSON.stringify({ devicetypes: [{ identifier: 'iphone-17', name: 'iPhone 17' }] });
+        }
+        if (cmd.includes('list devices')) {
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U0',
+                  name: 'stim-parked (iPhone 17 26.5) u0',
+                  state: 'Shutdown',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+                {
+                  udid: 'U1',
+                  name: 'stim-app',
+                  state: shutdown ? 'Shutdown' : 'Booted',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+              ],
+            },
+          });
+        }
+        return '';
+      },
+      runFile(_file, args = []) {
+        if (args[1] === 'delete' && args[2] === 'U0') throw new Error('simctl busy');
+        return '';
+      },
+      runQuiet(cmd) {
+        if (cmd.includes('simctl shutdown U1')) shutdown = true;
+        return '';
+      },
+      spawn: () => null,
+    });
+
+    const result = teardownOwnedIosSim('U1', { del: true, park: { projectPath, max: 1 } });
+
+    expect(result.status).toBe('torn-down');
+    expect(result.evictionFailures?.join('\n')).toMatch(/simctl busy/);
+    expect(
+      readParked('ios')
+        .map((record) => record.udid)
+        .toSorted(),
+    ).toEqual(['U0', 'U1']);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('teardownOwnedIosSim falls back to deletion when parking fails', () => {
   const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
   process.env.STIM_HOME = home;
@@ -233,6 +313,56 @@ test('teardownOwnedIosSim falls back to deletion when parking fails', () => {
     expect(result.parkFallback).toMatch(/device types unavailable/);
     expect(calls).toContain('xcrun simctl delete U1');
     expect(readParked('ios')).toEqual([]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('parking fallback re-resolves ownership immediately before deletion', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    let lists = 0;
+    const calls: string[] = [];
+    setExecutor({
+      run(cmd) {
+        calls.push(cmd);
+        if (cmd.includes('list devices')) {
+          lists++;
+          const name = lists < 3 ? 'stim-app' : 'My iPhone';
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U1',
+                  name,
+                  state: lists === 1 ? 'Booted' : 'Shutdown',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+              ],
+            },
+          });
+        }
+        if (cmd.includes('list devicetypes')) throw new Error('device types unavailable');
+        return '';
+      },
+      runFile: () => '',
+      runQuiet: () => '',
+      spawn: () => null,
+    });
+
+    const result = teardownOwnedIosSim('U1', { del: true, park: { projectPath, max: 1 } });
+
+    expect(result.status).toBe('failed');
+    expect(result.reason).toMatch(/not a Stim-owned sim/);
+    expect(calls.some((call) => call === 'xcrun simctl delete U1')).toBe(false);
+    expect(getProject(projectPath)?.platforms?.ios?.deviceUdid).toBe('U1');
   } finally {
     delete process.env.STIM_HOME;
     rmSync(home, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -44,6 +44,9 @@ function iosExecutor({ sims = [], occupied = '', throwOn = null }: IosExecutorOp
     calls.push(cmd);
     if (throwOn && cmd.includes(throwOn)) throw new Error('boom');
     if (cmd.includes('simctl list devices --json')) return listJson;
+    if (cmd.includes('simctl list devicetypes --json')) {
+      return JSON.stringify({ devicetypes: [{ identifier: 'iphone-17', name: 'iPhone 17' }] });
+    }
     if (/simctl spawn .* launchctl list/.test(cmd)) return occupied;
     return '';
   };
@@ -170,6 +173,7 @@ test('teardownOwnedIosSim parks an owned simulator and clears its project claim'
                   state: 'Shutdown',
                   isAvailable: true,
                   deviceTypeIdentifier: 'iphone-17',
+                  dataPath: join(home, 'device-data'),
                 },
               ],
             },
@@ -376,6 +380,32 @@ test('teardownOwnedIosSim deletes instead of parking when app data cannot be pro
     expect(result.status).toBe('torn-down');
     expect(result.parkFallback).toMatch(/container metadata unreadable/);
     expect(calls).toContain('xcrun simctl delete U1');
+    expect(readParked('ios')).toEqual([]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('teardownOwnedIosSim deletes instead of parking when app cleanup has no simulator data path', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    const exec = iosExecutor({ sims: [{ ...OWNED, state: 'Shutdown' }] });
+    setExecutor(exec);
+
+    const result = teardownOwnedIosSim('U1', {
+      del: true,
+      park: { projectPath, max: 1, bundleId: 'com.example.app', cacheKey: 'hash-debug-sim' },
+    });
+
+    expect(result.status).toBe('torn-down');
+    expect(result.parkFallback).toMatch(/did not report a data path/);
+    expect(exec.calls).toContain('xcrun simctl delete U1');
     expect(readParked('ios')).toEqual([]);
   } finally {
     delete process.env.STIM_HOME;

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { getProject, upsertProject } from '../config.ts';
 import { setExecutor, resetExecutor } from '../exec.ts';
 import { parkSim, readParked } from '../sim-pool.ts';
@@ -33,7 +33,12 @@ interface IosExecutorOptions {
 function iosExecutor({ sims = [], occupied = '', throwOn = null }: IosExecutorOptions = {}) {
   const calls: string[] = [];
   const listJson = JSON.stringify({
-    devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-26-5': sims },
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-26-5': sims.map((sim) => ({
+        deviceTypeIdentifier: 'iphone-17',
+        ...(sim as object),
+      })),
+    },
   });
   const answer = (cmd: string) => {
     calls.push(cmd);
@@ -311,6 +316,65 @@ test('teardownOwnedIosSim falls back to deletion when parking fails', () => {
     const result = teardownOwnedIosSim('U1', { del: true, park: { projectPath, max: 1 } });
     expect(result.status).toBe('torn-down');
     expect(result.parkFallback).toMatch(/device types unavailable/);
+    expect(calls).toContain('xcrun simctl delete U1');
+    expect(readParked('ios')).toEqual([]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('teardownOwnedIosSim deletes instead of parking when app data cannot be proven cleared', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    const dataPath = join(home, 'device-data');
+    const container = join(dataPath, 'Containers', 'Data', 'Application', 'APP-UUID');
+    mkdirSync(container, { recursive: true });
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    const calls: string[] = [];
+    setExecutor({
+      run(cmd) {
+        calls.push(cmd);
+        if (cmd.includes('list devicetypes')) {
+          return JSON.stringify({ devicetypes: [{ identifier: 'iphone-17', name: 'iPhone 17' }] });
+        }
+        if (cmd.includes('list devices')) {
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U1',
+                  name: 'stim-app',
+                  state: 'Shutdown',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                  dataPath,
+                },
+              ],
+            },
+          });
+        }
+        return '';
+      },
+      runFile(file) {
+        if (file === 'plutil') throw new Error('container metadata unreadable');
+        return '';
+      },
+      runQuiet: () => '',
+      spawn: () => null,
+    });
+
+    const result = teardownOwnedIosSim('U1', {
+      del: true,
+      park: { projectPath, max: 1, bundleId: 'com.example.app', cacheKey: 'hash-debug-sim' },
+    });
+
+    expect(result.status).toBe('torn-down');
+    expect(result.parkFallback).toMatch(/container metadata unreadable/);
     expect(calls).toContain('xcrun simctl delete U1');
     expect(readParked('ios')).toEqual([]);
   } finally {

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -1,6 +1,9 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { getProject, upsertProject } from '../config.ts';
 import { setExecutor, resetExecutor } from '../exec.ts';
+import { readParked } from '../sim-pool.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 
 let savedAndroidHome: string | undefined;
@@ -136,6 +139,154 @@ test('teardownOwnedIosSim contains a throw instead of propagating it', () => {
   const r = teardownOwnedIosSim('U1', { del: true });
   expect(r.status).toBe('failed');
   expect(r.reason).toMatch(/boom/);
+});
+
+test('teardownOwnedIosSim parks an owned simulator and clears its project claim', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    const calls: string[][] = [];
+    setExecutor({
+      run(cmd) {
+        if (cmd.includes('list devicetypes')) {
+          return JSON.stringify({ devicetypes: [{ identifier: 'iphone-17', name: 'iPhone 17' }] });
+        }
+        if (cmd.includes('list devices')) {
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U1',
+                  name: 'stim-app',
+                  state: 'Shutdown',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+              ],
+            },
+          });
+        }
+        return '';
+      },
+      runFile(file, args = []) {
+        calls.push([file, ...args]);
+        return '';
+      },
+      runQuiet: () => '',
+      spawn: () => null,
+    });
+    const result = teardownOwnedIosSim('U1', {
+      del: true,
+      park: { projectPath, max: 1, bundleId: 'com.example.app', cacheKey: 'hash-debug-sim' },
+    });
+    expect(result.status).toBe('torn-down');
+    expect(result.parked?.name).toBe('stim-parked (iPhone 17 26.5) u1');
+    expect(calls).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', 'stim-parked (iPhone 17 26.5) u1']);
+    expect(getProject(projectPath)?.platforms?.ios).toBeUndefined();
+    expect(readParked('ios')).toMatchObject([{ udid: 'U1', bundleId: 'com.example.app', cacheKey: 'hash-debug-sim' }]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('teardownOwnedIosSim falls back to deletion when parking fails', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    const calls: string[] = [];
+    setExecutor({
+      run(cmd) {
+        calls.push(cmd);
+        if (cmd.includes('list devicetypes')) throw new Error('device types unavailable');
+        if (cmd.includes('list devices')) {
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U1',
+                  name: 'stim-app',
+                  state: 'Shutdown',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+              ],
+            },
+          });
+        }
+        return '';
+      },
+      runFile: () => '',
+      runQuiet: () => '',
+      spawn: () => null,
+    });
+    const result = teardownOwnedIosSim('U1', { del: true, park: { projectPath, max: 1 } });
+    expect(result.status).toBe('torn-down');
+    expect(result.parkFallback).toMatch(/device types unavailable/);
+    expect(calls).toContain('xcrun simctl delete U1');
+    expect(readParked('ios')).toEqual([]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('teardownOwnedIosSim does not park a simulator that remains booted', () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pool-teardown-'));
+  process.env.STIM_HOME = home;
+  try {
+    const projectPath = '/tmp/pool-project';
+    upsertProject(projectPath, {
+      platforms: { ios: { deviceUdid: 'U1', deviceName: 'stim-app', owned: true } },
+    });
+    const calls: string[] = [];
+    setExecutor({
+      run(cmd) {
+        calls.push(cmd);
+        if (cmd.includes('list devices')) {
+          return JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+                {
+                  udid: 'U1',
+                  name: 'stim-app',
+                  state: 'Booted',
+                  isAvailable: true,
+                  deviceTypeIdentifier: 'iphone-17',
+                },
+              ],
+            },
+          });
+        }
+        return '';
+      },
+      runFile(file, args = []) {
+        calls.push([file, ...args].join(' '));
+        return '';
+      },
+      runQuiet: () => '',
+      spawn: () => null,
+    });
+
+    const result = teardownOwnedIosSim('U1', { del: true, park: { projectPath, max: 1 } });
+
+    expect(result.status).toBe('torn-down');
+    expect(result.parkFallback).toMatch(/still Booted/);
+    expect(calls.some((call) => call.includes('simctl rename'))).toBe(false);
+    expect(calls).toContain('xcrun simctl delete U1');
+    expect(readParked('ios')).toEqual([]);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 interface AndroidExecutorOptions {

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -262,7 +262,14 @@ function makeExecutor({
 }
 
 function simctlJson(sims: unknown[]) {
-  return JSON.stringify({ devices: { 'com.apple.CoreSimulator.SimRuntime.iOS-17-0': sims } });
+  return JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-17-0': sims.map((sim) => ({
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+        ...(sim as object),
+      })),
+    },
+  });
 }
 
 let tmpHome: string, mainDir: string, wtDir: string;

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -58,6 +58,11 @@ export function phaseLine(label: unknown, text: string): string {
   return `  ${String(label).padEnd(LABEL_WIDTH)} ${text}`;
 }
 
+export function shortUdid(udid: unknown): string {
+  const text = String(udid ?? '');
+  return text.length > 4 ? `${text.slice(0, 4)}..` : text;
+}
+
 export function shortHash(hash: unknown): string {
   const text = String(hash ?? '');
   return text.length > 8 ? `${text.slice(0, 6)}..` : text;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -33,7 +33,14 @@ import {
   parseRuntimeVersion,
   type IosSimRecord,
 } from '../sim/ios.ts';
-import { dropParked, parkedMaxSetting, POOL_SETTING_REMEDY, readParked, type ParkedSim } from '../sim-pool.ts';
+import {
+  dropParked,
+  parkedMaxSetting,
+  POOL_SETTING_REMEDY,
+  readParked,
+  removeParkedAfter,
+  type ParkedSim,
+} from '../sim-pool.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 import { listAvds, ownedAvdDirectory } from '../sim/android.ts';
 import {
@@ -109,7 +116,7 @@ export interface ParkedSimReport {
   runtime: string | null;
   parkedAt: string;
   bytes: number | null;
-  listed: boolean;
+  listed: boolean | null;
 }
 
 interface GcReport {
@@ -169,6 +176,9 @@ interface GcDependencies {
   avdDirectory?: typeof ownedAvdDirectory;
   directorySize?: typeof directorySize;
   settingShapeErrors?: () => string[];
+  listAllIosSims?: typeof listAllIosSims;
+  listIosDeviceTypes?: typeof listIosDeviceTypes;
+  deleteParkedIosSim?: typeof deleteParkedIosSim;
 }
 
 // simctl and emulator listings can exceed 10 seconds on loaded hosts; 30 seconds still bounds hangs.
@@ -654,10 +664,15 @@ function formatParkedSimReport(parkedSims: readonly ParkedSimReport[], now: numb
     const model = [sim.model, sim.runtime].filter(Boolean).join(' ');
     const age = parkedAge(sim.parkedAt, now);
     const bytes = sim.bytes === null ? '' : ` ${formatBytes(sim.bytes)}`;
-    const gone = sim.listed ? '' : ' - not on this machine';
+    const gone =
+      sim.listed === false ? ' - not on this machine' : sim.listed === null ? ' - listing unavailable; kept' : '';
     lines.push(`  ios ${sim.name} (${shortUdid(sim.udid)})${model ? ` ${model}` : ''} ${age}${bytes}${gone}`);
   }
-  lines.push('              --delete deletes every parked simulator and empties the pool.');
+  lines.push(
+    parkedSims.some((sim) => sim.listed === null)
+      ? '              --delete keeps entries it cannot verify and deletes the rest.'
+      : '              --delete deletes every parked simulator and empties the pool.',
+  );
   return lines;
 }
 
@@ -866,6 +881,7 @@ export function describeParkedSims(
   records: readonly ParkedSim[],
   sims: readonly IosSimRecord[],
   deviceTypes: readonly { identifier: string; name: string }[],
+  { simsChecked = true }: { simsChecked?: boolean } = {},
 ): ParkedSimReport[] {
   const listed = new Map(sims.map((sim) => [sim.udid, sim]));
   return records.map((record) => {
@@ -877,30 +893,44 @@ export function describeParkedSims(
       runtime: sim ? parseRuntimeVersion(sim.runtime) : parseRuntimeVersion(record.runtimeIdentifier),
       parkedAt: record.parkedAt,
       bytes: typeof sim?.dataPathSize === 'number' ? sim.dataPathSize : null,
-      listed: Boolean(sim),
+      listed: simsChecked ? Boolean(sim) : null,
     };
   });
 }
 
-function collectParkedSims(): ParkedSimReport[] {
+function collectParkedSims(deps: GcDependencies): ParkedSimReport[] {
   const records = readParked('ios');
   if (records.length === 0) return [];
-  let sims: IosSimRecord[] = [];
+  let sims: IosSimRecord[];
   let deviceTypes: { identifier: string; name: string }[] = [];
   try {
-    sims = listAllIosSims({ timeoutMs: DEVICE_LIST_TIMEOUT_MS, includeUnavailable: true });
-    deviceTypes = listIosDeviceTypes();
+    sims = (deps.listAllIosSims ?? listAllIosSims)({ timeoutMs: DEVICE_LIST_TIMEOUT_MS, includeUnavailable: true });
+  } catch {
+    return describeParkedSims(records, [], [], { simsChecked: false });
+  }
+  try {
+    deviceTypes = (deps.listIosDeviceTypes ?? listIosDeviceTypes)();
   } catch {}
   return describeParkedSims(records, sims, deviceTypes);
 }
 
-function deleteParkedSims(parkedSims: readonly ParkedSimReport[]): number {
+export function deleteParkedSims(parkedSims: readonly ParkedSimReport[], deps: GcDependencies = {}): number {
   let failures = 0;
   let emptied = 0;
   for (const sim of parkedSims) {
+    if (sim.listed === null) {
+      failures++;
+      console.log(chalk.red(`Could not verify parked ios sim ${sim.name} (${sim.udid}); its pool record was kept.`));
+      continue;
+    }
     try {
-      if (sim.listed) deleteParkedIosSim(sim.udid);
-      dropParked('ios', sim.udid);
+      const removed = sim.listed
+        ? removeParkedAfter('ios', sim.udid, () => (deps.deleteParkedIosSim ?? deleteParkedIosSim)(sim.udid))
+        : dropParked('ios', sim.udid);
+      if (!removed) {
+        console.log(chalk.dim(`Skipped ${sim.name} (${sim.udid}); it is no longer parked.`));
+        continue;
+      }
       emptied++;
       console.log(
         chalk.green(
@@ -1110,7 +1140,7 @@ export async function collectGcReport(
       };
     }
   }
-  const parkedSims = collectParkedSims();
+  const parkedSims = collectParkedSims(deps);
   const deadProjects: string[] = [];
   const skipped: GcSkip[] = [];
   for (const path of Object.keys(cfg?.projects || {})) {
@@ -1371,7 +1401,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     return;
   }
 
-  let deleteFailures = deleteParkedSims(report.parkedSims);
+  let deleteFailures = deleteParkedSims(report.parkedSims, deps);
 
   for (const path of deadProjects) {
     const result = await reclaimProject(path);

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 import chalk from 'chalk';
 import { InvalidArgumentError, type Command } from 'commander';
 import { clearDevice, getConfigDir, loadConfig } from '../config.ts';
+import { formatLongDuration, plural, shortUdid } from '../command-output.ts';
 import { directorySize, formatBytes, isOnMountedVolume, listMountedVolumes, volumeRootFor } from '../fs-util.ts';
 import { listBuildLocks, readBuildLock } from '../engine/build-lock.ts';
 import { listBuildSlots, readBuildSlot } from '../engine/build-slots.ts';
@@ -25,7 +26,14 @@ import { isPidAlive } from '../metro.ts';
 import { detectIsExpo, findProjectRoot } from '../project.ts';
 import { reclaimProject } from '../reclaim.ts';
 import { SETTING_SHAPE_REMEDY } from '../settings.ts';
-import { listAllIosSims, type IosSimRecord } from '../sim/ios.ts';
+import {
+  deleteParkedIosSim,
+  listAllIosSims,
+  listIosDeviceTypes,
+  parseRuntimeVersion,
+  type IosSimRecord,
+} from '../sim/ios.ts';
+import { dropParked, parkedMaxSetting, POOL_SETTING_REMEDY, readParked, type ParkedSim } from '../sim-pool.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 import { listAvds, ownedAvdDirectory } from '../sim/android.ts';
 import {
@@ -94,9 +102,20 @@ interface DeviceLeaseGarbage {
   kept: KeptLeaseFile[];
 }
 
+export interface ParkedSimReport {
+  udid: string;
+  name: string;
+  model: string | null;
+  runtime: string | null;
+  parkedAt: string;
+  bytes: number | null;
+  listed: boolean;
+}
+
 interface GcReport {
   skipped: GcSkip[];
   deadProjects: string[];
+  parkedSims: ParkedSimReport[];
   orphanedDevices: OrphanedDevice[];
   staleDevices: StaleProjectDevice[];
   staleDeviceRecords: StaleDeviceRecord[];
@@ -197,6 +216,9 @@ export function findOrphanedDevices({
     if (android?.avdName) {
       referenced.set(android.avdName, { path, mounted });
     }
+  }
+  for (const sim of readParked('ios', { config })) {
+    referenced.set(sim.udid, { path: 'the simulator pool', mounted: true });
   }
 
   const orphaned: OrphanedDevice[] = [];
@@ -616,21 +638,48 @@ function shortKey(key: unknown) {
   return text.length > 6 ? `${text.slice(0, 6)}..` : text;
 }
 
-export function formatGcReport({
-  skipped = [],
-  deadProjects = [],
-  orphanedDevices = [],
-  staleDevices = [],
-  staleDeviceRecords = [],
-  buildLocks = { stale: [], live: [] },
-  buildSlots = { stale: [], live: [] },
-  deviceLeases = { expired: [], kept: [] },
-  deviceSweepNotices = [],
-  easSessionSweep = { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
-  caches = [],
-  cacheScope = null,
-  olderThan = null,
-}: Partial<GcReport>): string[] {
+function parkedAge(parkedAt: string, now: number): string {
+  const at = Date.parse(parkedAt);
+  if (!Number.isFinite(at)) return 'parked at an unknown time';
+  return `parked ${formatLongDuration(Math.max(0, now - at))} ago`;
+}
+
+function formatParkedSimReport(parkedSims: readonly ParkedSimReport[], now: number): string[] {
+  if (parkedSims.length === 0) return [];
+  const known = parkedSims.filter((sim) => sim.bytes !== null);
+  const total = known.reduce((sum, sim) => sum + (sim.bytes ?? 0), 0);
+  const size = known.length === parkedSims.length ? `, ${formatBytes(total)}` : '';
+  const lines = [`Parked simulators (${parkedSims.length}${size}):`];
+  for (const sim of parkedSims) {
+    const model = [sim.model, sim.runtime].filter(Boolean).join(' ');
+    const age = parkedAge(sim.parkedAt, now);
+    const bytes = sim.bytes === null ? '' : ` ${formatBytes(sim.bytes)}`;
+    const gone = sim.listed ? '' : ' - not on this machine';
+    lines.push(`  ios ${sim.name} (${shortUdid(sim.udid)})${model ? ` ${model}` : ''} ${age}${bytes}${gone}`);
+  }
+  lines.push('              --delete deletes every parked simulator and empties the pool.');
+  return lines;
+}
+
+export function formatGcReport(
+  {
+    skipped = [],
+    deadProjects = [],
+    parkedSims = [],
+    orphanedDevices = [],
+    staleDevices = [],
+    staleDeviceRecords = [],
+    buildLocks = { stale: [], live: [] },
+    buildSlots = { stale: [], live: [] },
+    deviceLeases = { expired: [], kept: [] },
+    deviceSweepNotices = [],
+    easSessionSweep = { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
+    caches = [],
+    cacheScope = null,
+    olderThan = null,
+  }: Partial<GcReport>,
+  { now = Date.now() }: { now?: number } = {},
+): string[] {
   const lines: string[] = [];
   const staleLocks = buildLocks?.stale ?? [];
   const liveLocks = buildLocks?.live ?? [];
@@ -641,6 +690,7 @@ export function formatGcReport({
     lines.push(`Cache scope: "${cacheScope}". Devices, project entries and locks were not inspected.`);
   } else if (
     deadProjects.length === 0 &&
+    parkedSims.length === 0 &&
     orphanedDevices.length === 0 &&
     staleDevices.length === 0 &&
     staleDeviceRecords.length === 0 &&
@@ -670,6 +720,8 @@ export function formatGcReport({
     lines.push(`Dead project entries (${deadProjects.length}):`);
     for (const path of deadProjects) lines.push(`  ${path}`);
   }
+
+  lines.push(...formatParkedSimReport(parkedSims, now));
 
   if (orphanedDevices.length) {
     lines.push(`Orphaned devices (${orphanedDevices.length}):`);
@@ -808,6 +860,62 @@ function withAndroidAvdSizes<T extends { kind: 'ios' | 'android'; id: string; by
       return device;
     }
   });
+}
+
+export function describeParkedSims(
+  records: readonly ParkedSim[],
+  sims: readonly IosSimRecord[],
+  deviceTypes: readonly { identifier: string; name: string }[],
+): ParkedSimReport[] {
+  const listed = new Map(sims.map((sim) => [sim.udid, sim]));
+  return records.map((record) => {
+    const sim = listed.get(record.udid);
+    return {
+      udid: record.udid,
+      name: sim?.name ?? record.name,
+      model: deviceTypes.find((d) => d.identifier === record.deviceTypeIdentifier)?.name ?? null,
+      runtime: sim ? parseRuntimeVersion(sim.runtime) : parseRuntimeVersion(record.runtimeIdentifier),
+      parkedAt: record.parkedAt,
+      bytes: typeof sim?.dataPathSize === 'number' ? sim.dataPathSize : null,
+      listed: Boolean(sim),
+    };
+  });
+}
+
+function collectParkedSims(): ParkedSimReport[] {
+  const records = readParked('ios');
+  if (records.length === 0) return [];
+  let sims: IosSimRecord[] = [];
+  let deviceTypes: { identifier: string; name: string }[] = [];
+  try {
+    sims = listAllIosSims({ timeoutMs: DEVICE_LIST_TIMEOUT_MS, includeUnavailable: true });
+    deviceTypes = listIosDeviceTypes();
+  } catch {}
+  return describeParkedSims(records, sims, deviceTypes);
+}
+
+function deleteParkedSims(parkedSims: readonly ParkedSimReport[]): number {
+  let failures = 0;
+  let emptied = 0;
+  for (const sim of parkedSims) {
+    try {
+      if (sim.listed) deleteParkedIosSim(sim.udid);
+      dropParked('ios', sim.udid);
+      emptied++;
+      console.log(
+        chalk.green(
+          sim.listed
+            ? `Deleted parked ios sim ${sim.name} (${sim.udid})`
+            : `Dropped the parked record for ${sim.name} (${sim.udid}); it is not on this machine.`,
+        ),
+      );
+    } catch (err) {
+      failures++;
+      console.log(chalk.red(`Failed to delete parked ios sim ${sim.name}: ${(err as Error)?.message || err}`));
+    }
+  }
+  if (emptied) console.log(chalk.dim(`  emptied ${plural(emptied, 'parked simulator')} from the pool`));
+  return failures;
 }
 
 function projectLastTouched(path: string): number {
@@ -979,6 +1087,7 @@ export async function collectGcReport(
       deviceLeases: { expired: [], kept: [] },
       deviceSweepNotices: [],
       easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
+      parkedSims: [],
       caches,
       cacheScope: scope,
       olderThan,
@@ -1001,6 +1110,7 @@ export async function collectGcReport(
       };
     }
   }
+  const parkedSims = collectParkedSims();
   const deadProjects: string[] = [];
   const skipped: GcSkip[] = [];
   for (const path of Object.keys(cfg?.projects || {})) {
@@ -1099,6 +1209,7 @@ export async function collectGcReport(
   return {
     skipped,
     deadProjects,
+    parkedSims,
     orphanedDevices,
     staleDevices,
     staleDeviceRecords,
@@ -1121,6 +1232,10 @@ export async function collectGcReport(
 }
 
 export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}): Promise<void> {
+  const poolError = parkedMaxSetting('ios').error;
+  if (poolError) {
+    console.error(chalk.yellow(`${poolError} ${POOL_SETTING_REMEDY}`));
+  }
   const shapeErrors = (deps.settingShapeErrors ?? projectSettingShapeErrors)();
   if (shapeErrors.length) {
     for (const message of shapeErrors) console.error(chalk.red(message));
@@ -1233,6 +1348,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
   } = report;
   const actionable =
     deadProjects.length > 0 ||
+    report.parkedSims.length > 0 ||
     orphanedDevices.length > 0 ||
     staleDevices.length > 0 ||
     staleDeviceRecords.length > 0 ||
@@ -1255,7 +1371,8 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     return;
   }
 
-  let deleteFailures = 0;
+  let deleteFailures = deleteParkedSims(report.parkedSims);
+
   for (const path of deadProjects) {
     const result = await reclaimProject(path);
     if (result.keptEntry) console.log(chalk.yellow(`Could not fully prune ${path}; its registry entry was kept.`));
@@ -1361,7 +1478,6 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
       console.log(chalk.red(`Failed to clear the device lease at ${entry.path}: ${(err as Error)?.message || err}`));
     }
   }
-
   if (easSessionSweep.orphaned.length && easSessionSweep.deletionSafe && easSessionSweep.projectScope) {
     const projectScope = easSessionSweep.projectScope;
     const withProjectLock = deps.withEasProjectLock ?? withEasProjectLock;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -26,22 +26,9 @@ import { isPidAlive } from '../metro.ts';
 import { detectIsExpo, findProjectRoot } from '../project.ts';
 import { reclaimProject } from '../reclaim.ts';
 import { SETTING_SHAPE_REMEDY } from '../settings.ts';
-import {
-  deleteParkedIosSim,
-  listAllIosSims,
-  listIosDeviceTypes,
-  parseRuntimeVersion,
-  type IosSimRecord,
-} from '../sim/ios.ts';
-import {
-  dropParked,
-  parkedMaxSetting,
-  POOL_SETTING_REMEDY,
-  readParked,
-  removeParkedAfter,
-  type ParkedSim,
-} from '../sim-pool.ts';
-import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
+import { listAllIosSims, listIosDeviceTypes, parseRuntimeVersion, type IosSimRecord } from '../sim/ios.ts';
+import { dropParked, parkedMaxSetting, POOL_SETTING_REMEDY, readParked, type ParkedSim } from '../sim-pool.ts';
+import { teardownOwnedIosSim, teardownOwnedAvd, teardownParkedIosSim } from '../teardown.ts';
 import { listAvds, ownedAvdDirectory } from '../sim/android.ts';
 import {
   declaredCachePaths,
@@ -178,7 +165,7 @@ interface GcDependencies {
   settingShapeErrors?: () => string[];
   listAllIosSims?: typeof listAllIosSims;
   listIosDeviceTypes?: typeof listIosDeviceTypes;
-  deleteParkedIosSim?: typeof deleteParkedIosSim;
+  deleteParkedIosSim?: (udid: string) => void;
 }
 
 // simctl and emulator listings can exceed 10 seconds on loaded hosts; 30 seconds still bounds hangs.
@@ -924,11 +911,17 @@ export function deleteParkedSims(parkedSims: readonly ParkedSimReport[], deps: G
       continue;
     }
     try {
-      const removed = sim.listed
-        ? removeParkedAfter('ios', sim.udid, () => (deps.deleteParkedIosSim ?? deleteParkedIosSim)(sim.udid))
-        : dropParked('ios', sim.udid);
+      const teardown = sim.listed
+        ? teardownParkedIosSim(sim.udid, { label: sim.name, deleteSim: deps.deleteParkedIosSim })
+        : null;
+      const removed = sim.listed ? teardown?.status === 'torn-down' : dropParked('ios', sim.udid);
       if (!removed) {
-        console.log(chalk.dim(`Skipped ${sim.name} (${sim.udid}); it is no longer parked.`));
+        if (teardown?.status === 'failed') {
+          failures++;
+          console.log(chalk.red(`Failed to delete parked ios sim ${sim.name}: ${teardown.reason}`));
+        } else {
+          console.log(chalk.dim(`Skipped ${sim.name} (${sim.udid}); it is no longer parked.`));
+        }
         continue;
       }
       emptied++;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -655,11 +655,7 @@ function formatParkedSimReport(parkedSims: readonly ParkedSimReport[], now: numb
       sim.listed === false ? ' - not on this machine' : sim.listed === null ? ' - listing unavailable; kept' : '';
     lines.push(`  ios ${sim.name} (${shortUdid(sim.udid)})${model ? ` ${model}` : ''} ${age}${bytes}${gone}`);
   }
-  lines.push(
-    parkedSims.some((sim) => sim.listed === null)
-      ? '              --delete keeps entries it cannot verify and deletes the rest.'
-      : '              --delete deletes every parked simulator and empties the pool.',
-  );
+  lines.push('              --delete attempts verified deletions and keeps failures.');
   return lines;
 }
 

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -356,7 +356,8 @@ RULES
   - Never assume "booted" is your simulator. Other agents have theirs booted
     too.
   - Every device Stim creates or boots is one Stim created, named
-    stim-<label>. The exceptions are \`android --device\` and
+    stim-<label> (<model> <runtime>) on iOS. The exceptions are
+    \`android --device\` and
     \`ios --device\`, which use a connected physical device Stim never
     creates, boots, or deletes.`,
   },
@@ -1511,7 +1512,7 @@ STIM_CONFIG_CORRUPT  ("Stim config at <path> is not valid JSON")
   #    installed (or built), app launched wired to port 8082, device-log
   #    collector attached.
   stim ios          # or: stim android
-    device      stim-app-412 (BF2A..) booted (9s)
+    device      stim-app-412 (iPhone 17 26.5) (BF2A..) booted (9s)
     fingerprint a3f9b1.. hit (2s)
     install     from cache (3s)
     launch      com.example.app (1s)
@@ -1616,7 +1617,7 @@ PROGRESS ON A LONG RUN
   caller needs it to \`cd\` into; a removed path has no such use:
 
     branch      deleted worktree-e2e-1
-    device      deleted stim-e2e-1
+    device      parked stim-parked (iPhone 17 26.5) 9c1f (9C1F..)
     lease       released the ios lease on 00008101-000A10913C89001E (it ran until 14:32:10)
     workspace   removed /w/.stim/workspaces/3f9c2a
     removed     /w/worktree-e2e-1
@@ -1628,6 +1629,60 @@ PROGRESS ON A LONG RUN
   with a sentence instead of a \`removed\` line, because the checkout itself
   is never touched: \`Reclaimed the environment; the working tree stays (it
   is the main checkout).\`
+
+  THE SIMULATOR POOL
+  \`worktree remove\` PARKS this workspace's owned simulator instead of
+  deleting it, and the next workspace that wants the same model and runtime
+  ADOPTS it. A simulator that has booted before boots in about 9s; a freshly
+  created one costs about 30s, and \`simctl erase\` puts most of that back, so
+  a parked simulator keeps its app installed and is cleaned in pieces:
+
+    at park       shut down, the app's data cleared on disk (Documents,
+                  Library, tmp, SystemData: NSUserDefaults, AsyncStorage,
+                  SQLite), renamed \`stim-parked (<model> <runtime>) <4 hex>\`
+    at adoption   renamed for the adopting workspace, then, inside the boot
+                  the run pays anyway, \`simctl privacy reset all\` and
+                  \`simctl keychain reset\`; at install, every OTHER app the
+                  previous workspace left is uninstalled
+
+  A parked simulator KEEPS its system state: pasteboard, Safari data, photos,
+  contacts, calendars, installed profiles, Simulator settings, app-group
+  containers, and device-level defaults. Isolation covers the app's data, the
+  privacy grants, the keychain and the installed apps -- not a clean system
+  image. Set the bound to 0 when a project needs one.
+
+  Adoption matches the device type AND the runtime EXACTLY: a ticket that asks
+  for an iPad never gets an iPhone, and a request for iOS 18.5 never gets 26.5.
+  No match creates a new simulator, as before. After a runtime upgrade the
+  parked simulators on the old runtime are never adopted; they leave by
+  eviction or \`gc --delete\`.
+
+  The pool holds \`pool.iosParkedMax\` simulators (default 3, about 2.5 GB
+  each). Past that the oldest parked one is deleted:
+
+    device      parked stim-parked (iPhone 17 26.5) 9c1f (9C1F..)
+    device      deleted stim-parked (iPhone 17 26.5) 4b02 (pool over 3)
+
+  and an adopting run says so where a plain boot would say \`booted\`:
+
+    device      stim-app-412 (iPhone 17 26.5) (9C1F..) adopted (11s)
+
+  That time includes the two resets, so it runs longer than a plain boot.
+  \`stim status\` prints one line while the pool is not empty:
+
+    pool: 2 parked iOS simulators (max 3)
+
+  \`stim gc\` reports the pool, and \`stim gc --delete\` empties it:
+
+    Parked simulators (2, 5.1 GB):
+      ios stim-parked (iPhone 17 26.5) 9c1f (9C1F..) iPhone 17 26.5 parked 3d ago 2.6 GB
+                  --delete deletes every parked simulator and empties the pool.
+
+  That deletion works even under a redirected \`STIM_HOME\`, where the sweep
+  for unlisted \`stim-\` devices stays refused: a parked record in THIS config
+  proves that simulator is Stim's and parked by this home. \`stop\` never
+  parks -- it shuts the owned simulator down and keeps it assigned. Neither
+  does \`gc --delete\`, which is deleting what it finds.
 
   A GAP BETWEEN HEARTBEATS IS NOT A HANG. Stim runs device tools
   synchronously, so a long \`simctl\`, \`adb\` or copy call holds the timer
@@ -2216,8 +2271,10 @@ TWO REPORTS, TWO QUESTIONS
     body: () => `CLEANUP AND DISK
 
 WHAT RECLAIMS AN OWNED DEVICE
-  stim worktree remove    deletes every owned device under the worktree
-  stim gc --delete        sweeps stim-* devices no project references
+  stim worktree remove    parks the owned simulator (\`guide lifecycle\`) and
+                            deletes every other owned device under the worktree
+  stim gc --delete        sweeps stim-* devices no project references, and
+                            empties the pool of parked simulators
   stim gc --delete --older-than <days>
                             also reaps the device of a project nothing has
                             touched in that long, even though the project is
@@ -2660,6 +2717,28 @@ or via the environment, which overrides the file:
 
 Unset, 0, or any non-positive value means NO enforcement -- the default, where
 Stim limits nothing. See \`guide lifecycle\` for what each cap does.
+
+THE SIMULATOR POOL BOUND IS MACHINE-LEVEL TOO
+\`pool.iosParkedMax\` caps how many parked simulators \`worktree remove\` may
+leave behind for a later workspace to adopt. It is machine-level for the same
+reason: the disk they sit on is the whole machine's, about 2.5 GB each.
+
+  {
+    "pool": { "iosParkedMax": 3 }
+  }
+
+in ~/.stim/config.json, or STIM_POOL_IOS_PARKED_MAX in the environment, which
+overrides the file. Absent means 3. \`0\` turns parking and adoption off:
+\`worktree remove\` deletes the simulator, \`ios\` never adopts, and a pool
+that already exists stays where it is until \`gc --delete\`. A value that is
+not a whole number 0 or more is refused by name on \`worktree remove\` and
+\`ios\`, and warned about by \`status\`, \`gc\` and \`doctor\`.
+
+When STIM_HOME is set, parking and adoption are OFF unless
+STIM_POOL_IOS_PARKED_MAX is set too. A redirected home is a scoped config --
+test suites and the end-to-end harness use one -- and a scoped config must not
+leave simulators on the machine it cannot account for. A redirected home that
+wants a pool says so with the variable.
 
 STIM NEEDS NO PROJECT CHANGES TO RUN
 Nothing above is required to use Stim. The performance caches that used to

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1657,11 +1657,15 @@ PROGRESS ON A LONG RUN
   parked simulators on the old runtime are never adopted; they leave by
   eviction or \`gc --delete\`.
 
-  The pool holds \`pool.iosParkedMax\` simulators (default 3, about 2.5 GB
-  each). Past that the oldest parked one is deleted:
+  The pool targets at most \`pool.iosParkedMax\` simulators (default 3, about
+  2.5 GB each). Past that the oldest parked one is deleted:
 
     device      parked stim-parked (iPhone 17 26.5) 9c1f (9C1F..)
     device      deleted stim-parked (iPhone 17 26.5) 4b02 (pool over 3)
+
+  A failed or unverifiable deletion keeps its ownership record so \`gc\` can
+  retry it. The reported pool can temporarily exceed the bound rather than
+  orphaning a simulator.
 
   and an adopting run says so where a plain boot would say \`booted\`:
 
@@ -1672,11 +1676,16 @@ PROGRESS ON A LONG RUN
 
     pool: 2 parked iOS simulators (max 3)
 
-  \`stim gc\` reports the pool, and \`stim gc --delete\` empties it:
+  \`stim gc\` reports the pool, and \`stim gc --delete\` empties every entry
+  it can re-verify:
 
     Parked simulators (2, 5.1 GB):
       ios stim-parked (iPhone 17 26.5) 9c1f (9C1F..) iPhone 17 26.5 parked 3d ago 2.6 GB
                   --delete deletes every parked simulator and empties the pool.
+
+  If simulator listing or deletion fails, \`gc --delete\` reports the failure
+  and keeps that entry. It never turns an unverified absence into a dropped
+  ownership record.
 
   That deletion works even under a redirected \`STIM_HOME\`, where the sweep
   for unlisted \`stim-\` devices stays refused: a parked record in THIS config

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1681,7 +1681,7 @@ PROGRESS ON A LONG RUN
 
     Parked simulators (2, 5.1 GB):
       ios stim-parked (iPhone 17 26.5) 9c1f (9C1F..) iPhone 17 26.5 parked 3d ago 2.6 GB
-                  --delete deletes every parked simulator and empties the pool.
+                  --delete attempts every parked simulator and keeps failures.
 
   If simulator listing or deletion fails, \`gc --delete\` reports the failure
   and keeps that entry. It never turns an unverified absence into a dropped
@@ -2283,7 +2283,7 @@ WHAT RECLAIMS AN OWNED DEVICE
   stim worktree remove    parks the owned simulator (\`guide lifecycle\`) and
                             deletes every other owned device under the worktree
   stim gc --delete        sweeps stim-* devices no project references, and
-                            empties the pool of parked simulators
+                            clears verified parked simulators
   stim gc --delete --older-than <days>
                             also reaps the device of a project nothing has
                             touched in that long, even though the project is

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -29,7 +29,14 @@ import {
   untrackedNativeFiles,
 } from '../build-cache.ts';
 import type { FingerprintSource } from '@expo/fingerprint';
-import { formatDuration, launchErrorReport, phaseLine, shortHash, type LaunchErrorRecord } from '../command-output.ts';
+import {
+  formatDuration,
+  launchErrorReport,
+  phaseLine,
+  shortHash,
+  shortUdid,
+  type LaunchErrorRecord,
+} from '../command-output.ts';
 import { verifyCollectorOwnership } from '../collector/ownership.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../config.ts';
 import {
@@ -38,6 +45,7 @@ import {
   LAUNCH_FATAL,
   LAUNCH_UNVERIFIED,
   RELEASE_VERIFY_WAIT_MS,
+  clearOtherUserApps,
   devClientUrl,
   installIosApp,
   iosAppProcess,
@@ -59,12 +67,14 @@ import { acquireBuildSlot, releaseBuildSlot, type BuildSlotHandle } from '../eng
 import { readPodState, podsAreStale, runPodInstall } from '../engine/deps.ts';
 import {
   checkDeviceCapacity,
+  clearIosAdoptionPending,
   ensureBooted,
   ensureOwnedDevice,
   unknownIosDeviceTypeRefusal,
   unknownIosRuntimeRefusal,
 } from '../engine/device.ts';
 import { listIosRuntimes } from '../sim/ios.ts';
+import { parkedMaxSetting, POOL_SETTING_REMEDY } from '../sim-pool.ts';
 import {
   REMOTE_SESSION_ERROR,
   binOnPath,
@@ -167,7 +177,7 @@ import {
 import { MODE_BARE, MODE_EXPO, readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
 import { gitCommonDir, repoRoot } from '../worktree.ts';
 
-export { formatDuration, phaseLine, shortHash } from '../command-output.ts';
+export { formatDuration, phaseLine, shortHash, shortUdid } from '../command-output.ts';
 
 function writeNote(line: string): void {
   console.error(line);
@@ -192,6 +202,9 @@ interface DeviceLike {
   avdName?: string | null;
   deviceType?: string | null;
   runtime?: string | null;
+  adopted?: boolean;
+  adoptionPending?: boolean;
+  parkedCacheKey?: string;
 }
 
 interface IosBootLike {
@@ -322,11 +335,6 @@ export function stepClock(now: () => number = Date.now): () => number {
 export function stepTimer(now: () => number = Date.now): () => string {
   const elapsed = stepClock(now);
   return () => `(${formatDuration(elapsed())})`;
-}
-
-export function shortUdid(udid: unknown): string {
-  const text = String(udid ?? '');
-  return text.length > 4 ? `${text.slice(0, 4)}..` : text;
 }
 
 export function deviceLabel(device: DeviceLike | null | undefined, udid: unknown): string {
@@ -909,6 +917,8 @@ interface IosDeps {
   readBundleExecutable: typeof readBundleExecutable;
   swapJsBundle: typeof swapJsBundle;
   installIosApp: typeof installIosApp;
+  clearOtherUserApps: typeof clearOtherUserApps;
+  clearIosAdoptionPending: typeof clearIosAdoptionPending;
   launchIosApp: typeof launchIosApp;
   verifyLaunch: typeof verifyLaunch;
   verifyReleaseLaunch: typeof verifyReleaseLaunch;
@@ -986,6 +996,8 @@ const DEFAULT_DEPS: IosDeps = {
   readBundleExecutable,
   swapJsBundle,
   installIosApp,
+  clearOtherUserApps,
+  clearIosAdoptionPending,
   launchIosApp,
   verifyLaunch,
   verifyReleaseLaunch,
@@ -1444,6 +1456,59 @@ interface FinishIosRunArgs {
   recordRun: ReportIosResultArgs['recordRun'];
 }
 
+function cleanAdoptedIosApps({
+  d,
+  root,
+  udid,
+  bundleId,
+  phase,
+  note,
+}: {
+  d: IosDeps;
+  root: string;
+  udid: string;
+  bundleId: string | null;
+  phase: (name: unknown, text: string) => void;
+  note: (line: string) => void;
+}): void {
+  const swept = d.clearOtherUserApps({ udid, keep: bundleId });
+  if (swept.removed.length) {
+    phase('install', `removed ${swept.removed.join(', ')}, left by the previous workspace`);
+  }
+  for (const failure of swept.failed) {
+    note(chalk.yellow(phaseLine('install', `could not remove ${failure}, left by the previous workspace`)));
+  }
+  if (swept.listed && swept.failed.length === 0) {
+    d.clearIosAdoptionPending(root);
+  } else if (!swept.listed) {
+    note(chalk.yellow(phaseLine('install', 'could not list apps left by the previous workspace; cleanup will retry')));
+  }
+}
+
+function resolveRunBundleId(d: IosDeps, root: string, appPath: string | null, bundleId: string | null): string | null {
+  if (!appPath || bundleId) return bundleId;
+  return d.readBundleId(appPath) || d.detectBundleId(root);
+}
+
+function removeSwapDirectory(swapDir: string | null): void {
+  if (!swapDir) return;
+  try {
+    rmSync(swapDir, { recursive: true, force: true });
+  } catch {}
+}
+
+function readRunExecutable(d: IosDeps, appPath: string | null, note: (line: string) => void): string | null {
+  const executable = appPath ? d.readBundleExecutable(appPath) : null;
+  if (appPath && !executable) {
+    note(
+      chalk.dim(
+        `Could not read CFBundleExecutable from ${appPath}; the device log predicate falls back to the .app basename.`,
+      ),
+    );
+  }
+  return executable;
+}
+
 async function finishIosRun({
   d,
   root,
@@ -1505,16 +1570,14 @@ async function finishIosRun({
     return null;
   };
 
+  bundleId = resolveRunBundleId(d, root, appPath, bundleId);
   if (appPath && !bundleId) {
-    bundleId = d.readBundleId(appPath) || d.detectBundleId(root);
-    if (!bundleId) {
-      return fail({
-        code: 'STIM_INSTALL_FAILED',
-        message: `Could not read a bundle identifier from the cached app at ${appPath}.`,
-        remedy: 'Remove the cache entry (`stim gc`) and run again to rebuild it.',
-        build: { ...buildFailure, appPath },
-      });
-    }
+    return fail({
+      code: 'STIM_INSTALL_FAILED',
+      message: `Could not read a bundle identifier from the cached app at ${appPath}.`,
+      remedy: 'Remove the cache entry (`stim gc`) and run again to rebuild it.',
+      build: { ...buildFailure, appPath },
+    });
   }
 
   if (bundleId) d.upsertProject(root, { bundleId });
@@ -1527,24 +1590,13 @@ async function finishIosRun({
       remedy: booted?.remedy || 'Run `stim ios` again to re-establish an owned simulator for this workspace.',
     });
   }
-  phase('device', `${deviceLabel(device, udid)} ${physical ? 'connected' : `booted ${bootDuration()}`}`);
+  const deviceOutcome = physical ? 'connected' : `${device?.adopted ? 'adopted' : 'booted'} ${bootDuration()}`;
+  phase('device', `${deviceLabel(device, udid)} ${deviceOutcome}`);
 
   const scheme = release ? undefined : d.devClientScheme(root, appPath);
   const appName = appNameFromPath(appPath);
-  const appExecutable = appPath ? d.readBundleExecutable(appPath) : null;
-  if (appPath && !appExecutable) {
-    note(
-      chalk.dim(
-        `Could not read CFBundleExecutable from ${appPath}; the device log predicate falls back to the .app basename.`,
-      ),
-    );
-  }
-  const dropSwapDir = () => {
-    if (!swapDir) return;
-    try {
-      rmSync(swapDir, { recursive: true, force: true });
-    } catch {}
-  };
+  const appExecutable = readRunExecutable(d, appPath, note);
+  const dropSwapDir = () => removeSwapDirectory(swapDir);
   let installSkipped = false;
   let launched: ReturnType<IosDeps['launchIosApp']> | null = null;
   let launchedAt = d.now();
@@ -1618,8 +1670,19 @@ async function finishIosRun({
     };
     phase('launch', `${bundleId!} pid ${started.pid} ${launchTimer()}`);
   } else {
+    const adopting = Boolean(device?.adoptionPending);
+    if (adopting) cleanAdoptedIosApps({ d, root, udid, bundleId, phase, note });
     const installTimer = stepTimer(d.now);
-    const installed = d.installIosApp({ udid, appPath: appPath!, bundleId, devClientScheme: scheme }, { now: d.now });
+    const installed = d.installIosApp(
+      {
+        udid,
+        appPath: appPath!,
+        bundleId,
+        devClientScheme: scheme,
+        proveInstalled: !adopting || device?.parkedCacheKey === storeKey,
+      },
+      { now: d.now },
+    );
     if (installed?.failed) {
       return fail({
         code: installed.code || 'STIM_INSTALL_FAILED',
@@ -1904,6 +1967,9 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
       remedy: `Set ios.remote and android.remote to one of: ${REMOTE_DEVICE_BACKENDS.join(', ')}.`,
     });
   }
+
+  const poolError = parkedMaxSetting('ios').error;
+  if (poolError) return fail({ code: 'STIM_BAD_ARG', message: poolError, remedy: POOL_SETTING_REMEDY });
 
   for (const settingError of [
     iosSigningIdentitySettingError(settings),

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1470,19 +1470,20 @@ function cleanAdoptedIosApps({
   bundleId: string | null;
   phase: (name: unknown, text: string) => void;
   note: (line: string) => void;
-}): void {
+}): string | null {
   const swept = d.clearOtherUserApps({ udid, keep: bundleId });
   if (swept.removed.length) {
     phase('install', `removed ${swept.removed.join(', ')}, left by the previous workspace`);
   }
+  if (swept.listed && swept.failed.length === 0) {
+    d.clearIosAdoptionPending(root);
+    return null;
+  }
+  if (!swept.listed) return 'Could not list apps left by the previous workspace.';
   for (const failure of swept.failed) {
     note(chalk.yellow(phaseLine('install', `could not remove ${failure}, left by the previous workspace`)));
   }
-  if (swept.listed && swept.failed.length === 0) {
-    d.clearIosAdoptionPending(root);
-  } else if (!swept.listed) {
-    note(chalk.yellow(phaseLine('install', 'could not list apps left by the previous workspace; cleanup will retry')));
-  }
+  return `Could not remove ${swept.failed.join(', ')}, left by the previous workspace.`;
 }
 
 function resolveRunBundleId(d: IosDeps, root: string, appPath: string | null, bundleId: string | null): string | null {
@@ -1671,7 +1672,17 @@ async function finishIosRun({
     phase('launch', `${bundleId!} pid ${started.pid} ${launchTimer()}`);
   } else {
     const adopting = Boolean(device?.adoptionPending);
-    if (adopting) cleanAdoptedIosApps({ d, root, udid, bundleId, phase, note });
+    if (adopting) {
+      const cleanupFailure = cleanAdoptedIosApps({ d, root, udid, bundleId, phase, note });
+      if (cleanupFailure) {
+        return fail({
+          code: 'STIM_INSTALL_FAILED',
+          message: `${cleanupFailure} Stim kept the adoption cleanup pending and did not install or launch the app.`,
+          remedy: 'Run `stim ios` again after simulator tooling is responsive.',
+          build: { ...buildFailure, appPath, bundleId },
+        });
+      }
+    }
     const installTimer = stepTimer(d.now);
     const installed = d.installIosApp(
       {

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -25,9 +25,11 @@ import {
   diskLine,
   environmentState,
   parseDfFree,
+  poolLine,
   tightVolumes,
   unprovisionedWorktrees,
 } from '../status.ts';
+import { parkedMaxSetting, POOL_SETTING_REMEDY, readParked } from '../sim-pool.ts';
 import type { EnvironmentState, VolumeInfo, SimFacts, MetroFacts, WorktreeFacts } from '../status.ts';
 
 type SupervisorRecordExt = SupervisorRecord & { mode?: string | null };
@@ -100,6 +102,8 @@ export default function statusCommand(program: Command): void {
         worktrees as unknown as WorktreeFacts[],
         projects.map(([p]) => p),
       );
+      const poolMax = parkedMaxSetting('ios');
+      const pool = poolLine({ platform: 'ios', parked: readParked('ios').length, max: poolMax.max });
 
       if (opts.json) {
         console.log(
@@ -116,6 +120,8 @@ export default function statusCommand(program: Command): void {
 
       if (projects.length === 0 && orphanWorktrees.length === 0) {
         console.log(chalk.dim('No projects registered.'));
+        if (poolMax.error) console.log(chalk.yellow(`${poolMax.error} ${POOL_SETTING_REMEDY}`));
+        if (pool) console.log(chalk.dim(pool));
         for (const line of deviceLeaseLines(leases, leaseNow)) console.log(line);
         return;
       }
@@ -167,6 +173,9 @@ export default function statusCommand(program: Command): void {
         }
         for (const w of state.warnings) console.log(chalk.yellow(`  ! ${w}`));
       }
+
+      if (poolMax.error) console.log(chalk.yellow(`\n${poolMax.error} ${POOL_SETTING_REMEDY}`));
+      if (pool) console.log(chalk.dim(`\n${pool}`));
 
       const leaseLines = deviceLeaseLines(leases, leaseNow);
       if (leaseLines.length) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -2,12 +2,14 @@ import { existsSync, readdirSync, realpathSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import chalk from 'chalk';
 import { type Command, InvalidArgumentError } from 'commander';
-import { phaseLine, plural, releasedLeaseFact } from '../command-output.ts';
+import { phaseLine, plural, releasedLeaseFact, shortUdid } from '../command-output.ts';
 import { resolveSettings, SETTING_SHAPE_REMEDY, settingShapeErrors, unknownSettingKeys } from '../settings.ts';
 import { getProject, isPathPrefix, loadConfig, removeProject, upsertProject } from '../config.ts';
 import type { ReleasedLease } from '../engine/device-lease.ts';
 import { podInstallCommand } from '../engine/bundler.ts';
 import { reclaimProject } from '../reclaim.ts';
+import { parkedMaxSetting, POOL_SETTING_REMEDY } from '../sim-pool.ts';
+import type { ParkedDevice } from '../teardown.ts';
 import { withManagedRemoteWorktreeRemovalLock, withManagedTunnelRemovalLock } from '../engine/tunnel.ts';
 import { readMetroTunnel, readRemoteSession } from '../supervisor/state.ts';
 import {
@@ -555,6 +557,10 @@ interface ReclaimAllResult {
   dereferenced: string[];
   killedPids: number[];
   deletedDevices: string[];
+  parkedDevices: ParkedDevice[];
+  evictedDevices: ParkedDevice[];
+  poolNotes: string[];
+  parkedMax: number;
   skippedDevices: SkippedDevice[];
   keptEntries: string[];
   retainedResources: RetainedResource[];
@@ -592,6 +598,9 @@ async function reclaimAll(
   const dereferenced: string[] = [];
   const killedPids: number[] = [];
   const deletedDevices: string[] = [];
+  const parkedDevices: ParkedDevice[] = [];
+  const evictedDevices: ParkedDevice[] = [];
+  const poolNotes: string[] = [];
   const skippedDevices: SkippedDevice[] = [];
   const keptEntries: string[] = [];
   const retainedResources: RetainedResource[] = [];
@@ -603,11 +612,15 @@ async function reclaimAll(
   for (const key of keys) {
     const r = await reclaimProject(key, {
       deleteOwnedDevices: true,
+      parkOwnedDevices: true,
       preserveProjectRecord: preserveRootProject && key === rootPath,
     });
     dereferenced.push(...r.dereferenced);
     if (r.killedPid) killedPids.push(r.killedPid);
     deletedDevices.push(...r.deletedDevices);
+    parkedDevices.push(...r.parkedDevices);
+    evictedDevices.push(...r.evictedDevices);
+    poolNotes.push(...r.poolNotes);
     skippedDevices.push(...r.skippedDevices);
     if (r.stoppedSession) stoppedSessions.push(r.stoppedSession);
     if (r.stoppedTunnel) stoppedTunnels.push(r.stoppedTunnel);
@@ -647,6 +660,10 @@ async function reclaimAll(
     dereferenced,
     killedPids,
     deletedDevices,
+    parkedDevices,
+    evictedDevices,
+    poolNotes,
+    parkedMax: parkedMaxSetting('ios').max,
     skippedDevices,
     keptEntries,
     retainedResources,
@@ -657,6 +674,18 @@ async function reclaimAll(
     removedWorkspaceDirs,
     failedWorkspaceDirs,
   };
+}
+
+function poolLines(result: ReclaimAllResult): string[] {
+  const lines: string[] = [];
+  for (const device of result.parkedDevices) {
+    lines.push(chalk.dim(phaseLine('device', `parked ${device.name} (${shortUdid(device.udid)})`)));
+  }
+  for (const device of result.evictedDevices) {
+    lines.push(chalk.dim(phaseLine('device', `deleted ${device.name} (pool over ${result.parkedMax})`)));
+  }
+  for (const note of result.poolNotes) lines.push(chalk.yellow(phaseLine('device', note)));
+  return lines;
 }
 
 function reportRetainedResources(root: string, result: ReclaimAllResult): void {
@@ -682,6 +711,7 @@ async function reclaimEnvironment(root: string, why: string): Promise<void> {
   await withManagedRemoteWorktreeRemovalLock(root, () =>
     withReclaimLocks(root, async (lockedKeys) => {
       const result = await reclaimAll(root, lockedKeys);
+      for (const line of poolLines(result)) console.error(line);
       for (const device of result.deletedDevices) {
         console.error(chalk.dim(phaseLine('device', `deleted ${device}`)));
       }
@@ -788,6 +818,7 @@ function restorePodChurn(path: string, files: string[]): void {
 }
 
 function printRemovalCleanup(result: ReclaimAllResult, failed: boolean): void {
+  for (const line of poolLines(result)) console.error(line);
   for (const device of result.deletedDevices) {
     console.error(chalk.dim(phaseLine('device', `deleted ${device}`)));
   }
@@ -817,6 +848,13 @@ function printRemovalCleanup(result: ReclaimAllResult, failed: boolean): void {
 }
 
 async function runRemove(target: string | undefined, opts: RemoveOptions = {}): Promise<void> {
+  const poolError = parkedMaxSetting('ios').error;
+  if (poolError) {
+    console.error(chalk.red(poolError));
+    console.error(chalk.dim(POOL_SETTING_REMEDY));
+    process.exitCode = 1;
+    return;
+  }
   let path = removalPath(target);
   if (!existsSync(path)) {
     const pending = getProject(path);

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -13,6 +13,7 @@ import { liveOwnedDeviceCount } from './engine/device.ts';
 import { simslimIsOnPath } from './engine/simslim.ts';
 import { listBuildSlots } from './engine/build-slots.ts';
 import { type IosSimRecord, listAllIosSims } from './sim/ios.ts';
+import { parkedMaxSetting, POOL_SETTING_REMEDY } from './sim-pool.ts';
 import { ccacheEnabled, COMPILATION_CACHE_MIN_XCODE, detectXcodeMajor, parseXcodeMajor } from './engine/xcode.ts';
 import { type AdbDevices, listAdbDevices } from './sim/android.ts';
 import {
@@ -624,6 +625,12 @@ export function runDoctor(
   const settingShapeFindings = settingShapeErrors(projectSettings).map((error) =>
     finding('cost', 'A setting has the wrong type', error, SETTING_SHAPE_REMEDY),
   );
+  const poolSettingError = parkedMaxSetting('ios').error;
+  if (poolSettingError) {
+    settingShapeFindings.push(
+      finding('cost', 'The simulator pool bound is not a number', poolSettingError, POOL_SETTING_REMEDY),
+    );
+  }
   let simslimProfile: string | null = null;
   let simslimProfileError: string | null = null;
   try {

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -4,6 +4,7 @@ import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
 import { DEV_MENU_LAUNCH_ARGS } from '../collector/ios-device.ts';
+import { listUserApps, uninstallIosApp } from '../sim/ios.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -75,12 +76,19 @@ export function installIosApp(
     appPath,
     bundleId = null,
     devClientScheme = null,
-  }: { udid: string; appPath: string; bundleId?: string | null; devClientScheme?: string | null },
+    proveInstalled = true,
+  }: {
+    udid: string;
+    appPath: string;
+    bundleId?: string | null;
+    devClientScheme?: string | null;
+    proveInstalled?: boolean;
+  },
   { exec = null, now = null }: ExecOpt = {},
 ): IosInstallResult {
   const e = exec || getExecutor();
   const artifactStartedAt = now?.();
-  const skipped = bundleId ? deviceHoldsBundle({ udid, bundleId, appPath }, { exec: e }) : false;
+  const skipped = bundleId && proveInstalled ? deviceHoldsBundle({ udid, bundleId, appPath }, { exec: e }) : false;
   if (!skipped) {
     try {
       e.runFile('xcrun', ['simctl', 'install', udid, appPath]);
@@ -127,6 +135,33 @@ export function installIosApp(
     ...(devClientPreparationDurationMs === undefined ? {} : { devClientPreparationDurationMs }),
   };
   return skipped ? { ok: true, appPath, skipped: true, ...timing } : { ok: true, appPath, ...timing };
+}
+
+export function clearOtherUserApps(
+  { udid, keep }: { udid: string; keep?: string | null },
+  {
+    list = listUserApps,
+    uninstall = uninstallIosApp,
+  }: { list?: typeof listUserApps; uninstall?: typeof uninstallIosApp } = {},
+): { listed: boolean; removed: string[]; failed: string[] } {
+  const removed: string[] = [];
+  const failed: string[] = [];
+  let installed: string[];
+  try {
+    installed = list(udid);
+  } catch {
+    return { listed: false, removed, failed };
+  }
+  for (const bundleId of installed) {
+    if (bundleId === keep) continue;
+    try {
+      uninstall(udid, bundleId);
+      removed.push(bundleId);
+    } catch {
+      failed.push(bundleId);
+    }
+  }
+  return { listed: true, removed, failed };
 }
 
 export function jsLocationValue(metroPort: number | string): string {

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -5,6 +5,7 @@ import {
   clearDevice,
   loadConfig,
   releaseAndroidConsolePort,
+  saveConfig,
   setDevice,
   withConfigLock,
   type Config,
@@ -14,14 +15,23 @@ import { isPidAlive } from '../metro.ts';
 import {
   bootIosSim,
   createOwnedIosSim,
+  deleteParkedIosSim,
   IOS_BOOT_TIMEOUT_MS,
   listAllIosSims,
   iosRuntimeMatches,
   listIosDeviceTypes,
+  ownedSimName,
   parseRuntimeVersion,
+  renameIosSim,
+  resetIosKeychain,
+  resetIosPrivacy,
+  resolveIosCreation,
   resolveOwnedIosSim,
+  type IosCreationChoice,
   type IosRuntime,
+  type SimModel,
 } from '../sim/ios.ts';
+import { adoptParked, dropParked, parkedMaxSetting, readParked, selectParked } from '../sim-pool.ts';
 import {
   bootAndroidEmulator,
   configureNewOwnedAvd,
@@ -53,6 +63,9 @@ export interface OwnedDeviceRecord {
   deviceType?: string | null;
   runtime?: string | null;
   systemImage?: string | null;
+  adopted?: boolean;
+  adoptionPending?: boolean;
+  parkedCacheKey?: string;
   /**
    * The boot this call started, and the promise that finishes it: the wait on
    * `simctl bootstatus -b` and the SimSlim reconcile that follows it.
@@ -216,29 +229,39 @@ async function ensureOwnedIosDevice({
               'Run `stim worktree remove` (or `stim gc --delete`) to reap the current sim, then `stim ios` again to create the requested one.',
           );
         }
+        const model: SimModel = {
+          model: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
+          runtime: parseRuntimeVersion(sim.runtime),
+        };
+        const name = renameToOwnedName(sim, label, model);
         const updated = {
           deviceUdid: sim.udid,
           owned: true,
-          deviceName: record.deviceName ?? sim.name,
+          deviceName: name,
           ...(record.simslimManaged ? { simslimManaged: true } : {}),
+          ...(record.adopted ? { adopted: true } : {}),
+          ...(record.adoptionPending ? { adoptionPending: true } : {}),
+          ...(record.parkedCacheKey ? { parkedCacheKey: record.parkedCacheKey } : {}),
         };
-        const configure = () =>
-          configureOwnedIosSim({
+        const configure = async () => {
+          if (record.adoptionPending) resetAdoptedSim(sim.udid, out);
+          return configureOwnedIosSim({
             record: updated,
             projectPath,
             profile: simslimProfile,
             out,
             reconcileIosSimulator,
           });
-        const model = {
-          deviceType: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
-          runtime: parseRuntimeVersion(sim.runtime),
+        };
+        const facts = {
+          deviceType: model.model,
+          runtime: model.runtime,
         };
         if (sim.state !== 'Booted') {
-          out(chalk.dim(phaseLine('device', `booting ${sim.name} (${sim.udid})`)));
-          return { ...updated, booting: startIosBoot(sim.udid, configure), ...model };
+          out(chalk.dim(phaseLine('device', `booting ${name} (${sim.udid})`)));
+          return { ...updated, booting: startIosBoot(sim.udid, configure), ...facts };
         }
-        return { ...(await configure()), ...model };
+        return { ...(await configure()), ...facts };
       }
     } else {
       const sim = listAllIosSims().find((s) => s.udid === record.deviceUdid);
@@ -260,10 +283,32 @@ async function ensureOwnedIosDevice({
     }
   }
 
-  const created = createOwnedIosSim(label, {
+  const choice = resolveIosCreation({
     deviceType: flags.deviceType || settings.ios?.deviceType,
     runtime: flags.runtime || settings.ios?.runtime,
   });
+
+  const adopted = parkedMaxSetting('ios').max > 0 ? takeParkedIosSim({ projectPath, label, choice, out }) : null;
+  if (adopted) {
+    out(chalk.dim(phaseLine('device', `booting ${adopted.deviceName} (${adopted.deviceUdid})`)));
+    const booting = startIosBoot(adopted.deviceUdid, async () => {
+      resetAdoptedSim(adopted.deviceUdid, out);
+      await configureOwnedIosSim({
+        record: adopted,
+        projectPath,
+        profile: simslimProfile,
+        out,
+        reconcileIosSimulator,
+      });
+    });
+    return { ...adopted, booting, deviceType: choice.deviceType, runtime: choice.runtime };
+  }
+
+  const created = createOwnedIosSim(
+    label,
+    { deviceType: flags.deviceType || settings.ios?.deviceType, runtime: flags.runtime || settings.ios?.runtime },
+    choice,
+  );
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
   setDevice(projectPath, 'ios', newRecord);
   const booting = startIosBoot(created.udid, () =>
@@ -282,6 +327,85 @@ async function ensureOwnedIosDevice({
     deviceType: created.deviceType,
     runtime: created.runtime,
   };
+}
+
+function renameToOwnedName(sim: SimRecord, label: string, model: SimModel): string {
+  const wanted = ownedSimName(label, model);
+  if (sim.name === wanted) return wanted;
+  try {
+    renameIosSim(sim.udid, wanted);
+    return wanted;
+  } catch {
+    return sim.name;
+  }
+}
+
+function resetAdoptedSim(udid: string, out: Notify): void {
+  out(chalk.dim(phaseLine('device', `resetting privacy grants and the keychain on ${udid}`)));
+  resetIosPrivacy(udid);
+  resetIosKeychain(udid);
+}
+
+type AdoptedRecord = OwnedDeviceRecord & { deviceUdid: string; deviceName: string };
+
+function takeParkedIosSim({
+  projectPath,
+  label,
+  choice,
+  out,
+}: {
+  projectPath: string;
+  label: string;
+  choice: IosCreationChoice;
+  out: Notify;
+}): AdoptedRecord | null {
+  const candidates = selectParked(readParked('ios'), {
+    deviceTypeIdentifier: choice.deviceTypeId,
+    runtimeIdentifier: choice.runtimeId,
+  });
+  if (candidates.length === 0) return null;
+  const listed = new Map(listAllIosSims({ includeUnavailable: true }).map((sim) => [sim.udid, sim]));
+  const name = ownedSimName(label, { model: choice.deviceType, runtime: choice.runtime });
+  for (const parked of candidates) {
+    const sim = listed.get(parked.udid);
+    if (!sim || !sim.available) {
+      out(
+        chalk.dim(
+          phaseLine('device', `deleted parked ${parked.name} (${parked.udid}): ${sim ? 'unavailable' : 'gone'}`),
+        ),
+      );
+      if (sim) deleteParkedIosSim(parked.udid);
+      dropParked('ios', parked.udid);
+      continue;
+    }
+    const device = {
+      deviceUdid: parked.udid,
+      owned: true,
+      deviceName: name,
+      adopted: true,
+      adoptionPending: true,
+      ...(parked.simslimManaged ? { simslimManaged: true } : {}),
+      ...(parked.cacheKey ? { parkedCacheKey: parked.cacheKey } : {}),
+    };
+    if (!adoptParked({ platform: 'ios', projectPath, udid: parked.udid, device })) continue;
+    try {
+      renameIosSim(parked.udid, name);
+    } catch {}
+    return device;
+  }
+  return null;
+}
+
+export function clearIosAdoptionPending(projectPath: string): void {
+  withConfigLock(() => {
+    const cfg = loadConfig();
+    const ios = cfg?.projects?.[projectPath]?.platforms?.ios;
+    if (!cfg || !ios?.adoptionPending) return;
+    delete ios.adopted;
+    delete ios.adoptionPending;
+    delete ios.parkedCacheKey;
+    saveConfig(cfg);
+  });
 }
 
 async function configureOwnedIosSim({

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -388,6 +388,17 @@ function takeParkedIosSim({
       }
       continue;
     }
+    if (!sim.name.startsWith('stim-')) {
+      out(
+        chalk.yellow(
+          phaseLine(
+            'device',
+            `kept parked record for ${parked.udid}: simulator is now named ${JSON.stringify(sim.name)} and is not Stim-owned`,
+          ),
+        ),
+      );
+      continue;
+    }
     const device = {
       deviceUdid: parked.udid,
       owned: true,

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -15,7 +15,6 @@ import { isPidAlive } from '../metro.ts';
 import {
   bootIosSim,
   createOwnedIosSim,
-  deleteParkedIosSim,
   IOS_BOOT_TIMEOUT_MS,
   listAllIosSims,
   iosRuntimeMatches,
@@ -47,7 +46,7 @@ import {
   type SystemImage,
 } from '../sim/android.ts';
 import { androidAvdConfigSetting, androidDataPartitionSizeGbSetting, iosSimSlimProfileSetting } from '../settings.ts';
-import { teardownOwnedAvd } from '../teardown.ts';
+import { teardownOwnedAvd, teardownParkedIosSim } from '../teardown.ts';
 import { reconcileSimSlim } from './simslim.ts';
 
 export interface OwnedDeviceRecord {
@@ -369,13 +368,24 @@ function takeParkedIosSim({
   for (const parked of candidates) {
     const sim = listed.get(parked.udid);
     if (!sim || !sim.available) {
-      out(
-        chalk.dim(
-          phaseLine('device', `deleted parked ${parked.name} (${parked.udid}): ${sim ? 'unavailable' : 'gone'}`),
-        ),
-      );
-      if (sim) deleteParkedIosSim(parked.udid);
-      dropParked('ios', parked.udid);
+      const result = sim ? teardownParkedIosSim(parked.udid, { label: parked.name }) : null;
+      const removed = sim ? result?.status === 'torn-down' : dropParked('ios', parked.udid);
+      if (removed) {
+        out(
+          chalk.dim(
+            phaseLine('device', `deleted parked ${parked.name} (${parked.udid}): ${sim ? 'unavailable' : 'gone'}`),
+          ),
+        );
+      } else if (result?.status === 'failed') {
+        out(
+          chalk.yellow(
+            phaseLine(
+              'device',
+              `could not delete unavailable parked ${parked.name} (${parked.udid}): ${result.reason}`,
+            ),
+          ),
+        );
+      }
       continue;
     }
     const device = {

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -214,11 +214,16 @@ export function describeDereferenced(project: ProjectRecord | null): string[] {
   return devices;
 }
 
+export function parkedIosCacheKey(lastBuild: unknown): string | null {
+  if (lastBuild === null || typeof lastBuild !== 'object' || Array.isArray(lastBuild)) return null;
+  const build = lastBuild as Record<string, unknown>;
+  return build.platform === 'ios' && typeof build.cacheKey === 'string' ? build.cacheKey : null;
+}
+
 function parkRequest(project: ProjectRecord | null, projectPath: string): ParkRequest | undefined {
   const { max, error } = parkedMaxSetting('ios');
   if (error || max <= 0) return undefined;
-  const lastBuild = readWorkspaceState(projectPath)?.lastBuild as { cacheKey?: unknown } | undefined;
-  const cacheKey = typeof lastBuild?.cacheKey === 'string' ? lastBuild.cacheKey : null;
+  const cacheKey = parkedIosCacheKey(readWorkspaceState(projectPath)?.lastBuild);
   return {
     projectPath,
     max,

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -1,7 +1,8 @@
 import { type ProjectRecord, getProject, removeProject } from './config.ts';
 import { existsSync, rmSync } from 'node:fs';
 import { resolveProjectMetro, killMetroTree, isPidAlive } from './metro.ts';
-import { teardownOwnedIosSim, teardownOwnedAvd } from './teardown.ts';
+import { teardownOwnedIosSim, teardownOwnedAvd, type ParkedDevice, type ParkRequest } from './teardown.ts';
+import { parkedMaxSetting } from './sim-pool.ts';
 import { readCollectors } from './collector/state.ts';
 import { verifyCollectorOwnership } from './collector/ownership.ts';
 import { readProcessStartTime } from './process-args.ts';
@@ -10,6 +11,7 @@ import {
   clearRemoteSession,
   readMetroTunnel,
   readRemoteSessionId,
+  readWorkspaceState,
   type ManagedTunnelRecord,
 } from './supervisor/state.ts';
 import { endRecordedSession } from './engine/device-remote.ts';
@@ -212,12 +214,36 @@ export function describeDereferenced(project: ProjectRecord | null): string[] {
   return devices;
 }
 
-function reclaimOwnedDevices(project: ProjectRecord | null): {
+function parkRequest(project: ProjectRecord | null, projectPath: string): ParkRequest | undefined {
+  const { max, error } = parkedMaxSetting('ios');
+  if (error || max <= 0) return undefined;
+  const lastBuild = readWorkspaceState(projectPath)?.lastBuild as { cacheKey?: unknown } | undefined;
+  const cacheKey = typeof lastBuild?.cacheKey === 'string' ? lastBuild.cacheKey : null;
+  return {
+    projectPath,
+    max,
+    bundleId: typeof project?.bundleId === 'string' ? project.bundleId : null,
+    cacheKey,
+    simslimManaged: Boolean(project?.platforms?.ios?.simslimManaged),
+  };
+}
+
+function reclaimOwnedDevices(
+  project: ProjectRecord | null,
+  projectPath: string,
+  { park = false }: { park?: boolean } = {},
+): {
   deletedDevices: string[];
+  parkedDevices: ParkedDevice[];
+  evictedDevices: ParkedDevice[];
+  poolNotes: string[];
   skippedDevices: SkippedDevice[];
   failedDevices: SkippedDevice[];
 } {
   const deletedDevices: string[] = [];
+  const parkedDevices: ParkedDevice[] = [];
+  const evictedDevices: ParkedDevice[] = [];
+  const poolNotes: string[] = [];
   const skippedDevices: SkippedDevice[] = [];
   const failedDevices: SkippedDevice[] = [];
 
@@ -225,9 +251,18 @@ function reclaimOwnedDevices(project: ProjectRecord | null): {
   if (ios?.owned && ios.deviceUdid) {
     const udid = ios.deviceUdid as string;
     const label = (ios.deviceName as string | undefined) || udid;
-    const r = teardownOwnedIosSim(udid, { del: true, label });
-    if (r.status === 'torn-down') deletedDevices.push(r.label as string);
-    else if (r.status === 'skipped') {
+    const r = teardownOwnedIosSim(udid, {
+      del: true,
+      label,
+      ...(park ? { park: parkRequest(project, projectPath) } : {}),
+    });
+    if (r.parkFallback) poolNotes.push(`could not park ${label}: ${r.parkFallback} -- deleted it instead`);
+    for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
+    if (r.parked) {
+      parkedDevices.push(r.parked);
+      evictedDevices.push(...(r.evicted ?? []));
+    } else if (r.status === 'torn-down') deletedDevices.push(r.label as string);
+    if (r.status === 'skipped') {
       skippedDevices.push({ platform: 'ios', name: label, udid, reason: `${r.reason} -- not touched` });
     } else if (r.status === 'failed') {
       const entry: SkippedDevice = { platform: 'ios', name: label, udid, reason: `teardown failed: ${r.reason}` };
@@ -253,7 +288,7 @@ function reclaimOwnedDevices(project: ProjectRecord | null): {
     }
   }
 
-  return { deletedDevices, skippedDevices, failedDevices };
+  return { deletedDevices, parkedDevices, evictedDevices, poolNotes, skippedDevices, failedDevices };
 }
 
 export interface ReclaimResult {
@@ -263,6 +298,9 @@ export interface ReclaimResult {
   skippedMetro: string | null;
   metroPort: number | null;
   deletedDevices: string[];
+  parkedDevices: ParkedDevice[];
+  evictedDevices: ParkedDevice[];
+  poolNotes: string[];
   skippedDevices: SkippedDevice[];
   failedDevices: SkippedDevice[];
   keptEntry: boolean;
@@ -277,6 +315,7 @@ export async function reclaimProject(
   path: string,
   {
     deleteOwnedDevices = false,
+    parkOwnedDevices = false,
     preserveProjectRecord = false,
     stopSession = defaultStopSession,
     stopMetroTunnel = defaultStopMetroTunnel,
@@ -285,6 +324,7 @@ export async function reclaimProject(
     readCollectorStartTime = readProcessStartTime,
   }: {
     deleteOwnedDevices?: boolean;
+    parkOwnedDevices?: boolean;
     preserveProjectRecord?: boolean;
     stopSession?: StopSession;
     stopMetroTunnel?: StopMetroTunnelFn;
@@ -301,15 +341,16 @@ export async function reclaimProject(
     readStartTime: readCollectorStartTime,
   });
 
-  const {
-    deletedDevices,
-    skippedDevices,
-    failedDevices,
-  }: {
-    deletedDevices: string[];
-    skippedDevices: SkippedDevice[];
-    failedDevices: SkippedDevice[];
-  } = deleteOwnedDevices ? reclaimOwnedDevices(project) : { deletedDevices: [], skippedDevices: [], failedDevices: [] };
+  const { deletedDevices, parkedDevices, evictedDevices, poolNotes, skippedDevices, failedDevices } = deleteOwnedDevices
+    ? reclaimOwnedDevices(project, path, { park: parkOwnedDevices })
+    : {
+        deletedDevices: [] as string[],
+        parkedDevices: [] as ParkedDevice[],
+        evictedDevices: [] as ParkedDevice[],
+        poolNotes: [] as string[],
+        skippedDevices: [] as SkippedDevice[],
+        failedDevices: [] as SkippedDevice[],
+      };
   skippedDevices.push(...skippedCollectors);
   failedDevices.push(...failedCollectors);
 
@@ -368,6 +409,9 @@ export async function reclaimProject(
     skippedMetro,
     metroPort: project?.metroPort ?? null,
     deletedDevices,
+    parkedDevices,
+    evictedDevices,
+    poolNotes,
     skippedDevices,
     failedDevices,
     keptEntry,

--- a/packages/stim-cli/src/sim-pool.ts
+++ b/packages/stim-cli/src/sim-pool.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { ensureConfig, loadConfig, saveConfig, withConfigLock } from './config.ts';
 import type { Config, DeviceRecord } from './types.ts';
 
@@ -12,6 +13,7 @@ export interface ParkedSim {
   simslimManaged: boolean;
   bundleId?: string;
   cacheKey?: string;
+  deletionClaim?: unknown;
 }
 
 export const DEFAULT_PARKED_MAX = 3;
@@ -108,7 +110,12 @@ export function selectParked(
   { deviceTypeIdentifier, runtimeIdentifier }: { deviceTypeIdentifier: string; runtimeIdentifier: string },
 ): ParkedSim[] {
   return oldestFirst(
-    records.filter((r) => r.deviceTypeIdentifier === deviceTypeIdentifier && r.runtimeIdentifier === runtimeIdentifier),
+    records.filter(
+      (r) =>
+        r.deletionClaim === undefined &&
+        r.deviceTypeIdentifier === deviceTypeIdentifier &&
+        r.runtimeIdentifier === runtimeIdentifier,
+    ),
   );
 }
 
@@ -158,7 +165,7 @@ export function adoptParked({
     const cfg = ensureConfig();
     const records = readParked(platform, { config: cfg });
     const taken = records.find((r) => r.udid === udid);
-    if (!taken) return null;
+    if (!taken || taken.deletionClaim !== undefined) return null;
     writeParked(
       cfg,
       platform,
@@ -173,25 +180,92 @@ export function adoptParked({
   });
 }
 
-export function removeParkedAfter(
-  platform: PoolPlatform,
-  udid: string,
-  beforeRemove: (record: ParkedSim) => void,
-): ParkedSim | null {
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function parseDeletionClaim(value: unknown): { pid: number; token: string } | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const claim = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(claim.pid) || (claim.pid as number) <= 0) return null;
+  if (typeof claim.token !== 'string' || claim.token.length === 0) return null;
+  return { pid: claim.pid as number, token: claim.token };
+}
+
+function claimParkedRemoval(platform: PoolPlatform, udid: string): { record: ParkedSim; token: string } | null {
   return withConfigLock(() => {
     const cfg = loadConfig();
     if (!cfg) return null;
     const records = readParked(platform, { config: cfg });
     const record = records.find((candidate) => candidate.udid === udid);
     if (!record) return null;
-    beforeRemove(record);
+    const existingClaim = parseDeletionClaim(record.deletionClaim);
+    if (record.deletionClaim !== undefined && (!existingClaim || isProcessAlive(existingClaim.pid))) return null;
+    const token = randomUUID();
+    const claimedRecord = { ...record, deletionClaim: { pid: process.pid, token } };
+    writeParked(
+      cfg,
+      platform,
+      records.map((candidate) => (candidate.udid === udid ? claimedRecord : candidate)),
+    );
+    saveConfig(cfg);
+    const claimed = { ...record };
+    delete claimed.deletionClaim;
+    return { record: claimed, token };
+  });
+}
+
+function clearParkedRemovalClaim(platform: PoolPlatform, udid: string, token: string): void {
+  withConfigLock(() => {
+    const cfg = loadConfig();
+    if (!cfg) return;
+    const records = readParked(platform, { config: cfg });
+    const record = records.find((candidate) => candidate.udid === udid);
+    if (!record || parseDeletionClaim(record.deletionClaim)?.token !== token) return;
+    const restored = { ...record };
+    delete restored.deletionClaim;
+    writeParked(
+      cfg,
+      platform,
+      records.map((candidate) => (candidate.udid === udid ? restored : candidate)),
+    );
+    saveConfig(cfg);
+  });
+}
+
+export function removeParkedAfter(
+  platform: PoolPlatform,
+  udid: string,
+  beforeRemove: (record: ParkedSim) => void,
+): ParkedSim | null {
+  const claim = claimParkedRemoval(platform, udid);
+  if (!claim) return null;
+  try {
+    beforeRemove(claim.record);
+  } catch (error) {
+    try {
+      clearParkedRemovalClaim(platform, udid, claim.token);
+    } catch {}
+    throw error;
+  }
+  return withConfigLock(() => {
+    const cfg = loadConfig();
+    if (!cfg) return null;
+    const records = readParked(platform, { config: cfg });
+    const record = records.find((candidate) => candidate.udid === udid);
+    if (parseDeletionClaim(record?.deletionClaim)?.token !== claim.token) return null;
     writeParked(
       cfg,
       platform,
       records.filter((candidate) => candidate.udid !== udid),
     );
     saveConfig(cfg);
-    return record;
+    return claim.record;
   });
 }
 

--- a/packages/stim-cli/src/sim-pool.ts
+++ b/packages/stim-cli/src/sim-pool.ts
@@ -1,0 +1,190 @@
+import { ensureConfig, loadConfig, saveConfig, withConfigLock } from './config.ts';
+import type { Config, DeviceRecord } from './types.ts';
+
+export type PoolPlatform = 'ios' | 'android';
+
+export interface ParkedSim {
+  udid: string;
+  name: string;
+  deviceTypeIdentifier: string;
+  runtimeIdentifier: string;
+  parkedAt: string;
+  simslimManaged: boolean;
+  bundleId?: string;
+  cacheKey?: string;
+}
+
+export const DEFAULT_PARKED_MAX = 3;
+
+export const POOL_SETTING_REMEDY: string =
+  'Run `stim guide settings` for the simulator pool bound and where it can be set.';
+
+const MAX_SETTING: Record<PoolPlatform, { key: string; env: string }> = {
+  ios: { key: 'iosParkedMax', env: 'STIM_POOL_IOS_PARKED_MAX' },
+  android: { key: 'androidParkedMax', env: 'STIM_POOL_ANDROID_PARKED_MAX' },
+};
+
+export interface ParkedMax {
+  max: number;
+  error: string | null;
+}
+
+function parseMax(raw: unknown, strings: boolean): number | null {
+  const value = strings && typeof raw === 'string' ? (/^\d+$/.test(raw.trim()) ? Number(raw.trim()) : Number.NaN) : raw;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) return null;
+  return value;
+}
+
+export function parkedMaxSetting(
+  platform: PoolPlatform,
+  { config, env = process.env }: { config?: Config | null; env?: NodeJS.ProcessEnv } = {},
+): ParkedMax {
+  const { key, env: envKey } = MAX_SETTING[platform];
+  const fromEnv = env[envKey];
+  const explicit = fromEnv !== undefined && fromEnv !== '';
+  const cfg = config === undefined ? loadConfig() : config;
+  const pool = cfg?.pool;
+  if (!explicit && pool !== undefined && (pool === null || typeof pool !== 'object' || Array.isArray(pool))) {
+    return { max: 0, error: 'Invalid pool value. Expected an object with simulator and emulator bounds.' };
+  }
+  const fromConfig =
+    pool !== null && typeof pool === 'object' && !Array.isArray(pool)
+      ? (pool as Record<string, unknown>)[key]
+      : undefined;
+  const raw = explicit ? fromEnv : fromConfig;
+  if (raw === undefined) return { max: env.STIM_HOME ? 0 : DEFAULT_PARKED_MAX, error: null };
+  const parsed = parseMax(raw, explicit);
+  if (parsed === null) {
+    return {
+      max: 0,
+      error: `Invalid ${explicit ? envKey : `pool.${key}`} value ${JSON.stringify(raw)}. Expected a whole number of parked ${platform === 'ios' ? 'simulators' : 'emulators'}, 0 or more.`,
+    };
+  }
+  return { max: explicit ? parsed : env.STIM_HOME ? 0 : parsed, error: null };
+}
+
+function isParkedSim(value: unknown): value is ParkedSim {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.udid === 'string' &&
+    typeof record.name === 'string' &&
+    record.name.startsWith('stim-') &&
+    typeof record.deviceTypeIdentifier === 'string' &&
+    typeof record.runtimeIdentifier === 'string' &&
+    typeof record.parkedAt === 'string' &&
+    typeof record.simslimManaged === 'boolean' &&
+    (record.bundleId === undefined || typeof record.bundleId === 'string') &&
+    (record.cacheKey === undefined || typeof record.cacheKey === 'string')
+  );
+}
+
+function poolBlock(config: Config | null): Record<PoolPlatform, ParkedSim[]> {
+  const raw = config?.parked;
+  const block = raw !== null && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  const read = (platform: PoolPlatform): ParkedSim[] => {
+    const list = block[platform];
+    return Array.isArray(list) ? list.filter(isParkedSim) : [];
+  };
+  return { ios: read('ios'), android: read('android') };
+}
+
+export function readParked(platform: PoolPlatform, { config }: { config?: Config | null } = {}): ParkedSim[] {
+  return poolBlock(config === undefined ? loadConfig() : config)[platform];
+}
+
+function writeParked(config: Config, platform: PoolPlatform, records: ParkedSim[]): void {
+  const block = poolBlock(config);
+  block[platform] = records;
+  config.parked = { ios: block.ios, android: block.android };
+}
+
+function oldestFirst(records: readonly ParkedSim[]): ParkedSim[] {
+  return records.toSorted((a, b) => String(a.parkedAt).localeCompare(String(b.parkedAt)));
+}
+
+export function selectParked(
+  records: readonly ParkedSim[],
+  { deviceTypeIdentifier, runtimeIdentifier }: { deviceTypeIdentifier: string; runtimeIdentifier: string },
+): ParkedSim[] {
+  return oldestFirst(
+    records.filter((r) => r.deviceTypeIdentifier === deviceTypeIdentifier && r.runtimeIdentifier === runtimeIdentifier),
+  );
+}
+
+export function evictOverflow(records: readonly ParkedSim[], max: number): { keep: ParkedSim[]; evicted: ParkedSim[] } {
+  if (records.length <= max) return { keep: [...records], evicted: [] };
+  const ordered = oldestFirst(records);
+  const evicted = ordered.slice(0, ordered.length - max);
+  const dropped = new Set(evicted.map((r) => r.udid));
+  return { keep: records.filter((r) => !dropped.has(r.udid)), evicted };
+}
+
+export function parkSim({
+  platform,
+  projectPath,
+  record,
+  max,
+}: {
+  platform: PoolPlatform;
+  projectPath: string;
+  record: ParkedSim;
+  max: number;
+}): ParkedSim[] {
+  return withConfigLock(() => {
+    const cfg = ensureConfig();
+    const kept = readParked(platform, { config: cfg }).filter((r) => r.udid !== record.udid);
+    const { keep, evicted } = evictOverflow([...kept, record], max);
+    writeParked(cfg, platform, keep);
+    const platforms = cfg.projects?.[projectPath]?.platforms;
+    if (platforms) delete platforms[platform];
+    saveConfig(cfg);
+    return evicted;
+  });
+}
+
+export function adoptParked({
+  platform,
+  projectPath,
+  udid,
+  device,
+}: {
+  platform: PoolPlatform;
+  projectPath: string;
+  udid: string;
+  device: DeviceRecord;
+}): ParkedSim | null {
+  return withConfigLock(() => {
+    const cfg = ensureConfig();
+    const records = readParked(platform, { config: cfg });
+    const taken = records.find((r) => r.udid === udid);
+    if (!taken) return null;
+    writeParked(
+      cfg,
+      platform,
+      records.filter((r) => r.udid !== udid),
+    );
+    const project = cfg.projects[projectPath];
+    if (!project) throw new Error(`Project not registered: ${projectPath}`);
+    project.platforms = project.platforms || {};
+    project.platforms[platform] = device;
+    saveConfig(cfg);
+    return taken;
+  });
+}
+
+export function dropParked(platform: PoolPlatform, udid: string): boolean {
+  return withConfigLock(() => {
+    const cfg = loadConfig();
+    if (!cfg) return false;
+    const records = readParked(platform, { config: cfg });
+    if (!records.some((r) => r.udid === udid)) return false;
+    writeParked(
+      cfg,
+      platform,
+      records.filter((r) => r.udid !== udid),
+    );
+    saveConfig(cfg);
+    return true;
+  });
+}

--- a/packages/stim-cli/src/sim-pool.ts
+++ b/packages/stim-cli/src/sim-pool.ts
@@ -135,7 +135,7 @@ export function parkSim({
     const cfg = ensureConfig();
     const kept = readParked(platform, { config: cfg }).filter((r) => r.udid !== record.udid);
     const { keep, evicted } = evictOverflow([...kept, record], max);
-    writeParked(cfg, platform, keep);
+    writeParked(cfg, platform, [...keep, ...evicted]);
     const platforms = cfg.projects?.[projectPath]?.platforms;
     if (platforms) delete platforms[platform];
     saveConfig(cfg);
@@ -173,18 +173,28 @@ export function adoptParked({
   });
 }
 
-export function dropParked(platform: PoolPlatform, udid: string): boolean {
+export function removeParkedAfter(
+  platform: PoolPlatform,
+  udid: string,
+  beforeRemove: (record: ParkedSim) => void,
+): ParkedSim | null {
   return withConfigLock(() => {
     const cfg = loadConfig();
-    if (!cfg) return false;
+    if (!cfg) return null;
     const records = readParked(platform, { config: cfg });
-    if (!records.some((r) => r.udid === udid)) return false;
+    const record = records.find((candidate) => candidate.udid === udid);
+    if (!record) return null;
+    beforeRemove(record);
     writeParked(
       cfg,
       platform,
-      records.filter((r) => r.udid !== udid),
+      records.filter((candidate) => candidate.udid !== udid),
     );
     saveConfig(cfg);
-    return true;
+    return record;
   });
+}
+
+export function dropParked(platform: PoolPlatform, udid: string): boolean {
+  return removeParkedAfter(platform, udid, () => {}) !== null;
 }

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -42,7 +42,11 @@ export function parseSimctlList(
   jsonOutput: string,
   { includeUnavailable = false }: { includeUnavailable?: boolean } = {},
 ): IosSimRecord[] {
-  const data = JSON.parse(jsonOutput) as {
+  const parsed: unknown = JSON.parse(jsonOutput);
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Expected simctl list to return a JSON object with a devices object.');
+  }
+  const data = parsed as {
     devices?: Record<
       string,
       Array<{
@@ -56,8 +60,12 @@ export function parseSimctlList(
       }>
     >;
   };
+  if (data.devices === null || typeof data.devices !== 'object' || Array.isArray(data.devices)) {
+    throw new Error('Expected simctl list to return a JSON object with a devices object.');
+  }
   const sims: IosSimRecord[] = [];
-  for (const [runtime, devices] of Object.entries(data.devices || {})) {
+  for (const [runtime, devices] of Object.entries(data.devices)) {
+    if (!Array.isArray(devices)) throw new Error(`Expected simctl devices for ${runtime} to be an array.`);
     if (!/\.iOS-/.test(runtime)) continue;
     for (const dev of devices) {
       const available = Boolean(dev.isAvailable);

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -64,7 +64,7 @@ export function parseSimctlList(
           throw new Error(`Expected simctl device field ${field} for ${runtime} to be a non-empty string.`);
         }
       }
-      if (record.isAvailable !== undefined && typeof record.isAvailable !== 'boolean') {
+      if (typeof record.isAvailable !== 'boolean') {
         throw new Error(`Expected simctl device field isAvailable for ${runtime} to be a boolean.`);
       }
       if (record.dataPath !== undefined && typeof record.dataPath !== 'string') {
@@ -81,7 +81,7 @@ export function parseSimctlList(
         name: string;
         state: string;
         deviceTypeIdentifier: string;
-        isAvailable?: boolean;
+        isAvailable: boolean;
         dataPath?: string;
         dataPathSize?: number;
       };

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { getExecutor } from '../exec.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
 
@@ -7,6 +10,9 @@ export interface IosSimRecord {
   state: string;
   runtime: string;
   deviceTypeIdentifier: string;
+  dataPath?: string;
+  dataPathSize?: number;
+  available: boolean;
 }
 
 export interface IosDeviceType {
@@ -32,33 +38,51 @@ export interface ResolvedIosSim {
   notOwned?: string;
 }
 
-export function parseSimctlList(jsonOutput: string): IosSimRecord[] {
+export function parseSimctlList(
+  jsonOutput: string,
+  { includeUnavailable = false }: { includeUnavailable?: boolean } = {},
+): IosSimRecord[] {
   const data = JSON.parse(jsonOutput) as {
     devices?: Record<
       string,
-      Array<{ udid: string; name: string; state: string; deviceTypeIdentifier: string; isAvailable?: boolean }>
+      Array<{
+        udid: string;
+        name: string;
+        state: string;
+        deviceTypeIdentifier: string;
+        isAvailable?: boolean;
+        dataPath?: string;
+        dataPathSize?: number;
+      }>
     >;
   };
   const sims: IosSimRecord[] = [];
   for (const [runtime, devices] of Object.entries(data.devices || {})) {
     if (!/\.iOS-/.test(runtime)) continue;
     for (const dev of devices) {
-      if (!dev.isAvailable) continue;
+      const available = Boolean(dev.isAvailable);
+      if (!available && !includeUnavailable) continue;
       sims.push({
         udid: dev.udid,
         name: dev.name,
         state: dev.state,
         runtime,
         deviceTypeIdentifier: dev.deviceTypeIdentifier,
+        available,
+        ...(typeof dev.dataPath === 'string' ? { dataPath: dev.dataPath } : {}),
+        ...(typeof dev.dataPathSize === 'number' ? { dataPathSize: dev.dataPathSize } : {}),
       });
     }
   }
   return sims;
 }
 
-export function listAllIosSims({ timeoutMs }: { timeoutMs?: number } = {}): IosSimRecord[] {
+export function listAllIosSims({
+  timeoutMs,
+  includeUnavailable = false,
+}: { timeoutMs?: number; includeUnavailable?: boolean } = {}): IosSimRecord[] {
   const out = getExecutor().run('xcrun simctl list devices --json', { timeoutMs });
-  return parseSimctlList(out);
+  return parseSimctlList(out, { includeUnavailable });
 }
 
 export function listBootedIosSims(): IosSimRecord[] {
@@ -245,15 +269,51 @@ export function sanitizeDeviceLabel(label: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
-export function ownedSimName(label: string): string {
-  const clean = sanitizeDeviceLabel(label);
-  return `stim-${clean.startsWith('stim-') ? clean.slice('stim-'.length) : clean}`;
+const SIM_NAME_MAX = 60;
+
+const PARKED_SIM_LABEL = 'parked';
+
+export interface SimModel {
+  model: string | null;
+  runtime: string | null;
 }
 
-export function createOwnedIosSim(
-  label: string,
-  { deviceType, runtime }: { deviceType?: string; runtime?: string } = {},
-): { udid: string; name: string; deviceType: string | null; runtime: string | null } {
+function fitSimName(label: string, { model, runtime }: SimModel, suffix = '', preserveLabel = false): string {
+  const version = runtime ?? '';
+  const modelName = model ?? '';
+  if (!version && !modelName) return `stim-${label}${suffix}`;
+  const fixed = `stim-`.length + ' ('.length + 1 + ')'.length + version.length + suffix.length;
+  let over = fixed + label.length + modelName.length - SIM_NAME_MAX;
+  let shortLabel = label;
+  if (over > 0 && !preserveLabel) {
+    const cut = Math.min(over, label.length);
+    shortLabel = label.slice(0, label.length - cut);
+    over -= cut;
+  }
+  const shortModel = over > 0 ? modelName.slice(0, Math.max(0, modelName.length - over)) : modelName;
+  return `stim-${shortLabel} (${shortModel} ${version})${suffix}`;
+}
+
+export function ownedSimName(label: string, model: SimModel = { model: null, runtime: null }): string {
+  const clean = sanitizeDeviceLabel(label);
+  return fitSimName(clean.startsWith('stim-') ? clean.slice('stim-'.length) : clean, model);
+}
+
+export function parkedSimName(udid: string, model: SimModel): string {
+  return fitSimName(PARKED_SIM_LABEL, model, ` ${udid.replace(/-/g, '').slice(0, 4).toLowerCase()}`, true);
+}
+
+export interface IosCreationChoice {
+  deviceTypeId: string;
+  runtimeId: string;
+  deviceType: string | null;
+  runtime: string | null;
+}
+
+export function resolveIosCreation({
+  deviceType,
+  runtime,
+}: { deviceType?: string; runtime?: string } = {}): IosCreationChoice {
   const deviceTypes = listIosDeviceTypes();
   const runtimes = listIosRuntimes();
   const pick = pickDefaultIosCreation(deviceTypes, runtimes, { deviceType, runtime });
@@ -262,14 +322,111 @@ export function createOwnedIosSim(
       'No matching simulator device type / runtime is installed. Install one via Xcode, or pass --device-type / --runtime.',
     );
   }
-  const name = ownedSimName(label);
-  const udid = getExecutor().run(`xcrun simctl create "${name}" "${pick.deviceTypeId}" "${pick.runtimeId}"`).trim();
   return {
-    udid,
-    name,
+    deviceTypeId: pick.deviceTypeId,
+    runtimeId: pick.runtimeId,
     deviceType: deviceTypes.find((d) => d.identifier === pick.deviceTypeId)?.name ?? null,
     runtime: runtimes.find((r) => r.identifier === pick.runtimeId)?.version ?? null,
   };
+}
+
+export function createOwnedIosSim(
+  label: string,
+  { deviceType, runtime }: { deviceType?: string; runtime?: string } = {},
+  choice: IosCreationChoice = resolveIosCreation({ deviceType, runtime }),
+): { udid: string; name: string; deviceType: string | null; runtime: string | null } {
+  const name = ownedSimName(label, { model: choice.deviceType, runtime: choice.runtime });
+  const udid = getExecutor().run(`xcrun simctl create "${name}" "${choice.deviceTypeId}" "${choice.runtimeId}"`).trim();
+  return { udid, name, deviceType: choice.deviceType, runtime: choice.runtime };
+}
+
+export function renameIosSim(udid: string, name: string): void {
+  getExecutor().runFile('xcrun', ['simctl', 'rename', udid, name]);
+}
+
+export function resetIosPrivacy(udid: string): void {
+  getExecutor().runFile('xcrun', ['simctl', 'privacy', udid, 'reset', 'all']);
+}
+
+export function resetIosKeychain(udid: string): void {
+  getExecutor().runFile('xcrun', ['simctl', 'keychain', udid, 'reset']);
+}
+
+export function uninstallIosApp(udid: string, bundleId: string): void {
+  getExecutor().runFile('xcrun', ['simctl', 'uninstall', udid, bundleId]);
+}
+
+interface ListedApp {
+  ApplicationType?: unknown;
+}
+
+export function parseUserApps(jsonOutput: string): string[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(jsonOutput);
+  } catch {
+    return [];
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) return [];
+  return Object.entries(data as Record<string, ListedApp>)
+    .filter(([, app]) => app !== null && typeof app === 'object' && app.ApplicationType === 'User')
+    .map(([bundleId]) => bundleId);
+}
+
+const LISTAPPS_TIMEOUT_MS = 60000;
+
+export function listUserApps(udid: string): string[] {
+  const exec = getExecutor();
+  const dir = mkdtempSync(join(tmpdir(), 'stim-listapps-'));
+  const plist = join(dir, 'apps.plist');
+  try {
+    writeFileSync(plist, exec.runFile('xcrun', ['simctl', 'listapps', udid], { timeoutMs: LISTAPPS_TIMEOUT_MS }));
+    return parseUserApps(exec.runFile('plutil', ['-convert', 'json', '-o', '-', plist]));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const CONTAINER_METADATA = '.com.apple.mobile_container_manager.metadata.plist';
+const CLEARED_CONTAINER_DIRS = ['Documents', 'Library', 'tmp', 'SystemData'];
+const PLUTIL_TIMEOUT_MS = 10000;
+
+export function findAppDataContainer(dataPath: string, bundleId: string): string | null {
+  const root = join(dataPath, 'Containers', 'Data', 'Application');
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return null;
+  }
+  const exec = getExecutor();
+  for (const entry of entries) {
+    const dir = join(root, entry);
+    let identifier: string | null;
+    try {
+      identifier = exec.runFile('plutil', ['-extract', 'MCMMetadataIdentifier', 'raw', join(dir, CONTAINER_METADATA)], {
+        timeoutMs: PLUTIL_TIMEOUT_MS,
+      });
+    } catch {
+      continue;
+    }
+    if (identifier.trim() === bundleId) return dir;
+  }
+  return null;
+}
+
+export function clearAppDataContainer(container: string): void {
+  for (const name of CLEARED_CONTAINER_DIRS) {
+    const dir = join(container, name);
+    let children: string[];
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+      children = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const child of children) rmSync(join(dir, child), { recursive: true, force: true });
+  }
 }
 
 export function resolveOwnedIosSim(udid: string): ResolvedIosSim {
@@ -288,6 +445,15 @@ export function deleteIosSim(udid: string): void {
     );
   }
   getExecutor().run(`xcrun simctl delete ${udid}`);
+}
+
+export function deleteParkedIosSim(udid: string): void {
+  const sim = listAllIosSims({ includeUnavailable: true }).find((entry) => entry.udid === udid);
+  if (!sim) return;
+  if (!sim.name.startsWith('stim-')) {
+    throw new Error(`Simulator ${udid} is now named "${sim.name}" and is not Stim-owned; refusing to delete it.`);
+  }
+  getExecutor().runFile('xcrun', ['simctl', 'delete', udid]);
 }
 
 export function listIosRuntimes(): IosRuntime[] {

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -46,20 +46,7 @@ export function parseSimctlList(
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Expected simctl list to return a JSON object with a devices object.');
   }
-  const data = parsed as {
-    devices?: Record<
-      string,
-      Array<{
-        udid: string;
-        name: string;
-        state: string;
-        deviceTypeIdentifier: string;
-        isAvailable?: boolean;
-        dataPath?: string;
-        dataPathSize?: number;
-      }>
-    >;
-  };
+  const data = parsed as { devices?: Record<string, unknown> };
   if (data.devices === null || typeof data.devices !== 'object' || Array.isArray(data.devices)) {
     throw new Error('Expected simctl list to return a JSON object with a devices object.');
   }
@@ -68,17 +55,47 @@ export function parseSimctlList(
     if (!Array.isArray(devices)) throw new Error(`Expected simctl devices for ${runtime} to be an array.`);
     if (!/\.iOS-/.test(runtime)) continue;
     for (const dev of devices) {
-      const available = Boolean(dev.isAvailable);
+      if (dev === null || typeof dev !== 'object' || Array.isArray(dev)) {
+        throw new Error(`Expected every simctl device for ${runtime} to be an object.`);
+      }
+      const record = dev as Record<string, unknown>;
+      for (const field of ['udid', 'name', 'state', 'deviceTypeIdentifier'] as const) {
+        if (typeof record[field] !== 'string' || record[field].length === 0) {
+          throw new Error(`Expected simctl device field ${field} for ${runtime} to be a non-empty string.`);
+        }
+      }
+      if (record.isAvailable !== undefined && typeof record.isAvailable !== 'boolean') {
+        throw new Error(`Expected simctl device field isAvailable for ${runtime} to be a boolean.`);
+      }
+      if (record.dataPath !== undefined && typeof record.dataPath !== 'string') {
+        throw new Error(`Expected simctl device field dataPath for ${runtime} to be a string.`);
+      }
+      if (
+        record.dataPathSize !== undefined &&
+        (typeof record.dataPathSize !== 'number' || !Number.isFinite(record.dataPathSize))
+      ) {
+        throw new Error(`Expected simctl device field dataPathSize for ${runtime} to be a finite number.`);
+      }
+      const typed = record as unknown as {
+        udid: string;
+        name: string;
+        state: string;
+        deviceTypeIdentifier: string;
+        isAvailable?: boolean;
+        dataPath?: string;
+        dataPathSize?: number;
+      };
+      const available = Boolean(typed.isAvailable);
       if (!available && !includeUnavailable) continue;
       sims.push({
-        udid: dev.udid,
-        name: dev.name,
-        state: dev.state,
+        udid: typed.udid,
+        name: typed.name,
+        state: typed.state,
         runtime,
-        deviceTypeIdentifier: dev.deviceTypeIdentifier,
+        deviceTypeIdentifier: typed.deviceTypeIdentifier,
         available,
-        ...(typeof dev.dataPath === 'string' ? { dataPath: dev.dataPath } : {}),
-        ...(typeof dev.dataPathSize === 'number' ? { dataPathSize: dev.dataPathSize } : {}),
+        ...(typed.dataPath !== undefined ? { dataPath: typed.dataPath } : {}),
+        ...(typed.dataPathSize !== undefined ? { dataPathSize: typed.dataPathSize } : {}),
       });
     }
   }
@@ -364,18 +381,23 @@ export function uninstallIosApp(udid: string, bundleId: string): void {
   getExecutor().runFile('xcrun', ['simctl', 'uninstall', udid, bundleId]);
 }
 
-interface ListedApp {
-  ApplicationType?: unknown;
-}
-
 export function parseUserApps(jsonOutput: string): string[] {
   const data: unknown = JSON.parse(jsonOutput);
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
     throw new Error('Expected simctl listapps to convert to a JSON object.');
   }
-  return Object.entries(data as Record<string, ListedApp>)
-    .filter(([, app]) => app !== null && typeof app === 'object' && app.ApplicationType === 'User')
-    .map(([bundleId]) => bundleId);
+  const userApps: string[] = [];
+  for (const [bundleId, app] of Object.entries(data as Record<string, unknown>)) {
+    if (app === null || typeof app !== 'object' || Array.isArray(app)) {
+      throw new Error(`Expected simctl listapps entry ${JSON.stringify(bundleId)} to be an object.`);
+    }
+    const applicationType = (app as Record<string, unknown>).ApplicationType;
+    if (applicationType !== 'User' && applicationType !== 'System') {
+      throw new Error(`Expected simctl listapps entry ${JSON.stringify(bundleId)} to name a known ApplicationType.`);
+    }
+    if (applicationType === 'User') userApps.push(bundleId);
+  }
+  return userApps;
 }
 
 const LISTAPPS_TIMEOUT_MS = 60000;
@@ -401,20 +423,18 @@ export function findAppDataContainer(dataPath: string, bundleId: string): string
   let entries: string[];
   try {
     entries = readdirSync(root);
-  } catch {
-    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+    throw error;
   }
   const exec = getExecutor();
   for (const entry of entries) {
     const dir = join(root, entry);
-    let identifier: string | null;
-    try {
-      identifier = exec.runFile('plutil', ['-extract', 'MCMMetadataIdentifier', 'raw', join(dir, CONTAINER_METADATA)], {
-        timeoutMs: PLUTIL_TIMEOUT_MS,
-      });
-    } catch {
-      continue;
-    }
+    const identifier = exec.runFile(
+      'plutil',
+      ['-extract', 'MCMMetadataIdentifier', 'raw', join(dir, CONTAINER_METADATA)],
+      { timeoutMs: PLUTIL_TIMEOUT_MS },
+    );
     if (identifier.trim() === bundleId) return dir;
   }
   return null;
@@ -425,10 +445,11 @@ export function clearAppDataContainer(container: string): void {
     const dir = join(container, name);
     let children: string[];
     try {
-      if (!statSync(dir).isDirectory()) continue;
+      if (!statSync(dir).isDirectory()) throw new Error(`Expected app data path ${dir} to be a directory.`);
       children = readdirSync(dir);
-    } catch {
-      continue;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') continue;
+      throw error;
     }
     for (const child of children) rmSync(join(dir, child), { recursive: true, force: true });
   }
@@ -452,13 +473,17 @@ export function deleteIosSim(udid: string): void {
   getExecutor().run(`xcrun simctl delete ${udid}`);
 }
 
+const PARKED_DELETE_TIMEOUT_MS = 30000;
+
 export function deleteParkedIosSim(udid: string): void {
-  const sim = listAllIosSims({ includeUnavailable: true }).find((entry) => entry.udid === udid);
+  const sim = listAllIosSims({ includeUnavailable: true, timeoutMs: PARKED_DELETE_TIMEOUT_MS }).find(
+    (entry) => entry.udid === udid,
+  );
   if (!sim) return;
   if (!sim.name.startsWith('stim-')) {
     throw new Error(`Simulator ${udid} is now named "${sim.name}" and is not Stim-owned; refusing to delete it.`);
   }
-  getExecutor().runFile('xcrun', ['simctl', 'delete', udid]);
+  getExecutor().runFile('xcrun', ['simctl', 'delete', udid], { timeoutMs: PARKED_DELETE_TIMEOUT_MS });
 }
 
 export function listIosRuntimes(): IosRuntime[] {

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -361,13 +361,10 @@ interface ListedApp {
 }
 
 export function parseUserApps(jsonOutput: string): string[] {
-  let data: unknown;
-  try {
-    data = JSON.parse(jsonOutput);
-  } catch {
-    return [];
+  const data: unknown = JSON.parse(jsonOutput);
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Expected simctl listapps to convert to a JSON object.');
   }
-  if (data === null || typeof data !== 'object' || Array.isArray(data)) return [];
   return Object.entries(data as Record<string, ListedApp>)
     .filter(([, app]) => app !== null && typeof app === 'object' && app.ApplicationType === 'User')
     .map(([bundleId]) => bundleId);

--- a/packages/stim-cli/src/status.ts
+++ b/packages/stim-cli/src/status.ts
@@ -1,4 +1,4 @@
-import { clockTime, formatElapsed } from './command-output.ts';
+import { clockTime, formatElapsed, plural } from './command-output.ts';
 import type { ProjectRecord } from './config.ts';
 import type { LeaseFileEntry } from './engine/device-lease.ts';
 
@@ -59,6 +59,18 @@ export interface DiskInfo {
 export interface VolumeInfo {
   volume: string;
   disk: DiskInfo | null;
+}
+
+export interface PoolFacts {
+  platform: 'ios' | 'android';
+  parked: number;
+  max: number;
+}
+
+export function poolLine({ platform, parked, max }: PoolFacts): string | null {
+  if (parked <= 0) return null;
+  const what = plural(parked, `parked ${platform === 'ios' ? 'iOS simulator' : 'Android emulator'}`);
+  return max > 0 ? `pool: ${what} (max ${max})` : `pool: ${what} (parking off; gc --delete removes them)`;
 }
 
 export function environmentState(

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -1,5 +1,23 @@
-import { resolveOwnedIosSim, shutdownIosSim, deleteIosSim } from './sim/ios.ts';
+import {
+  clearAppDataContainer,
+  deleteParkedIosSim,
+  deleteIosSim,
+  findAppDataContainer,
+  listIosDeviceTypes,
+  parkedSimName,
+  parseRuntimeVersion,
+  renameIosSim,
+  resolveOwnedIosSim,
+  shutdownIosSim,
+  type IosSimRecord,
+} from './sim/ios.ts';
 import { resolveOwnedAvdSerial, shutdownAndroidEmulator, deleteAvd } from './sim/android.ts';
+import { parkSim, type ParkedSim } from './sim-pool.ts';
+
+export interface ParkedDevice {
+  udid: string;
+  name: string;
+}
 
 export interface TeardownOutcome {
   status: 'torn-down' | 'missing' | 'skipped' | 'failed';
@@ -8,12 +26,53 @@ export interface TeardownOutcome {
   reason?: string;
   serial?: string | null;
   holders?: string[];
+  parked?: ParkedDevice;
+  evicted?: ParkedDevice[];
+  evictionFailures?: string[];
+  parkFallback?: string;
+}
+
+export interface ParkRequest {
+  projectPath: string;
+  max: number;
+  bundleId?: string | null;
+  cacheKey?: string | null;
+  simslimManaged?: boolean;
+}
+
+function parkOwnedIosSim(udid: string, park: ParkRequest): { record: ParkedSim; evicted: ParkedSim[] } {
+  const resolved = resolveOwnedIosSim(udid);
+  if (resolved.missing) throw new Error(`simulator ${udid} disappeared after shutdown`);
+  if (resolved.notOwned) throw new Error(`simulator ${udid} is now named ${JSON.stringify(resolved.notOwned)}`);
+  const sim = resolved.sim as IosSimRecord;
+  if (sim.state !== 'Shutdown') throw new Error(`simulator ${udid} is still ${sim.state} after shutdown`);
+  const model = listIosDeviceTypes().find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null;
+  const runtime = parseRuntimeVersion(sim.runtime);
+  if (park.bundleId && sim.dataPath) {
+    const container = findAppDataContainer(sim.dataPath, park.bundleId);
+    if (container) clearAppDataContainer(container);
+  }
+  const name = parkedSimName(sim.udid, { model, runtime });
+  renameIosSim(sim.udid, name);
+  const record: ParkedSim = {
+    udid: sim.udid,
+    name,
+    deviceTypeIdentifier: sim.deviceTypeIdentifier,
+    runtimeIdentifier: sim.runtime,
+    parkedAt: new Date().toISOString(),
+    simslimManaged: Boolean(park.simslimManaged),
+    ...(park.bundleId ? { bundleId: park.bundleId } : {}),
+    ...(park.cacheKey ? { cacheKey: park.cacheKey } : {}),
+  };
+  const evicted = parkSim({ platform: 'ios', projectPath: park.projectPath, record, max: park.max });
+  return { record, evicted };
 }
 
 export function teardownOwnedIosSim(
   udid: string,
-  { del = false, label }: { del?: boolean; label?: string } = {},
+  { del = false, label, park }: { del?: boolean; label?: string; park?: ParkRequest } = {},
 ): TeardownOutcome {
+  let parkFallback: string | undefined;
   try {
     const resolved = resolveOwnedIosSim(udid);
     if (resolved.notOwned) {
@@ -25,10 +84,41 @@ export function teardownOwnedIosSim(
     }
     if (resolved.missing) return { status: 'missing' };
     shutdownIosSim(udid);
+    const sim = resolved.sim as IosSimRecord;
+    if (del && park && park.max > 0) {
+      try {
+        const { record, evicted } = parkOwnedIosSim(udid, park);
+        const removed: ParkedDevice[] = [];
+        const failures: string[] = [];
+        for (const entry of evicted) {
+          try {
+            deleteParkedIosSim(entry.udid);
+            removed.push({ udid: entry.udid, name: entry.name });
+          } catch (e) {
+            failures.push(
+              `could not delete evicted ${entry.name} (${entry.udid}): ${String((e as Error)?.message || e)}`,
+            );
+          }
+        }
+        return {
+          status: 'torn-down',
+          label: label ?? sim.name ?? udid,
+          parked: { udid: record.udid, name: record.name },
+          evicted: removed,
+          ...(failures.length ? { evictionFailures: failures } : {}),
+        };
+      } catch (e) {
+        parkFallback = String((e as Error)?.message || e);
+      }
+    }
     if (del) deleteIosSim(udid);
-    return { status: 'torn-down', label: label ?? resolved.sim?.name ?? udid };
+    return { status: 'torn-down', label: label ?? sim.name ?? udid, ...(parkFallback ? { parkFallback } : {}) };
   } catch (e) {
-    return { status: 'failed', reason: String((e as Error)?.message || e) };
+    return {
+      status: 'failed',
+      reason: String((e as Error)?.message || e),
+      ...(parkFallback ? { parkFallback } : {}),
+    };
   }
 }
 

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -61,7 +61,8 @@ function parkOwnedIosSim(udid: string, park: ParkRequest): { record: ParkedSim; 
   if (sim.state !== 'Shutdown') throw new Error(`simulator ${udid} is still ${sim.state} after shutdown`);
   const model = listIosDeviceTypes().find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null;
   const runtime = parseRuntimeVersion(sim.runtime);
-  if (park.bundleId && sim.dataPath) {
+  if (park.bundleId) {
+    if (!sim.dataPath) throw new Error(`simulator ${udid} did not report a data path for app cleanup`);
     const container = findAppDataContainer(sim.dataPath, park.bundleId);
     if (container) clearAppDataContainer(container);
   }

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -12,7 +12,7 @@ import {
   type IosSimRecord,
 } from './sim/ios.ts';
 import { resolveOwnedAvdSerial, shutdownAndroidEmulator, deleteAvd } from './sim/android.ts';
-import { parkSim, type ParkedSim } from './sim-pool.ts';
+import { parkSim, removeParkedAfter, type ParkedSim } from './sim-pool.ts';
 
 export interface ParkedDevice {
   udid: string;
@@ -92,8 +92,8 @@ export function teardownOwnedIosSim(
         const failures: string[] = [];
         for (const entry of evicted) {
           try {
-            deleteParkedIosSim(entry.udid);
-            removed.push({ udid: entry.udid, name: entry.name });
+            const deleted = removeParkedAfter('ios', entry.udid, () => deleteParkedIosSim(entry.udid));
+            if (deleted) removed.push({ udid: entry.udid, name: entry.name });
           } catch (e) {
             failures.push(
               `could not delete evicted ${entry.name} (${entry.udid}): ${String((e as Error)?.message || e)}`,

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -40,6 +40,19 @@ export interface ParkRequest {
   simslimManaged?: boolean;
 }
 
+export function teardownParkedIosSim(
+  udid: string,
+  { label, deleteSim = deleteParkedIosSim }: { label?: string; deleteSim?: typeof deleteParkedIosSim } = {},
+): TeardownOutcome {
+  try {
+    const removed = removeParkedAfter('ios', udid, () => deleteSim(udid));
+    if (!removed) return { status: 'skipped', kind: 'not-parked', reason: 'simulator is no longer parked' };
+    return { status: 'torn-down', label: label ?? removed.name };
+  } catch (error) {
+    return { status: 'failed', reason: String((error as Error)?.message || error) };
+  }
+}
+
 function parkOwnedIosSim(udid: string, park: ParkRequest): { record: ParkedSim; evicted: ParkedSim[] } {
   const resolved = resolveOwnedIosSim(udid);
   if (resolved.missing) throw new Error(`simulator ${udid} disappeared after shutdown`);
@@ -91,13 +104,11 @@ export function teardownOwnedIosSim(
         const removed: ParkedDevice[] = [];
         const failures: string[] = [];
         for (const entry of evicted) {
-          try {
-            const deleted = removeParkedAfter('ios', entry.udid, () => deleteParkedIosSim(entry.udid));
-            if (deleted) removed.push({ udid: entry.udid, name: entry.name });
-          } catch (e) {
-            failures.push(
-              `could not delete evicted ${entry.name} (${entry.udid}): ${String((e as Error)?.message || e)}`,
-            );
+          const result = teardownParkedIosSim(entry.udid, { label: entry.name });
+          if (result.status === 'torn-down') {
+            removed.push({ udid: entry.udid, name: entry.name });
+          } else if (result.status === 'failed') {
+            failures.push(`could not delete evicted ${entry.name} (${entry.udid}): ${result.reason}`);
           }
         }
         return {

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -72,6 +72,8 @@ export interface StimConfig {
   projects: Record<string, ProjectRecord>;
   repos: Record<string, RepoRecord>;
   concurrency?: { maxBuilds?: unknown; maxDevices?: unknown };
+  pool?: { iosParkedMax?: unknown; androidParkedMax?: unknown };
+  parked?: { ios?: unknown; android?: unknown };
   caches?: { buildCache?: unknown; metroCache?: unknown; injectMetroStore?: unknown };
   [key: string]: unknown;
 }

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -67,6 +67,8 @@ const ENV = {
   STIM_METRO_CACHE: METRO_CACHE_ROOT,
   TMPDIR: CACHE_TMP_DIR,
   CI: '1',
+  STIM_POOL_IOS_PARKED_MAX: '0',
+  STIM_POOL_ANDROID_PARKED_MAX: '0',
 };
 process.env.STIM_HOME = HOME_DIR;
 // Android runs get a throwaway gradle home so build-cache-1 starts empty and

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -34,7 +34,13 @@ const COMPILE_SIGNS =
 
 const HOME_DIR = args.dryRun ? '<dry-run>' : args.home || mkdtempSync(join(tmpdir(), `stim-native-${VARIANT}-home-`));
 const WORK_DIR = args.dryRun ? '<dry-run>' : mkdtempSync(join(tmpdir(), `stim-native-${VARIANT}-`));
-const ENV = { ...process.env, STIM_HOME: HOME_DIR, CI: '1' };
+const ENV = {
+  ...process.env,
+  STIM_HOME: HOME_DIR,
+  CI: '1',
+  STIM_POOL_IOS_PARKED_MAX: '0',
+  STIM_POOL_ANDROID_PARKED_MAX: '0',
+};
 process.env.STIM_HOME = HOME_DIR;
 const WARM_CACHE = process.env.STIM_E2E_WARM_CACHE === '1';
 

--- a/test/e2e/native/run-pool-e2e.mjs
+++ b/test/e2e/native/run-pool-e2e.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  FIXTURE_COMMANDS,
+  assert,
+  cleanupTmp,
+  createFixture,
+  createHarness,
+  dumpDiagnostics,
+  preflight,
+  quote,
+  verifyCleanup,
+} from './harness.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, '..', '..', '..');
+const CLI = join(REPO, 'packages', 'stim-cli', 'dist', 'cli.mjs');
+const PLATFORM = 'ios';
+const PARKED_MAX = '1';
+
+const args = parseArgs(process.argv.slice(2));
+const FRAMEWORK = args.framework;
+const HOME_DIR = args.dryRun ? '<dry-run>' : args.home || mkdtempSync(join(tmpdir(), `stim-pool-${FRAMEWORK}-home-`));
+const WORK_DIR = args.dryRun ? '<dry-run>' : mkdtempSync(join(tmpdir(), `stim-pool-${FRAMEWORK}-`));
+const ENV = { ...process.env, STIM_HOME: HOME_DIR, CI: '1', STIM_POOL_IOS_PARKED_MAX: PARKED_MAX };
+process.env.STIM_HOME = HOME_DIR;
+
+const h = createHarness({ env: ENV, cliPath: CLI, label: `pool-e2e ${FRAMEWORK}` });
+const { cli, sh, log, banner, die } = h;
+
+const created = [];
+
+async function main() {
+  preflight(h, PLATFORM);
+
+  const appDir = args.appDir
+    ? resolve(args.appDir)
+    : createFixture({ framework: FRAMEWORK, platform: PLATFORM, workDir: WORK_DIR, h });
+
+  banner('two workspaces on an empty pool: both create');
+  const wt1 = worktreeCreate('pool-1', appDir);
+  const first = runIos(wt1);
+  assert(first.adopted === false, `wt1 ran on an empty pool and must have created, not adopted:\n${first.deviceLine}`);
+  const wt2 = worktreeCreate('pool-2', appDir);
+  const second = runIos(wt2);
+  assert(second.adopted === false, `wt2 must have created its own sim, not adopted:\n${second.deviceLine}`);
+  assert(second.udid !== first.udid, 'two workspaces shared one simulator');
+
+  banner('remove: the first parks');
+  cli(['stop'], { cwd: wt1 });
+  const removed1 = worktreeRemove(wt1);
+  assert(/ {2}device {6}parked stim-parked /.test(removed1), `worktree remove did not park:\n${removed1}`);
+  assertPoolSize(1);
+
+  banner('remove: the second parks and evicts the first');
+  cli(['stop'], { cwd: wt2 });
+  const removed2 = worktreeRemove(wt2);
+  assert(/ {2}device {6}parked stim-parked /.test(removed2), `the second remove did not park:\n${removed2}`);
+  assert(
+    new RegExp(` {2}device {6}deleted stim-parked .* \\(pool over ${PARKED_MAX}\\)`).test(removed2),
+    `the second remove did not evict the oldest parked sim:\n${removed2}`,
+  );
+  assertPoolSize(1);
+  assertSimCount(1);
+
+  banner('a third workspace adopts');
+  const wt3 = worktreeCreate('pool-3', appDir);
+  const third = runIos(wt3);
+  assert(third.adopted === true, `wt3 must have adopted the parked simulator:\n${third.deviceLine}`);
+  assert(third.udid === second.udid, `wt3 adopted ${third.udid}, not the parked ${second.udid}`);
+  assertPoolSize(0);
+
+  banner('remove: the third parks');
+  cli(['stop'], { cwd: wt3 });
+  const removed3 = worktreeRemove(wt3);
+  assert(/ {2}device {6}parked stim-parked /.test(removed3), `the third remove did not park:\n${removed3}`);
+  assertPoolSize(1);
+
+  banner('gc --delete empties the pool');
+  const gc = cli(['gc'], { allowFail: true });
+  assert(/^Parked simulators \(1/m.test(gc.stdout), `gc did not report the pool:\n${gc.stdout}`);
+  const deleted = cli(['gc', '--delete']);
+  assert(
+    /Deleted parked ios sim /.test(deleted.stdout),
+    `gc --delete did not delete the parked sim:\n${deleted.stdout}`,
+  );
+  assertPoolSize(0);
+
+  verifyCleanup({ h, platform: PLATFORM, appDir, created });
+}
+
+function worktreeCreate(name, appDir) {
+  const r = cli(['worktree', 'create', name, '--base', 'head', '--carry-ignored'], { cwd: appDir });
+  const path = r.stdout.trim().split('\n').findLast(Boolean);
+  assert(path && existsSync(path), `worktree create did not yield a real path: ${JSON.stringify(r.stdout)}`);
+  created.push(path);
+  log(`worktree ${name} -> ${path}`);
+  return path;
+}
+
+function runIos(cwd) {
+  cli(['start', '--json', '--wait', '240'], { cwd });
+  const r = cli([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
+  const facts = JSON.parse(r.stdout.trim().split('\n').findLast(Boolean));
+  const deviceLine = r.stderr.split('\n').find((line) => / {2}device {6}.*(booted|adopted) /.test(line)) ?? '';
+  log(`device line: ${deviceLine.trim()}`);
+  return { udid: facts.udid, adopted: / adopted /.test(deviceLine), deviceLine };
+}
+
+function worktreeRemove(path) {
+  sh('git', ['-C', path, 'checkout', '--', '.'], { allowFail: true });
+  sh('git', ['-C', path, 'clean', '-fdq', 'ios', 'android'], { allowFail: true });
+  const r = cli(['worktree', 'remove', path], { allowFail: true });
+  assert(r.code === 0, `worktree remove refused a clean worktree:\n${r.stderr}`);
+  log(`removed worktree ${path}`);
+  return r.stderr;
+}
+
+function assertPoolSize(expected) {
+  const status = cli(['status'], { allowFail: true }).stdout;
+  const line = /^pool: (\d+) parked iOS simulators?/m.exec(status);
+  const actual = line ? Number(line[1]) : 0;
+  assert(actual === expected, `pool holds ${actual} parked simulators, expected ${expected}:\n${status}`);
+  log(`pool: ${actual} parked`);
+}
+
+function assertSimCount(expected) {
+  const out = sh('xcrun', ['simctl', 'list', 'devices']).stdout;
+  const actual = out.split('\n').filter((line) => line.includes('stim-')).length;
+  assert(actual === expected, `${actual} stim-* simulators exist, expected ${expected}:\n${out}`);
+}
+
+function cleanupAfterFailure() {
+  for (const path of created.toReversed()) {
+    if (!existsSync(path)) continue;
+    cli(['stop'], { cwd: path, allowFail: true });
+    sh('git', ['-C', path, 'checkout', '--', '.'], { allowFail: true });
+    sh('git', ['-C', path, 'clean', '-fdq', 'ios', 'android'], { allowFail: true });
+    cli(['worktree', 'remove', path, '--force'], { allowFail: true });
+  }
+  cli(['gc', '--delete'], { allowFail: true });
+}
+
+function parseArgs(argv) {
+  const out = { framework: 'expo', appDir: null, keep: false, dryRun: false, home: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--framework') out.framework = argv[++i];
+    else if (a === '--app-dir') out.appDir = argv[++i];
+    else if (a === '--home') out.home = argv[++i];
+    else if (a === '--keep') out.keep = true;
+    else if (a === '--dry-run') out.dryRun = true;
+    else {
+      process.stderr.write(`[pool-e2e] ERROR: unknown arg: ${a}\n`);
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+if (!['bare', 'expo'].includes(FRAMEWORK)) {
+  die('usage: run-pool-e2e.mjs [--framework <bare|expo>] [--app-dir P] [--keep] [--dry-run]');
+}
+
+banner(`pool e2e: ${FRAMEWORK}-ios (STIM_POOL_IOS_PARKED_MAX=${PARKED_MAX})`);
+log(`STIM_HOME=${HOME_DIR}`);
+log(`work dir=${WORK_DIR}`);
+log(
+  args.appDir
+    ? `using existing app: ${resolve(args.appDir)}`
+    : `fixture: ${FIXTURE_COMMANDS[FRAMEWORK]('<appDir>').map(quote).join(' ')}`,
+);
+if (args.dryRun) {
+  log('dry run: no side effects. Exiting.');
+  process.exit(0);
+}
+
+main().then(
+  () => {
+    log(`PASS pool ${FRAMEWORK}-ios`);
+    if (!args.keep) cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR]);
+    process.exit(0);
+  },
+  (err) => {
+    log(`FAIL pool ${FRAMEWORK}-ios: ${err?.message || err}`);
+    dumpDiagnostics(h, created);
+    cleanupAfterFailure();
+    if (!args.keep) cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR]);
+    process.exit(1);
+  },
+);

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -94,6 +94,7 @@ Run `stim guide settings` for the complete key and value list.
 ```json
 {
   "concurrency": { "maxBuilds": 2, "maxDevices": 3 },
+  "pool": { "iosParkedMax": 3 },
   "caches": {
     "buildCache": "/Volumes/Cache/stim/build-cache",
     "metroCache": "/Volumes/Cache/stim/metro-cache"
@@ -101,20 +102,25 @@ Run `stim guide settings` for the complete key and value list.
 }
 ```
 
+`pool.iosParkedMax` bounds the simulators `worktree remove` parks for a later
+workspace to adopt. Absent means 3; `0` turns parking and adoption off. When
+`STIM_HOME` is set, parking is off unless `STIM_POOL_IOS_PARKED_MAX` is set too.
+
 The committed `.stim.json` `caches` key and this machine-file `caches` key are
 different shapes: the committed key is an array of extra paths for `gc` to
 report, and this machine-file key is an object of named cache locations.
 
 ## Environment variables
 
-| Variable                | Purpose                                |
-| ----------------------- | -------------------------------------- |
-| `STIM_HOME`             | Runtime state root. Default: `~/.stim` |
-| `STIM_BUILD_CACHE`      | Native artifact cache root             |
-| `STIM_METRO_CACHE`      | Metro transform cache root             |
-| `STIM_MAX_BUILDS`       | Maximum concurrent native builds       |
-| `STIM_MAX_DEVICES`      | Maximum booted owned devices           |
-| `STIM_METRO_PUBLIC_URL` | Public Metro URL for remote use        |
+| Variable                   | Purpose                                |
+| -------------------------- | -------------------------------------- |
+| `STIM_HOME`                | Runtime state root. Default: `~/.stim` |
+| `STIM_BUILD_CACHE`         | Native artifact cache root             |
+| `STIM_METRO_CACHE`         | Metro transform cache root             |
+| `STIM_MAX_BUILDS`          | Maximum concurrent native builds       |
+| `STIM_MAX_DEVICES`         | Maximum booted owned devices           |
+| `STIM_POOL_IOS_PARKED_MAX` | Maximum parked simulators              |
+| `STIM_METRO_PUBLIC_URL`    | Public Metro URL for remote use        |
 
 Proxy remote devices also use `AGENT_DEVICE_DAEMON_BASE_URL` and
 `AGENT_DEVICE_DAEMON_AUTH_TOKEN`. Those variables belong to the optional proxy


### PR DESCRIPTION
## Description

A cache-hit iOS run in a fresh worktree still paid the simulator's first boot: 30-35 seconds locally, versus about 9 seconds after that simulator had booted once. `worktree remove` deleted the owned simulator, so no later workspace could reuse that warmed state.

This implements phase 1 of the simulator-pool design for owned iOS simulators. The blast radius is the local iOS lifecycle: `worktree remove`, the next `ios` run, `status`, and `gc`. A parked simulator retains some system-level state (Safari data, pasteboard, photos, profiles, and Simulator settings); app data, privacy grants, keychain state, and apps from other workspaces are cleared. Projects that require a clean system image can set the pool bound to `0`.

## Solution

`worktree remove` now shuts down an owned simulator, clears the departing app's container, renames it, and atomically transfers its ownership record into a bounded pool. The default bound is three; redirected `STIM_HOME` environments opt out unless they explicitly set `STIM_POOL_IOS_PARKED_MAX`, keeping tests and temporary homes hermetic.

An `ios` run adopts the oldest exact device-type/runtime match before creating a simulator. It revalidates the live simulator's Stim-owned name as well as its model and runtime before transferring ownership. Privacy and keychain resets overlap the boot, other user apps are removed before install proof, and the parked build key cheaply rules out an impossible unchanged-install result. Adoption remains retryable across crashes through a persisted pending marker. If app listing or removal cannot be proven complete, Stim retains that marker and refuses before install or launch. Parking likewise falls back to ownership-checked deletion if the departing app's data path, container directories, or metadata cannot be proven readable and cleared.

`gc` reports and deletes pool entries. Every parked-simulator deletion now routes through the centralized teardown path and uses a persisted, PID-live deletion claim around the timeout-bounded `simctl` work. Adoption honors that claim, and only the matching deletion token can finalize or clear it, so neither the ordinary config-lock stale window nor a concurrent workspace can transfer and then lose the same simulator. Structurally invalid `simctl` JSON, missing required availability fields, malformed device records, and malformed app records fail closed. A failed simulator listing or deletion retains the ownership record for a later `gc`, and failed overflow eviction can temporarily leave the pool above its bound rather than orphaning the simulator.

This is stacked on #275, which is stacked on #272; the pool relies on their boot/fingerprint overlap. The pool implementation and review hardening are the final five commits on this branch.

## Test plan

- Ran `node test/e2e/native/run-pool-e2e.mjs --framework expo` on an iPhone 17 / iOS 26.5 simulator. It created two distinct simulators, parked and evicted at a bound of one, adopted the survivor in 9.6 seconds, proved the retained app unchanged in 291 ms, then left no simulator, process, worktree, or registry entry after `gc --delete`.
- Exercised the changed real `simctl` calls on a bounded scratch simulator: create, boot, privacy reset, keychain reset, listapps/plutil parsing, shutdown rename, re-boot, shutdown, and delete. Fresh boot completed in 35 seconds; the warmed re-boot completed in 9 seconds.
- Added regressions for GC/adoption races, a cross-process deletion exceeding the ordinary 10-second lock stale window, renamed-away ownership before adoption, failed simulator enumeration, structurally invalid and incomplete `simctl` records, timeout-bounded parked deletion, failed overflow eviction, missing or unreadable departing app data, incomplete cross-workspace app cleanup, malformed app-list JSON, ownership re-resolution on parking fallback, and platform-correct installed-app hints.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm test` (3,390 tests), `pnpm run test:e2e` (20 tests), `pnpm run test:runtime`, and `pnpm run knip` pass. `knip` retains its existing `pod` configuration hint.

Fixes #273
