### PR TITLE
feat: filter doctor findings by platform

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -31,6 +31,9 @@ stim logs --errors
 stim stop
 ```
 
+Use `stim doctor --platform ios` or `stim doctor --platform android` when only
+one native platform is in scope; shared project checks still run.
+
 Create a warm isolated worktree with:
 
 ```bash

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -36,12 +36,12 @@ needs. Use `--json` only when a script must parse a stable payload.
 Work in the current checkout by default. When the agent creates an app worktree
 for isolation or parallel work, carry its dependencies and native outputs.
 
-Before a native worktree task, run `stim doctor`: it checks the main checkout
-even from a linked worktree. Fix its dependency and CocoaPods findings, and
-inspect any locally known upstream gap.
+Before a native worktree task, run `stim doctor --platform ios` (or `android`).
+It checks the main checkout from a linked worktree. Fix relevant findings and
+inspect the upstream gap.
 
 ```bash
-stim doctor
+stim doctor --platform ios
 
 # In the main checkout, seed the shared build caches when more native
 # worktrees are coming; skip one-off or JavaScript-only work.

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -21,7 +21,8 @@ import {
   parseXcodeMajor,
   checkConcurrency,
 } from '../doctor.ts';
-import doctorCommand from '../commands/doctor.ts';
+import doctorCommand, { parseDoctorPlatform } from '../commands/doctor.ts';
+import type { Finding } from '../doctor.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import type { EasAuthResult } from '../engine/remote-cache.ts';
 import assert from 'node:assert';
@@ -46,6 +47,34 @@ test('checkMainCheckout reports missing dependencies, Pods, and native output', 
   } finally {
     rmSync(project, { recursive: true, force: true });
   }
+});
+
+test('checkMainCheckout filters native warm state and CocoaPods by platform', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-platform-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
+    mkdirSync(join(project, 'node_modules'));
+    mkdirSync(join(project, 'ios'), { recursive: true });
+    mkdirSync(join(project, 'android'), { recursive: true });
+    writeFileSync(join(project, 'ios', 'Podfile.lock'), 'pods\n');
+
+    const ios = checkMainCheckout(project, { platform: 'ios', brokenPods: [], upstream: null });
+    expect(ios.map((finding) => finding.title)).toEqual([
+      'The main checkout CocoaPods state is missing',
+      'The main checkout has no iOS warm build output',
+    ]);
+
+    const android = checkMainCheckout(project, { platform: 'android', brokenPods: [], upstream: null });
+    expect(android.map((finding) => finding.title)).toEqual(['The main checkout has no Android warm build output']);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('parseDoctorPlatform accepts the two native platforms and rejects other values', () => {
+  expect(parseDoctorPlatform('ios')).toBe('ios');
+  expect(parseDoctorPlatform('android')).toBe('android');
+  expect(() => parseDoctorPlatform('web')).toThrow(/ios, android/);
 });
 
 test('checkMainCheckout recognizes non-npm dependency installs', () => {
@@ -766,6 +795,30 @@ test('detectFingerprintParity against a real repo: a clean checkout is silent', 
   }
 });
 
+test('detectFingerprintParity fingerprints only the selected platform', async () => {
+  resetExecutor();
+  const base = mkdtempSync(join(tmpdir(), 'stim-parity-platform-'));
+  try {
+    execSync('git init -q', { cwd: base });
+    execSync('git config user.email test@example.com', { cwd: base });
+    execSync('git config user.name test', { cwd: base });
+    writeFileSync(join(base, 'app.json'), JSON.stringify({ expo: { name: 'app' } }));
+    mkdirSync(join(base, 'ios'));
+    mkdirSync(join(base, 'android'));
+    execSync('git add . && git commit -q -m init', { cwd: base });
+    const platforms: string[][] = [];
+    const createFingerprint = async (_root: string, options?: { platforms?: string[] }) => {
+      platforms.push(options?.platforms ?? []);
+      return { hash: 'same', sources: [] };
+    };
+
+    expect(await detectFingerprintParity(base, { createFingerprint, platform: 'android' })).toBe(null);
+    expect(platforms).toEqual([['android'], ['android']]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test('detectFingerprintParity skips silently outside a git repo without invoking the fingerprinter', async () => {
   resetExecutor();
   const dir = mkdtempSync(join(tmpdir(), 'stim-parity-nogit-'));
@@ -877,6 +930,60 @@ test.each([
   }
 });
 
+test('runDoctor keeps shared checks and filters native checks and remote backends', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-platform-'));
+  const home = mkdtempSync(join(tmpdir(), 'stim-doc-platform-home-'));
+  process.env.STIM_HOME = home;
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    mkdirSync(join(project, 'ios'));
+    mkdirSync(join(project, 'android'));
+    writeFileSync(join(project, 'ios', 'Podfile'), 'COMPILATION_CACHE_ENABLE_CACHING = YES\n');
+    writeFileSync(join(project, 'ios', 'Podfile.properties.json'), JSON.stringify({ 'apple.ccacheEnabled': 'true' }));
+    writeFileSync(join(project, 'simslim.json'), '{}\n');
+    writeFileSync(join(project, 'metro.config.js'), 'if (process.env.CACHE) config.cacheStores = [];\n');
+    writeFileSync(
+      join(project, '.stim.json'),
+      JSON.stringify({
+        ios: { remote: 'proxy', simslimProfile: 'simslim.json' },
+        android: { remote: 'eas' },
+      }),
+    );
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ pool: { iosParkedMax: 'bad' } }));
+    const options = {
+      concurrency: { maxBuilds: 0, maxDevices: 0 },
+      remoteEnv: {
+        AGENT_DEVICE_DAEMON_BASE_URL: 'https://proxy.example/agent-device',
+        AGENT_DEVICE_DAEMON_AUTH_TOKEN: 'tok_proxy',
+      },
+      lookupAgentDevice: () => true,
+      lookupEasCli: () => false,
+      lookupSimSlim: () => false,
+    };
+
+    const ios = runDoctor(project, { ...options, platform: 'ios', xcodeMajor: 26 });
+    const android = runDoctor(project, { ...options, platform: 'android', xcodeMajor: null });
+
+    for (const findings of [ios, android]) {
+      expect(findings.some((finding) => finding.title.includes('metro.config.js'))).toBe(true);
+    }
+    expect(ios.some((finding) => finding.title.includes('ccache'))).toBe(true);
+    expect(ios.some((finding) => finding.title.includes('SimSlim'))).toBe(true);
+    expect(ios.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(true);
+    expect(ios.some((finding) => finding.title.includes('simulator pool bound'))).toBe(true);
+    expect(ios.some((finding) => finding.title.includes('no eas-cli'))).toBe(false);
+    expect(android.some((finding) => finding.title.includes('ccache'))).toBe(false);
+    expect(android.some((finding) => finding.title.includes('SimSlim'))).toBe(false);
+    expect(android.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(false);
+    expect(android.some((finding) => finding.title.includes('simulator pool bound'))).toBe(false);
+    expect(android.some((finding) => finding.title.includes('no eas-cli'))).toBe(true);
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('runDoctor checks one shared backend once', () => {
   const project = mkdtempSync(join(tmpdir(), 'stim-doc-remote-'));
   try {
@@ -975,4 +1082,82 @@ test('doctor --json prints exactly one line of JSON on stdout', async () => {
   const payload = JSON.parse(line);
   expect(Array.isArray(payload.findings)).toBe(true);
   expect(typeof payload.project).toBe('string');
+  expect(payload.platform).toBe(null);
+});
+
+test('doctor --platform includes the selection in JSON and suppresses the other warm-state finding', async () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-platform-'));
+  const home = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-platform-home-'));
+  process.env.STIM_HOME = home;
+  const cwd = process.cwd();
+  const logs: string[] = [];
+  const originalLog = console.log;
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
+  mkdirSync(join(project, 'node_modules'));
+  mkdirSync(join(project, 'ios'));
+  mkdirSync(join(project, 'android'));
+  const program = new Command();
+  doctorCommand(program);
+  console.log = (msg) => logs.push(String(msg));
+  process.chdir(project);
+  try {
+    await program.parseAsync(['node', 'stim', 'doctor', '--json', '--platform', 'ios']);
+  } finally {
+    process.chdir(cwd);
+    console.log = originalLog;
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+  expect(logs).toHaveLength(1);
+  const payload = JSON.parse(logs[0] as string);
+  expect(payload.platform).toBe('ios');
+  expect(payload.findings.some((finding: Finding) => finding.title.includes('Android warm'))).toBe(false);
+  expect(payload.findings.some((finding: Finding) => finding.title.includes('iOS warm'))).toBe(true);
+});
+
+test('doctor --platform android does not invoke Xcode tooling', async () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-android-'));
+  const home = mkdtempSync(join(tmpdir(), 'stim-doctor-cli-android-home-'));
+  process.env.STIM_HOME = home;
+  const cwd = process.cwd();
+  const logs: string[] = [];
+  const calls: string[] = [];
+  const originalLog = console.log;
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
+  mkdirSync(join(project, 'node_modules'));
+  mkdirSync(join(project, 'android'));
+  setExecutor({
+    run: (command: string) => {
+      calls.push(command);
+      return '';
+    },
+    runQuiet: (command: string) => {
+      calls.push(command);
+      return null;
+    },
+    runFile: (file: string, args: string[]) => {
+      calls.push([file, ...args].join(' '));
+      return '';
+    },
+    spawn: () => {
+      throw new Error('unexpected spawn');
+    },
+  });
+  const program = new Command();
+  doctorCommand(program);
+  console.log = (msg) => logs.push(String(msg));
+  process.chdir(project);
+  try {
+    await program.parseAsync(['node', 'stim', 'doctor', '--json', '--platform', 'android']);
+  } finally {
+    process.chdir(cwd);
+    console.log = originalLog;
+    resetExecutor();
+    delete process.env.STIM_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+  expect(logs).toHaveLength(1);
+  expect(calls.some((call) => call.includes('xcodebuild'))).toBe(false);
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -236,9 +236,9 @@ test('the flags the guide advertises are the flags the commands define', () => {
     'logs.ts': ['--errors', '--follow', '--since', '--grep', '--tail'],
     'gc.ts': ['--delete', '--older-than', '--cache'],
     'worktree.ts': ['--carry-ignored', '--base', '--dir', '--label', '--force'],
-    'doctor.ts': ['--json', '--fix'],
+    'doctor.ts': ['--json', '--fix', '--platform'],
   };
-  expect(/doctor\s+--json --fix/.test(lifecycle)).toBeTruthy();
+  expect(/doctor\s+--json --fix --platform <ios\|android>/.test(lifecycle)).toBeTruthy();
 
   const retired: Record<string, string[]> = { 'gc.ts': ['--all'] };
   for (const [file, flags] of Object.entries(retired)) {

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { Command } from 'commander';
+import { InvalidArgumentError, type Command } from 'commander';
 import { findProjectRoot } from '../project.ts';
 import { repoRoot } from '../worktree.ts';
 import {
@@ -12,11 +12,17 @@ import {
   sandboxFinding,
 } from '../sandbox.ts';
 import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.ts';
-import type { Finding } from '../doctor.ts';
+import type { DoctorPlatform, Finding } from '../doctor.ts';
 
 interface DoctorOptions {
   json?: boolean;
   fix?: boolean;
+  platform?: DoctorPlatform;
+}
+
+export function parseDoctorPlatform(value: string): DoctorPlatform {
+  if (value === 'ios' || value === 'android') return value;
+  throw new InvalidArgumentError('expected one of: ios, android');
 }
 
 /**
@@ -68,9 +74,14 @@ export default function doctorCommand(program: Command): void {
   program
     .command('doctor')
     .description(
-      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed.',
+      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed; --platform filters native findings.',
     )
     .option('--json', 'print the findings as JSON')
+    .option(
+      '--platform <platform>',
+      'report shared findings plus only this native platform: ios or android',
+      parseDoctorPlatform,
+    )
     .option(
       '--fix',
       'apply the findings Stim can repair itself and report the rest, which stay read-only. Every repair writes a per-user file, never a committed one, and refuses a file it cannot read back rather than replace it. Today one finding qualifies: the sandbox allowance.',
@@ -86,10 +97,11 @@ export default function doctorCommand(program: Command): void {
       if (opts.fix) applySandboxFix(root);
 
       const findings: Finding[] = runDoctor(root, {
-        xcodeMajor: detectXcodeMajor(),
+        xcodeMajor: opts.platform === 'android' ? null : detectXcodeMajor(),
+        platform: opts.platform,
       });
 
-      const parity = await detectFingerprintParity(root);
+      const parity = await detectFingerprintParity(root, { platform: opts.platform });
       if (parity) findings.push(parity);
 
       if (detectHarness()) {
@@ -98,15 +110,21 @@ export default function doctorCommand(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify({ project: root, findings }));
+        console.log(JSON.stringify({ project: root, platform: opts.platform ?? null, findings }));
         return;
       }
 
       if (findings.length === 0) {
         console.log(chalk.green('Nothing to flag.'));
+        const nativeChecks =
+          opts.platform === 'ios'
+            ? 'CocoaPods, iOS warm state, dev client, Metro cacheStores, Xcode compilation cache, ccache, build cache provider, iOS remote device and SimSlim profile'
+            : opts.platform === 'android'
+              ? 'Android warm state, dev client, Metro cacheStores, build cache provider and Android remote device'
+              : 'CocoaPods, iOS and Android warm state, dev client, ccache, Metro cacheStores, compilation cache, build cache provider, remote devices and SimSlim profile';
         console.log(
           chalk.dim(
-            'Checked: main-checkout dependencies, CocoaPods, native warm state and local upstream; dev client, ccache, Metro cacheStores, compilation cache, build cache provider, EAS session, SimSlim profile, the type of every setting Stim reads and, on a checkout without installed dependencies, fingerprint parity.',
+            `Checked: main-checkout dependencies, ${nativeChecks}, local upstream, EAS session, the type of every setting Stim reads and, on a checkout without installed dependencies, fingerprint parity.`,
           ),
         );
         console.log(

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1920,7 +1920,8 @@ THE OPTION SURFACE, IN FULL
   stop            --json --force
   status          --json          (already machine-wide)
   stats           --json          (this project and machine-wide)
-  doctor          --json --fix    (--fix applies the findings Stim can repair)
+  doctor          --json --fix --platform <ios|android>
+                                  (--platform keeps shared checks and filters native findings)
   gc              --delete --older-than <days> --cache <name|all>
   worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
 

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -44,6 +44,8 @@ export interface Finding {
   fix: string | null;
 }
 
+export type DoctorPlatform = 'ios' | 'android';
+
 function finding(level: 'cost' | 'note', title: string, detail: string, fix: string | null): Finding {
   return { level, title, detail, fix };
 }
@@ -156,10 +158,12 @@ export function checkMainCheckout(
     npmTreeValid,
     brokenPods = undefined,
     upstream = undefined,
+    platform,
   }: {
     npmTreeValid?: boolean | null;
     brokenPods?: string[];
     upstream?: UpstreamState | null;
+    platform?: DoctorPlatform;
   } = {},
 ): Finding[] {
   const mainRoot = mainCheckoutProjectRoot(projectRoot);
@@ -196,7 +200,7 @@ export function checkMainCheckout(
   const podfileLock = join(mainRoot, 'ios', 'Podfile.lock');
   const podManifest = join(mainRoot, 'ios', 'Pods', 'Manifest.lock');
   const podsRoot = join(mainRoot, 'ios', 'Pods');
-  if (existsSync(podfileLock)) {
+  if (platform !== 'android' && existsSync(podfileLock)) {
     let podsState: 'missing' | 'stale' | null = null;
     if (!existsSync(podManifest)) podsState = 'missing';
     else {
@@ -235,17 +239,19 @@ export function checkMainCheckout(
   }
 
   const coldPlatforms = [
+    platform !== 'android' &&
     existsSync(join(mainRoot, 'ios')) &&
     !existsSync(join(mainRoot, 'ios', 'build')) &&
     !existsSync(join(workspaceDerivedData(mainRoot), 'Build', 'Products'))
       ? 'iOS'
       : null,
+    platform !== 'ios' &&
     existsSync(join(mainRoot, 'android')) &&
     !existsSync(join(mainRoot, 'android', 'build')) &&
     !existsSync(join(mainRoot, 'android', 'app', 'build'))
       ? 'Android'
       : null,
-  ].filter((platform): platform is string => platform !== null);
+  ].filter((coldPlatform): coldPlatform is string => coldPlatform !== null);
   if (coldPlatforms.length) {
     findings.push(
       finding(
@@ -558,6 +564,7 @@ export function runDoctor(
     lookupAgentDevice = null,
     lookupEasCli = null,
     lookupSimSlim = null,
+    platform,
   }: {
     readFile?: typeof readFileSync;
     xcodeMajor?: number | null;
@@ -569,6 +576,7 @@ export function runDoctor(
     lookupAgentDevice?: (() => boolean) | null;
     lookupEasCli?: (() => boolean) | null;
     lookupSimSlim?: (() => boolean) | null;
+    platform?: DoctorPlatform;
   } = {},
 ): Finding[] {
   const read = (rel: string): string | null => {
@@ -625,26 +633,36 @@ export function runDoctor(
   const settingShapeFindings = settingShapeErrors(projectSettings).map((error) =>
     finding('cost', 'A setting has the wrong type', error, SETTING_SHAPE_REMEDY),
   );
-  const poolSettingError = parkedMaxSetting('ios').error;
-  if (poolSettingError) {
-    settingShapeFindings.push(
-      finding('cost', 'The simulator pool bound is not a number', poolSettingError, POOL_SETTING_REMEDY),
-    );
+  if (platform !== 'android') {
+    const poolSettingError = parkedMaxSetting('ios').error;
+    if (poolSettingError) {
+      settingShapeFindings.push(
+        finding('cost', 'The simulator pool bound is not a number', poolSettingError, POOL_SETTING_REMEDY),
+      );
+    }
   }
   let simslimProfile: string | null = null;
   let simslimProfileError: string | null = null;
-  try {
-    simslimProfile = iosSimSlimProfileSetting(projectSettings, settingsRepoRoot);
-  } catch (error) {
-    simslimProfileError = String((error as Error)?.message || error);
+  if (platform !== 'android') {
+    try {
+      simslimProfile = iosSimSlimProfileSetting(projectSettings, settingsRepoRoot);
+    } catch (error) {
+      simslimProfileError = String((error as Error)?.message || error);
+    }
   }
-  const simslimFinding = checkSimSlim({
-    configured: Boolean(simslimProfile),
-    profileError: simslimProfileError,
-    onPath: simslimProfile ? (lookupSimSlim ? lookupSimSlim() : simslimIsOnPath()) : false,
-  });
+  const simslimFinding =
+    platform === 'android'
+      ? null
+      : checkSimSlim({
+          configured: Boolean(simslimProfile),
+          profileError: simslimProfileError,
+          onPath: simslimProfile ? (lookupSimSlim ? lookupSimSlim() : simslimIsOnPath()) : false,
+        });
   const remoteBackends = [
-    ...new Set([remoteIosSetting(projectSettings), remoteAndroidSetting(projectSettings)]),
+    ...new Set([
+      ...(platform !== 'android' ? [remoteIosSetting(projectSettings)] : []),
+      ...(platform !== 'ios' ? [remoteAndroidSetting(projectSettings)] : []),
+    ]),
   ].filter((backend): backend is RemoteDeviceBackend => backend !== null);
   const daemonInEnv = Boolean(
     remoteEnv.AGENT_DEVICE_DAEMON_BASE_URL?.trim() && remoteEnv.AGENT_DEVICE_DAEMON_AUTH_TOKEN?.trim(),
@@ -671,11 +689,11 @@ export function runDoctor(
     .filter((remoteFinding): remoteFinding is Finding => remoteFinding !== null);
 
   return [
-    ...checkMainCheckout(projectRoot),
+    ...checkMainCheckout(projectRoot, { platform }),
     checkDevClient(pkg, isExpo),
     checkMetroCache(metroConfig),
-    checkCompilationCache(podfile, xcodeMajor),
-    checkCcacheConflict(podfile, podfileProperties),
+    platform === 'android' ? null : checkCompilationCache(podfile, xcodeMajor),
+    platform === 'android' ? null : checkCcacheConflict(podfile, podfileProperties),
     checkBuildCacheProvider(appConfig, sdkMajor, isExpo, dynamicConfig),
     easFinding,
     concurrencyFinding,
@@ -750,10 +768,12 @@ export async function detectFingerprintParity(
     createFingerprint = expoFingerprint.createFingerprintAsync,
     differ = expoFingerprint.diffFingerprints,
     dirtyFiles = dirtyFingerprintFiles,
+    platform: selectedPlatform,
   }: {
     createFingerprint?: typeof expoFingerprint.createFingerprintAsync;
     differ?: typeof expoFingerprint.diffFingerprints | null;
     dirtyFiles?: (root: string) => string[];
+    platform?: DoctorPlatform;
   } = {},
 ): Promise<Finding | null> {
   const exec = getExecutor();
@@ -764,11 +784,9 @@ export async function detectFingerprintParity(
   // that is only the missing install. The question has an answer only on a cold checkout.
   if (hasInstalledDependencies(projectRoot)) return null;
 
-  const platform = existsSync(join(projectRoot, 'ios'))
-    ? 'ios'
-    : existsSync(join(projectRoot, 'android'))
-      ? 'android'
-      : undefined;
+  const platform =
+    selectedPlatform ??
+    (existsSync(join(projectRoot, 'ios')) ? 'ios' : existsSync(join(projectRoot, 'android')) ? 'android' : undefined);
 
   const base = mkdtempSync(join(tmpdir(), 'stim-parity-'));
   const worktree = join(base, 'head');


### PR DESCRIPTION
## Description

`stim doctor` currently combines iOS and Android findings even when only one native platform is in scope. This caused an iOS-only benchmark agent to inspect and dismiss an irrelevant Android warm-output finding.

The existing default remains unfiltered so current callers continue to receive findings for both platforms.

## Solution

Add `stim doctor --platform ios|android` while retaining shared dependency, project-setting, upstream, sandbox, capacity, Metro, development-client, and build-cache checks.

- iOS keeps CocoaPods, iOS warm state, Xcode compilation cache, ccache, SimSlim, iOS pool, and iOS remote-device checks.
- Android keeps Android warm state and Android remote-device checks without invoking Xcode tooling.
- Fingerprint parity uses the selected native platform.
- JSON output records the selected platform as `ios`, `android`, or `null`.

The README, bundled Stim skill, guide option surface, and guide contract tests document the new workflow.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (3,396 tests passed)
- `pnpm run test:e2e` (20 tests passed)
- Integrated doctor tests cover shared/native/remote/pool filtering, platform-scoped fingerprints, and the Android no-Xcode path.

No child-process argument list changed, so no new real-tool argument verification is required.

Fixes #288
