### PR TITLE
docs: define benchmark v4 readiness protocol

### DIFF
--- a/docs/agent-benchmark-v3.md
+++ b/docs/agent-benchmark-v3.md
@@ -2,6 +2,9 @@
 
 Date: 2026-09-02. Issue: #281. This protocol supersedes the single-pair v2
 protocol in [`trailhead-agent-benchmark.md`](./trailhead-agent-benchmark.md).
+The later Settings-readiness and parked-simulator pilot is specified separately
+in [`agent-benchmark-v4.md`](./agent-benchmark-v4.md); its timings are not pooled
+with v3.
 The versions share an application test case, but their runner setup, cache
 preparation, and timing definitions differ, so v2 timings are historical
 context rather than samples in the v3 result.

--- a/docs/agent-benchmark-v4.md
+++ b/docs/agent-benchmark-v4.md
@@ -128,10 +128,11 @@ JavaScript source and captured Metro bundle must contain the changed subtitle.
 Native must have the exact run marker in the live window accessibility node.
 Missing proof makes the attempt invalid even when the app process is alive.
 
-The initial Luna pilot predated this UDID-binding correction. Each of its four
-valid snapshots still proved the target through the run-specific changed text
-or native accessibility marker, so those attempts remain valid. Any later
-block must use the explicit UDID command above.
+The initial Luna pilot predated this UDID-binding correction. Its retained
+launch, watcher, command, and screenshot evidence shows the changed JavaScript
+subtitle or run-specific native accessibility marker on the intended
+simulator, so those four attempts remain valid. Any later block must use the
+explicit UDID command above.
 
 ## Metrics and records
 

--- a/docs/agent-benchmark-v4.md
+++ b/docs/agent-benchmark-v4.md
@@ -97,14 +97,15 @@ creates a new benchmark-named iPhone 17 on iOS 26.5.
 ## Settings readiness proof
 
 App-process liveness is retained as a secondary milestone. The primary
-readiness endpoint is the first successful copied Settings screenshot after
-the expected changed content is present.
+readiness endpoint is completion of the successful Settings screenshot command
+after the expected changed content is present. Copying that PNG into retained
+results is a validity gate, not a later timing endpoint.
 
 After launch, every agent must use `agent-device`. The required command
 sequence is:
 
 ```text
-agent-device open com.appandflow.trailhead --foreground
+agent-device open com.appandflow.trailhead --foreground --platform ios --udid <run-udid>
 <handle Expo onboarding if it appears and navigate by semantic label to Settings>
 agent-device wait text "<expected text>"
 agent-device screenshot /tmp/<run-id>-settings.png
@@ -112,22 +113,30 @@ cp /tmp/<run-id>-settings.png <run-dir>/proof/settings.png
 agent-device close
 ```
 
-The explicit bundle identifier prevents an existing automation session from
-selecting unrelated hardware. The temporary screenshot path avoids Simulator
-write restrictions on external volumes. JavaScript waits for `Keep saved trail
-maps available offline`; native waits for `Offline maps`.
+The agent reads `<run-udid>` from the Stim result or control simulator-creation
+output. The explicit UDID prevents an existing automation session from
+selecting unrelated hardware; a bundle identifier alone is insufficient. The
+temporary screenshot path avoids Simulator write restrictions on external
+volumes. JavaScript waits for `Keep saved trail maps available offline`; native
+waits for `Offline maps`.
 
-The collector accepts the screenshot only when all required commands completed
-in order after dispatch, the PNG has a valid signature and dimensions, its
-timestamps fit the run, and the copied file exists. The JavaScript source and
-captured Metro bundle must contain the changed subtitle. Native must have the
-exact run marker in the live window accessibility node. Missing proof makes the
-attempt invalid even when the app process is alive.
+The collector accepts the screenshot only when the targeted open command names
+the same UDID recorded by the independent app watcher, all required commands
+completed in order after dispatch, the PNG has a valid signature and
+dimensions, its timestamps fit the run, and the copied file exists. The
+JavaScript source and captured Metro bundle must contain the changed subtitle.
+Native must have the exact run marker in the live window accessibility node.
+Missing proof makes the attempt invalid even when the app process is alive.
+
+The initial Luna pilot predated this UDID-binding correction. Each of its four
+valid snapshots still proved the target through the run-specific changed text
+or native accessibility marker, so those attempts remain valid. Any later
+block must use the explicit UDID command above.
 
 ## Metrics and records
 
 The primary metric is `dispatchToScreenReadySeconds`: dispatch to completion
-of the copied, validated Settings screenshot. Report
+of the successful, validated `agent-device screenshot` command. Report
 `dispatchToAppAliveSeconds` separately. Also retain command count, raw token
 fields, worktree and simulator evidence, cache and adoption/build output, and
 invalid-attempt reasons.

