### PR TITLE
fix: report a relative registry key as an invalid record, not an unmounted volume

### DIFF
--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -205,6 +205,17 @@ test('upsertProject preserves existing fields when called again', () => {
   expect(proj.metroPort).toBe(8082);
 });
 
+test('upsertProject refuses a project key that is not an absolute path', () => {
+  expect(() => upsertProject('.claude/stim-worktrees/nestrel', { label: 'nestrel' })).toThrow(/not an absolute path/);
+  expect(loadConfig()?.projects?.['.claude/stim-worktrees/nestrel']).toBe(undefined);
+});
+
+test('setDevice refuses a project key that is not an absolute path', () => {
+  saveConfig(makeConfig({ projects: { 'rel/proj': { metroPort: null, platforms: {} } } }));
+  expect(() => setDevice('rel/proj', 'ios', { deviceUdid: 'ABC' })).toThrow(/not an absolute path/);
+  expect(loadConfig()?.projects?.['rel/proj']?.platforms?.ios).toBe(undefined);
+});
+
 test('setDevice and clearDevice mutate platforms', () => {
   upsertProject('/p', { bundleId: 'com.a', androidPackage: 'com.a', isExpo: false });
   setDevice('/p', 'ios', { deviceUdid: 'ABC' });

--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -13,6 +13,7 @@ import {
   upsertProject,
   removeProject,
   setDevice,
+  setSupervisor,
   releaseAndroidConsolePort,
   clearDevice,
   allMetroPorts,
@@ -214,6 +215,13 @@ test('setDevice refuses a project key that is not an absolute path', () => {
   saveConfig(makeConfig({ projects: { 'rel/proj': { metroPort: null, platforms: {} } } }));
   expect(() => setDevice('rel/proj', 'ios', { deviceUdid: 'ABC' })).toThrow(/not an absolute path/);
   expect(loadConfig()?.projects?.['rel/proj']?.platforms?.ios).toBe(undefined);
+});
+
+test('setSupervisor refuses a project key that is not an absolute path', () => {
+  expect(() => setSupervisor('rel/proj', { pid: 1, port: 8081, startedAt: '2026-01-01T00:00:00.000Z' })).toThrow(
+    /not an absolute path/,
+  );
+  expect(loadConfig()?.projects?.['rel/proj']).toBe(undefined);
 });
 
 test('setDevice and clearDevice mutate platforms', () => {

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -1881,6 +1881,82 @@ test('a dead project on an unmounted volume is not unregistered', async () => {
   expect(cfg.projects[localDeadPath]).toBe(undefined);
 });
 
+describe('a registry key that is not an absolute path', () => {
+  const relativeKey = '.claude/stim-worktrees/nestrel';
+
+  test('is an invalid record, not an unmounted volume', async () => {
+    saveConfig({
+      version: 2,
+      projects: { [relativeKey]: { metroPort: 8100, platforms: {} } },
+      repos: {},
+    });
+    installExecutor();
+
+    const report = await collectGcReport();
+
+    expect(report.invalidProjects).toEqual([relativeKey]);
+    expect(report.deadProjects).toEqual([]);
+    expect(report.skipped).toEqual([]);
+  });
+
+  test('is kept, with the real reason, while it still records a device', async () => {
+    saveConfig({
+      version: 2,
+      projects: {
+        [relativeKey]: { metroPort: 8100, platforms: { ios: { deviceUdid: 'UDID-1', owned: true } } },
+      },
+      repos: {},
+    });
+    installExecutor();
+
+    const report = await collectGcReport();
+
+    expect(report.invalidProjects).toEqual([]);
+    expect(report.deadProjects).toEqual([]);
+    expect(report.skipped).toHaveLength(1);
+    expect(report.skipped[0]?.dir).toBe(relativeKey);
+    expect(report.skipped[0]?.reason).toMatch(/not an absolute path/);
+    expect(report.skipped[0]?.reason).toMatch(/UDID-1/);
+    expect(report.skipped[0]?.reason).not.toMatch(/not mounted/);
+  });
+
+  test('the report names it as an invalid record', () => {
+    const lines = formatGcReport({ invalidProjects: [relativeKey] }).join('\n');
+    expect(lines).toMatch(/Invalid project entries \(1\)/);
+    expect(lines).toMatch(/not an absolute path/);
+    expect(lines).toMatch(new RegExp(relativeKey.replace(/\./g, '\\.')));
+    expect(lines).not.toMatch(/Nothing to reclaim/);
+  });
+
+  test('--delete removes it when it claims no device', async () => {
+    saveConfig({
+      version: 2,
+      projects: { [relativeKey]: { metroPort: 8100, platforms: {} } },
+      repos: {},
+    });
+    installExecutor();
+
+    await cli(['--delete']);
+
+    expect(currentConfig().projects[relativeKey]).toBe(undefined);
+  });
+
+  test('--delete keeps it while it claims a device', async () => {
+    saveConfig({
+      version: 2,
+      projects: {
+        [relativeKey]: { metroPort: 8100, platforms: { ios: { deviceUdid: 'UDID-1', owned: true } } },
+      },
+      repos: {},
+    });
+    installExecutor();
+
+    await cli(['--delete']);
+
+    expect(currentConfig().projects[relativeKey]?.platforms?.ios?.deviceUdid).toBe('UDID-1');
+  });
+});
+
 interface DeviceSpec {
   udid: string;
   name: string;

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -620,6 +620,32 @@ test('findStaleProjectDevices only proposes devices present in the live listing'
   expect(stale.length).toBe(0);
 });
 
+test('findStaleProjectDevices never reaps a device recorded under a key that is not absolute', () => {
+  const now = Date.now();
+  const stale = findStaleProjectDevices({
+    config: makeConfig({
+      projects: { '.claude/stim-worktrees/nestrel': { platforms: { ios: { deviceUdid: 'U-STALE', owned: true } } } },
+    }),
+    sims: staleSims,
+    avds: [],
+    olderThanDays: 30,
+    now,
+    lastTouched: () => now - 90 * DAY_MS,
+  });
+  expect(stale.length).toBe(0);
+});
+
+test('findStaleDeviceRecords still clears a dangling claim held by a key that is not absolute', () => {
+  const stale = findStaleDeviceRecords({
+    config: makeConfig({
+      projects: { '.claude/stim-worktrees/nestrel': { platforms: { ios: { deviceUdid: 'GONE', owned: true } } } },
+    }),
+    sims: [],
+    avds: [],
+  });
+  expect(stale.map((r) => r.id)).toEqual(['GONE']);
+});
+
 test('findStaleProjectDevices skips projects the dead-entry sweep already claimed', () => {
   const now = Date.now();
   const stale = findStaleProjectDevices({
@@ -1917,6 +1943,7 @@ describe('a registry key that is not an absolute path', () => {
     expect(report.skipped[0]?.dir).toBe(relativeKey);
     expect(report.skipped[0]?.reason).toMatch(/not an absolute path/);
     expect(report.skipped[0]?.reason).toMatch(/UDID-1/);
+    expect(report.skipped[0]?.reason).toMatch(/gc removes it once that claim is gone/);
     expect(report.skipped[0]?.reason).not.toMatch(/not mounted/);
   });
 

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -3,7 +3,7 @@ import { homedir, tmpdir } from 'os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 import chalk from 'chalk';
 import { InvalidArgumentError, type Command } from 'commander';
-import { clearDevice, getConfigDir, loadConfig } from '../config.ts';
+import { clearDevice, getConfigDir, loadConfig, removeProject } from '../config.ts';
 import { formatLongDuration, plural, shortUdid } from '../command-output.ts';
 import { directorySize, formatBytes, isOnMountedVolume, listMountedVolumes, volumeRootFor } from '../fs-util.ts';
 import { listBuildLocks, readBuildLock } from '../engine/build-lock.ts';
@@ -24,7 +24,7 @@ import { resolveEasCliBin } from '../engine/remote-cache.ts';
 import { getExecutor } from '../exec.ts';
 import { isPidAlive } from '../metro.ts';
 import { detectIsExpo, findProjectRoot } from '../project.ts';
-import { reclaimProject } from '../reclaim.ts';
+import { describeDereferenced, reclaimProject } from '../reclaim.ts';
 import { SETTING_SHAPE_REMEDY } from '../settings.ts';
 import { listAllIosSims, listIosDeviceTypes, parseRuntimeVersion, type IosSimRecord } from '../sim/ios.ts';
 import { dropParked, parkedMaxSetting, POOL_SETTING_REMEDY, readParked, type ParkedSim } from '../sim-pool.ts';
@@ -109,6 +109,7 @@ export interface ParkedSimReport {
 interface GcReport {
   skipped: GcSkip[];
   deadProjects: string[];
+  invalidProjects: string[];
   parkedSims: ParkedSimReport[];
   orphanedDevices: OrphanedDevice[];
   staleDevices: StaleProjectDevice[];
@@ -659,10 +660,22 @@ function formatParkedSimReport(parkedSims: readonly ParkedSimReport[], now: numb
   return lines;
 }
 
+function projectEntryLines(header: string, paths: string[]): string[] {
+  return paths.length ? [header, ...paths.map((path) => `  ${path}`)] : [];
+}
+
+function removeInvalidProjectEntries(invalidProjects: string[]): void {
+  for (const path of invalidProjects) {
+    removeProject(path);
+    console.log(chalk.green(`Removed the invalid registry entry ${path}`));
+  }
+}
+
 export function formatGcReport(
   {
     skipped = [],
     deadProjects = [],
+    invalidProjects = [],
     parkedSims = [],
     orphanedDevices = [],
     staleDevices = [],
@@ -688,6 +701,7 @@ export function formatGcReport(
     lines.push(`Cache scope: "${cacheScope}". Devices, project entries and locks were not inspected.`);
   } else if (
     deadProjects.length === 0 &&
+    invalidProjects.length === 0 &&
     parkedSims.length === 0 &&
     orphanedDevices.length === 0 &&
     staleDevices.length === 0 &&
@@ -714,10 +728,13 @@ export function formatGcReport(
     }
   }
 
-  if (deadProjects.length) {
-    lines.push(`Dead project entries (${deadProjects.length}):`);
-    for (const path of deadProjects) lines.push(`  ${path}`);
-  }
+  lines.push(...projectEntryLines(`Dead project entries (${deadProjects.length}):`, deadProjects));
+  lines.push(
+    ...projectEntryLines(
+      `Invalid project entries (${invalidProjects.length}) - the key is not an absolute path:`,
+      invalidProjects,
+    ),
+  );
 
   lines.push(...formatParkedSimReport(parkedSims, now));
 
@@ -1098,6 +1115,7 @@ export async function collectGcReport(
     return {
       skipped: [],
       deadProjects: [],
+      invalidProjects: [],
       orphanedDevices: [],
       staleDevices: [],
       staleDeviceRecords: [],
@@ -1131,8 +1149,21 @@ export async function collectGcReport(
   }
   const parkedSims = collectParkedSims(deps);
   const deadProjects: string[] = [];
+  const invalidProjects: string[] = [];
   const skipped: GcSkip[] = [];
-  for (const path of Object.keys(cfg?.projects || {})) {
+  for (const [path, project] of Object.entries(cfg?.projects || {})) {
+    if (!isAbsolute(path)) {
+      const claimed = describeDereferenced(project);
+      if (claimed.length) {
+        skipped.push({
+          dir: path,
+          reason: `not an absolute path, so this record is invalid; kept because it still claims ${claimed.join(' and ')}`,
+        });
+      } else {
+        invalidProjects.push(path);
+      }
+      continue;
+    }
     if (existsSync(path)) continue;
     if (!isOnMountedVolume(path, mountedVolumes)) {
       const volume = volumeRootFor(path);
@@ -1228,6 +1259,7 @@ export async function collectGcReport(
   return {
     skipped,
     deadProjects,
+    invalidProjects,
     parkedSims,
     orphanedDevices,
     staleDevices,
@@ -1356,6 +1388,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
 
   const {
     deadProjects,
+    invalidProjects,
     orphanedDevices,
     staleDevices,
     staleDeviceRecords,
@@ -1366,7 +1399,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     caches,
   } = report;
   const actionable =
-    deadProjects.length > 0 ||
+    deadProjects.length + invalidProjects.length > 0 ||
     report.parkedSims.length > 0 ||
     orphanedDevices.length > 0 ||
     staleDevices.length > 0 ||
@@ -1391,6 +1424,8 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
   }
 
   let deleteFailures = deleteParkedSims(report.parkedSims, deps);
+
+  removeInvalidProjectEntries(invalidProjects);
 
   for (const path of deadProjects) {
     const result = await reclaimProject(path);

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -273,7 +273,7 @@ export function findStaleProjectDevices({
 
   const stale: StaleProjectDevice[] = [];
   for (const [path, proj] of Object.entries(config?.projects || {})) {
-    if (dead.has(path)) continue;
+    if (dead.has(path) || !isAbsolute(path)) continue;
     const touched = lastTouched(path);
     if (!Number.isFinite(touched) || touched >= cutoff) continue;
     const idleDays = Math.floor((now - touched) / DAY_MS);
@@ -1157,7 +1157,9 @@ export async function collectGcReport(
       if (claimed.length) {
         skipped.push({
           dir: path,
-          reason: `not an absolute path, so this record is invalid; kept because it still claims ${claimed.join(' and ')}`,
+          reason:
+            `not an absolute path, so this record is invalid; kept because it still claims ${claimed.join(' and ')}; ` +
+            'gc removes it once that claim is gone, or drop the entry from the config file by hand',
         });
       } else {
         invalidProjects.push(path);

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
 import { isOnMountedVolume } from './fs-util.ts';
 import { withDirLock } from './dir-lock.ts';
@@ -91,7 +91,16 @@ export function getProject(projectPath: string): ProjectRecord | null {
   return cfg?.projects?.[projectPath] || null;
 }
 
+function requireAbsoluteProjectPath(projectPath: string): void {
+  if (isAbsolute(projectPath)) return;
+  throw new Error(
+    `Project key "${projectPath}" is not an absolute path. ` +
+      'The registry is keyed by the realpath of a workspace root, so a relative key can never resolve.',
+  );
+}
+
 export function upsertProject(projectPath: string, fields: Partial<ProjectRecord>): ProjectRecord {
+  requireAbsoluteProjectPath(projectPath);
   return withConfigLock(() => {
     const cfg = ensureConfig();
     const existing = cfg.projects[projectPath] || {
@@ -132,6 +141,7 @@ export function claimMetroPort(projectPath: string, port: number): number | null
 }
 
 export function setDevice(projectPath: string, platform: string, deviceFields: DeviceRecord): void {
+  requireAbsoluteProjectPath(projectPath);
   withConfigLock(() => {
     const cfg = ensureConfig();
     if (!cfg.projects[projectPath]) {

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -174,6 +174,7 @@ export function clearDevice(projectPath: string, platform: string): void {
 }
 
 export function setSupervisor(projectPath: string, { pid, port, startedAt }: SupervisorRecord): SupervisorRecord {
+  requireAbsoluteProjectPath(projectPath);
   return withConfigLock(() => {
     const cfg = ensureConfig();
     if (!cfg.projects[projectPath]) {


### PR DESCRIPTION
## Description

The project registry in `$STIM_HOME/config.json` is keyed by the realpath of a workspace root, but nothing enforced that. A record written by an older version can carry a relative key, and `gc` then reports it forever as an unmounted volume:

```text
Skipped (1) - not classified as dead:
  .claude/stim-worktrees/nestrel: volume / is not mounted
```

The root volume is mounted. `resolveWorkspaceRealish` (`fs-util.ts`) returns `null` for a path that does not start with `/`, `isOnMountedVolume` turns that `null` into "not mounted", and `gc` keeps the entry under the fail-closed rule (invariant 8). That rule is correct for an absolute path on a volume that is genuinely absent; it is wrong here. A relative key is not an unmounted volume, it is a record that can never resolve to anything, and the two were conflated.

## Solution

`upsertProject`, `setDevice` and `setSupervisor` refuse a key that is not absolute. Those are the three writers that can create a project record. Every caller already passes a realpath'd root, so this is a regression guard, not a behavior change.

`gc` classifies a non-absolute key on its own terms. With no device claim it is an invalid record, listed under a header that says why, and `--delete` removes the registry entry. With a device claim it stays in the skipped list, and the reason names the device it still holds and the route out, so an owned simulator or AVD recorded by an old version is never silently orphaned:

```text
Invalid project entries (1) - the key is not an absolute path:
  .claude/stim-worktrees/nestrel
Skipped (1) - not classified as dead:
  .claude/stim-worktrees/withdevice: not an absolute path, so this record is invalid; kept because it still claims ios sim AAAA-BBBB; gc removes it once that claim is gone, or drop the entry from the config file by hand
```

Deleting an invalid entry removes the registry record only; it does not run `reclaimProject`. That path resolves a project's workspace directory and Metro ownership through `path.resolve`/`realpathSync`, both of which resolve a relative key against the current working directory, so it could reach state belonging to a different, live project. The workspace output directory for such a key is not identifiable for the same reason and is left alone.

`findStaleProjectDevices` had the same cwd hazard: it reads each key's mtime through `statSync`, so under `--delete --older-than <days>` an unrelated directory that happens to sit at the relative key decided whether the owned device recorded there was torn down. It now skips keys that are not absolute. `findStaleDeviceRecords` keeps covering them: it proves a claim dangles from the machine's own device listing rather than from the key, and clearing such a claim is what lets the entry become removable on a later run.

Absolute paths keep the existing "volume X is not mounted" wording and fail-closed handling. `formatGcReport` and `runGcCore` were both already at the lint complexity ceiling of 80, so the two blocks this change touches were lifted into `projectEntryLines` and `removeInvalidProjectEntries` to stay under it.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip` all clean.
- `pnpm test`: 3510 passed. The 15 failures are the four files that time out on this machine for an environmental reason (`collector-run`, `engine-build-lock`, `engine-build-slots`, `engine-device-lease`, tracked by #379) and pass on CI; each passes in isolation here.
- `pnpm run test:e2e`: 20/20.
- New coverage: `config.test.ts` asserts all three writers throw and leave the config untouched; `gc.test.ts` covers the four report cases (classified as invalid, kept with the device reason, rendered as an invalid record, and both `--delete` outcomes) plus the two sweep rules (`findStaleProjectDevices` proposes nothing for a non-absolute key, `findStaleDeviceRecords` still clears a dangling claim held by one). Each new test fails without its guard.
- Real CLI against a temp `STIM_HOME` holding the issue's record shape: the dry run printed the output above, `gc --delete` removed `.claude/stim-worktrees/nestrel` and left `.claude/stim-worktrees/withdevice` with its `ios` record intact, and a config holding `/Volumes/NoSuchDisk/proj` still printed `volume /Volumes/NoSuchDisk is not mounted`. No child-process tool calls changed, so invariant 9 has nothing new to exercise.

Fixes #377
