### PR TITLE
feat: add copyable agent prompts

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -934,12 +934,31 @@ test('website command tabs synchronize with Global as the default', () => {
   expect(tabs).toContain("const npxPrefix = 'npx stim-cli'");
 });
 
+test('the website offers copyable outcome prompts and explains skill activation', () => {
+  const promptBox = readFileSync(new URL('../../../../website/src/components/PromptBox.tsx', import.meta.url), 'utf-8');
+  const gettingStarted = readFileSync(new URL('../../../../website/docs/getting-started.md', import.meta.url), 'utf-8');
+  const agentSkills = readFileSync(new URL('../../../../website/docs/agent-skills.md', import.meta.url), 'utf-8');
+
+  expect(promptBox).toContain("import CodeBlock from '@theme/CodeBlock'");
+  expect(promptBox).toContain('<CodeBlock language="text">');
+  expect(gettingStarted).toContain('You normally do not need to name Stim');
+  expect(gettingStarted).toContain('The current checkout is the default');
+  expect(gettingStarted).toContain('Build and run the app on an iPhone 17 simulator with iOS 26.5');
+  expect(gettingStarted).toContain('cache hit rate, mean cold and cached duration');
+  expect(gettingStarted).toContain('Use agent-device to record the affected flow before the change');
+  expect(gettingStarted).toContain('Before and After recordings in a table');
+  expect(agentSkills).toMatch(/requests match\s+the skill without naming Stim/);
+});
+
 test('the agent guide carries the normal workflow and safety rules', () => {
   const agent = renderTopic('agent');
   assert(agent);
   expect(agent).toContain('stim doctor --platform ios');
   expect(agent).toContain('stim worktree create <name> --carry-ignored');
   expect(agent).toMatch(/ios and android install the app, launch it, and check readiness/);
+  expect(agent).toMatch(/give the user one compact result: exact device,[\s\S]*total duration/);
+  expect(agent).toMatch(/whether stim logs\s+--errors passed/);
+  expect(agent).toMatch(/Do not repeat the\s+phase transcript/);
   expect(agent).toMatch(/Exit code 0 from logs --errors is the pass condition/);
   expect(agent).toContain('No matching log records');
   expect(agent).toMatch(/Ordinary stim stop and an authorized clean\s+stim worktree remove do not need/);

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -63,6 +63,10 @@ RULES DURING THE LOOP
   exact device, app, Metro, and launch facts in the final summary. Use the full
   reported device ID. Never assume a simulator named booted belongs to this
   workspace.
+- After each ios or android run, give the user one compact result: exact device,
+  app id, launch state, cache result, total duration, and whether stim logs
+  --errors passed. Include a remedy only when action remains. Do not repeat the
+  phase transcript.
 - An OK summary with no launch qualifier proves the launch. "bundle requested,
   still building" means Metro has not finished; wait and query the logs. For
   launch UNVERIFIED, follow the printed remedy before claiming success. JSON

--- a/website/docs/agent-skills.md
+++ b/website/docs/agent-skills.md
@@ -15,6 +15,15 @@ the agent to load `stim guide agent` before using Stim. The normal workflow,
 ownership rules, destructive-command rules, and routing to detailed topics all
 come from the installed CLI and therefore match its version.
 
+You normally ask for the outcome: "build and run the app on iOS", "show the
+recent app errors", or "run this on my connected phone". Those requests match
+the skill without naming Stim. Add "use Stim" only when you want to override a
+project wrapper or another tool choice.
+
+Stim uses the current checkout by default. Ask for a separate worktree when you
+want isolated or parallel work; the agent may also choose one when the task
+already requires that isolation.
+
 Upgrading Stim also upgrades the guidance. The static skill does not need to be
 reinstalled when commands or behavior change.
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -5,6 +5,7 @@ description: 'Install Stim, add the agent skill, and run the first isolated app'
 ---
 
 import StimTabs, { StimInstallTabs } from '@site/src/components/StimTabs';
+import PromptBox, { PromptGrid } from '@site/src/components/PromptBox';
 
 ## Install Stim
 
@@ -26,9 +27,14 @@ so upgrading Stim does not require reinstalling the skill.
 
 Give the agent an outcome, not a command sequence:
 
-```text
-Build and run the app on the iOS simulator. Fix any build or launch errors.
-```
+<PromptBox title="Build and run">
+  {`Build and run the app on iOS. Fix any build or launch errors.`}
+</PromptBox>
+
+You normally do not need to name Stim. Installing the skill lets a compatible
+agent route build, run, device, log, and worktree requests to Stim. Say "use
+Stim" only when you want to force that choice instead of a project-specific
+wrapper.
 
 The agent normally runs:
 
@@ -44,9 +50,42 @@ Use `stim android` for Android. Stim works with React Native Community CLI and
 Expo projects. It needs no project initialization and writes no runtime state
 into the repository.
 
+After a build, the agent should report only the exact device and app, launch
+state, cache result, total duration, and whether the error log is clean. Ask for
+build-performance details when you want history across runs.
+
+## Common prompts
+
+Each prompt has a copy button.
+
+<PromptGrid>
+  <PromptBox title="Choose an iOS simulator">
+    {`Build and run the app on an iPhone 17 simulator with iOS 26.5. Fix any build or launch errors.`}
+  </PromptBox>
+  <PromptBox title="Run on a connected phone">
+    {`Build and run the app on my connected iPhone. Tell me if I need to approve anything on the phone.`}
+  </PromptBox>
+  <PromptBox title="Inspect recent errors">
+    {`Show me the app errors from the last 10 minutes and explain which ones need action.`}
+  </PromptBox>
+  <PromptBox title="Check the environment">
+    {`Tell me which app build, device, and Metro server are active for this workspace.`}
+  </PromptBox>
+  <PromptBox title="Review build performance">
+    {`Compare this project's iOS build performance: run count, cache hit rate, mean cold and cached duration, and estimated time saved.`}
+  </PromptBox>
+  <PromptBox title="Work in parallel">
+    {`Make this change in a separate worktree, run it on iOS, and preserve the branch when you finish.`}
+  </PromptBox>
+  <PromptBox title="Record PR validation">
+    {`Fix this issue in a separate worktree. Use agent-device to record the affected flow before the change, implement and run the fix on iOS, then record the same flow after the change. Open a PR with the Before and After recordings in a table and summarize the validation.`}
+  </PromptBox>
+</PromptGrid>
+
 ## Run work in parallel
 
-An agent can create a separate worktree when a task needs isolation:
+The current checkout is the default. An agent creates a separate worktree only
+when the task needs isolation or parallel work, or when you ask for one:
 
 <StimTabs
 code={`stim worktree create feature-name --carry-ignored

--- a/website/src/components/PromptBox.module.css
+++ b/website/src/components/PromptBox.module.css
@@ -1,0 +1,53 @@
+.promptGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.promptBox {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.75rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.promptTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.promptBox :global(.theme-code-block) {
+  margin-bottom: 0;
+}
+
+.promptBox :global(.theme-code-block) button {
+  opacity: 1;
+}
+
+.promptBox:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+
+.promptBox pre {
+  overflow-x: hidden;
+}
+
+.promptBox pre,
+.promptBox pre code,
+.promptBox pre code div,
+.promptBox pre code span {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 768px) {
+  .promptGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .promptBox:last-child:nth-child(odd) {
+    grid-column: auto;
+  }
+}

--- a/website/src/components/PromptBox.tsx
+++ b/website/src/components/PromptBox.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import styles from './PromptBox.module.css';
+
+export function PromptGrid({ children }: { children: ReactNode }): ReactNode {
+  return <div className={styles.promptGrid}>{children}</div>;
+}
+
+export default function PromptBox({ title, children }: { title: string; children: string }): ReactNode {
+  return (
+    <article className={styles.promptBox}>
+      <h3 className={styles.promptTitle}>{title}</h3>
+      <CodeBlock language="text">{children.trim()}</CodeBlock>
+    </article>
+  );
+}


### PR DESCRIPTION
## Description

Adds a copyable prompt gallery to the website Getting Started page and aligns `stim guide agent` with the expected post-build report.

Closes #325.

## Solution

- Add a reusable prompt card grid using Docusaurus's built-in copyable code block.
- Cover simulator and connected-device selection, recent logs, active environment details, cache hit rate, cached versus cold duration, parallel work, and PR validation.
- Make the PR-validation prompt request agent-device recordings of the same user flow before and after the change, presented in a Markdown table.
- Clarify that natural build and run requests may activate the installed Stim skill without naming Stim.
- Clarify that agents should use the current checkout unless the user asks for isolated or parallel work, or the task already requires that isolation.
- Instruct agents through `stim guide agent` to report the device, app, launch state, cache result, duration, and error-log status after a build.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run knip`
- `pnpm test` (3,443 passed)
- `pnpm --filter website run build`
- Visually checked the prompt gallery, wrapping, persistent copy controls, and full-width PR-validation card on the local production site.
