### PR TITLE
fix: trim simulator name separators

### DIFF
--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -472,6 +472,12 @@ test('ownedSimName does not double the ownership prefix', () => {
 
 test('owned and parked simulator names show model and runtime and stay within 60 characters', () => {
   expect(ownedSimName('feat-login', { model: 'iPhone 17', runtime: '26.5' })).toBe('stim-feat-login (iPhone 17 26.5)');
+  expect(
+    ownedSimName('58bd14ac-bench-luna-rc12-gpt-5-6-luna-native-stim', {
+      model: 'iPhone 17',
+      runtime: '26.5',
+    }),
+  ).toBe('stim-58bd14ac-bench-luna-rc12-gpt-5-6-luna (iPhone 17 26.5)');
   const long = parkedSimName('A1F3-0000', {
     model: 'iPad Pro 13-inch (M4) with a deliberately very long qualifier',
     runtime: '26.5',

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -312,7 +312,7 @@ function fitSimName(label: string, { model, runtime }: SimModel, suffix = '', pr
   let shortLabel = label;
   if (over > 0 && !preserveLabel) {
     const cut = Math.min(over, label.length);
-    shortLabel = label.slice(0, label.length - cut);
+    shortLabel = label.slice(0, label.length - cut).replace(/[._-]+$/g, '');
     over -= cut;
   }
   const shortModel = over > 0 ? modelName.slice(0, Math.max(0, modelName.length - over)) : modelName;


### PR DESCRIPTION
## Description

The 60-character CoreSimulator name fit can truncate a long workspace label immediately after `-`, leaving names such as `stim-...-luna- (iPhone 17 26.5)`. The extra separator is visual noise in Stim output and Simulator.

## Solution

Strip trailing `.`, `_`, and `-` separators only from labels shortened by the existing fit step. Short names, the `stim-` ownership prefix, model/runtime text, and the collision-resistant label prefix are unchanged.

## Test plan

- Verified the benchmark label from the report now fits as `stim-58bd14ac-bench-luna-rc12-gpt-5-6-luna (iPhone 17 26.5)`.
- Created that name with real `simctl` against iPhone 17 / iOS 26.5, then deleted the exact temporary Stim-owned simulator.
- Ran formatting, lint, build, typecheck, and the full 3,410-test suite.

Fixes #299
