### PR TITLE
fix: avoid percent escapes in slash worktree paths

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -68,7 +68,7 @@ test('the lifecycle topic documents slash-separated worktree names', () => {
   assert(body);
   expect(body).toMatch(/worktree create app\/412/);
   expect(body).toMatch(/worktree-app\/412/);
-  expect(body).toMatch(/encoded directory directly under worktreeDir/);
+  expect(body).toMatch(/flat \+ separated directory directly under worktreeDir/);
   expect(body).toMatch(/device labels include a stable hash/);
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -160,7 +160,7 @@ test('create action: slash name keeps the Git hierarchy in one worktree director
 
     const { logs } = await runCreateInRepo(repo, 'bench/run-1', {});
 
-    const expected = join(defaultWorktreeDir(repo), 'bench%2Frun-1');
+    const expected = join(defaultWorktreeDir(repo), 'bench+run-1');
     expect(logs).toEqual([expected]);
     expect(realpathSync(expected)).toBe(expected);
     expect(execSync('git branch --show-current', { cwd: expected, encoding: 'utf-8' })).toBe('worktree-bench/run-1\n');

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -41,12 +41,21 @@ test('default worktree dir is a sibling of the repo', () => {
 
 test('worktreePath joins the dir and the name', () => {
   expect(worktreePath({ worktreeDir: '/wt', name: 'feat-x' })).toBe('/wt/feat-x');
-  expect(worktreePath({ worktreeDir: '/wt', name: 'bench/run-1' })).toBe('/wt/bench%2Frun-1');
+  expect(worktreePath({ worktreeDir: '/wt', name: 'feat_x' })).toBe('/wt/feat_x');
+  expect(worktreePath({ worktreeDir: '/wt', name: 'bench/run_1' })).toBe('/wt/bench+run_1');
 });
 
 test('worktree names accept safe branch paths without accepting traversal or invalid refs', () => {
   expect(isValidWorktreeName('bench/run-1')).toBe(true);
-  for (const name of ['bench//run', '/bench', 'bench/', 'bench/../run', 'bench/.hidden', 'bench/run.lock']) {
+  for (const name of [
+    'bench//run',
+    '/bench',
+    'bench/',
+    'bench/../run',
+    'bench/.hidden',
+    'bench/run.lock',
+    'bench+run',
+  ]) {
     expect(isValidWorktreeName(name)).toBe(false);
   }
 });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1503,8 +1503,8 @@ STIM_CONFIG_CORRUPT  ("Stim config at <path> is not valid JSON")
   cd "$(stim worktree create app/412 --carry-ignored)"
 
   # Slash-separated names create branches such as worktree-app/412 while the
-  # checkout remains one encoded directory directly under worktreeDir. Their
-  # default device labels include a stable hash so flat names cannot collide.
+  # checkout remains one flat + separated directory directly under worktreeDir.
+  # Default device labels include a stable hash so flat names cannot collide.
 
   # 2. The dev server, under a detached supervisor. Blocks until it is
   #    verifiably THIS project's, then hands your shell back.

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -67,7 +67,7 @@ export function isValidWorktreeName(name: string): boolean {
 }
 
 export function worktreePath({ worktreeDir, name }: { worktreeDir: string; name: string }): string {
-  return join(worktreeDir, encodeURIComponent(name));
+  return join(worktreeDir, name.replaceAll('/', '+'));
 }
 
 export function defaultWorktreeLabel(name: string): string {


### PR DESCRIPTION
## Description

Slash-separated names currently create flat `%2F` paths such as `repro%2Fnative`, which break Expo SDK 57's nested Xcode build; plain paths pass the same cold/warm-cache matrix.

The percent encoding was [deliberately added](https://github.com/appandflow/stim/blob/5b17558b09bb458d1e9b125b1377f0ad2e9e2555/packages/stim-cli/src/worktree.ts#L69-L71) to keep slash branches in one checkout directory. That intent remains; only the filesystem representation changes.

## Solution

Map slash separators to `+`, producing `repro+native` while retaining the Git branch `worktree-repro/native`.

This is collision-free for valid Stim names because `+` is outside the accepted input alphabet. Flat names and hashed device labels are unchanged. The behavioral risk is limited to the printed path for newly created slash names; reverting the mapping is local if another native tool rejects `+`.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, and `pnpm run typecheck`
- `pnpm test` — 3,400 tests passed
- `pnpm run test:e2e` — 20 tests passed
- Real Expo 57/Xcode 26.5 verification: a new `+` worktree rebuilt ExpoModulesJSI, installed and launched Trailhead, verified Metro, and logged no errors.
- Regression coverage verifies the `+` path, the slash Git branch, rejection of `+` in input names, and unchanged flat names containing underscores.

Fixes #293
