### PR TITLE
docs: name task phrases in the skill description

### DIFF
--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stim
-description: The React Native / Expo CLI for AI agents. Use when an agent needs an isolated Metro server and simulator or emulator, must build and launch an app, inspect build or runtime errors, create a parallel worktree, or identify the correct device for UI interaction.
+description: The React Native / Expo CLI for AI agents. Use when running or building a React Native or Expo app on a simulator, emulator, or device, including expo run:ios, expo run:android, react-native run-ios, react-native run-android, expo start, and Metro; when reading build, launch, or redbox errors; when working in parallel worktrees; or when identifying the correct device for UI interaction.
 ---
 
 # Stim

--- a/packages/stim-cli/skill/SKILL.md
+++ b/packages/stim-cli/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stim
-description: The React Native / Expo CLI for AI agents. Use when running or building a React Native or Expo app on a simulator, emulator, or device, including expo run:ios, expo run:android, react-native run-ios, react-native run-android, expo start, and Metro; when reading build, launch, or redbox errors; when working in parallel worktrees; or when identifying the correct device for UI interaction.
+description: The React Native / Expo CLI for AI agents. Use when running or building a React Native or Expo app on a simulator, emulator, or device, including expo run:ios, expo run:android, react-native run-ios, react-native run-android, expo start, and Metro; when reading build, launch, redbox, or runtime errors from the app logs; when working in parallel worktrees; or when identifying the correct device for UI interaction.
 ---
 
 # Stim

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -910,6 +910,29 @@ test('the static skill is only the agent guide router', () => {
   }
 });
 
+test('the skill description names the task phrases an agent sees', () => {
+  const skill = readFileSync(new URL('../../skill/SKILL.md', import.meta.url), 'utf-8');
+  const description = skill.match(/^description: (.+)$/m)?.[1];
+  assert(description);
+  expect(description).toMatch(/^The React Native \/ Expo CLI for AI agents\./);
+
+  for (const trigger of [
+    'expo run:ios',
+    'expo run:android',
+    'react-native run-ios',
+    'react-native run-android',
+    'expo start',
+    'Metro',
+    'simulator',
+    'emulator',
+    'device',
+    'redbox',
+    'parallel worktrees',
+  ]) {
+    expect(description).toContain(trigger);
+  }
+});
+
 test('every guide topic explains the npx fallback for short stim commands', () => {
   for (const name of topicNames()) {
     const topic = renderTopic(name);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -927,6 +927,8 @@ test('the skill description names the task phrases an agent sees', () => {
     'emulator',
     'device',
     'redbox',
+    'runtime',
+    'logs',
     'parallel worktrees',
   ]) {
     expect(description).toContain(trigger);


### PR DESCRIPTION
## Description

`packages/stim-cli/skill/SKILL.md` is a discovery router: its only job is to fire on
a matching task and send the agent to `stim guide agent`. The activation description
is therefore the whole activation surface, and it was written in Stim's vocabulary
(isolated Metro server, owned simulator, parallel worktree) rather than the words an
agent actually reads in a task before it knows Stim exists: `expo run:ios`,
`npx react-native run-android`, `expo start`, Metro, a build or redbox error. An
agent whose prompt never names Stim has weaker odds of loading the skill and reaches
for the Expo or React Native CLI directly, which shares ports and devices with other
workspaces. The `agent-device`, `ios-simulator`, and `android-emulator` skills that
ship next to it do list concrete task phrasings.

## Solution

Only the `description:` line changes; the body is byte-identical. The description
keeps the one-sentence identity, then names the triggers as an agent meets them:
running or building a React Native or Expo app on a simulator, emulator, or device;
the `expo run:*`, `react-native run-*`, and `expo start` commands and Metro; reading
build, launch, redbox, or runtime errors from the app logs; parallel worktrees; and
picking the right device for UI interaction. The errors clause keeps the `runtime`
wording the old description had and adds the `logs` vocabulary the `logs` command
never had, so a task phrased as the website's own "Show app errors from the last 10
minutes" still matches. Invariant 1 allows the static skill to change when its
activation description changes and forbids a fallback, version check, or
compatibility branch, so nothing operational moved into the skill.

Two constraints shaped the wording: the value avoids `": "`, which YAML reads as a
mapping inside a plain scalar, and the skill grew from 74 to 94 words against the
100-word cap the existing router test enforces. A new contract test in
`packages/stim-cli/src/__tests__/guide.test.ts` pins the identity sentence and each
trigger phrase so a future edit cannot quietly drop them.

## Test plan

- PyYAML parses the frontmatter into exactly `name` and `description`, the
  description as one 416-character plain scalar - the real parse the harness does,
  which is what the unescaped `/` and the `run:ios` colons needed to clear.
- `npx vitest run packages/stim-cli/src/__tests__/guide.test.ts`: 86 passed, including
  the new description test (each pinned trigger fails against the description on
  `main`) and the existing word-count and forbidden-substring router test.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`,
  `pnpm run knip`: clean.
- `pnpm test`: 3501 passed, 15 failed. The failures are the known local timeouts in
  `collector-run`, `engine-build-lock`, `engine-build-slots`, and
  `engine-device-lease` (#379); they are unrelated to this diff and pass on CI.

Fixes #380
