### PR TITLE
fix: run git through argument arrays, not shell strings

### DIFF
--- a/packages/stim-cli/src/__tests__/_factories.ts
+++ b/packages/stim-cli/src/__tests__/_factories.ts
@@ -128,6 +128,7 @@ export function makeExecutor(overrides: Partial<Executor> = {}): Executor {
     run: () => '',
     runFile: () => '',
     runQuiet: () => null,
+    runFileQuiet: () => null,
     spawn: () => makeChildProcess(),
   };
   return { ...base, ...overrides };

--- a/packages/stim-cli/src/__tests__/caches.test.ts
+++ b/packages/stim-cli/src/__tests__/caches.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 test('discoverCaches includes declared paths and expands a leading ~', () => {
   const dir = mkdtempSync(join(tmpdir(), 'stim-declared-'));
   try {
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
     const found = discoverCaches({ declared: [dir, '/definitely/not/here'] });
     const declared = found.filter((c) => c.note.includes('caches` setting'));
     expect(declared.length).toBe(1);
@@ -53,7 +53,7 @@ test('metro file maps are reported as an explicit file list, never as a director
   const stray = join(tmpdir(), `metro-file-map-stim-test-${process.pid}`);
   writeFileSync(stray, 'x'.repeat(1024));
   try {
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
     const found = discoverCaches().find((c) => c.name === 'Metro file maps');
     expect(found).toBeTruthy();
     assert(found);
@@ -297,7 +297,7 @@ test('declaredCachePaths reads the caches setting of the project it is run in', 
     writeFileSync(join(projectRoot, 'package.json'), JSON.stringify({ name: 'demo' }));
     upsertProject(projectRoot, {});
     setProjectSetting(projectRoot, 'caches', [declared]);
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
 
     expect(declaredCachePaths(projectRoot)).toEqual([declared]);
 
@@ -312,7 +312,7 @@ test('declaredCachePaths reads the caches setting of the project it is run in', 
 test('declaredCachePaths is empty outside a project rather than an error', () => {
   const notAProject = mkdtempSync(join(tmpdir(), 'stim-noproj-'));
   try {
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
     expect(declaredCachePaths(notAProject)).toEqual([]);
   } finally {
     rmSync(notAProject, { recursive: true, force: true });
@@ -323,7 +323,7 @@ test('discoverCaches says of each cache whether a project registered it', () => 
   const registeredDir = mkdtempSync(join(tmpdir(), 'stim-src-reg-'));
   const declaredDir = mkdtempSync(join(tmpdir(), 'stim-src-decl-'));
   try {
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
     register({ dir: registeredDir, name: 'Registered one' });
 
     const found = discoverCaches({ declared: [declaredDir] });
@@ -342,7 +342,7 @@ test('discoverCaches says of each cache whether a project registered it', () => 
 test('a declared path that only differs in spelling dedups against the registration', () => {
   const dir = mkdtempSync(join(tmpdir(), 'stim-dedup-'));
   try {
-    setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+    setExecutor({ run: () => '', runQuiet: () => null, runFileQuiet: () => null, spawn: () => {} });
     register({ dir, name: 'Registered one' });
 
     const found = discoverCaches({ declared: [join(dir, 'sub', '..')] });

--- a/packages/stim-cli/src/__tests__/device-remote.test.ts
+++ b/packages/stim-cli/src/__tests__/device-remote.test.ts
@@ -79,6 +79,9 @@ function mockExec({
     runQuiet() {
       throw new Error('device-remote must use runFile, not the shell');
     },
+    runFileQuiet() {
+      throw new Error('device-remote must use runFile, not runFileQuiet');
+    },
     spawn() {
       throw new Error('device-remote does not spawn');
     },

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -124,6 +124,7 @@ test('checkMainCheckout runs its expensive probes only when their preconditions 
   setExecutor({
     run: () => '',
     runQuiet: () => null,
+    runFileQuiet: () => null,
     runFile: (file: string, args: string[] = []) => {
       calls.push([file, ...args]);
       return '';
@@ -363,6 +364,7 @@ test('detectXcodeMajor reports unknown rather than throwing when xcodebuild is m
       throw new Error('not found');
     },
     runQuiet: () => null,
+    runFileQuiet: () => null,
     spawn: () => {},
   });
   try {
@@ -1166,6 +1168,10 @@ test('doctor --platform android does not invoke Xcode tooling', async () => {
     runFile: (file: string, args: string[]) => {
       calls.push([file, ...args].join(' '));
       return '';
+    },
+    runFileQuiet: (file: string, args: string[]) => {
+      calls.push([file, ...args].join(' '));
+      return null;
     },
     spawn: () => {
       throw new Error('unexpected spawn');

--- a/packages/stim-cli/src/__tests__/eas-simulator.test.ts
+++ b/packages/stim-cli/src/__tests__/eas-simulator.test.ts
@@ -41,6 +41,9 @@ function recordingExec(outputs: Record<string, string> = {}): Executor & { calls
     runQuiet() {
       throw new Error('eas-simulator must use runFile, not the shell');
     },
+    runFileQuiet() {
+      throw new Error('eas-simulator must use runFile, not runFileQuiet');
+    },
     spawn() {
       throw new Error('eas-simulator does not spawn');
     },

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -90,6 +90,9 @@ function recordingExec({
     runQuiet() {
       throw new Error('app-install must use runFile, not the shell');
     },
+    runFileQuiet() {
+      throw new Error('app-install must use runFile, not runFileQuiet');
+    },
     spawn() {
       throw new Error('app-install does not spawn');
     },
@@ -1271,6 +1274,7 @@ describe('installAndroidApp: the uninstall-and-retry, exactly once', () => {
       },
       run: () => '',
       runQuiet: () => null,
+      runFileQuiet: () => null,
       spawn: () => {
         throw new Error('not used');
       },

--- a/packages/stim-cli/src/__tests__/engine-installed-artifact.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-installed-artifact.test.ts
@@ -49,6 +49,9 @@ function recordingExec({
     runQuiet: () => {
       throw new Error('the identity check must use runFile, not the shell');
     },
+    runFileQuiet: () => {
+      throw new Error('the identity check must use runFile, not runFileQuiet');
+    },
     spawn: () => {
       throw new Error('the identity check does not spawn');
     },

--- a/packages/stim-cli/src/__tests__/exec.test.ts
+++ b/packages/stim-cli/src/__tests__/exec.test.ts
@@ -22,3 +22,14 @@ test('setExecutor replaces the active executor', () => {
   expect(getExecutor().runQuiet('anything')).toBe('mocked-quiet');
   resetExecutor();
 });
+
+test('runFileQuiet returns trimmed stdout and null on failure', () => {
+  resetExecutor();
+  expect(getExecutor().runFileQuiet('echo', ['hello'])).toBe('hello');
+  expect(getExecutor().runFileQuiet('false')).toBe(null);
+});
+
+test('runFileQuiet passes arguments without a shell, so metacharacters stay literal', () => {
+  resetExecutor();
+  expect(getExecutor().runFileQuiet('echo', ['$HOME `id` "x"'])).toBe('$HOME `id` "x"');
+});

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -260,6 +260,7 @@ test('parked deletion keeps ownership records after malformed simctl list output
       throw new Error(`unexpected run: ${cmd}`);
     },
     runQuiet: () => null,
+    runFileQuiet: () => null,
     spawn: () => null,
   });
 
@@ -375,6 +376,7 @@ test('gc sizes only listed owned Android AVDs after ownership classification', a
       throw new Error(`unexpected run: ${cmd}`);
     },
     runQuiet: () => null,
+    runFileQuiet: () => null,
     spawn: () => null,
   });
 
@@ -651,6 +653,9 @@ function installExecutor() {
       throw new Error(`unexpected run: ${cmd}`);
     },
     runQuiet() {
+      return null;
+    },
+    runFileQuiet() {
       return null;
     },
     spawn(cmd) {
@@ -1371,9 +1376,12 @@ describe('EAS orphan session sweep', () => {
       run(cmd) {
         throw new Error(`unexpected run: ${cmd}`);
       },
-      runQuiet(cmd) {
-        if (!cmd.includes('--git-common-dir')) return null;
-        return cmd.includes(otherWorkspace) ? otherGitCommon : projectGitCommon;
+      runQuiet() {
+        return null;
+      },
+      runFileQuiet(_file: string, args: string[]) {
+        if (!args.includes('--git-common-dir')) return null;
+        return args.some((arg) => arg.includes(otherWorkspace)) ? otherGitCommon : projectGitCommon;
       },
       spawn(cmd) {
         throw new Error(`unexpected spawn: ${cmd}`);
@@ -1926,6 +1934,10 @@ function installDeviceExecutor({
       if (shutdownMatch && throwOnShutdownFor.has(shutdownMatch[1])) {
         throw new Error(`simulated shutdown failure for ${shutdownMatch[1]}`);
       }
+      return '';
+    },
+    runFileQuiet(file: string, args: string[] = []) {
+      execCalls.push([file, ...args].join(' '));
       return '';
     },
     spawn(cmd) {

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -102,6 +102,7 @@ interface MetroExecutorMock {
   run(): string;
   runFile(): string;
   runQuiet(cmd: string): string;
+  runFileQuiet(): string;
   spawn(cmd: string, args: readonly string[], opts: SpawnOptions): ChildStub;
 }
 
@@ -132,6 +133,9 @@ function metroExecutor({
       if (listening) return listeners[listening[1] ?? ''] ? String(listeners[listening[1] ?? '']) : '';
       if (/lsof -a -p \d+ -d cwd/.test(cmd)) return `p1\nfcwd\nn${cwd}`;
       if (/ps -o pgid=/.test(cmd)) return '777';
+      return '';
+    },
+    runFileQuiet() {
       return '';
     },
     spawn(cmd, args, opts) {

--- a/packages/stim-cli/src/__tests__/stats.test.ts
+++ b/packages/stim-cli/src/__tests__/stats.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
   setExecutor({
     run: () => '',
     runQuiet: () => null,
+    runFileQuiet: () => null,
     spawn() {
       throw new Error('stats spawns nothing');
     },

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -42,6 +42,7 @@ beforeEach(() => {
       if (cmd.includes('simctl list devices --json')) return listJson;
       return null;
     },
+    runFileQuiet: () => null,
     spawn() {
       throw new Error('spawn should not be called from status');
     },
@@ -126,6 +127,7 @@ test('status reports simctl as unreadable instead of warning that every sim is g
     runQuiet() {
       return null;
     },
+    runFileQuiet: () => null,
     spawn() {
       throw new Error('spawn should not be called from status');
     },
@@ -235,6 +237,7 @@ test('status reports a supervisor whose port answers as this project as healthy'
         if (cmd.startsWith('ps -o pgid=')) return String(listenerPid);
         return null;
       },
+      runFileQuiet: () => null,
       spawn() {
         throw new Error('spawn should not be called from status');
       },
@@ -428,6 +431,7 @@ function dfExecutor(byVolume: Record<string, string>) {
       asked.push(vol);
       return byVolume[vol] ?? null;
     },
+    runFileQuiet: () => null,
     spawn() {
       throw new Error('spawn should not be called from status');
     },

--- a/packages/stim-cli/src/__tests__/worktree-create.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-create.test.ts
@@ -699,9 +699,10 @@ test('create action: a branch that appears between the pre-check and the add is 
       run: (cmd: string, opts: unknown) => real.run(cmd, opts as never),
       runFile: (file: string, args: string[], opts: unknown) => real.runFile(file, args, opts as never),
       spawn: (cmd: string, args: string[], opts: unknown) => real.spawn(cmd, args, opts as never),
-      runQuiet: (cmd: string, opts: unknown) => {
-        const out = real.runQuiet(cmd, opts as never);
-        if (cmd.includes('refs/heads/worktree-feat-race') && ++verified === 1) {
+      runQuiet: (cmd: string, opts: unknown) => real.runQuiet(cmd, opts as never),
+      runFileQuiet: (file: string, args: string[], opts: unknown) => {
+        const out = real.runFileQuiet(file, args, opts as never);
+        if (args.includes('refs/heads/worktree-feat-race') && ++verified === 1) {
           git('git branch worktree-feat-race');
         }
         return out;
@@ -770,6 +771,7 @@ test('create action: the rollback compares against the base captured before the 
     setExecutor({
       run: (cmd: string, opts: unknown) => real.run(cmd, opts as never),
       runQuiet: (cmd: string, opts: unknown) => real.runQuiet(cmd, opts as never),
+      runFileQuiet: (file: string, args: string[], opts: unknown) => real.runFileQuiet(file, args, opts as never),
       spawn: (cmd: string, args: string[], opts: unknown) => real.spawn(cmd, args, opts as never),
       runFile: (file: string, args: string[], opts: unknown) => {
         if (file === 'git' && args[0] === 'worktree' && args[1] === 'add') {

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -237,23 +237,27 @@ function makeExecutor({
     },
     runQuiet(cmd: string) {
       runQuietCalls.push(cmd);
-      const revMatch = cmd.match(/^git -C "(.+)" rev-parse --path-format=absolute --git-dir --git-common-dir$/);
-      if (revMatch) {
-        const p = revMatch[1] ?? '';
-        return mainTrees.includes(p) ? `${p}/.git\n${p}/.git` : null;
-      }
-      if (/status --porcelain/.test(cmd)) return dirty;
-      const diffMatch = cmd.match(/ diff -- "(.+)"$/);
-      if (diffMatch) return diffs[diffMatch[1] ?? ''] ?? '';
-      if (/ checkout -- /.test(cmd)) return '';
-      if (/log --oneline HEAD --not --remotes/.test(cmd)) return unpushed;
-      if (/worktree list --porcelain/.test(cmd)) return worktrees;
-      if (cmd.endsWith('remote')) return remote;
       const spawnMatch = cmd.match(/simctl spawn (\S+) launchctl list/);
       if (spawnMatch) {
         const udid = spawnMatch[1] ?? '';
         return occupied[udid] ? '082a\t0\tUIKitApplication:com.example.MyAppUITests.xctrunner[082a][rb-legacy]' : '';
       }
+      return null;
+    },
+    runFileQuiet(file: string, args: string[] = []) {
+      const cmd = [file, ...args].join(' ');
+      runQuietCalls.push(cmd);
+      if (args.includes('--git-dir') && args.includes('--git-common-dir')) {
+        const p = args[1] ?? '';
+        return mainTrees.includes(p) ? `${p}/.git\n${p}/.git` : null;
+      }
+      if (/status --porcelain/.test(cmd)) return dirty;
+      const diffMatch = cmd.match(/ diff -- (.+)$/);
+      if (diffMatch) return diffs[diffMatch[1] ?? ''] ?? '';
+      if (/ checkout -- /.test(cmd)) return '';
+      if (/log --oneline HEAD --not --remotes/.test(cmd)) return unpushed;
+      if (/worktree list --porcelain/.test(cmd)) return worktrees;
+      if (cmd.endsWith('remote')) return remote;
       return null;
     },
     spawn() {},
@@ -757,10 +761,10 @@ test('action: a branch deletion failure keeps ownership state and exits unsucces
   rmSync(wtDir, { recursive: true, force: true });
   process.exitCode = 0;
   const changedExec = makeExecutor({ refSha: 'def456' });
-  const changedRunQuiet = changedExec.runQuiet.bind(changedExec);
-  changedExec.runQuiet = (cmd) => {
-    if (/rev-parse --verify --quiet/.test(cmd)) return 'def456';
-    return changedRunQuiet(cmd);
+  const changedRunFileQuiet = changedExec.runFileQuiet.bind(changedExec);
+  changedExec.runFileQuiet = (file, args = []) => {
+    if (/rev-parse --verify --quiet/.test([file, ...args].join(' '))) return 'def456';
+    return changedRunFileQuiet(file, args);
   };
   setExecutor(changedExec);
 
@@ -772,10 +776,10 @@ test('action: a branch deletion failure keeps ownership state and exits unsucces
 
   process.exitCode = 0;
   const retryExec = makeExecutor({ refSha: 'abc123' });
-  const originalRunQuiet = retryExec.runQuiet.bind(retryExec);
-  retryExec.runQuiet = (cmd) => {
-    if (/rev-parse --verify --quiet/.test(cmd)) return 'abc123';
-    return originalRunQuiet(cmd);
+  const originalRunFileQuiet = retryExec.runFileQuiet.bind(retryExec);
+  retryExec.runFileQuiet = (file, args = []) => {
+    if (/rev-parse --verify --quiet/.test([file, ...args].join(' '))) return 'abc123';
+    return originalRunFileQuiet(file, args);
   };
   setExecutor(retryExec);
 
@@ -800,10 +804,10 @@ test('action: pending cleanup keeps a branch that another worktree checks out', 
     worktrees: porcelain([{ path: mainDir, branch: 'worktree-feat-x' }]),
     mainTrees: [mainDir],
   });
-  const originalRunQuiet = exec.runQuiet.bind(exec);
-  exec.runQuiet = (cmd) => {
-    if (/rev-parse --verify --quiet/.test(cmd)) return 'abc123';
-    return originalRunQuiet(cmd);
+  const originalRunFileQuiet = exec.runFileQuiet.bind(exec);
+  exec.runFileQuiet = (file, args = []) => {
+    if (/rev-parse --verify --quiet/.test([file, ...args].join(' '))) return 'abc123';
+    return originalRunFileQuiet(file, args);
   };
   setExecutor(exec);
 
@@ -1171,10 +1175,10 @@ test('action: an unregistered nested remote start cannot bypass the worktree rem
       { path: wtDir, branch: 'feat-x' },
     ]),
   });
-  const originalRunQuiet = exec.runQuiet.bind(exec);
-  exec.runQuiet = (cmd) => {
-    if (cmd.includes('rev-parse --show-toplevel')) return wtDir;
-    return originalRunQuiet(cmd);
+  const originalRunFileQuiet = exec.runFileQuiet.bind(exec);
+  exec.runFileQuiet = (file, args = []) => {
+    if ([file, ...args].join(' ').includes('rev-parse --show-toplevel')) return wtDir;
+    return originalRunFileQuiet(file, args);
   };
   let nestedStart: Promise<void> | null = null;
   const originalRunFile = exec.runFile.bind(exec);

--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { setExecutor, resetExecutor } from '../exec.ts';
@@ -29,6 +29,13 @@ import {
   removeWorktree,
   resolveBaseRef,
   resolveRef,
+  repoRoot,
+  gitCommonDir,
+  isMainWorkingTree,
+  branchExists,
+  hasRemote,
+  dirtyPaths,
+  restoreFile,
 } from '../worktree.ts';
 
 afterEach(() => resetExecutor());
@@ -87,56 +94,70 @@ test('matchesInclude treats ? as a single-character wildcard, not a quantifier',
 });
 
 test('hasUncommittedWork reflects git status output', () => {
-  setExecutor({ run: () => ' M file.js', runQuiet: () => ' M file.js', spawn: () => {} });
+  setExecutor({ run: () => '', runFileQuiet: () => ' M file.js', spawn: () => {} });
   expect(hasUncommittedWork('/wt')).toBe(true);
-  setExecutor({ run: () => '', runQuiet: () => '', spawn: () => {} });
+  setExecutor({ run: () => '', runFileQuiet: () => '', spawn: () => {} });
   expect(hasUncommittedWork('/wt')).toBe(false);
 });
 
 test('unpushedCommits lists commits missing from every remote and every other local branch', () => {
   setExecutor({
-    runQuiet: (cmd: string) => (/symbolic-ref/.test(cmd) ? 'worktree-ws' : 'abc123 first\ndef456 second'),
+    runFileQuiet: (_file: string, args: string[]) =>
+      args.includes('symbolic-ref') ? 'worktree-ws' : 'abc123 first\ndef456 second',
     spawn: () => {},
   });
   expect(unpushedCommits('/wt')).toEqual(['abc123 first', 'def456 second']);
 });
 
 test('unpushedCommits returns empty when git reports nothing', () => {
-  setExecutor({ runQuiet: (cmd: string) => (/symbolic-ref/.test(cmd) ? 'worktree-ws' : ''), spawn: () => {} });
+  setExecutor({
+    runFileQuiet: (_file: string, args: string[]) => (args.includes('symbolic-ref') ? 'worktree-ws' : ''),
+    spawn: () => {},
+  });
   expect(unpushedCommits('/wt')).toEqual([]);
 });
 
 test('unpushedCommits excludes only the worktree own branch from the local-branch protection', () => {
-  const calls: string[] = [];
+  const calls: string[][] = [];
   setExecutor({
-    runQuiet: (cmd: string) => {
-      calls.push(cmd);
-      if (/symbolic-ref/.test(cmd)) return 'worktree-ws';
-      if (/ log /.test(cmd)) return 'abc123 own-work';
+    runFileQuiet: (_file: string, args: string[]) => {
+      calls.push(args);
+      if (args.includes('symbolic-ref')) return 'worktree-ws';
+      if (args.includes('log')) return 'abc123 own-work';
       return null;
     },
     spawn: () => {},
   });
   expect(unpushedCommits('/wt')).toEqual(['abc123 own-work']);
-  const log = calls.find((c) => / log /.test(c));
-  expect(log).toContain('log --oneline HEAD --not --remotes --exclude="worktree-ws" --branches');
+  const log = calls.find((args) => args.includes('log'));
+  expect(log).toEqual([
+    '-C',
+    '/wt',
+    'log',
+    '--oneline',
+    'HEAD',
+    '--not',
+    '--remotes',
+    '--exclude=worktree-ws',
+    '--branches',
+  ]);
 });
 
 test('unpushedCommits falls back to the remotes-only count on a detached HEAD or an unsafe branch name', () => {
   for (const branch of [null, 'evil"; touch PWNED; "']) {
-    const calls: string[] = [];
+    const calls: string[][] = [];
     setExecutor({
-      runQuiet: (cmd: string) => {
-        calls.push(cmd);
-        if (/symbolic-ref/.test(cmd)) return branch;
-        if (/ log /.test(cmd)) return '';
+      runFileQuiet: (_file: string, args: string[]) => {
+        calls.push(args);
+        if (args.includes('symbolic-ref')) return branch;
+        if (args.includes('log')) return '';
         return null;
       },
       spawn: () => {},
     });
     expect(unpushedCommits('/wt')).toEqual([]);
-    const log = calls.find((c) => / log /.test(c));
-    expect(log).toMatch(/--not --remotes$/);
+    const log = calls.find((args) => args.includes('log'));
+    expect(log?.slice(-2)).toEqual(['--not', '--remotes']);
   }
 });
 
@@ -212,8 +233,8 @@ test('resolveBaseRef("head") returns HEAD and never touches origin/HEAD', () => 
   const calls: string[] = [];
   setExecutor({
     run: () => '',
-    runQuiet: (cmd) => {
-      calls.push(cmd);
+    runFileQuiet: (file: string, args: string[]) => {
+      calls.push([file, ...args].join(' '));
       return '';
     },
     spawn: () => {},
@@ -223,7 +244,7 @@ test('resolveBaseRef("head") returns HEAD and never touches origin/HEAD', () => 
 });
 
 test('resolveBaseRef("fresh") returns origin/HEAD\'s branch when it resolves, no warning', () => {
-  setExecutor({ run: () => '', runQuiet: () => 'origin/main', spawn: () => {} });
+  setExecutor({ run: () => '', runFileQuiet: () => 'origin/main', spawn: () => {} });
   const errs: string[] = [];
   const originalError = console.error;
   console.error = (msg) => errs.push(msg);
@@ -236,7 +257,7 @@ test('resolveBaseRef("fresh") returns origin/HEAD\'s branch when it resolves, no
 });
 
 test('resolveBaseRef("fresh") falls back to HEAD and warns on stderr when origin/HEAD is missing', () => {
-  setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+  setExecutor({ run: () => '', runFileQuiet: () => null, spawn: () => {} });
   const errs: string[] = [];
   const originalError = console.error;
   console.error = (msg) => errs.push(msg);
@@ -265,7 +286,7 @@ test('listWorktrees parses a detached-HEAD entry without dropping neighbours', (
     'branch refs/heads/feat-x',
     '',
   ].join('\n');
-  setExecutor({ run: () => porcelain, runQuiet: () => porcelain, spawn: () => {} });
+  setExecutor({ run: () => porcelain, runFileQuiet: () => porcelain, spawn: () => {} });
   expect(listWorktrees('/repo')).toEqual([
     { path: '/repo', branch: 'main' },
     { path: '/repo-worktrees/detached' },
@@ -282,14 +303,14 @@ test('carryOverFiles copies only files that are both gitignored and pattern-matc
     mkdirSync(join(root, 'dist'), { recursive: true });
     writeFileSync(join(root, 'dist/build.log'), 'log output');
 
-    let capturedCmd;
+    let capturedArgs: string[] | undefined;
     setExecutor({
       run: (cmd) => {
         throw new Error(`unexpected run: ${cmd}`);
       },
-      runQuiet: (cmd) => {
-        if (cmd.includes('ls-files -z')) return '';
-        capturedCmd = cmd;
+      runFileQuiet: (_file: string, args: string[]) => {
+        if (args.includes('-z')) return '';
+        capturedArgs = args;
         return 'apps/mobile/.env\ndist/build.log';
       },
       spawn: () => {},
@@ -302,8 +323,8 @@ test('carryOverFiles copies only files that are both gitignored and pattern-matc
     expect(existsSync(join(target, 'apps/mobile/.env'))).toBe(true);
     expect(readFileSync(join(target, 'apps/mobile/.env'), 'utf-8')).toBe('SECRET=1');
     expect(existsSync(join(target, 'dist/build.log'))).toBe(false);
-    expect(capturedCmd).toMatch(/--others/);
-    expect(capturedCmd).toMatch(/--ignored/);
+    expect(capturedArgs).toContain('--others');
+    expect(capturedArgs).toContain('--ignored');
   } finally {
     rmSync(root, { recursive: true, force: true });
     rmSync(target, { recursive: true, force: true });
@@ -320,7 +341,8 @@ test('carryOverFiles reports per-file failures instead of swallowing them', () =
       run: (cmd) => {
         throw new Error(`unexpected run: ${cmd}`);
       },
-      runQuiet: (cmd) => (cmd.includes('ls-files -z') ? '' : 'apps/mobile/.env\napps/missing/.env'),
+      runFileQuiet: (_file: string, args: string[]) =>
+        args.includes('-z') ? '' : 'apps/mobile/.env\napps/missing/.env',
       spawn: () => {},
     });
 
@@ -337,31 +359,31 @@ test('carryOverFiles reports per-file failures instead of swallowing them', () =
 });
 
 test('listGitignoredEntries keeps collapsed directories and does not exclude node_modules', () => {
-  let capturedCmd;
+  let capturedArgs: string[] | undefined;
   setExecutor({
     run: (cmd) => {
       throw new Error(`unexpected run: ${cmd}`);
     },
-    runQuiet: (cmd) => {
-      capturedCmd = cmd;
+    runFileQuiet: (_file: string, args: string[]) => {
+      capturedArgs = args;
       return 'node_modules/\nios/Pods/\nios/.xcode.env.local';
     },
     spawn: () => {},
   });
 
   expect(listGitignoredEntries('/repo')).toEqual(['node_modules', 'ios/Pods', 'ios/.xcode.env.local']);
-  expect(capturedCmd).toMatch(/--directory/);
-  expect(capturedCmd).not.toMatch(/exclude,glob/);
+  expect(capturedArgs).toContain('--directory');
+  expect(capturedArgs?.some((arg) => arg.includes('exclude,glob'))).toBe(false);
 });
 
 test('listCarryableIgnoredEntries skips a collapsed ignored parent that contains a registered worktree', () => {
   setExecutor({
     run: () => '',
-    runQuiet: (cmd) => {
-      if (cmd.includes('worktree list --porcelain')) {
+    runFileQuiet: (_file: string, args: string[]) => {
+      if (args.includes('worktree')) {
         return 'worktree /repo\nbranch refs/heads/main\n\nworktree /repo/.claude/worktrees/task\nbranch refs/heads/task\n';
       }
-      if (cmd.includes('ls-files --others --ignored')) return '.claude/\nnode_modules/\nios/Pods/';
+      if (args.includes('ls-files')) return '.claude/\nnode_modules/\nios/Pods/';
       return '';
     },
     spawn: () => {},
@@ -373,11 +395,11 @@ test('listCarryableIgnoredEntries skips a collapsed ignored parent that contains
 test('listCarryableIgnoredEntries skips entries inside a registered nested worktree', () => {
   setExecutor({
     run: () => '',
-    runQuiet: (cmd) => {
-      if (cmd.includes('worktree list --porcelain')) {
+    runFileQuiet: (_file: string, args: string[]) => {
+      if (args.includes('worktree')) {
         return 'worktree /repo\nbranch refs/heads/main\n\nworktree /repo/tools/tasks/one\nbranch refs/heads/one\n';
       }
-      if (cmd.includes('ls-files --others --ignored')) {
+      if (args.includes('ls-files')) {
         return 'tools/tasks/one/node_modules/\ntools/shared-cache/\n';
       }
       return '';
@@ -391,7 +413,7 @@ test('listCarryableIgnoredEntries skips entries inside a registered nested workt
 test('listCarryableIgnoredEntries fails closed when Git cannot list worktrees', () => {
   setExecutor({
     run: () => '',
-    runQuiet: (cmd) => (cmd.includes('worktree list --porcelain') ? null : 'node_modules/'),
+    runFileQuiet: (_file: string, args: string[]) => (args.includes('worktree') ? null : 'node_modules/'),
     spawn: () => {},
   });
 
@@ -444,9 +466,9 @@ test('cloneIgnoredEntries skips excluded paths and reports a clone that fell bac
         if (file === 'cp' && args[0] === '-Rc') throw new Error('clonefile refused');
         return '';
       },
-      runQuiet: (cmd) => {
-        if (cmd.includes('ls-files -z')) return '';
-        if (cmd.startsWith('git ')) return 'node_modules/\nbench/results/logs/';
+      runFileQuiet: (file: string, args: string[]) => {
+        if (args.includes('-z')) return '';
+        if (file === 'git') return 'node_modules/\nbench/results/logs/';
         return '';
       },
       spawn: () => {},
@@ -779,9 +801,9 @@ test('cloneIgnoredEntries treats .stim like any other gitignored project directo
     setExecutor({
       run: () => '',
       runFile: () => '',
-      runQuiet: (cmd) => {
-        if (cmd.includes('ls-files -z')) return '';
-        if (cmd.startsWith('git ')) return 'node_modules/\n.stim/\napps/mobile/.stim/\napps/mobile/ios/Pods/';
+      runFileQuiet: (file: string, args: string[]) => {
+        if (args.includes('-z')) return '';
+        if (file === 'git') return 'node_modules/\n.stim/\napps/mobile/.stim/\napps/mobile/ios/Pods/';
         return '';
       },
       spawn: () => {},
@@ -803,9 +825,9 @@ test('.worktreeexclude can skip a project-owned .stim directory normally', () =>
     setExecutor({
       run: () => '',
       runFile: () => '',
-      runQuiet: (cmd) => {
-        if (cmd.includes('ls-files -z')) return '';
-        if (cmd.startsWith('git ')) return 'node_modules/\ncoverage/\napps/mobile/.stim/';
+      runFileQuiet: (file: string, args: string[]) => {
+        if (args.includes('-z')) return '';
+        if (file === 'git') return 'node_modules/\ncoverage/\napps/mobile/.stim/';
         return '';
       },
       spawn: () => {},
@@ -829,7 +851,8 @@ test('carryOverFiles treats files inside .stim like ordinary project files', () 
     writeFileSync(join(root, 'config/local.json'), '{}');
     setExecutor({
       run: () => '',
-      runQuiet: (cmd) => (cmd.includes('ls-files -z') ? '' : 'apps/mobile/.stim/state.json\nconfig/local.json'),
+      runFileQuiet: (_file: string, args: string[]) =>
+        args.includes('-z') ? '' : 'apps/mobile/.stim/state.json\nconfig/local.json',
       spawn: () => {},
     });
 
@@ -967,22 +990,22 @@ test('carry against a real git repo leaves a tracked file under an ignored direc
 });
 
 test('listTrackedPaths asks git for a NUL-delimited list and reports an unanswerable query as null', () => {
-  let capturedCmd;
+  let capturedArgs: string[] | undefined;
   setExecutor({
     run: (cmd) => {
       throw new Error(`unexpected run: ${cmd}`);
     },
-    runQuiet: (cmd) => {
-      capturedCmd = cmd;
+    runFileQuiet: (_file: string, args: string[]) => {
+      capturedArgs = args;
       return 'ios/Podfile.lock\0android/app/debug.keystore\0';
     },
     spawn: () => {},
   });
   expect(listTrackedPaths('/wt')).toEqual(['ios/Podfile.lock', 'android/app/debug.keystore']);
-  expect(capturedCmd).toMatch(/ls-files/);
-  expect(capturedCmd).toMatch(/-z/);
+  expect(capturedArgs).toContain('ls-files');
+  expect(capturedArgs).toContain('-z');
 
-  setExecutor({ run: () => '', runQuiet: () => null, spawn: () => {} });
+  setExecutor({ run: () => '', runFileQuiet: () => null, spawn: () => {} });
   expect(listTrackedPaths('/wt')).toBe(null);
 });
 
@@ -998,8 +1021,8 @@ test('carry fails closed when the destination cannot be asked what it tracks', (
 
     setExecutor({
       run: () => '',
-      runQuiet: (cmd) => {
-        if (cmd.includes('ls-files -z')) return null;
+      runFileQuiet: (_file: string, args: string[]) => {
+        if (args.includes('-z')) return null;
         return 'apps/mobile/.env\napps/mobile/other.env';
       },
       spawn: () => {},
@@ -1249,7 +1272,7 @@ const TEXT_PATCH = [
 
 test('carryUncommittedChanges does nothing on a clean source tree, and when git cannot answer', () => {
   setExecutor({
-    runQuiet: () => '',
+    runFileQuiet: () => '',
     runFile: () => {
       throw new Error('nothing may be applied for an empty diff');
     },
@@ -1257,14 +1280,15 @@ test('carryUncommittedChanges does nothing on a clean source tree, and when git 
   });
   expect(carryUncommittedChanges({ root: '/src', target: '/wt' })).toBe(null);
 
-  setExecutor({ runQuiet: () => null, spawn: () => {} });
+  setExecutor({ runFileQuiet: () => null, spawn: () => {} });
   expect(carryUncommittedChanges({ root: '/src', target: '/wt' })).toBe(null);
 });
 
 test('carryUncommittedChanges checks first, applies second, through one temp patch file it removes', () => {
   const runFileCalls: string[][] = [];
   setExecutor({
-    runQuiet: (cmd: string) => (/--binary/.test(cmd) ? TEXT_PATCH : /--name-only/.test(cmd) ? 'app.json' : ''),
+    runFileQuiet: (_file: string, args: string[]) =>
+      args.includes('--binary') ? TEXT_PATCH : args.includes('--name-only') ? 'app.json' : '',
     runFile: (file: string, args: string[]) => {
       runFileCalls.push([file, ...args]);
       return '';
@@ -1289,8 +1313,8 @@ test('carryUncommittedChanges checks first, applies second, through one temp pat
 test('carryUncommittedChanges reports a conflict and applies NOTHING when --check refuses', () => {
   const runFileCalls: string[][] = [];
   setExecutor({
-    runQuiet: (cmd: string) =>
-      /--binary/.test(cmd) ? TEXT_PATCH : /--name-only/.test(cmd) ? 'app.json\nios/Podfile.lock' : '',
+    runFileQuiet: (_file: string, args: string[]) =>
+      args.includes('--binary') ? TEXT_PATCH : args.includes('--name-only') ? 'app.json\nios/Podfile.lock' : '',
     runFile: (file: string, args: string[]) => {
       runFileCalls.push([file, ...args]);
       if (args.includes('--check')) throw new Error('error: patch does not apply');
@@ -1309,7 +1333,8 @@ test('carryUncommittedChanges reports a conflict and applies NOTHING when --chec
 
 test('a check that passes but an apply that fails is reported as the conflict case, not as carried', () => {
   setExecutor({
-    runQuiet: (cmd: string) => (/--binary/.test(cmd) ? TEXT_PATCH : /--name-only/.test(cmd) ? 'app.json' : ''),
+    runFileQuiet: (_file: string, args: string[]) =>
+      args.includes('--binary') ? TEXT_PATCH : args.includes('--name-only') ? 'app.json' : '',
     runFile: (_file: string, args: string[]) => {
       if (args.includes('--check')) return '';
       throw new Error('error: app.json: No such file or directory');
@@ -1323,21 +1348,71 @@ test('a check that passes but an apply that fails is reported as the conflict ca
 });
 
 test('dirtyFingerprintFiles asks git about exactly the fingerprint inputs and parses the paths', () => {
-  const cmds: string[] = [];
+  const calls: string[][] = [];
   setExecutor({
-    runQuiet: (cmd: string) => {
-      cmds.push(cmd);
+    runFileQuiet: (_file: string, args: string[]) => {
+      calls.push(args);
       return 'M app.json\nM  package.json';
     },
     spawn: () => {},
   });
   expect(dirtyFingerprintFiles('/p')).toEqual(['app.json', 'package.json']);
-  expect(cmds[0]).toContain('status --porcelain -- app.json app.config.ts app.config.js app.config.mjs package.json');
+  expect(calls[0]).toEqual([
+    '-C',
+    '/p',
+    'status',
+    '--porcelain',
+    '--',
+    'app.json',
+    'app.config.ts',
+    'app.config.js',
+    'app.config.mjs',
+    'package.json',
+  ]);
 });
 
 test('dirtyFingerprintFiles is empty on a clean tree and when git cannot answer', () => {
-  setExecutor({ runQuiet: () => '', spawn: () => {} });
+  setExecutor({ runFileQuiet: () => '', spawn: () => {} });
   expect(dirtyFingerprintFiles('/p')).toEqual([]);
-  setExecutor({ runQuiet: () => null, spawn: () => {} });
+  setExecutor({ runFileQuiet: () => null, spawn: () => {} });
   expect(dirtyFingerprintFiles('/p')).toEqual([]);
+});
+
+test('git runs against a real repo whose path holds a space, a double quote, a dollar sign and a backtick', () => {
+  resetExecutor();
+  const base = mkdtempSync(join(tmpdir(), 'stim-test-hostile-'));
+  const root = join(base, 'we "ird $HOME `id` repo');
+  try {
+    mkdirSync(root, { recursive: true });
+    const git = (cmd: string) => execSync(cmd, { cwd: root, encoding: 'utf-8' });
+    git('git init -q -b main');
+    git('git config user.email test@example.com');
+    git('git config user.name test');
+    writeFileSync(join(root, '.gitignore'), 'secrets.env\n');
+    writeFileSync(join(root, 'tracked.txt'), 'original\n');
+    writeFileSync(join(root, 'secrets.env'), 'SECRET=1\n');
+    git('git add .gitignore tracked.txt');
+    git('git commit -q -m init');
+
+    expect(repoRoot(root)).toBe(realpathSync(root));
+    expect(gitCommonDir(root)).toBe(join(realpathSync(root), '.git'));
+    expect(isMainWorkingTree(root)).toBe(true);
+    expect(hasUncommittedWork(root)).toBe(false);
+    expect(branchExists(root, 'main')).toBe(true);
+    expect(branchExists(root, 'missing')).toBe(false);
+    expect(hasRemote(root)).toBe(false);
+    expect(listTrackedPaths(root)).toEqual(['.gitignore', 'tracked.txt']);
+    expect(listGitignoredFiles(root)).toEqual(['secrets.env']);
+    expect(listWorktrees(root)).toEqual([{ path: realpathSync(root), branch: 'main' }]);
+    expect(unpushedCommits(root)?.length).toBe(1);
+
+    writeFileSync(join(root, 'tracked.txt'), 'dirty\n');
+    expect(hasUncommittedWork(root)).toBe(true);
+    expect(dirtyPaths(root)).toEqual([' M tracked.txt']);
+    expect(restoreFile(root, 'tracked.txt')).toBe(true);
+    expect(readFileSync(join(root, 'tracked.txt'), 'utf-8')).toBe('original\n');
+    expect(existsSync(join(root, 'PWNED'))).toBe(false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -777,8 +777,9 @@ export async function detectFingerprintParity(
   } = {},
 ): Promise<Finding | null> {
   const exec = getExecutor();
-  const quotedRoot = JSON.stringify(projectRoot);
-  if (exec.runQuiet(`git -C ${quotedRoot} rev-parse --git-dir`, { timeoutMs: 10000 }) == null) return null;
+  if (exec.runFileQuiet('git', ['-C', projectRoot, 'rev-parse', '--git-dir'], { timeoutMs: 10000 }) == null) {
+    return null;
+  }
   // A fresh `git worktree add` of HEAD carries no node_modules, and @expo/fingerprint reads
   // installed packages as sources, so from an installed checkout every comparison reports drift
   // that is only the missing install. The question has an answer only on a cold checkout.
@@ -790,7 +791,7 @@ export async function detectFingerprintParity(
 
   const base = mkdtempSync(join(tmpdir(), 'stim-parity-'));
   const worktree = join(base, 'head');
-  const added = exec.runQuiet(`git -C ${quotedRoot} worktree add --detach ${JSON.stringify(worktree)} HEAD`, {
+  const added = exec.runFileQuiet('git', ['-C', projectRoot, 'worktree', 'add', '--detach', worktree, 'HEAD'], {
     timeoutMs: 60000,
   });
   if (added == null) {
@@ -818,8 +819,8 @@ export async function detectFingerprintParity(
   } catch {
     return null;
   } finally {
-    exec.runQuiet(`git -C ${quotedRoot} worktree remove --force ${JSON.stringify(worktree)}`, { timeoutMs: 30000 });
+    exec.runFileQuiet('git', ['-C', projectRoot, 'worktree', 'remove', '--force', worktree], { timeoutMs: 30000 });
     rmSync(base, { recursive: true, force: true });
-    exec.runQuiet(`git -C ${quotedRoot} worktree prune`, { timeoutMs: 10000 });
+    exec.runFileQuiet('git', ['-C', projectRoot, 'worktree', 'prune'], { timeoutMs: 10000 });
   }
 }

--- a/packages/stim-cli/src/exec.ts
+++ b/packages/stim-cli/src/exec.ts
@@ -11,6 +11,7 @@ export interface Executor {
   run(cmd: string, opts?: ExecOptions): string;
   runFile(file: string, args?: string[], opts?: ExecOptions): string;
   runQuiet(cmd: string, opts?: ExecOptions): string | null;
+  runFileQuiet(file: string, args?: string[], opts?: ExecOptions): string | null;
   spawn(cmd: string, args?: readonly string[], opts?: SpawnOptions): ChildProcess;
 }
 
@@ -45,6 +46,13 @@ const defaultExecutor: Executor = {
   runQuiet(cmd, opts) {
     try {
       return this.run(cmd, opts);
+    } catch {
+      return null;
+    }
+  },
+  runFileQuiet(file, args, opts) {
+    try {
+      return this.runFile(file, args, opts);
     } catch {
       return null;
     }

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -37,12 +37,19 @@ function pruneCarriedArtifacts(dest: string): void {
 }
 
 export function gitCommonDir(cwd: string): string | null {
-  const out = getExecutor().runQuiet(`git -C "${cwd}" rev-parse --path-format=absolute --git-common-dir`);
+  const out = getExecutor().runFileQuiet('git', ['-C', cwd, 'rev-parse', '--path-format=absolute', '--git-common-dir']);
   return out ? out.trim() : null;
 }
 
 export function isMainWorkingTree(path: string): boolean {
-  const out = getExecutor().runQuiet(`git -C "${path}" rev-parse --path-format=absolute --git-dir --git-common-dir`);
+  const out = getExecutor().runFileQuiet('git', [
+    '-C',
+    path,
+    'rev-parse',
+    '--path-format=absolute',
+    '--git-dir',
+    '--git-common-dir',
+  ]);
   if (!out) return false;
   const [gitDir, commonDir] = out
     .trim()
@@ -52,7 +59,7 @@ export function isMainWorkingTree(path: string): boolean {
 }
 
 export function repoRoot(cwd: string): string | null {
-  const out = getExecutor().runQuiet(`git -C "${cwd}" rev-parse --show-toplevel`);
+  const out = getExecutor().runFileQuiet('git', ['-C', cwd, 'rev-parse', '--show-toplevel']);
   return out ? out.trim() : null;
 }
 
@@ -110,9 +117,18 @@ function readPatternFile(p: string): string[] | null {
 }
 
 export function listGitignoredFiles(root: string): string[] {
-  const out = getExecutor().runQuiet(
-    `git -C "${root}" ls-files --others --ignored --exclude-standard --directory -- . ":(exclude,glob)**/node_modules/**"`,
-  );
+  const out = getExecutor().runFileQuiet('git', [
+    '-C',
+    root,
+    'ls-files',
+    '--others',
+    '--ignored',
+    '--exclude-standard',
+    '--directory',
+    '--',
+    '.',
+    ':(exclude,glob)**/node_modules/**',
+  ]);
   if (!out) return [];
   return out
     .split('\n')
@@ -131,7 +147,7 @@ function canonicalPath(path: string): string {
 function nestedWorktreePaths(root: string): string[] {
   const source = canonicalPath(root);
   const paths = new Set<string>();
-  const out = getExecutor().runQuiet(`git -C "${root}" worktree list --porcelain`);
+  const out = getExecutor().runFileQuiet('git', ['-C', root, 'worktree', 'list', '--porcelain']);
   if (out === null) {
     throw new Error('Could not list Git worktrees. Refusing to carry ignored files.');
   }
@@ -151,7 +167,7 @@ function overlapsNestedWorktree(rel: string, nestedPaths: string[]): boolean {
 }
 
 export function listTrackedPaths(dir: string): string[] | null {
-  const out = getExecutor().runQuiet(`git -C "${dir}" ls-files -z`);
+  const out = getExecutor().runFileQuiet('git', ['-C', dir, 'ls-files', '-z']);
   if (out === null) return null;
   return out.split('\0').filter(Boolean);
 }
@@ -230,9 +246,16 @@ export function carryOverFiles({
 }
 
 export function listGitignoredEntries(root: string): string[] {
-  const out = getExecutor().runQuiet(
-    `git -C "${root}" ls-files --others --ignored --exclude-standard --directory --no-empty-directory`,
-  );
+  const out = getExecutor().runFileQuiet('git', [
+    '-C',
+    root,
+    'ls-files',
+    '--others',
+    '--ignored',
+    '--exclude-standard',
+    '--directory',
+    '--no-empty-directory',
+  ]);
   if (!out) return [];
   return out
     .split('\n')
@@ -349,7 +372,14 @@ export function depsOutOfSync(
 const FINGERPRINT_INPUT_FILES = ['app.json', 'app.config.ts', 'app.config.js', 'app.config.mjs', 'package.json'];
 
 export function dirtyFingerprintFiles(root: string): string[] {
-  const out = getExecutor().runQuiet(`git -C "${root}" status --porcelain -- ${FINGERPRINT_INPUT_FILES.join(' ')}`);
+  const out = getExecutor().runFileQuiet('git', [
+    '-C',
+    root,
+    'status',
+    '--porcelain',
+    '--',
+    ...FINGERPRINT_INPUT_FILES,
+  ]);
   if (out === null || out.trim() === '') return [];
   return out
     .split('\n')
@@ -367,9 +397,9 @@ export interface CarriedChanges {
 
 export function carryUncommittedChanges({ root, target }: { root: string; target: string }): CarriedChanges | null {
   const exec = getExecutor();
-  const patch = exec.runQuiet(`git -C "${root}" diff HEAD --binary`);
+  const patch = exec.runFileQuiet('git', ['-C', root, 'diff', 'HEAD', '--binary']);
   if (patch === null || patch.trim() === '') return null;
-  const files = (exec.runQuiet(`git -C "${root}" diff HEAD --name-only`) || '')
+  const files = (exec.runFileQuiet('git', ['-C', root, 'diff', 'HEAD', '--name-only']) || '')
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line !== '');
@@ -395,13 +425,13 @@ export function carryUncommittedChanges({ root, target }: { root: string; target
 }
 
 export function hasUncommittedWork(dir: string): boolean | null {
-  const out = getExecutor().runQuiet(`git -C "${dir}" status --porcelain`);
+  const out = getExecutor().runFileQuiet('git', ['-C', dir, 'status', '--porcelain']);
   if (out === null) return null;
   return out.trim().length > 0;
 }
 
 export function dirtyPaths(dir: string, { limit = 10 }: { limit?: number } = {}): string[] {
-  const out = getExecutor().runQuiet(`git -C "${dir}" status --porcelain`);
+  const out = getExecutor().runFileQuiet('git', ['-C', dir, 'status', '--porcelain']);
   if (out === null) return [];
   const lines = out
     .split('\n')
@@ -416,7 +446,7 @@ function normalizePorcelainLine(line: string): string {
 }
 
 export function restoreFile(dir: string, file: string): boolean {
-  return getExecutor().runQuiet(`git -C "${dir}" checkout -- "${file}"`) !== null;
+  return getExecutor().runFileQuiet('git', ['-C', dir, 'checkout', '--', file]) !== null;
 }
 
 export function isPodInstallChurn(paths: string[] | null | undefined): boolean {
@@ -428,10 +458,11 @@ const SAFE_BRANCH_NAME = /^[A-Za-z0-9._/-]+$/;
 
 export function unpushedCommits(dir: string): string[] | null {
   const exec = getExecutor();
-  const branch = exec.runQuiet(`git -C "${dir}" symbolic-ref --quiet --short HEAD`);
+  const branch = exec.runFileQuiet('git', ['-C', dir, 'symbolic-ref', '--quiet', '--short', 'HEAD']);
   const own = branch === null ? '' : branch.trim();
-  const protection = own && SAFE_BRANCH_NAME.test(own) ? `--remotes --exclude="${own}" --branches` : '--remotes';
-  const out = exec.runQuiet(`git -C "${dir}" log --oneline HEAD --not ${protection}`);
+  const protection =
+    own && SAFE_BRANCH_NAME.test(own) ? ['--remotes', `--exclude=${own}`, '--branches'] : ['--remotes'];
+  const out = exec.runFileQuiet('git', ['-C', dir, 'log', '--oneline', 'HEAD', '--not', ...protection]);
   if (out === null) return null;
   return out
     .split('\n')
@@ -440,12 +471,19 @@ export function unpushedCommits(dir: string): string[] | null {
 }
 
 export function hasRemote(dir: string): boolean {
-  const out = getExecutor().runQuiet(`git -C "${dir}" remote`);
+  const out = getExecutor().runFileQuiet('git', ['-C', dir, 'remote']);
   return Boolean(out && out.trim().length > 0);
 }
 
 export function branchExists(cwd: string, branch: string): boolean {
-  const out = getExecutor().runQuiet(`git -C "${cwd}" rev-parse --verify --quiet "refs/heads/${branch}"`);
+  const out = getExecutor().runFileQuiet('git', [
+    '-C',
+    cwd,
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `refs/heads/${branch}`,
+  ]);
   return Boolean(out);
 }
 
@@ -560,13 +598,13 @@ function parseWorktrees(out: string): WorktreeEntry[] {
 }
 
 export function listWorktrees(cwd: string): WorktreeEntry[] {
-  const out = getExecutor().runQuiet(`git -C "${cwd}" worktree list --porcelain`);
+  const out = getExecutor().runFileQuiet('git', ['-C', cwd, 'worktree', 'list', '--porcelain']);
   return out ? parseWorktrees(out) : [];
 }
 
 export function resolveBaseRef(cwd: string, baseRef: string): string {
   if (baseRef === 'head') return 'HEAD';
-  const head = getExecutor().runQuiet(`git -C "${cwd}" rev-parse --abbrev-ref origin/HEAD`);
+  const head = getExecutor().runFileQuiet('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'origin/HEAD']);
   if (head) return head.trim();
   console.error('warning: origin/HEAD not found; falling back to HEAD as the base ref.');
   return 'HEAD';


### PR DESCRIPTION
## Description

Every git call in `worktree.ts` went through `getExecutor().runQuiet`, which only accepts a shell string, so each one interpolated a path inside plain double quotes:

```
git -C "${cwd}" rev-parse --show-toplevel
```

Inside double quotes `sh` still expands `$` and backticks, and a `"` in the path closes the quoting outright. `runQuiet` swallows the resulting failure and returns `null`, so callers read a mangled command as "git could not answer": `repoRoot` returns null, `listWorktrees` returns `[]`, `hasUncommittedWork` returns null. `doctor.ts` had the same shape with `JSON.stringify` doing the quoting, which is also double quotes.

Run against a real repo whose directory name is `we "ird $HOME` + a backtick-`id`-backtick + ` repo`, the two forms disagree:

```
old shell form  : null
new argv form   : /private/var/.../we "ird $HOME `id` repo
```

The paths here are the user's own repository and worktree locations, not attacker input, so this is a correctness bug rather than an injection one. AGENTS.md already routes user-controlled paths through `runFile`; these call sites predate a quiet variant of it.

## Solution

`runFile` had no quiet counterpart, which is why these calls were shell strings in the first place. This adds one method, `runFileQuiet(file, args, opts)` -- `runFile` with `runQuiet`'s contract, returning `null` instead of throwing so callers can keep treating "git could not answer" as a value rather than an exception -- and moves the 19 git calls in `worktree.ts` and the four in `doctor.ts` onto it. Argument arrays reach `execFileSync` directly, so no shell parses the path.

Each argument list is the command the shell used to build, with the hand-quoting dropped: `--exclude="${own}"` becomes `--exclude=${own}`, and the `:(exclude,glob)**/node_modules/**` pathspec becomes one literal argument. `cwd`, `timeoutMs` and output trimming are unchanged.

`lsof`, `ps`, `adb`, `simctl` and `xcodebuild` keep their shell strings: those interpolate numeric ports and pids and simctl-reported UDIDs, which cannot carry shell metacharacters.

## Test plan

Real-tool verification (invariant 9): a new test in `worktree.test.ts` initializes a real git repo at a path holding a space, a double quote, a `$` and a backtick, then drives the real executor through `repoRoot`, `gitCommonDir`, `isMainWorkingTree`, `hasUncommittedWork`, `branchExists`, `hasRemote`, `listTrackedPaths`, `listGitignoredFiles`, `listWorktrees`, `unpushedCommits`, `dirtyPaths` and `restoreFile`. The same calls run standalone against real git print:

```
dir           : /private/var/.../we "ird $HOME `id` repo
rev-parse     : /private/var/.../we "ird $HOME `id` repo
git-common-dir: /private/var/.../we "ird $HOME `id` repo/.git
status        : ""
worktree list : worktree /private/var/.../we "ird $HOME `id` repo
failure -> null: null
```

Tests that assert what git was asked now assert the argument list rather than the command string, and the executor mocks that stood in for git gained `runFileQuiet`.

Checks from the worktree root: `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck` and `pnpm run knip` are clean; `pnpm test` is 3503 passed, 15 failed; `pnpm run test:e2e` is 20/20. The 15 failures are the pre-existing 5 s timeouts on this machine in `collector-run`, `engine-build-lock`, `engine-build-slots` and `engine-device-lease` (#379) -- unrelated to this diff.

Fixes #376
