### PR TITLE
chore: scope image-size audit exceptions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,13 @@ allowBuilds:
   core-js: false
   esbuild: false
 
+# Docusaurus uses image-size only while building repository-owned content, and
+# image-size has no patched release (facebook/docusaurus#12231).
+audit:
+  ignore:
+    - GHSA-5p2g-fcmc-qvqq
+    - GHSA-w3rx-r6r6-pgpr
+
 # website's Docusaurus toolchain pulls these transitively at vulnerable
 # versions; the published packages under packages/ do not depend on them
 # (see issue #267).


### PR DESCRIPTION
## Description

Docusaurus 3.10.2 brings `image-size@2.0.2` only into the website build; no published Stim package depends on it. The current pnpm audit reports two high-severity denial-of-service advisories for that single installation. `image-size` has no patched release.

## Solution

Ignore only GHSA-5p2g-fcmc-qvqq and GHSA-w3rx-r6r6-pgpr in pnpm's audit configuration. This keeps the advisories visible as ignored while making the audit actionable for Stim's threat model. The dependency remains pinned through Docusaurus rather than being aliased to an unreviewed community fork; Docusaurus is tracking a maintained replacement in facebook/docusaurus#12231.

The exceptions do not fix the parser: a malformed local image can still hang the website build. Published Stim packages are unaffected.

## Test plan

- `pnpm audit --audit-level high` exits 0 and reports `2 high (2 ignored)`.
- All repository checks pass: format, lint, build, typecheck, and 92 test files with 3,499 tests.
- `pnpm --filter website run build` produces the optimized static site; the root build intentionally excludes the website.

Fixes #285.

