### PR TITLE
feat: add benchmark deep links

### DIFF
--- a/website/src/components/benchmarkData.test.ts
+++ b/website/src/components/benchmarkData.test.ts
@@ -1,15 +1,36 @@
 import { describe, expect, it } from 'vitest';
 import {
   assignCommandLanes,
+  benchmarkSelectionFromSearch,
+  benchmarkSelectionSearch,
   comparableRuns,
   comparisonOutcome,
   commandAtCursor,
   formatSeconds,
   initialAuditSelection,
   timeBreakdown,
+  type BenchmarkData,
   type BenchmarkCommand,
   type BenchmarkRun,
 } from './benchmarkData';
+
+const navigationBenchmarks = [
+  {
+    stage: 'luna-rc12',
+    runs: [
+      { id: 'javascript-stim', valid: true },
+      { id: 'native-stim', valid: true },
+      { id: 'luna-invalid', valid: false },
+    ],
+  },
+  {
+    stage: 'sol-rc12',
+    runs: [
+      { id: 'javascript-stim', valid: true },
+      { id: 'native-stim', valid: true },
+    ],
+  },
+] as BenchmarkData[];
 
 function command(id: string, startSeconds: number, endSeconds: number): BenchmarkCommand {
   return { id, startSeconds, endSeconds, command: id, output: '', exitCode: 0 };
@@ -53,6 +74,33 @@ describe('comparableRuns', () => {
     const missing = { id: 'missing', valid: true, settingsReadySeconds: null } as BenchmarkRun;
 
     expect(comparableRuns([valid, invalid, missing]).map((run) => run.id)).toEqual(['valid']);
+  });
+});
+
+describe('benchmark URL selection', () => {
+  it('selects an explicitly linked benchmark and valid run', () => {
+    expect(benchmarkSelectionFromSearch('?benchmark=sol-rc12&run=native-stim', navigationBenchmarks)).toEqual({
+      stage: 'sol-rc12',
+      runId: 'native-stim',
+    });
+  });
+
+  it('requires the benchmark for a run link and rejects invalid runs', () => {
+    expect(benchmarkSelectionFromSearch('?run=native-stim', navigationBenchmarks)).toEqual({
+      stage: 'luna-rc12',
+      runId: 'javascript-stim',
+    });
+    expect(benchmarkSelectionFromSearch('?benchmark=luna-rc12&run=luna-invalid', navigationBenchmarks)).toEqual({
+      stage: 'luna-rc12',
+      runId: 'javascript-stim',
+    });
+  });
+
+  it('uses a clean URL for the default and stable query parameters otherwise', () => {
+    expect(benchmarkSelectionSearch({ stage: 'luna-rc12', runId: 'javascript-stim' }, navigationBenchmarks)).toBe('');
+    expect(benchmarkSelectionSearch({ stage: 'sol-rc12', runId: 'native-stim' }, navigationBenchmarks)).toBe(
+      '?benchmark=sol-rc12&run=native-stim',
+    );
   });
 });
 

--- a/website/src/components/benchmarkData.ts
+++ b/website/src/components/benchmarkData.ts
@@ -118,6 +118,11 @@ export type BenchmarkComparison = {
   tone: 'gain' | 'loss' | 'neutral';
 };
 
