### PR TITLE
feat: add benchmark overview

### DIFF
--- a/website/src/components/benchmarkData.test.ts
+++ b/website/src/components/benchmarkData.test.ts
@@ -3,6 +3,7 @@ import {
   assignCommandLanes,
   benchmarkSelectionFromSearch,
   benchmarkSelectionSearch,
+  benchmarkOverview,
   comparableRuns,
   comparisonOutcome,
   commandAtCursor,
@@ -101,6 +102,72 @@ describe('benchmark URL selection', () => {
     expect(benchmarkSelectionSearch({ stage: 'luna-rc12', runId: 'javascript-stim' }, navigationBenchmarks)).toBe('');
     expect(benchmarkSelectionSearch({ stage: 'sol-rc12', runId: 'native-stim' }, navigationBenchmarks)).toBe(
       '?benchmark=sol-rc12&run=native-stim',
+    );
+  });
+});
+
+describe('benchmarkOverview', () => {
+  it('builds paired rows with shared scaling and exact audit links', () => {
+    const overview = benchmarkOverview(
+      [
+        {
+          stage: 'first',
+          title: 'First',
+          runs: [
+            { id: 'first-stim', arm: 'stim', variant: 'native', valid: true, settingsReadySeconds: 50 },
+            { id: 'first-control', arm: 'control', variant: 'native', valid: true, settingsReadySeconds: 100 },
+          ],
+        },
+        {
+          stage: 'second',
+          title: 'Second',
+          runs: [
+            { id: 'second-stim', arm: 'stim', variant: 'native', valid: true, settingsReadySeconds: 200 },
+            { id: 'wrong-variant', arm: 'control', variant: 'javascript', valid: true, settingsReadySeconds: 400 },
+          ],
+        },
+      ] as BenchmarkData[],
+      'native',
+    );
+
+    expect(overview.maxSeconds).toBe(200);
+    expect(overview.rows[0]?.arms.map(({ arm, widthPercent, href }) => ({ arm, widthPercent, href }))).toEqual([
+      { arm: 'stim', widthPercent: 25, href: '/benchmarks#audit-title' },
+      { arm: 'control', widthPercent: 50, href: '/benchmarks?benchmark=first&run=first-control#audit-title' },
+    ]);
+    expect(overview.rows[1]?.arms[0]).toMatchObject({
+      arm: 'stim',
+      label: 'Stim',
+      widthPercent: 100,
+      href: '/benchmarks?benchmark=second&run=second-stim#audit-title',
+    });
+    expect(overview.rows[1]?.arms[1]).toEqual({
+      arm: 'control',
+      label: 'Control',
+      run: null,
+      widthPercent: 0,
+      href: null,
+    });
+  });
+
+  it('treats invalid and valid runs without a Settings endpoint as missing', () => {
+    const overview = benchmarkOverview(
+      [
+        {
+          stage: 'missing',
+          title: 'Missing',
+          runs: [
+            { id: 'invalid', arm: 'stim', variant: 'javascript', valid: false, settingsReadySeconds: 30 },
+            { id: 'no-endpoint', arm: 'control', variant: 'javascript', valid: true, settingsReadySeconds: null },
+          ],
+        },
+      ] as BenchmarkData[],
+      'javascript',
+    );
+
+    expect(overview.maxSeconds).toBe(1);
+    expect(overview.rows[0]?.arms.every((arm) => arm.run === null && arm.href === null && arm.widthPercent === 0)).toBe(
+      true,
     );
   });
 });

--- a/website/src/components/benchmarkData.ts
+++ b/website/src/components/benchmarkData.ts
@@ -123,6 +123,25 @@ export type BenchmarkRouteSelection = {
   runId: string;
 };
 
