### PR TITLE
fix(website): rename benchmark events lane

### DIFF
--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -463,7 +463,7 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
             </>
           ) : null}
 
-          <div className={styles.laneLabel}>App/device</div>
+          <div className={styles.laneLabel}>Events</div>
           <div className={styles.dotTrack}>
             {run.markers.map((marker) => (
               <button


### PR DESCRIPTION
## Description

The benchmark timeline groups app and device activity under an ambiguous `App/device` label.

## Solution

Rename the lane to `Events` so it covers all timeline markers clearly.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run knip`
- `pnpm test` — 87 files and 3,449 tests passed
- `pnpm --filter website run typecheck`
- `pnpm --filter website run build`
- Confirmed the benchmark details page visibly displays `Events` in the timeline.

Fixes #338
