### PR TITLE
fix: remove versions from benchmark labels

### DIFF
--- a/website/src/components/benchmarkData.test.ts
+++ b/website/src/components/benchmarkData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   assignCommandLanes,
+  benchmarkDisplayTitle,
   benchmarkSelectionFromSearch,
   benchmarkSelectionSearch,
   benchmarkOverview,
@@ -66,6 +67,18 @@ describe('formatSeconds', () => {
     expect(formatSeconds(59.6)).toBe('1m 0s');
     expect(formatSeconds(59.4)).toBe('59s');
     expect(formatSeconds(null)).toBe('unavailable');
+  });
+});
+
+describe('benchmarkDisplayTitle', () => {
+  it('removes release and benchmark versions from display titles', () => {
+    expect(benchmarkDisplayTitle('Luna rc.12')).toBe('Luna');
+    expect(benchmarkDisplayTitle('Sonnet RC12')).toBe('Sonnet');
+    expect(benchmarkDisplayTitle('Benchmark v4')).toBe('Benchmark');
+  });
+
+  it('keeps model version numbers that are part of the name', () => {
+    expect(benchmarkDisplayTitle('GPT-5.6 Luna')).toBe('GPT-5.6 Luna');
   });
 });
 

--- a/website/src/components/benchmarkData.ts
+++ b/website/src/components/benchmarkData.ts
@@ -184,6 +184,10 @@ export function totalTokens(usage: BenchmarkUsage): number {
   return usage.input_tokens + usage.output_tokens;
 }
 
+export function benchmarkDisplayTitle(title: string): string {
+  return title.replace(/\s+(?:rc\.?\d+(?:\.\d+)*|v\d+(?:\.\d+)*)$/i, '');
+}
+
 export function comparableRuns(runs: BenchmarkRun[]): Array<BenchmarkRun & { settingsReadySeconds: number }> {
   return runs.filter(
     (run): run is BenchmarkRun & { settingsReadySeconds: number } => run.valid && run.settingsReadySeconds !== null,

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -7,6 +7,7 @@ import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
 import {
+  benchmarkDisplayTitle,
   comparableRuns,
   benchmarkOverview,
   benchmarkSelectionFromSearch,
@@ -100,7 +101,7 @@ function OverviewChart({
       </div>
       {overview.rows.map((row) => (
         <div className={styles.overviewModel} key={row.stage}>
-          <strong>{row.title}</strong>
+          <strong>{benchmarkDisplayTitle(row.title)}</strong>
           <div className={styles.overviewBars}>
             {row.arms.map((arm) => {
               if (!arm.run || !arm.href) {
@@ -116,7 +117,7 @@ function OverviewChart({
                   className={styles.overviewBarLink}
                   key={arm.arm}
                   to={arm.href}
-                  aria-label={`${row.title} ${displayVariant(variant)}, ${arm.arm}, ${formatSeconds(arm.run.settingsReadySeconds)}. Open run audit.`}
+                  aria-label={`${benchmarkDisplayTitle(row.title)} ${displayVariant(variant)}, ${arm.arm}, ${formatSeconds(arm.run.settingsReadySeconds)}. Open run audit.`}
                 >
                   <span>{arm.label}</span>
                   <span className={styles.overviewTrack} aria-hidden="true">
@@ -185,7 +186,7 @@ export default function Benchmarks(): ReactNode {
       <main className={styles.page}>
         <div className="container">
           <header className={styles.hero}>
-            <div className={styles.eyebrow}>Agent benchmark / protocol v{benchmark.protocolVersion}</div>
+            <div className={styles.eyebrow}>Agent benchmark</div>
             <Heading as="h1">Stim agent benchmarks</Heading>
             <p>
               Compare how coding agents launch the same React Native app with Stim and the local Expo/Apple toolchain.
@@ -232,7 +233,9 @@ export default function Benchmarks(): ReactNode {
               </div>
               <div>
                 <dt>Two arms</dt>
-                <dd>Stim uses its pinned RC and parked simulator; control uses local Expo and Apple tooling.</dd>
+                <dd>
+                  Stim uses its pinned published build and parked simulator; control uses local Expo and Apple tooling.
+                </dd>
               </div>
               <div>
                 <dt>Proof, not process liveness</dt>
@@ -247,7 +250,7 @@ export default function Benchmarks(): ReactNode {
 
           <div className={styles.detailHeading}>
             <span className={styles.eyebrow}>Detailed audit</span>
-            <Heading as="h2">{benchmark.title}: Stim vs local toolchain</Heading>
+            <Heading as="h2">{benchmarkDisplayTitle(benchmark.title)}: Stim vs local toolchain</Heading>
           </div>
 
           <nav className={styles.modelPicker} aria-label="Benchmark model">
@@ -261,7 +264,7 @@ export default function Benchmarks(): ReactNode {
                   navigateTo(candidate.stage, defaultRun(candidate)?.id ?? '');
                 }}
               >
-                {candidate.title}
+                {benchmarkDisplayTitle(candidate.title)}
               </button>
             ))}
           </nav>


### PR DESCRIPTION
## Description

The benchmark page gives release-candidate and protocol versions prominent space even though they do not help compare model performance. The provenance must remain available and existing deep links must not change.

## Solution

Render concise model labels such as Luna and Sonnet, replace the protocol-version eyebrow with Agent benchmark, and describe the Stim arm as a pinned published build. Raw dataset titles, protocol metadata, model identifiers, and stage/run query values remain unchanged for auditability and URL compatibility.

## Test plan

- Built and inspected /benchmarks locally: the overview, detail heading, model picker, and accessible chart labels omit rc.12 and v4.
- Opened an existing benchmark query using its luna-rc12 stage and confirmed it still selects the same run.
- Ran the full repository suite: 87 files and 3,446 tests passed; the production documentation build succeeded.

Fixes #328