--- a/docs/agent-benchmark-v4.md
+++ b/docs/agent-benchmark-v4.md
@@ -1,0 +1,171 @@
+# Agent benchmark v4
+
+Date: 2026-09-03. Issue: #287. This protocol extends the v3 agent benchmark
+with rendered-screen readiness and published simulator-pool behavior. Its
+timings are a new, non-comparable block because v3 stopped at process liveness,
+did not navigate the app, and created a new simulator for every run.
+
+## Question and pilot gate
+
+The primary question is whether Stim reduces elapsed time from agent dispatch
+to a changed Trailhead app visibly ready on its Settings screen. JavaScript and
+native changes are different workloads and are never combined into one run or
+one headline number.
+
+The first pilot contains four sequential cells, all on `gpt-5.6-luna`:
+
+| Change     | Arm     | Simulator state                     |
+| ---------- | ------- | ----------------------------------- |
+| JavaScript | Stim    | adopt the prepared parked simulator |
+| JavaScript | Control | create a new simulator              |
+| Native     | Stim    | adopt the prepared parked simulator |
+| Native     | Control | create a new simulator              |
+
+Do not dispatch another model until the Luna report and visual evidence are
+reviewed. Later model blocks keep the same pins and cell definitions. Results
+from different change kinds, models, or deliberately changed pins remain
+separate.
+
+## Pins and preparation
+
+Pin the exact published `stim-cli` version and package integrity, fixture
+commit, Codex version, model, reasoning effort, service tier, `agent-device`
+version and executable hash, Node.js, CocoaPods, macOS, Xcode, iPhone model,
+and iOS runtime before preparing the block. The Luna pilot uses published
+`stim-cli@1.0.0-rc.11`, iPhone 17, and iOS 26.5.
+
+Preparation runs outside the timer. It creates one Stim-owned simulator, warms
+the fixed fixture, removes its seed worktree, and verifies that cleanup parked
+the simulator. The golden must contain exactly one available, shut-down pool
+record whose device name starts with `stim-parked`, plus the matching iOS build
+artifact. Set the opt-in parked capacity explicitly for every command that uses
+the isolated benchmark `STIM_HOME`.
+
+Before each dispatch, verify the package version and integrity, fixture commit,
+clean main checkout, golden build artifact, exact parked simulator identity and
+state, required disk space, no benchmark-owned process from an earlier run,
+and no unexpected listener on Metro ports 8081 through 8090. Wait for a
+one-minute load average at or below 3.0 for two consecutive 15-second samples.
+Runs are sequential.
+
+## Fixed changes
+
+The JavaScript cell changes only the Settings Offline maps subtitle:
+
+```diff
+-subtitle="Keep map tiles for saved trails on device"
++subtitle="Keep saved trail maps available offline"
+```
+
+The native cell changes only `ios/Trailhead/AppDelegate.swift`, immediately
+after the existing window assignment:
+
+```swift
+window?.accessibilityIdentifier = "Trailhead <run-id>"
+```
+
+The native marker must appear as the live app window label in the
+`agent-device` accessibility snapshot. This proves that the changed compiled
+AppDelegate executed; searching an optimized Swift executable for an ASCII
+literal is not sufficient.
+
+## Arm isolation
+
+Each run uses a disposable runner home and starts in the clean fixture main
+checkout. The Stim profile exposes only the pinned Stim skill and the
+independently pinned `agent-device` skill. The control profile exposes only
+`agent-device`; the Stim binary and skill are unavailable. Both profiles have
+the same model settings, filesystem authority, and app task.
+
+The agent creates its own worktree after dispatch. Stim must use this exact
+slash-containing form, which also exercises branch/path handling:
+
+```text
+stim worktree create bench/<run-id> --dir <worktree-parent> --carry-ignored
+```
+
+The Stim worktree must therefore use Git branch
+`worktree-bench/<run-id>`. Its filesystem leaf may encode the slash. The
+control creates the corresponding Git worktree using local Git. Both carry the
+same installed dependencies and native outputs from the fixture checkout.
+
+The Stim arm uses the inherited isolated `STIM_HOME`, invokes the pinned RC as
+exactly `stim`, requests iPhone 17 and iOS 26.5, and must report adoption of the
+prepared simulator. The control must not inspect that home or use Stim; it
+creates a new benchmark-named iPhone 17 on iOS 26.5.
+
+## Settings readiness proof
+
+App-process liveness is retained as a secondary milestone. The primary
+readiness endpoint is the first successful copied Settings screenshot after
+the expected changed content is present.
+
+After launch, every agent must use `agent-device`. The required command
+sequence is:
+
+```text
+agent-device open com.appandflow.trailhead --foreground
+<handle Expo onboarding if it appears and navigate by semantic label to Settings>
+agent-device wait text "<expected text>"
+agent-device screenshot /tmp/<run-id>-settings.png
+cp /tmp/<run-id>-settings.png <run-dir>/proof/settings.png
+agent-device close
+```
+
+The explicit bundle identifier prevents an existing automation session from
+selecting unrelated hardware. The temporary screenshot path avoids Simulator
+write restrictions on external volumes. JavaScript waits for `Keep saved trail
+maps available offline`; native waits for `Offline maps`.
+
+The collector accepts the screenshot only when all required commands completed
+in order after dispatch, the PNG has a valid signature and dimensions, its
+timestamps fit the run, and the copied file exists. The JavaScript source and
+captured Metro bundle must contain the changed subtitle. Native must have the
+exact run marker in the live window accessibility node. Missing proof makes the
+attempt invalid even when the app process is alive.
+
+## Metrics and records
+
+The primary metric is `dispatchToScreenReadySeconds`: dispatch to completion
+of the copied, validated Settings screenshot. Report
+`dispatchToAppAliveSeconds` separately. Also retain command count, raw token
+fields, worktree and simulator evidence, cache and adoption/build output, and
+invalid-attempt reasons.
+
+The coordinator timestamps every runner event and reconstructs every command's
+start, end, duration, exit status, and output. A generated interactive HTML
+timeline provides per-run tabs, agent messages, command bars, Stim phases,
+app-alive and screen-ready milestones, output drill-down, and the proof image.
+The Markdown report is the machine-readable summary; the timeline is an audit
+view and does not redefine metrics.
+
+Invalid attempts are immutable audit records. Fix only a coordinator defect or
+environmental prerequisite, then reschedule the same cell under a new run id.
+Never relabel an invalid attempt to improve a result. Collector-only proof
+logic may be corrected without rerunning when preserved live evidence already
+demonstrates the intended invariant.
+
+## Cleanup
+
+After collection, close the run's `agent-device` session, remove its temporary
+screenshot, and terminate only benchmark-owned processes. For Stim, run
+`stim stop` and `stim worktree remove --force`, then verify that the same
+simulator is shut down, renamed as parked, and is the sole pool record. For
+control, remove its worktree and branch and shut down and delete only the newly
+created benchmark simulator. Do not touch unrelated physical-device leases or
+automation sessions.
+
+## JavaScript launch-crash extension
+
+A launch-crash diagnostic is a separate suite, not a fifth performance cell.
+Inject a deterministic root-render JavaScript exception before the first app
+screen, then give each agent the same repair task. Compare dispatch to the
+first actionable diagnosis, commands and tokens to diagnosis, and dispatch to
+a repaired Settings screenshot. The Stim arm must preserve `stim ios` launch
+output and `stim logs --errors`; control collects the equivalent Metro and
+simulator logs manually. The injected error text is unique per run so the
+collector can prove that the reported stack and repair refer to this failure.
+
+Run the crash suite only after the four-cell readiness pilot is accepted. Keep
+its goldens, prompts, metrics, and report separate from the normal JS/native
+speed results.


