### PR TITLE
fix(website): space standalone prompt cards

### DIFF
--- a/website/src/components/PromptBox.module.css
+++ b/website/src/components/PromptBox.module.css
@@ -7,10 +7,15 @@
 
 .promptBox {
   min-width: 0;
+  margin-bottom: 1.5rem;
   padding: 1rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 0.75rem;
   background: var(--ifm-background-surface-color);
+}
+
+.promptGrid > .promptBox {
+  margin-bottom: 0;
 }
 
 .promptTitle {


### PR DESCRIPTION
## Description

The standalone “Build and run” prompt card on Getting Started sat almost flush against the paragraph below it. Prompt cards inside the common-prompt grid already get spacing from the grid container.

## Solution

Give prompt cards a 1.5rem bottom margin and remove that margin for direct children of the prompt grid, preserving the grid’s existing gap and outer spacing.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` — 3,492 passed
- `pnpm --dir website run typecheck`
- `pnpm --dir website run build`
- Visually verified the local Getting Started page at desktop and narrow viewport widths.

Fixes #352