+export type BenchmarkOverviewArm = {
+  arm: BenchmarkRun['arm'];
+  label: 'Stim' | 'Control';
+  run: (BenchmarkRun & { settingsReadySeconds: number }) | null;
+  widthPercent: number;
+  href: string | null;
+};
+
+export type BenchmarkOverviewRow = {
+  stage: string;
+  title: string;
+  arms: BenchmarkOverviewArm[];
+};
+
+export type BenchmarkOverview = {
+  maxSeconds: number;
+  rows: BenchmarkOverviewRow[];
+};
+
 function orderedCopy<T>(values: T[], compare: (a: T, b: T) => number): T[] {
   const result: T[] = [];
   for (const value of values) {
@@ -193,6 +212,31 @@ export function benchmarkSelectionSearch(selection: BenchmarkRouteSelection, ben
 export function timelineZoomFromPinch(initialZoom: number, initialDistance: number, distance: number): number {
   if (initialDistance <= 0 || distance <= 0) return Math.min(4, Math.max(1, initialZoom));
   return Number(Math.min(4, Math.max(1, initialZoom * (distance / initialDistance))).toFixed(2));
+}
+
+export function benchmarkOverview(benchmarks: BenchmarkData[], variant: BenchmarkRun['variant']): BenchmarkOverview {
+  const candidates = benchmarks.map((benchmark) => ({
+    benchmark,
+    runs: comparableRuns(benchmark.runs).filter((run) => run.variant === variant),
+  }));
+  const maxSeconds = Math.max(1, ...candidates.flatMap(({ runs }) => runs.map((run) => run.settingsReadySeconds)));
+  const rows = candidates.map(({ benchmark, runs }) => ({
+    stage: benchmark.stage,
+    title: benchmark.title,
+    arms: (['stim', 'control'] as const).map((arm) => {
+      const run = runs.find((candidate) => candidate.arm === arm) ?? null;
+      return {
+        arm,
+        label: arm === 'stim' ? 'Stim' : 'Control',
+        run,
+        widthPercent: run ? (run.settingsReadySeconds / maxSeconds) * 100 : 0,
+        href: run
+          ? `/benchmarks${benchmarkSelectionSearch({ stage: benchmark.stage, runId: run.id }, benchmarks)}#audit-title`
+          : null,
+      };
+    }),
+  }));
+  return { maxSeconds, rows };
 }
 
 export function comparisonOutcome(

--- a/website/src/pages/benchmarks.module.css
+++ b/website/src/pages/benchmarks.module.css
@@ -28,6 +28,183 @@
   line-height: 1.7;
 }
 
+.overview {
+  margin-bottom: 2rem;
+}
+
+.overviewGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.overviewChart {
+  padding: 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 1rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.overviewChartHead,
+.overviewLegend {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.overviewChartHead h3 {
+  margin: 0;
+}
+
+.overviewChartHead > span,
+.overviewLegend {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.72rem;
+}
+
+.overviewLegend {
+  justify-content: flex-end;
+  gap: 1rem;
+  margin: 0.4rem 0 1rem;
+}
+
+.stimKey::before,
+.controlKey::before {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-right: 0.35rem;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  content: '';
+}
+
+.controlKey::before {
+  background: #f97316;
+}
+
+.overviewModel {
+  display: grid;
+  grid-template-columns: 6.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.overviewModel > strong {
+  padding-top: 0.2rem;
+  font-size: 0.78rem;
+}
+
+.overviewBars {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.overviewBarLink,
+.missingBar {
+  display: grid;
+  grid-template-columns: 3.25rem minmax(4rem, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+  color: var(--ifm-font-color-base);
+  font-size: 0.72rem;
+  text-decoration: none;
+}
+
+.overviewBarLink:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.overviewBarLink:focus-visible {
+  border-radius: 0.25rem;
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 0.2rem;
+}
+
+.overviewBarLink strong,
+.missingBar > :last-child {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.overviewTrack {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.overviewBar {
+  display: block;
+  min-width: 0.35rem;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--ifm-color-primary);
+}
+
+.missingBar {
+  color: var(--ifm-color-emphasis-600);
+}
+
+.missingBar > :last-child {
+  grid-column: 2 / 4;
+}
+
+.methodology {
+  display: grid;
+  grid-template-columns: minmax(14rem, 0.75fr) minmax(0, 1.25fr);
+  gap: 2rem;
+  margin-bottom: 3.5rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-surface-color));
+}
+
+.methodology h2 {
+  margin-top: 0;
+}
+
+.methodology p,
+.methodology dl,
+.methodology dd {
+  margin: 0;
+}
+
+.methodology p {
+  margin-bottom: 0.75rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.methodology dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.methodology dt {
+  margin-bottom: 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.methodology dd {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.82rem;
+}
+
+.detailHeading {
+  margin-bottom: 1.75rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.detailHeading h2 {
+  margin: 0;
+}
+
 .modelPicker {
   display: flex;
   flex-wrap: wrap;
@@ -255,8 +432,14 @@
     padding-top: 2rem;
   }
 
+  .overviewGrid,
   .comparisonGrid {
     grid-template-columns: 1fr;
+  }
+
+  .methodology {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
   }
 
   .environment {
@@ -270,5 +453,20 @@
 
   .sectionHeading p {
     margin-top: 0.4rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .overviewModel {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .overviewModel > strong {
+    padding-top: 0;
+  }
+
+  .methodology dl {
+    grid-template-columns: 1fr;
   }
 }

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -229,7 +229,9 @@ export default function Benchmarks(): ReactNode {
                 endpoint starts when the agent is dispatched and stops only after agent-device finds the expected text
                 on Settings and saves a screenshot.
               </p>
-              <a href="https://github.com/appandflow/stim/blob/main/docs/agent-benchmark-v4.md">Read the full protocol</a>
+              <a href="https://github.com/appandflow/stim/blob/main/docs/agent-benchmark-v4.md">
+                Read the full protocol
+              </a>
             </div>
             <dl>
               <div>

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -200,7 +200,7 @@ export default function Benchmarks(): ReactNode {
                 <Heading as="h2" id="overview-title">
                   Performance across models
                 </Heading>
-                <p>One matched pilot run per arm and task. Lower Settings-ready time is better.</p>
+                <p>Each bar is one valid pilot run; missing or invalid cells are labeled. Lower time is better.</p>
               </div>
             </div>
             <div className={styles.overviewGrid}>

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -8,6 +8,7 @@ import Heading from '@theme/Heading';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
 import {
   comparableRuns,
+  benchmarkOverview,
   benchmarkSelectionFromSearch,
   benchmarkSelectionSearch,
   comparisonOutcome,
@@ -86,11 +87,7 @@ function OverviewChart({
   variant: BenchmarkRun['variant'];
   benchmarks: BenchmarkData[];
 }): ReactNode {
-  const rows = allBenchmarks.map((candidate) => ({
-    benchmark: candidate,
-    runs: comparableRuns(candidate.runs).filter((run) => run.variant === variant),
-  }));
-  const maxSeconds = Math.max(1, ...rows.flatMap(({ runs }) => runs.map((run) => run.settingsReadySeconds)));
+  const overview = benchmarkOverview(allBenchmarks, variant);
   return (
     <article className={styles.overviewChart}>
       <div className={styles.overviewChartHead}>
@@ -101,39 +98,34 @@ function OverviewChart({
         <span className={styles.stimKey}>Stim</span>
         <span className={styles.controlKey}>Control</span>
       </div>
-      {rows.map(({ benchmark: candidate, runs }) => (
-        <div className={styles.overviewModel} key={candidate.stage}>
-          <strong>{candidate.title}</strong>
+      {overview.rows.map((row) => (
+        <div className={styles.overviewModel} key={row.stage}>
+          <strong>{row.title}</strong>
           <div className={styles.overviewBars}>
-            {(['stim', 'control'] as const).map((arm) => {
-              const run = runs.find((candidateRun) => candidateRun.arm === arm);
-              if (!run) {
+            {row.arms.map((arm) => {
+              if (!arm.run || !arm.href) {
                 return (
-                  <span className={styles.missingBar} key={arm}>
-                    <span>{arm === 'stim' ? 'Stim' : 'Control'}</span>
+                  <span className={styles.missingBar} key={arm.arm}>
+                    <span>{arm.label}</span>
                     <span>No valid run</span>
                   </span>
                 );
               }
-              const href = `/benchmarks${benchmarkSelectionSearch(
-                { stage: candidate.stage, runId: run.id },
-                allBenchmarks,
-              )}#audit-title`;
               return (
                 <Link
                   className={styles.overviewBarLink}
-                  key={arm}
-                  to={href}
-                  aria-label={`${candidate.title} ${displayVariant(variant)}, ${arm}, ${formatSeconds(run.settingsReadySeconds)}. Open run audit.`}
+                  key={arm.arm}
+                  to={arm.href}
+                  aria-label={`${row.title} ${displayVariant(variant)}, ${arm.arm}, ${formatSeconds(arm.run.settingsReadySeconds)}. Open run audit.`}
                 >
-                  <span>{arm === 'stim' ? 'Stim' : 'Control'}</span>
+                  <span>{arm.label}</span>
                   <span className={styles.overviewTrack} aria-hidden="true">
                     <span
-                      className={`${styles.overviewBar} ${arm === 'control' ? styles.controlBar : ''}`}
-                      style={{ width: `${(run.settingsReadySeconds / maxSeconds) * 100}%` }}
+                      className={`${styles.overviewBar} ${arm.arm === 'control' ? styles.controlBar : ''}`}
+                      style={{ width: `${arm.widthPercent}%` }}
                     />
                   </span>
-                  <strong>{formatSeconds(run.settingsReadySeconds)}</strong>
+                  <strong>{formatSeconds(arm.run.settingsReadySeconds)}</strong>
                 </Link>
               );
             })}

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { useHistory, useLocation } from '@docusaurus/router';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
@@ -78,6 +79,71 @@ function ComparisonCard({
   );
 }
 
+function OverviewChart({
+  variant,
+  benchmarks: allBenchmarks,
+}: {
+  variant: BenchmarkRun['variant'];
+  benchmarks: BenchmarkData[];
+}): ReactNode {
+  const rows = allBenchmarks.map((candidate) => ({
+    benchmark: candidate,
+    runs: comparableRuns(candidate.runs).filter((run) => run.variant === variant),
+  }));
+  const maxSeconds = Math.max(1, ...rows.flatMap(({ runs }) => runs.map((run) => run.settingsReadySeconds)));
+  return (
+    <article className={styles.overviewChart}>
+      <div className={styles.overviewChartHead}>
+        <h3>{displayVariant(variant)}</h3>
+        <span>Settings-ready time</span>
+      </div>
+      <div className={styles.overviewLegend} aria-hidden="true">
+        <span className={styles.stimKey}>Stim</span>
+        <span className={styles.controlKey}>Control</span>
+      </div>
+      {rows.map(({ benchmark: candidate, runs }) => (
+        <div className={styles.overviewModel} key={candidate.stage}>
+          <strong>{candidate.title}</strong>
+          <div className={styles.overviewBars}>
+            {(['stim', 'control'] as const).map((arm) => {
+              const run = runs.find((candidateRun) => candidateRun.arm === arm);
+              if (!run) {
+                return (
+                  <span className={styles.missingBar} key={arm}>
+                    <span>{arm === 'stim' ? 'Stim' : 'Control'}</span>
+                    <span>No valid run</span>
+                  </span>
+                );
+              }
+              const href = `/benchmarks${benchmarkSelectionSearch(
+                { stage: candidate.stage, runId: run.id },
+                allBenchmarks,
+              )}#audit-title`;
+              return (
+                <Link
+                  className={styles.overviewBarLink}
+                  key={arm}
+                  to={href}
+                  aria-label={`${candidate.title} ${displayVariant(variant)}, ${arm}, ${formatSeconds(run.settingsReadySeconds)}. Open run audit.`}
+                >
+                  <span>{arm === 'stim' ? 'Stim' : 'Control'}</span>
+                  <span className={styles.overviewTrack} aria-hidden="true">
+                    <span
+                      className={`${styles.overviewBar} ${arm === 'control' ? styles.controlBar : ''}`}
+                      style={{ width: `${(run.settingsReadySeconds / maxSeconds) * 100}%` }}
+                    />
+                  </span>
+                  <strong>{formatSeconds(run.settingsReadySeconds)}</strong>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </article>
+  );
+}
+
 export default function Benchmarks(): ReactNode {
   const history = useHistory();
   const location = useLocation();
@@ -128,12 +194,67 @@ export default function Benchmarks(): ReactNode {
         <div className="container">
           <header className={styles.hero}>
             <div className={styles.eyebrow}>Agent benchmark / protocol v{benchmark.protocolVersion}</div>
-            <Heading as="h1">{benchmark.title}: Stim vs local toolchain</Heading>
+            <Heading as="h1">Stim agent benchmarks</Heading>
             <p>
-              One matched run per arm. The sole performance endpoint is elapsed time from agent dispatch to a validated
-              Settings screenshot; lower is better. Every command and proof image remains available below for audit.
+              Compare how coding agents launch the same React Native app with Stim and the local Expo/Apple toolchain.
+              Results are split into JavaScript and native tasks, and every published time links to its command-level
+              audit and Settings-screen proof.
             </p>
           </header>
+
+          <section className={styles.overview} aria-labelledby="overview-title">
+            <div className={styles.sectionHeading}>
+              <div>
+                <Heading as="h2" id="overview-title">
+                  Performance across models
+                </Heading>
+                <p>One matched pilot run per arm and task. Lower Settings-ready time is better.</p>
+              </div>
+            </div>
+            <div className={styles.overviewGrid}>
+              {(['javascript', 'native'] as const).map((variant) => (
+                <OverviewChart key={variant} variant={variant} benchmarks={benchmarks} />
+              ))}
+            </div>
+          </section>
+
+          <section className={styles.methodology} aria-labelledby="methodology-title">
+            <div>
+              <span className={styles.eyebrow}>Methodology</span>
+              <Heading as="h2" id="methodology-title">
+                What these numbers measure
+              </Heading>
+              <p>
+                Each pair uses the same clean app fixture, requested model, machine, and fixed code change. The primary
+                endpoint starts when the agent is dispatched and stops only after agent-device finds the expected text
+                on Settings and saves a screenshot.
+              </p>
+              <a href="https://github.com/appandflow/stim/blob/main/docs/agent-benchmark-v4.md">Read the full protocol</a>
+            </div>
+            <dl>
+              <div>
+                <dt>Two tasks</dt>
+                <dd>JavaScript-only and native changes run as separate benchmark passes.</dd>
+              </div>
+              <div>
+                <dt>Two arms</dt>
+                <dd>Stim uses its pinned RC and parked simulator; control uses local Expo and Apple tooling.</dd>
+              </div>
+              <div>
+                <dt>Proof, not process liveness</dt>
+                <dd>The reported time is the validated Settings screenshot, not the earlier app-process marker.</dd>
+              </div>
+              <div>
+                <dt>Audited attempts</dt>
+                <dd>Transcript rules, device identity, isolation, and proof are checked; invalid runs are excluded.</dd>
+              </div>
+            </dl>
+          </section>
+
+          <div className={styles.detailHeading}>
+            <span className={styles.eyebrow}>Detailed audit</span>
+            <Heading as="h2">{benchmark.title}: Stim vs local toolchain</Heading>
+          </div>
 
           <nav className={styles.modelPicker} aria-label="Benchmark model">
             <span>Model</span>


### PR DESCRIPTION
## Description

The public benchmark viewer grew from one model into four, but it still opened on one model's detailed audit. Readers could not see the methodology or compare Stim/control performance across models and the separate JavaScript/native tasks without manually switching every dataset.

## Solution

Turn the top of `/benchmarks` into a shareable overview. Two cross-model charts show the valid Stim and control Settings-ready times for JavaScript and native changes; each bar links to the exact benchmark/run audit, and a missing valid cell is labeled instead of plotted as zero. A concise methodology section explains the fixed fixture, separate tasks, two arms, screenshot endpoint, and validity filtering, with a link to the full protocol. The existing per-model comparison, machine details, timeline, playback, terminal output, and proof remain below.

## Test plan

- Safari visual QA for the overview charts, methodology, dark theme, and transition into the detailed audit
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (86 files, 3,439 tests)
- `pnpm --dir website build`

Fixes #321