### PR DESCRIPTION
## Description

The v3 benchmark stopped at process liveness, did not prove that the changed Settings screen rendered, and required a newly created simulator for every run. Those constraints exclude Expo onboarding from the measured workflow and cannot exercise the published parked-simulator pool.

This protocol starts a non-comparable v4 block rather than rewriting historical v3 results. JavaScript and native work remain separate measurements, and the Luna four-cell pilot gates any later model expansion.

## Solution

Define the v4 readiness endpoint as a validated Settings screenshot produced through an exact `agent-device` command sequence after semantic navigation and expected-text verification. Pin the published `stim-cli@1.0.0-rc.11`; prepare one shut-down Stim-owned parked iPhone 17; require Stim cells to adopt it; and require control cells to create their own simulator.

The protocol also specifies live native-change proof through the window accessibility marker, slash-containing Stim worktree names, complete command timelines, cleanup ownership, immutable invalid attempts, and a separate future root-render JavaScript crash diagnostic that is not pooled with normal performance cells.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (84 files, 3,400 tests)
- Completed the four-cell Luna pilot with valid Settings screenshots for JavaScript/Stim, JavaScript/control, native/Stim, and native/control.
- Observed the prepared simulator adopted and re-parked by both Stim cells; each control cell created and deleted a new iPhone 17.
- Observed the native marker in the live `agent-device` accessibility tree and Expo developer-menu onboarding in the native control cell.

Fixes #287
