### PR TITLE
fix(website): follow the benchmark playhead

### DIFF
--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -17,7 +17,12 @@ import {
   type BenchmarkCommand,
   type BenchmarkRun,
 } from './benchmarkData';
-import { installTimelineWheelZoom, timelineAnchoredScrollLeft, timelinePinchGeometry } from './timelineGesture';
+import {
+  installTimelineWheelZoom,
+  timelineAnchoredScrollLeft,
+  timelinePinchGeometry,
+  timelinePlaybackScrollLeft,
+} from './timelineGesture';
 import styles from './BenchmarkTimeline.module.css';
 
 function position(seconds: number, total: number): string {
@@ -171,6 +176,21 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
   }, [zoom]);
 
   useEffect(() => {
+    const scroller = timelineScroller.current;
+    if (!playing || !scroller) return;
+    scroller.scrollLeft = timelinePlaybackScrollLeft(
+      cursorSeconds / Math.max(1, run.totalSeconds),
+      scroller.scrollWidth,
+      scroller.clientWidth,
+      timelineDimensions.labelWidth,
+    );
+  }, [cursorSeconds, playing, run.totalSeconds, timelineDimensions.labelWidth]);
+
+  useEffect(() => {
+    if (playing && cursorSeconds >= run.totalSeconds) setPlaying(false);
+  }, [cursorSeconds, playing, run.totalSeconds]);
+
+  useEffect(() => {
     if (!playing) return;
     let frame = 0;
     let previous = performance.now();
@@ -178,9 +198,7 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
       const elapsed = ((now - previous) / 1000) * speed;
       previous = now;
       setCursorSeconds((current) => {
-        const next = Math.min(run.totalSeconds, current + elapsed);
-        if (next >= run.totalSeconds) setPlaying(false);
-        return next;
+        return Math.min(run.totalSeconds, current + elapsed);
       });
       frame = requestAnimationFrame(advance);
     };

--- a/website/src/components/timelineGesture.test.ts
+++ b/website/src/components/timelineGesture.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   installTimelineWheelZoom,
   timelineAnchoredScrollLeft,
+  timelinePlaybackScrollLeft,
   timelinePinchGeometry,
   type TimelineWheelZoom,
 } from './timelineGesture';
@@ -45,6 +46,20 @@ describe('installTimelineWheelZoom', () => {
 describe('timelineAnchoredScrollLeft', () => {
   it('keeps the content ratio under the gesture midpoint after zoom', () => {
     expect(timelineAnchoredScrollLeft(0.5, 1600, 200)).toBe(600);
+  });
+});
+
+describe('timelinePlaybackScrollLeft', () => {
+  it('keeps the early playhead in view without scrolling', () => {
+    expect(timelinePlaybackScrollLeft(0.2, 2112, 1000, 112)).toBe(0);
+  });
+
+  it('follows the playhead after it crosses 70% of the visible track', () => {
+    expect(timelinePlaybackScrollLeft(0.5, 2112, 1000, 112)).toBeCloseTo(378.4);
+  });
+
+  it('stops at the end of the scrollable timeline', () => {
+    expect(timelinePlaybackScrollLeft(1, 2112, 1000, 112)).toBe(1112);
   });
 });
 

--- a/website/src/components/timelineGesture.ts
+++ b/website/src/components/timelineGesture.ts
@@ -33,3 +33,16 @@ export function installTimelineWheelZoom(
 export function timelineAnchoredScrollLeft(contentRatio: number, scrollWidth: number, viewportOffset: number): number {
   return contentRatio * scrollWidth - viewportOffset;
 }
+
+export function timelinePlaybackScrollLeft(
+  cursorRatio: number,
+  scrollWidth: number,
+  viewportWidth: number,
+  labelWidth: number,
+): number {
+  const trackWidth = Math.max(0, scrollWidth - labelWidth);
+  const viewportTrackWidth = Math.max(0, viewportWidth - labelWidth);
+  const playheadPosition = labelWidth + Math.min(1, Math.max(0, cursorRatio)) * trackWidth;
+  const followPosition = labelWidth + viewportTrackWidth * 0.7;
+  return Math.min(Math.max(0, scrollWidth - viewportWidth), Math.max(0, playheadPosition - followPosition));
+}


### PR DESCRIPTION
## Description

At increased timeline zoom, playback can move the playhead beyond the visible area while the horizontal scroll position stays fixed. Paused and manual timeline inspection should remain unchanged.

## Solution

While playback is active, the timeline now follows the playhead after it reaches 70% of the visible track and clamps scrolling at the timeline boundaries.

## Test plan

- At 4x zoom and 60x playback with a 1,108 px viewport, verified scroll starts at 0, reaches 2,342 px at 123.6s with the playhead at 799.82 px, and finishes at the 2,999 px maximum with the playhead still visible.
- `pnpm exec vitest run website/src/components/timelineGesture.test.ts` — 8 tests passed, covering early playback, the follow threshold, and end clamping.
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run knip`
- `pnpm test` — 88 files and 3,455 tests passed
- `pnpm --filter website run typecheck`
- `pnpm --filter website run build`

Fixes #339
