### PR TITLE
fix: recover live bundle errors without relaunch

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2481,6 +2481,8 @@ describe('launch verification', () => {
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
     expect(text).not.toMatch(/a native framework error/);
     expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).toContain('adb -s emulator-5584 shell am broadcast -a com.example.app.RELOAD_APP_ACTION');
+    expect(text).toMatch(/invoke React Native's native reload receiver/);
     expect(text).toMatch(/Do not run `stim android` unless native inputs changed or the app process exits/);
   });
 
@@ -2509,7 +2511,9 @@ describe('launch verification', () => {
     const text = h.stderr.join('\n');
     expect(result.ok).toBe(false);
     expect(text).toMatch(/native app is still running/);
-    expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).toContain('adb -s emulator-5584 shell am broadcast -a com.example.app.RELOAD_APP_ACTION');
+    expect(text).toMatch(/invoke React Native's native reload receiver/);
+    expect(text).not.toContain('agent-device metro reload --metro-port 8082');
     expect(text).toMatch(/Do not run `stim android` unless native inputs changed or the app process exits/);
   });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -966,6 +966,10 @@ test('the agent guide carries the normal workflow and safety rules', () => {
   expect(agent).toMatch(/Exit code 0 from logs --errors is the pass condition/);
   expect(agent).toContain('No matching log records');
   expect(agent).toContain('agent-device metro reload --metro-port <reported-port>');
+  expect(agent).toContain('adb -s <reported-serial> shell am broadcast -a <app-id>.RELOAD_APP_ACTION');
+  expect(agent).toContain('agent-device snapshot -i --platform ios --udid <reported-device>');
+  expect(agent).toContain('agent-device press <reported-ref> --settle');
+  expect(agent).toMatch(/bundle-build error can prevent the app from handling Metro's reload/);
   expect(agent).toMatch(/app error but also says the native process is alive,[\s\S]*app did not crash/);
   expect(agent).toMatch(/FATAL because the app process exited,[\s\S]*Metro cannot restart it/);
   expect(agent).toMatch(/Ordinary stim stop and an authorized clean\s+stim worktree remove do not need/);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -850,6 +850,8 @@ describe('launch verification', () => {
     const text = errs.join('\n');
     expect(text).toMatch(/native app is still running/);
     expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).toContain(`agent-device snapshot -i --platform ios --udid ${UDID}`);
+    expect(text).toMatch(/press its Reload button by the reported ref or label/);
     expect(text).toMatch(/Do not run `stim ios` unless native inputs changed or the app process exits/);
   });
 
@@ -911,7 +913,9 @@ describe('launch verification', () => {
     const text = errs.join('\n');
     expect(exitCode).toBe(1);
     expect(text).toMatch(/native app is still running/);
-    expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).toContain(`agent-device snapshot -i --platform ios --udid ${UDID}`);
+    expect(text).toMatch(/press the error overlay's Reload button by its reported ref or label/);
+    expect(text).not.toContain('agent-device metro reload --metro-port 8082');
     expect(text).toMatch(/Do not run `stim ios` unless native inputs changed or the app process exits/);
   });
 

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -953,7 +953,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error, then run \`agent-device metro reload --metro-port ${metroPort}\`. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. Fix the JavaScript or TypeScript error, then run \`adb -s ${serial} shell am broadcast -a ${androidPackage}.RELOAD_APP_ACTION\` to invoke React Native's native reload receiver. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
         ),
       );
     }
@@ -974,7 +974,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run \`agent-device metro reload --metro-port ${metroPort}\`. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run \`agent-device metro reload --metro-port ${metroPort}\`. If it still remains, run \`adb -s ${serial} shell am broadcast -a ${androidPackage}.RELOAD_APP_ACTION\` to invoke React Native's native reload receiver. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
         ),
       );
     }

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -48,6 +48,13 @@ upstream gap.
   # JavaScript and TypeScript edits use Fast Refresh. If an error screen stays
   # after the edit, reload the running app through its reported Metro port.
   agent-device metro reload --metro-port <reported-port>
+  # A bundle-build error can prevent the app from handling Metro's reload. On
+  # Android, invoke React Native's native reload receiver. On iOS, inspect the
+  # same reported device and press the overlay's Reload button by the ref or
+  # label from the snapshot.
+  adb -s <reported-serial> shell am broadcast -a <app-id>.RELOAD_APP_ACTION
+  agent-device snapshot -i --platform ios --udid <reported-device>
+  agent-device press <reported-ref> --settle
   stim logs --since 30s --level error
 
   stim stop

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1188,7 +1188,7 @@ async function verifyIosRun({
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error, then run \`agent-device metro reload --metro-port ${metroPort}\`. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. Fix the JavaScript or TypeScript error, then inspect it with \`agent-device snapshot -i --platform ios --udid ${udid}\` and press the error overlay's Reload button by its reported ref or label. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );
@@ -1209,7 +1209,7 @@ async function verifyIosRun({
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run \`agent-device metro reload --metro-port ${metroPort}\`. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run \`agent-device metro reload --metro-port ${metroPort}\`. If it still remains, inspect it with \`agent-device snapshot -i --platform ios --udid ${udid}\` and press its Reload button by the reported ref or label. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );


### PR DESCRIPTION
## Description

A JavaScript bundle-resolution failure leaves the React Native process alive but can prevent that process from handling Metro's reload command. The existing remedy therefore told an agent to run a command that appeared to succeed while leaving the error overlay unchanged, increasing the chance of an unnecessary second native launch.

## Solution

Classify the recovery by platform while preserving the existing no-rebuild boundary. Android remedies invoke React Native's exported native reload receiver on the exact Stim-owned emulator. iOS remedies inspect the exact Stim-owned simulator with agent-device and press the error overlay's Reload control. Ordinary runtime errors still try Metro reload first and provide the native path only as a fallback.

The agent guide carries the same distinction so bundle-build failures are not treated like native process crashes.

## Test plan

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run knip`
- `pnpm test` — 92 files, 3,515 tests
- `pnpm run test:e2e` — 20 tests
- `pnpm run test:runtime`
- Bare React Native 0.85.3 on iOS: introduced an unresolved startup import, confirmed Stim reported the live-process bundle error with stack/code frame, repaired it, then recovered the unchanged starter screen by pressing the overlay Reload control through agent-device on the same simulator without a second `stim ios`.
- Bare React Native 0.85.3 on Android: introduced the same unresolved startup import, repaired it, then recovered the unchanged starter screen with `<package>.RELOAD_APP_ACTION` on the same emulator without a second `stim android`.

Fixes #351
