### PR TITLE
fix: group benchmark background lanes

### DIFF
--- a/website/src/components/BenchmarkTimeline.module.css
+++ b/website/src/components/BenchmarkTimeline.module.css
@@ -237,19 +237,27 @@
 .laneLabel,
 .dotTrack,
 .shellTracks,
-.backgroundTrack {
+.backgroundTracks {
   min-width: 0;
   border-bottom: 1px solid var(--bench-line);
 }
 
+.backgroundTracks {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(var(--lane-count), 2.65rem);
+  gap: 0.35rem;
+  padding: 0.5rem 0;
+}
+
 .backgroundTrack {
   position: relative;
-  height: 3.7rem;
+  min-width: 44rem;
 }
 
 .backgroundBar {
   position: absolute;
-  top: 0.52rem;
+  top: 0;
   height: 2.65rem;
   overflow: hidden;
   padding: 0 0.65rem;

--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from 'react';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import {
   assignCommandLanes,
@@ -337,19 +337,23 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
             ))}
           </div>
 
-          {run.backgroundProcesses.length
-            ? run.backgroundProcesses.map((process, index) => {
-                const active =
-                  playbackMode && cursorSeconds >= process.startSeconds && cursorSeconds <= process.endSeconds;
-                const selectedProcess =
-                  !playbackMode && selected?.kind === 'background' && selected.event.id === process.id;
-                return (
-                  <Fragment key={process.id}>
-                    <div className={styles.laneLabel}>{index === 0 ? 'Background' : null}</div>
-                    <div className={styles.backgroundTrack}>
-                      {playbackMode ? (
-                        <i className={styles.playhead} style={{ left: position(cursorSeconds, run.totalSeconds) }} />
-                      ) : null}
+          {run.backgroundProcesses.length ? (
+            <>
+              <div className={styles.laneLabel}>Background</div>
+              <div
+                className={styles.backgroundTracks}
+                style={{ '--lane-count': run.backgroundProcesses.length } as CSSProperties}
+              >
+                {playbackMode ? (
+                  <i className={styles.playhead} style={{ left: position(cursorSeconds, run.totalSeconds) }} />
+                ) : null}
+                {run.backgroundProcesses.map((process) => {
+                  const active =
+                    playbackMode && cursorSeconds >= process.startSeconds && cursorSeconds <= process.endSeconds;
+                  const selectedProcess =
+                    !playbackMode && selected?.kind === 'background' && selected.event.id === process.id;
+                  return (
+                    <div className={styles.backgroundTrack} key={process.id}>
                       <button
                         type="button"
                         className={`${styles.backgroundBar} ${active || selectedProcess ? styles.commandSelected : ''}`}
@@ -368,10 +372,11 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
                         {process.label}
                       </button>
                     </div>
-                  </Fragment>
-                );
-              })
-            : null}
+                  );
+                })}
+              </div>
+            </>
+          ) : null}
 
           <div className={styles.laneLabel}>App/device</div>
           <div className={styles.dotTrack}>


### PR DESCRIPTION
## Description

Detached commands that ran concurrently were rendered as separate full timeline rows. On mobile that added repeated dividers and made the Background section look like unrelated lanes rather than concurrent processes in one category.

## Solution

Render all detected background processes inside one labeled Background container. Each process keeps its own sub-lane so concurrent spans never overlap, while a single outer border and playhead make the category read as one box.

## Test plan

- Browser inspection confirmed a single Background label/container in the audit timeline
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (86 files, 3,436 tests)
- `pnpm --dir website build`

Fixes #314