+export type BenchmarkRouteSelection = {
+  stage: string;
+  runId: string;
+};
+
 function orderedCopy<T>(values: T[], compare: (a: T, b: T) => number): T[] {
   const result: T[] = [];
   for (const value of values) {
@@ -164,6 +169,25 @@ export function comparableRuns(runs: BenchmarkRun[]): Array<BenchmarkRun & { set
   return runs.filter(
     (run): run is BenchmarkRun & { settingsReadySeconds: number } => run.valid && run.settingsReadySeconds !== null,
   );
+}
+
+export function benchmarkSelectionFromSearch(search: string, benchmarks: BenchmarkData[]): BenchmarkRouteSelection {
+  const params = new URLSearchParams(search);
+  const requestedStage = params.get('benchmark');
+  const requestedRun = requestedStage ? params.get('run') : null;
+  const benchmark = benchmarks.find((candidate) => candidate.stage === requestedStage) ?? benchmarks[0];
+  const validRuns = benchmark?.runs.filter((run) => run.valid) ?? [];
+  const run = validRuns.find((candidate) => candidate.id === requestedRun) ?? validRuns[0];
+  return { stage: benchmark?.stage ?? '', runId: run?.id ?? '' };
+}
+
+export function benchmarkSelectionSearch(selection: BenchmarkRouteSelection, benchmarks: BenchmarkData[]): string {
+  const defaults = benchmarkSelectionFromSearch('', benchmarks);
+  if (selection.stage === defaults.stage && selection.runId === defaults.runId) return '';
+  const params = new URLSearchParams();
+  params.set('benchmark', selection.stage);
+  params.set('run', selection.runId);
+  return `?${params.toString()}`;
 }
 
 export function comparisonOutcome(

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -1,10 +1,14 @@
 import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useHistory, useLocation } from '@docusaurus/router';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
 import {
   comparableRuns,
+  benchmarkSelectionFromSearch,
+  benchmarkSelectionSearch,
   comparisonOutcome,
   formatCost,
   formatSeconds,
@@ -75,11 +79,23 @@ function ComparisonCard({
 }
 
 export default function Benchmarks(): ReactNode {
-  const [stage, setStage] = useState(benchmarks[0]?.stage ?? '');
+  const history = useHistory();
+  const location = useLocation();
+  const isBrowser = useIsBrowser();
+  const search = isBrowser ? location.search : '';
+  const selection = useMemo(() => benchmarkSelectionFromSearch(search, benchmarks), [search]);
+  const stage = selection.stage;
   const benchmark = benchmarks.find((candidate) => candidate.stage === stage) ?? benchmarks[0];
   const publishedRuns = useMemo(() => benchmark?.runs.filter((run) => run.valid) ?? [], [benchmark]);
-  const [activeId, setActiveId] = useState(defaultRun(benchmark)?.id ?? '');
+  const activeId = selection.runId;
   const activeRun = publishedRuns.find((run) => run.id === activeId) ?? defaultRun(benchmark);
+  const navigateTo = (nextStage: string, nextRunId: string) => {
+    history.push({
+      pathname: location.pathname,
+      search: benchmarkSelectionSearch({ stage: nextStage, runId: nextRunId }, benchmarks),
+      hash: location.hash,
+    });
+  };
   const grouped = useMemo(
     () =>
       (['javascript', 'native'] as const).map((variant) => ({
@@ -127,8 +143,7 @@ export default function Benchmarks(): ReactNode {
                 type="button"
                 aria-pressed={candidate.stage === benchmark.stage}
                 onClick={() => {
-                  setStage(candidate.stage);
-                  setActiveId(defaultRun(candidate)?.id ?? '');
+                  navigateTo(candidate.stage, defaultRun(candidate)?.id ?? '');
                 }}
               >
                 {candidate.title}
@@ -193,7 +208,7 @@ export default function Benchmarks(): ReactNode {
                   key={run.id}
                   type="button"
                   aria-pressed={run.id === activeRun.id}
-                  onClick={() => setActiveId(run.id)}
+                  onClick={() => navigateTo(benchmark.stage, run.id)}
                 >
                   {run.variant} / {run.arm}
                 </button>


### PR DESCRIPTION
## Description

The benchmark viewer selected a benchmark and run only in component state. A reviewer could not link directly to a specific audit timeline, and refreshing always returned to the default run.

## Solution

Encode non-default selections as `?benchmark=<stage>&run=<id>` and derive the selected view from the URL after hydration. Because run IDs repeat across benchmark stages, a run is honored only when its benchmark is also named; incomplete or unknown values fall back safely, and the default selection keeps `/benchmarks` clean. Selecting a benchmark or run updates browser history without a page reload.

## Test plan

- Unit tests for explicit benchmark/run links, run-only fallback, invalid run fallback, and clean default URLs
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (86 files, 3,439 tests)
- `pnpm --dir website build`

Fixes #313
