### PR TITLE
chore: remove ignored Vite override

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "typescript": "7.0.2",
     "vitest": "5.0.0"
   },
-  "overrides": {
-    "vite": "npm:rolldown-vite@7.3.1"
-  },
   "engines": {
     "node": ">=22.18.0"
   },


### PR DESCRIPTION
## Description

The root `package.json` still declares an npm-style Vite override, but pnpm 12 reads workspace overrides from `pnpm-workspace.yaml`, so the field is dead configuration. Vitest already resolves to stable Vite 8.2.2 despite the manifest claiming a `rolldown-vite` 7.3.1 substitution.

## Solution

Remove the dead override rather than restoring the alias. The override was added while npm was substituting the temporary `rolldown-vite` package. The later migration from npm to pnpm left that npm-only top-level field in `package.json`, so the current pnpm 12 setup does not read it. See the [introducing commit](https://github.com/appandflow/stim/commit/33a92880655194f5dc454d6e9fe32a515dce1e1f). Restoring the alias would also move the repository away from the current stable Vite 8 release, which already uses Rolldown.

The lockfile is unchanged. `pnpm why vite` resolves one version: Vite 8.2.2 through Vitest 5.0.0.

## Test plan

- `pnpm install --lockfile-only --offline --frozen-lockfile`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test` (92 files, 3,515 tests)
- `pnpm run test:e2e` (20 tests)

Fixes #280
