### PR TITLE
fix: accept slash-separated worktree names

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -34,8 +34,12 @@ stim stop
 Create a warm isolated worktree with:
 
 ```bash
-stim worktree create feature-name --carry-ignored
+stim worktree create feature/settings --carry-ignored
 ```
+
+Slash-separated names keep the matching Git branch hierarchy while the
+worktree itself remains one directory under the configured worktree root. Its
+default device label includes a stable hash so a flat name cannot collide.
 
 Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -63,6 +63,15 @@ test('the lifecycle topic shows the lifecycle commands in the same label column'
   expect(body).toMatch(/port\s+released 8084/);
 });
 
+test('the lifecycle topic documents slash-separated worktree names', () => {
+  const body = renderTopic('lifecycle');
+  assert(body);
+  expect(body).toMatch(/worktree create app\/412/);
+  expect(body).toMatch(/worktree-app\/412/);
+  expect(body).toMatch(/encoded directory directly under worktreeDir/);
+  expect(body).toMatch(/device labels include a stable hash/);
+});
+
 test('the errors topic names the two device fallbacks under the label that prints them', () => {
   const body = renderTopic('errors');
   assert(body);

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -151,6 +151,30 @@ test('create action: success path writes exactly one stdout line, the worktree p
   }
 });
 
+test('create action: slash name keeps the Git hierarchy in one worktree directory', async () => {
+  resetExecutor();
+  const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-slash-')));
+  const repo = join(base, 'repo');
+  try {
+    initScratchRepo(repo);
+
+    const { logs } = await runCreateInRepo(repo, 'bench/run-1', {});
+
+    const expected = join(defaultWorktreeDir(repo), 'bench%2Frun-1');
+    expect(logs).toEqual([expected]);
+    expect(realpathSync(expected)).toBe(expected);
+    expect(execSync('git branch --show-current', { cwd: expected, encoding: 'utf-8' })).toBe('worktree-bench/run-1\n');
+    expect(getProject(expected)).toMatchObject({
+      label: expect.stringMatching(/^[0-9a-f]{8}-bench-run-1$/),
+      worktreeBranch: 'worktree-bench/run-1',
+      worktreeBranchOwned: true,
+    });
+  } finally {
+    process.exitCode = 0;
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('create action: a nested create records the repository main checkout', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-create-nested-')));

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -6,6 +6,8 @@ import { join, dirname } from 'node:path';
 import { setExecutor, resetExecutor } from '../exec.ts';
 import {
   defaultWorktreeDir,
+  defaultWorktreeLabel,
+  isValidWorktreeName,
   worktreePath,
   matchesInclude,
   isCarrySkipped,
@@ -39,6 +41,20 @@ test('default worktree dir is a sibling of the repo', () => {
 
 test('worktreePath joins the dir and the name', () => {
   expect(worktreePath({ worktreeDir: '/wt', name: 'feat-x' })).toBe('/wt/feat-x');
+  expect(worktreePath({ worktreeDir: '/wt', name: 'bench/run-1' })).toBe('/wt/bench%2Frun-1');
+});
+
+test('worktree names accept safe branch paths without accepting traversal or invalid refs', () => {
+  expect(isValidWorktreeName('bench/run-1')).toBe(true);
+  for (const name of ['bench//run', '/bench', 'bench/', 'bench/../run', 'bench/.hidden', 'bench/run.lock']) {
+    expect(isValidWorktreeName(name)).toBe(false);
+  }
+});
+
+test('slash worktree names get collision-resistant device labels while flat names stay unchanged', () => {
+  expect(defaultWorktreeLabel('bench-run-1')).toBe('bench-run-1');
+  expect(defaultWorktreeLabel('bench/run-1')).toMatch(/^[0-9a-f]{8}-bench-run-1$/);
+  expect(defaultWorktreeLabel('bench/run-1')).not.toBe(defaultWorktreeLabel('bench-run-1'));
 });
 
 test('matchesInclude supports gitignore-style patterns', () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1500,7 +1500,11 @@ STIM_CONFIG_CORRUPT  ("Stim config at <path> is not valid JSON")
   # 1. Isolated worktree (skip if you are already in one).
   #    It branches from the current HEAD. Use --base fresh for origin/HEAD.
   #    It does NOT install dependencies -- that is yours.
-  cd "$(stim worktree create app-412 --carry-ignored)"
+  cd "$(stim worktree create app/412 --carry-ignored)"
+
+  # Slash-separated names create branches such as worktree-app/412 while the
+  # checkout remains one encoded directory directly under worktreeDir. Their
+  # default device labels include a stable hash so flat names cannot collide.
 
   # 2. The dev server, under a detached supervisor. Blocks until it is
   #    verifiably THIS project's, then hands your shell back.

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -19,6 +19,7 @@ import {
   carryUncommittedChanges,
   depsOutOfSync,
   deleteBranch,
+  defaultWorktreeLabel,
   cloneIgnoredEntries,
   defaultWorktreeDir,
   dirtyPaths,
@@ -26,6 +27,7 @@ import {
   hasRemote,
   hasUncommittedWork,
   isMainWorkingTree,
+  isValidWorktreeName,
   isPodInstallChurn,
   listCarryableIgnoredEntries,
   listTrackedPaths,
@@ -212,9 +214,11 @@ export function registerCreate(worktree: Command): void {
       "clone the source's working state: every safe gitignored path (node_modules, Pods, build output) except nested Git worktrees and paths in .worktreeexclude, plus its uncommitted tracked changes (applied when they fit this base)",
     )
     .action(async (name, opts) => {
-      if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+      if (!isValidWorktreeName(name)) {
         console.error(
-          chalk.red(`Invalid worktree name: "${name}". Use only letters, numbers, dots, dashes, and underscores.`),
+          chalk.red(
+            `Invalid worktree name: "${name}". Use slash-separated names made from letters, numbers, dots, dashes, and underscores.`,
+          ),
         );
         process.exitCode = 1;
         return;
@@ -395,7 +399,7 @@ export function registerCreate(worktree: Command): void {
 
       const mainRoot = listWorktrees(root).find((candidate) => isMainWorkingTree(candidate.path))?.path || root;
       upsertProject(target, {
-        label: opts.label || name,
+        label: opts.label || defaultWorktreeLabel(name),
         worktreeRoot: true,
         worktreeBranch: branch,
         worktreeBranchOwned: !reusedBranch,

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -11,6 +11,7 @@ import {
 } from 'fs';
 import { tmpdir } from 'os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
+import { createHash } from 'node:crypto';
 import { getExecutor } from './exec.ts';
 
 const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
@@ -59,8 +60,20 @@ export function defaultWorktreeDir(root: string): string {
   return join(dirname(root), `${basename(root)}-worktrees`);
 }
 
+export function isValidWorktreeName(name: string): boolean {
+  if (!/^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/.test(name)) return false;
+  if (name.includes('..') || name.endsWith('.')) return false;
+  return name.split('/').every((segment) => !segment.startsWith('.') && !segment.endsWith('.lock'));
+}
+
 export function worktreePath({ worktreeDir, name }: { worktreeDir: string; name: string }): string {
-  return join(worktreeDir, name);
+  return join(worktreeDir, encodeURIComponent(name));
+}
+
+export function defaultWorktreeLabel(name: string): string {
+  if (!name.includes('/')) return name;
+  const digest = createHash('sha256').update(name).digest('hex').slice(0, 8);
+  return `${digest}-${name.replaceAll('/', '-')}`;
 }
 
 export function matchesInclude(path: string, patterns: string[] | null | undefined): boolean {


### PR DESCRIPTION
## Description

`stim worktree create bench/run-1` currently rejects the name before invoking Git, even though slash-separated branch names are valid and common in agent workflows. That forces callers to flatten the name and sometimes rename the generated branch manually.

## Solution

Accept a restricted set of slash-separated components and keep the hierarchy in the generated branch, such as `worktree-bench/run-1`. The checkout uses the encoded single-directory name `bench%2Frun-1`, avoiding nested paths and traversal while preserving existing paths for names without slashes.

Flat names retain their current default labels. Slash names receive a stable SHA-256 prefix before the readable flattened label, so they cannot alias a flat name across iOS truncation, Android AVDs, or remote sessions.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (3,394 tests passed)
- `pnpm run test:e2e` (20 tests passed)
- Focused worktree and guide suites passed 259 tests, including a collision regression for `bench/run-1` versus `bench-run-1`.
- The focused real-Git test creates `bench%2Frun-1` on branch `worktree-bench/run-1`.

Fixes #289
