### PR TITLE
docs: show realistic cache savings

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -92,7 +92,7 @@ com.appandflow.trailhead · Metro 8083 · launch ready`}
   </PromptBox>
   <PromptBox
     title="Review build performance"
-    response={`iOS · 2 runs · 100% cache hits · cached average 46s · estimated savings ~0s`}
+    response={`iOS · 3 runs · 67% cache hits · cached average 46s · estimated savings ~7m`}
   >
     {`Show iOS build performance.`}
   </PromptBox>


### PR DESCRIPTION
## Description

The simulated iOS build-performance response reported two 100% cache-hit runs but zero estimated savings, making the example look internally inconsistent.

## Solution

Use an internally consistent bucket with one cold run and two 46-second cache hits. A 4m16s cold baseline makes the aggregate savings exactly seven minutes.

## Test plan

- pnpm run format:check
- pnpm run lint
- pnpm run build
- pnpm run typecheck
- pnpm --dir website run typecheck
- pnpm --dir website run build
- pnpm test: 3491 passed; one unrelated connected-iPhone process-probe assertion failed locally

Fixes #349