### PR TITLE
fix: support Safari timeline zoom

### DIFF
--- a/website/src/components/BenchmarkTimeline.module.css
+++ b/website/src/components/BenchmarkTimeline.module.css
@@ -218,6 +218,7 @@
   border-top: 1px solid var(--bench-line);
   border-bottom: 1px solid var(--bench-line);
   overscroll-behavior-inline: contain;
+  touch-action: pan-x pan-y;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -1,5 +1,5 @@
-import type { CSSProperties, ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import type { CSSProperties, ReactNode, TouchEvent as ReactTouchEvent } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import {
   assignCommandLanes,
@@ -8,6 +8,7 @@ import {
   formatSeconds,
   formatTokens,
   initialAuditSelection,
+  timelineZoomFromPinch,
   timeBreakdown,
   totalTokens,
   type BenchmarkAuditSelection,
@@ -15,6 +16,7 @@ import {
   type BenchmarkCommand,
   type BenchmarkRun,
 } from './benchmarkData';
+import { installTimelineWheelZoom, timelineAnchoredScrollLeft, timelinePinchGeometry } from './timelineGesture';
 import styles from './BenchmarkTimeline.module.css';
 
 function position(seconds: number, total: number): string {
@@ -88,6 +90,10 @@ function TerminalDetail({
   );
 }
 
+function pinchGeometry(event: ReactTouchEvent<HTMLDivElement>): ReturnType<typeof timelinePinchGeometry> {
+  return timelinePinchGeometry(Array.from(event.touches, ({ clientX, clientY }) => ({ clientX, clientY })));
+}
+
 export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): ReactNode {
   const [selected, setSelected] = useState<BenchmarkAuditSelection | null>(() => initialAuditSelection(run));
   const [playbackMode, setPlaybackMode] = useState(false);
@@ -95,11 +101,56 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
   const [cursorSeconds, setCursorSeconds] = useState(0);
   const [speed, setSpeed] = useState(20);
   const [zoom, setZoom] = useState(1);
+  const pinch = useRef<{ distance: number; zoom: number } | null>(null);
+  const timelineScroller = useRef<HTMLDivElement>(null);
+  const zoomAnchor = useRef<{ contentRatio: number; viewportOffset: number } | null>(null);
   const { commands, laneCount } = useMemo(() => assignCommandLanes(run.commands), [run.commands]);
   const breakdown = useMemo(() => timeBreakdown(run), [run]);
   const playbackCommand = useMemo(() => commandAtCursor(run.commands, cursorSeconds), [run.commands, cursorSeconds]);
   const proofSrc = useBaseUrl(run.proof?.src ?? '');
   const ticks = [0, 0.25, 0.5, 0.75, 1];
+  const beginPinch = (event: ReactTouchEvent<HTMLDivElement>) => {
+    const gesture = pinchGeometry(event);
+    if (!gesture) return;
+    pinch.current = { distance: gesture.distance, zoom };
+  };
+  const updatePinch = (event: ReactTouchEvent<HTMLDivElement>) => {
+    const gesture = pinchGeometry(event);
+    if (!gesture || !pinch.current) return;
+    const scroller = timelineScroller.current;
+    if (scroller) {
+      const viewportOffset = gesture.midpointX - scroller.getBoundingClientRect().left;
+      zoomAnchor.current = {
+        contentRatio: (scroller.scrollLeft + viewportOffset) / scroller.scrollWidth,
+        viewportOffset,
+      };
+    }
+    setZoom(timelineZoomFromPinch(pinch.current.zoom, pinch.current.distance, gesture.distance));
+  };
+  const finishPinch = (event: ReactTouchEvent<HTMLDivElement>) => {
+    if (event.touches.length < 2) pinch.current = null;
+  };
+
+  useEffect(() => {
+    const scroller = timelineScroller.current;
+    if (!scroller) return;
+    return installTimelineWheelZoom(scroller, ({ clientX, scale }) => {
+      const viewportOffset = clientX - scroller.getBoundingClientRect().left;
+      zoomAnchor.current = {
+        contentRatio: (scroller.scrollLeft + viewportOffset) / scroller.scrollWidth,
+        viewportOffset,
+      };
+      setZoom((current) => timelineZoomFromPinch(current, 1, scale));
+    });
+  }, []);
+
+  useEffect(() => {
+    const scroller = timelineScroller.current;
+    const anchor = zoomAnchor.current;
+    if (!scroller || !anchor) return;
+    scroller.scrollLeft = timelineAnchoredScrollLeft(anchor.contentRatio, scroller.scrollWidth, anchor.viewportOffset);
+    zoomAnchor.current = null;
+  }, [zoom]);
 
   useEffect(() => {
     if (!playing) return;
@@ -263,12 +314,21 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
           step={0.5}
           value={zoom}
           aria-valuetext={`${zoom} times`}
-          onChange={(event) => setZoom(Number(event.currentTarget.value))}
+          onInput={(event) => setZoom(Number(event.currentTarget.value))}
         />
         <output>{zoom}x</output>
       </label>
 
-      <div className={styles.timelineScroller} tabIndex={0} aria-label="Benchmark command timeline">
+      <div
+        ref={timelineScroller}
+        className={styles.timelineScroller}
+        tabIndex={0}
+        aria-label="Benchmark command timeline"
+        onTouchStart={beginPinch}
+        onTouchMove={updatePinch}
+        onTouchEnd={finishPinch}
+        onTouchCancel={finishPinch}
+      >
         <div
           className={styles.timeline}
           style={{ width: zoom === 1 ? '100%' : `max(${49.5 * zoom}rem, ${zoom * 100}%)` }}

--- a/website/src/components/benchmarkData.test.ts
+++ b/website/src/components/benchmarkData.test.ts
@@ -8,6 +8,7 @@ import {
   commandAtCursor,
   formatSeconds,
   initialAuditSelection,
+  timelineZoomFromPinch,
   timeBreakdown,
   type BenchmarkData,
   type BenchmarkCommand,
@@ -116,6 +117,14 @@ describe('comparisonOutcome', () => {
       tone: 'neutral',
     });
     expect(comparisonOutcome(null, 100)).toEqual({ label: 'Matched run unavailable', tone: 'neutral' });
+  });
+});
+
+describe('timelineZoomFromPinch', () => {
+  it('scales from the gesture start and clamps to the supported range', () => {
+    expect(timelineZoomFromPinch(2, 100, 150)).toBe(3);
+    expect(timelineZoomFromPinch(3, 100, 200)).toBe(4);
+    expect(timelineZoomFromPinch(2, 100, 20)).toBe(1);
   });
 });
 

--- a/website/src/components/benchmarkData.ts
+++ b/website/src/components/benchmarkData.ts
@@ -190,6 +190,11 @@ export function benchmarkSelectionSearch(selection: BenchmarkRouteSelection, ben
   return `?${params.toString()}`;
 }
 
+export function timelineZoomFromPinch(initialZoom: number, initialDistance: number, distance: number): number {
+  if (initialDistance <= 0 || distance <= 0) return Math.min(4, Math.max(1, initialZoom));
+  return Number(Math.min(4, Math.max(1, initialZoom * (distance / initialDistance))).toFixed(2));
+}
+
 export function comparisonOutcome(
   stimSeconds: number | null | undefined,
   controlSeconds: number | null | undefined,

--- a/website/src/components/timelineGesture.test.ts
+++ b/website/src/components/timelineGesture.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  installTimelineWheelZoom,
+  timelineAnchoredScrollLeft,
+  timelinePinchGeometry,
+  type TimelineWheelZoom,
+} from './timelineGesture';
+
+function wheel(ctrlKey: boolean, deltaY = -25, clientX = 240): Event {
+  const event = new Event('wheel', { cancelable: true });
+  Object.assign(event, { ctrlKey, deltaY, clientX });
+  return event;
+}
+
+describe('installTimelineWheelZoom', () => {
+  it('cancels Ctrl-wheel page zoom and reports the focal point and scale', () => {
+    const target = new EventTarget();
+    const onZoom = vi.fn<(gesture: TimelineWheelZoom) => void>();
+    const remove = installTimelineWheelZoom(target as HTMLElement, onZoom);
+    const event = wheel(true);
+
+    target.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onZoom).toHaveBeenCalledWith({ clientX: 240, scale: Math.exp(0.25) });
+    remove();
+  });
+
+  it('leaves an ordinary wheel event untouched and removes its listener', () => {
+    const target = new EventTarget();
+    const onZoom = vi.fn<(gesture: TimelineWheelZoom) => void>();
+    const remove = installTimelineWheelZoom(target as HTMLElement, onZoom);
+    const ordinary = wheel(false);
+
+    target.dispatchEvent(ordinary);
+    expect(ordinary.defaultPrevented).toBe(false);
+    expect(onZoom).not.toHaveBeenCalled();
+
+    remove();
+    target.dispatchEvent(wheel(true));
+    expect(onZoom).not.toHaveBeenCalled();
+  });
+});
+
+describe('timelineAnchoredScrollLeft', () => {
+  it('keeps the content ratio under the gesture midpoint after zoom', () => {
+    expect(timelineAnchoredScrollLeft(0.5, 1600, 200)).toBe(600);
+  });
+});
+
+describe('timelinePinchGeometry', () => {
+  it('reports a two-touch distance and midpoint', () => {
+    expect(
+      timelinePinchGeometry([
+        { clientX: 100, clientY: 20 },
+        { clientX: 200, clientY: 20 },
+      ]),
+    ).toEqual({ distance: 100, midpointX: 150 });
+  });
+
+  it('leaves one-finger timeline scrolling alone', () => {
+    expect(timelinePinchGeometry([{ clientX: 100, clientY: 20 }])).toBeNull();
+  });
+});

--- a/website/src/components/timelineGesture.ts
+++ b/website/src/components/timelineGesture.ts
@@ -1,0 +1,35 @@
+export interface TimelineWheelZoom {
+  clientX: number;
+  scale: number;
+}
+
+export interface TimelineTouchPoint {
+  clientX: number;
+  clientY: number;
+}
+
+export function timelinePinchGeometry(touches: TimelineTouchPoint[]): { distance: number; midpointX: number } | null {
+  const [first, second] = touches;
+  if (touches.length !== 2 || !first || !second) return null;
+  return {
+    distance: Math.hypot(second.clientX - first.clientX, second.clientY - first.clientY),
+    midpointX: (first.clientX + second.clientX) / 2,
+  };
+}
+
+export function installTimelineWheelZoom(
+  element: HTMLElement,
+  onZoom: (gesture: TimelineWheelZoom) => void,
+): () => void {
+  const listener = (event: WheelEvent) => {
+    if (!event.ctrlKey) return;
+    event.preventDefault();
+    onZoom({ clientX: event.clientX, scale: Math.exp(-event.deltaY * 0.01) });
+  };
+  element.addEventListener('wheel', listener, { passive: false });
+  return () => element.removeEventListener('wheel', listener);
+}
+
+export function timelineAnchoredScrollLeft(contentRatio: number, scrollWidth: number, viewportOffset: number): number {
+  return contentRatio * scrollWidth - viewportOffset;
+}


### PR DESCRIPTION
## Description

The timeline zoom range did not update reliably in Safari, and the horizontally scrollable timeline had no direct pinch gesture on touch devices.

## Solution

Handle the range control's native `input` event, add two-touch pinch scaling on the timeline, and support Safari's Ctrl-wheel trackpad pinch events through a non-passive native listener. Zoom remains clamped from 1× to 4×, stays anchored beneath the gesture midpoint, and the scroller keeps ordinary one-finger/wheel panning.

## Test plan

- Unit tests for pinch scaling and clamps, two-touch geometry, one-touch passthrough, focal anchoring, Ctrl-wheel cancellation, ordinary-wheel passthrough, and listener cleanup
- Safari browser QA: dragging the range control from 1× to 4× expanded the timeline and preserved sticky lane labels
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (86 files, 3,437 tests)
- `pnpm --dir website build`

Fixes #315
