### PR TITLE
chore: release 1.0.0-rc.13

### DIFF
--- a/docs/releases/1.0.0-rc.13.md
+++ b/docs/releases/1.0.0-rc.13.md
@@ -1,0 +1,16 @@
+# 1.0.0-rc.13
+
+## New
+
+- [`91724f4`](https://github.com/appandflow/stim/commit/91724f411193b888d2204a35d25b666a0e8f7bd7) structures successful `stim doctor` output into labeled project, platform, shared-service, and automatically handled checks, and adds the selected platform to reports with findings.
+- [`f06cd45`](https://github.com/appandflow/stim/commit/f06cd452c061cbbd3fab3650d3a1d6ad3e850353) adds `stim guide agent` as the version-matched coding-agent workflow. The skill installed by `npx skills add appandflow/stim` is now a tiny one-time router to that CLI guidance.
+
+## Fixes
+
+- [`58140dc`](https://github.com/appandflow/stim/commit/58140dcf669d56c2f2b6eb3c16451fce0c750ce9) removes dangling separators when Stim shortens long owned iOS simulator names.
+
+## Docs
+
+- The benchmark site now includes an overview, interactive timeline, model selection, playback, valid-attempt filtering, run activity, zoom, deep links, grouped background lanes, Safari gestures, corrected device-session evidence, and clearer result labels ([`efb389d`](https://github.com/appandflow/stim/commit/efb389dcfce19e3da9c9df164d16aa4b369403b6), [`198c996`](https://github.com/appandflow/stim/commit/198c996c33744c93abd68f49ef4d2552f50f4489), [`ff52efc`](https://github.com/appandflow/stim/commit/ff52efcaf393a4fa41dde860750d53b9a4473245), [`0ba0db6`](https://github.com/appandflow/stim/commit/0ba0db654f26b9d05c713d38fb801ab513a9d5c8), [`fbadca6`](https://github.com/appandflow/stim/commit/fbadca6e2aba393ccd69d35f5dffd373fdf101f7), [`7ab80fa`](https://github.com/appandflow/stim/commit/7ab80fa99c532a4cb6b5e06d7aeee2b3522ae72b), [`e6d8040`](https://github.com/appandflow/stim/commit/e6d8040baf3ecb3c4a7a0715f38fe2cd2b64c5c3), [`47802ba`](https://github.com/appandflow/stim/commit/47802ba473fe2b15605b4c32f8cb3d7f51ec3c64), [`f2c2752`](https://github.com/appandflow/stim/commit/f2c27520b07a765bda2724a70908e1fcf3666d92), [`7689578`](https://github.com/appandflow/stim/commit/7689578a81927dde5316fb31f410988eddd74f7a), [`d91a97e`](https://github.com/appandflow/stim/commit/d91a97eebcaf00654e90e0dd046550bece089c85)).
+- [`82855e0`](https://github.com/appandflow/stim/commit/82855e0087ed330cf07dc0fc7bd765046a4a6b33) adds copyable prompts for common build, device, log, cache, and PR-validation workflows and clarifies when agents should use Stim or create a worktree.
+- [`3390c6f`](https://github.com/appandflow/stim/commit/3390c6fd11dc453fb44e61196486ea1a3acc01bd) adds an automated continuous benchmark replay for the website and social sharing, including the audited clock and recreated real-speed device interaction.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/cache",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "Cache provider contract and tier coordination for Stim.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/core",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "Shared internal cache and runtime primitives for Stim packages.",
   "license": "MIT",
   "repository": {

--- a/packages/expo-build-cache/package.json
+++ b/packages/expo-build-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/expo-build-cache",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "Local Expo build cache provider: installs a cached .app/.apk instead of compiling when no native input changed.",
   "license": "MIT",
   "repository": {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/metro",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "Metro integration for Stim: shared transforms across worktrees and structured logs.",
   "license": "MIT",
   "repository": {

--- a/packages/stim-cli/package.json
+++ b/packages/stim-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stim-cli",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "Stim: fast, isolated React Native environments for coding agents",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Description

Publishes the changes since rc.12 as 1.0.0-rc.13 across all five packages. The release includes the version-matched agent guide, structured doctor output, an iOS simulator-name fix, copyable agent prompts, and the expanded benchmark site.

Manual native simulator and browser passes were omitted at the user's request; the complete automated preflight passed. Residual risk is limited to another unexpected long simulator-name format or an unobserved doctor/website presentation regression.

## Solution

Bump the five package manifests to 1.0.0-rc.13 and add the reviewed release notes. The release commit itself changes no runtime behavior beyond the package version.

## Test plan

- Full candidate preflight passed: format, lint, build, typecheck, knip, 3,447 unit tests, 20 end-to-end tests, and the Node 20 runtime-floor check.
- Built CLI passed `--help`, exact `--version`, and `guide agent` smoke tests.
- All five npm tarball manifests matched their expected file whitelists and included their README; `stim-cli` included `skill/SKILL.md`.

Related: #320, #323, #325, #326, #327, and #333
