### PR TITLE
test: give the live-process suites a 30s timeout

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -80,13 +80,13 @@ function state() {
 
 async function until<T>(
   predicate: () => T | null | undefined,
-  { timeoutMs = 15000, label = 'condition' } = {},
+  { timeoutMs = 8000, label = 'condition' } = {},
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const value = predicate();
     if (value) return value;
-    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+    if (Date.now() >= deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${label}`);
     await new Promise((r) => setTimeout(r, 50));
   }
 }
@@ -269,7 +269,7 @@ function iosShimLines() {
   return text.split('\n').filter((l) => l.startsWith('{'));
 }
 
-describe('the ios collector, spawned for real against a fake xcrun', () => {
+describe('the ios collector, spawned for real against a fake xcrun', { timeout: 30_000 }, () => {
   test('registers its own pid, writes records, and clears the registration on SIGTERM', async () => {
     const banner = 'Filtering the log data using "processImagePath ENDSWITH \\"/MyApp.app/MyApp\\""';
     writeShim(
@@ -402,7 +402,7 @@ describe('the ios collector, spawned for real against a fake xcrun', () => {
   });
 });
 
-describe('the ios device collector, spawned for real against a fake devicectl', () => {
+describe('the ios device collector, spawned for real against a fake devicectl', { timeout: 30_000 }, () => {
   const consoleLines = () =>
     readFileSync(fileURLToPath(new URL('./fixtures/ios-device-console.txt', import.meta.url)), 'utf-8')
       .split('\n')
@@ -546,7 +546,7 @@ describe('the ios device collector, spawned for real against a fake devicectl', 
   });
 });
 
-describe('the android collector, spawned for real against a fake adb', () => {
+describe('the android collector, spawned for real against a fake adb', { timeout: 30_000 }, () => {
   test('resolves the app pid, filters logcat on it, and cleans up on SIGTERM', async () => {
     writeShim(
       'adb',
@@ -689,7 +689,7 @@ describe('runCollector seams', () => {
   });
 });
 
-describe('the android collector follows the app across a restart', () => {
+describe('the android collector follows the app across a restart', { timeout: 30_000 }, () => {
   const restartingShim = () =>
     writeShim(
       'adb',

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -80,7 +80,7 @@ function state() {
 
 async function until<T>(
   predicate: () => T | null | undefined,
-  { timeoutMs = 8000, label = 'condition' } = {},
+  { timeoutMs = 6000, label = 'condition' } = {},
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
@@ -91,10 +91,17 @@ async function until<T>(
   }
 }
 
-function exited(child: ChildProcess) {
-  return new Promise<{ code: number | null; signal: string | null }>((resolve) =>
-    child.on('exit', (code, signal) => resolve({ code, signal })),
-  );
+function exited(child: ChildProcess, timeoutMs = 6000) {
+  return new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out after ${timeoutMs}ms waiting for the collector (pid ${child.pid}) to exit`)),
+      timeoutMs,
+    );
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
 }
 
 describe('parseArgs', () => {

--- a/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
@@ -397,6 +397,8 @@ describe('waitingLine', () => {
 describe('a real race between real processes', { timeout: 30_000 }, () => {
   const LOCK_URL = new URL('../engine/build-lock.ts', import.meta.url).href;
   const CACHE_URL = new URL('../build-cache.ts', import.meta.url).href;
+  const CHILD_TIMEOUT_MS = 20_000;
+  const HANDSHAKE_MS = 10_000;
 
   function script(name: string, body: string) {
     const path = join(root, name);
@@ -411,9 +413,10 @@ describe('a real race between real processes', { timeout: 30_000 }, () => {
         [path, ...args],
         {
           env: { ...process.env, STIM_HOME: home, ...env },
-          timeout: 60000,
+          timeout: CHILD_TIMEOUT_MS,
         },
         (err, stdout, stderr) => {
+          if (err?.killed) return reject(new Error(`${path} was killed after ${CHILD_TIMEOUT_MS}ms (${err.signal})`));
           if (err && err.code === undefined) return reject(err);
           resolve({ code: err?.code ?? 0, stdout: String(stdout), stderr: String(stderr) });
         },
@@ -460,18 +463,29 @@ describe('a real race between real processes', { timeout: 30_000 }, () => {
       [
         `const { acquireBuildLock, releaseBuildLock } = await import(${JSON.stringify(LOCK_URL)});`,
         `const { storeBuild } = await import(${JSON.stringify(CACHE_URL)});`,
-        'const { mkdirSync, writeFileSync } = await import("node:fs");',
+        'const { existsSync, mkdirSync, writeFileSync } = await import("node:fs");',
         'const { join } = await import("node:path");',
         `const got = acquireBuildLock({ platform: "ios", key: ${JSON.stringify(key)}, root: process.argv[2], logFile: join(process.argv[2], "build.ndjson") });`,
         'if (!got.acquired) { console.log(JSON.stringify({ raced: true })); process.exit(0); }',
         'writeFileSync(join(process.argv[2], "lock-ready"), "");',
+        'const lost = process.argv[3];',
         'try {',
-        '  await new Promise(r => setTimeout(r, 900));',
-        '  const app = join(process.argv[2], "Fixture.app");',
-        '  mkdirSync(app, { recursive: true });',
-        '  writeFileSync(join(app, "Fixture"), "binary");',
-        `  const stored = storeBuild("ios", ${JSON.stringify(key)}, app);`,
-        '  console.log(JSON.stringify({ built: true, stored }));',
+        `  const deadline = Date.now() + ${HANDSHAKE_MS};`,
+        '  let seen = false;',
+        '  for (;;) {',
+        '    if (existsSync(lost)) { seen = true; break; }',
+        '    if (Date.now() >= deadline) break;',
+        '    await new Promise(r => setTimeout(r, 20));',
+        '  }',
+        '  if (!seen) {',
+        '    console.log(JSON.stringify({ built: false, missing: lost }));',
+        '  } else {',
+        '    const app = join(process.argv[2], "Fixture.app");',
+        '    mkdirSync(app, { recursive: true });',
+        '    writeFileSync(join(app, "Fixture"), "binary");',
+        `    const stored = storeBuild("ios", ${JSON.stringify(key)}, app);`,
+        '    console.log(JSON.stringify({ built: true, stored }));',
+        '  }',
         '} finally {',
         '  releaseBuildLock(got);',
         '}',
@@ -482,8 +496,10 @@ describe('a real race between real processes', { timeout: 30_000 }, () => {
       'waiter.mjs',
       [
         `const { acquireBuildLock, waitForBuild } = await import(${JSON.stringify(LOCK_URL)});`,
+        'const { writeFileSync } = await import("node:fs");',
         `const got = acquireBuildLock({ platform: "ios", key: ${JSON.stringify(key)}, root: process.argv[2], logFile: null });`,
         'if (got.acquired) { console.log(JSON.stringify({ wonInstead: true })); process.exit(0); }',
+        'writeFileSync(process.argv[3], "");',
         `const result = await waitForBuild({ platform: "ios", key: ${JSON.stringify(key)}, intervalMs: 50, out: (l) => console.error(l) });`,
         'console.log(JSON.stringify({ ...result, held: got.held }));',
       ].join('\n'),
@@ -491,16 +507,17 @@ describe('a real race between real processes', { timeout: 30_000 }, () => {
 
     const buildRoot = join(root, 'builder');
     mkdirSync(buildRoot, { recursive: true });
-    const started = runNode(builder, [buildRoot]);
+    const lost = join(buildRoot, 'waiter-lost');
+    const started = runNode(builder, [buildRoot, lost]);
     const ready = join(buildRoot, 'lock-ready');
     for (let attempts = 0; attempts < 400 && !existsSync(ready); attempts += 1) {
       await new Promise((r) => setTimeout(r, 20));
     }
     expect(existsSync(ready), `the builder never wrote ${ready}`).toBe(true);
-    const [built, waited] = await Promise.all([started, runNode(waiter, [join(root, 'waiter')])]);
+    const [built, waited] = await Promise.all([started, runNode(waiter, [join(root, 'waiter'), lost])]);
 
     const builderOut = JSON.parse(built.stdout.trim());
-    expect(builderOut.built).toBe(true);
+    expect(builderOut.built, `the builder gave up waiting for ${lost}`).toBe(true);
     const waiterOut = JSON.parse(waited.stdout.trim());
     expect(waiterOut.wonInstead).toBe(undefined);
     expect(waiterOut.hit).toBe(builderOut.stored);

--- a/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
@@ -394,7 +394,7 @@ describe('waitingLine', () => {
   });
 });
 
-describe('a real race between real processes', () => {
+describe('a real race between real processes', { timeout: 30_000 }, () => {
   const LOCK_URL = new URL('../engine/build-lock.ts', import.meta.url).href;
   const CACHE_URL = new URL('../build-cache.ts', import.meta.url).href;
 
@@ -493,10 +493,10 @@ describe('a real race between real processes', () => {
     mkdirSync(buildRoot, { recursive: true });
     const started = runNode(builder, [buildRoot]);
     const ready = join(buildRoot, 'lock-ready');
-    for (let attempts = 0; attempts < 100 && !existsSync(ready); attempts += 1) {
+    for (let attempts = 0; attempts < 400 && !existsSync(ready); attempts += 1) {
       await new Promise((r) => setTimeout(r, 20));
     }
-    expect(existsSync(ready)).toBe(true);
+    expect(existsSync(ready), `the builder never wrote ${ready}`).toBe(true);
     const [built, waited] = await Promise.all([started, runNode(waiter, [join(root, 'waiter')])]);
 
     const builderOut = JSON.parse(built.stdout.trim());

--- a/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
@@ -101,8 +101,11 @@ describe('waitForFile', () => {
   test('resolves once the file appears', async () => {
     const path = join(tmpHome, 'late');
     const timer = setTimeout(() => writeFileSync(path, ''), 30);
-    await waitForFile(path);
-    clearTimeout(timer);
+    try {
+      await waitForFile(path);
+    } finally {
+      clearTimeout(timer);
+    }
     expect(existsSync(path)).toBe(true);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
@@ -97,7 +97,22 @@ describe('listBuildSlots', () => {
   });
 });
 
-describe('live: 2 slots, 3 processes', () => {
+describe('waitForFile', () => {
+  test('resolves once the file appears', async () => {
+    const path = join(tmpHome, 'late');
+    const timer = setTimeout(() => writeFileSync(path, ''), 30);
+    await waitForFile(path);
+    clearTimeout(timer);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test('gives up with a message naming the file it waited for', async () => {
+    const path = join(tmpHome, 'never');
+    await expect(waitForFile(path, 50)).rejects.toThrow(`timed out after 50ms waiting for ${path}`);
+  });
+});
+
+describe('live: 2 slots, 3 processes', { timeout: 30_000 }, () => {
   test('the third process waits for a slot and gets one on release', async () => {
     const script = join(tmpHome, 'holder.mjs');
     const slotsUrl = new URL('../engine/build-slots.ts', import.meta.url).href;
@@ -125,26 +140,18 @@ describe('live: 2 slots, 3 processes', () => {
           err ? reject(err) : resolve(),
         );
       });
-    const waitFor = async (file: string, timeoutMs = 8000) => {
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        if (existsSync(join(dir, file))) return true;
-        await new Promise((r) => setTimeout(r, 20));
-      }
-      return false;
-    };
 
     const a = spawn('A');
     const b = spawn('B');
-    expect(await waitFor('acquired-A')).toBeTruthy();
-    expect(await waitFor('acquired-B')).toBeTruthy();
+    await waitForFile(join(dir, 'acquired-A'));
+    await waitForFile(join(dir, 'acquired-B'));
 
     const c = spawn('C');
     await new Promise((r) => setTimeout(r, 400));
     expect(existsSync(join(dir, 'acquired-C'))).toBe(false);
 
     writeFileSync(join(dir, 'release-A'), '1');
-    expect(await waitFor('acquired-C')).toBeTruthy();
+    await waitForFile(join(dir, 'acquired-C'));
     const releasedA = Number(readFileSync(join(dir, 'released-A'), 'utf-8'));
     const acquiredC = Number(readFileSync(join(dir, 'acquired-C'), 'utf-8'));
     expect(acquiredC >= releasedA).toBeTruthy();
@@ -154,6 +161,15 @@ describe('live: 2 slots, 3 processes', () => {
     await Promise.all([a, b, c]);
   });
 });
+
+async function waitForFile(path: string, timeoutMs = 8000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (existsSync(path)) return;
+    if (Date.now() >= deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${path}`);
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
 
 function mkslot(i: number) {
   mkdirSync(buildSlotPath(i), { recursive: true });

--- a/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
@@ -419,7 +419,7 @@ describe('choosing a device from the pool', () => {
   });
 });
 
-describe('the real file protocol', () => {
+describe('the real file protocol', { timeout: 30_000 }, () => {
   const LEASE_URL = new URL('../engine/device-lease.ts', import.meta.url).href;
   let scratch: string;
 

--- a/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
@@ -421,6 +421,7 @@ describe('choosing a device from the pool', () => {
 
 describe('the real file protocol', { timeout: 30_000 }, () => {
   const LEASE_URL = new URL('../engine/device-lease.ts', import.meta.url).href;
+  const CHILD_TIMEOUT_MS = 20_000;
   let scratch: string;
 
   beforeEach(() => {
@@ -442,8 +443,9 @@ describe('the real file protocol', { timeout: 30_000 }, () => {
       execFile(
         process.execPath,
         [path, ...args],
-        { env: { ...process.env, STIM_HOME: home }, timeout: 60000 },
+        { env: { ...process.env, STIM_HOME: home }, timeout: CHILD_TIMEOUT_MS },
         (err, stdout, stderr) => {
+          if (err?.killed) return reject(new Error(`${path} was killed after ${CHILD_TIMEOUT_MS}ms (${err.signal})`));
           if (err && err.code === undefined) return reject(err);
           resolve({ stdout: String(stdout), stderr: String(stderr) });
         },

--- a/packages/stim-cli/src/__tests__/metro.test.ts
+++ b/packages/stim-cli/src/__tests__/metro.test.ts
@@ -181,6 +181,7 @@ test('killMetroTree reports false when nothing could be signalled', () => {
 
 test.skipIf(!CAN_READ_CWD)(
   'resolveProjectMetro identifies and kills a REAL listening process from the project dir',
+  { timeout: 30_000 },
   async () => {
     const dir = mkdtempSync(join(tmpdir(), 'stim-metro-'));
     const script = join(dir, 'fake-metro.js');


### PR DESCRIPTION
## Description

Eight tests spawn real child processes, and all of them ran under vitest's 5000 ms default. Each one
starts three to six children and polls for what they write, so its own waits are the same order as
the budget it runs under: `engine-build-slots.test.ts` polled a file for up to 8000 ms inside a
5000 ms test. Whenever a child costs more than a second or two, vitest kills the test first and the
only output is `Test timed out in 5000ms` -- never the file or record that failed to appear. #150
recorded the same class of failure on one real-xcodebuild test, fixed in #160 by giving that test an
explicit timeout.

Two of those tests are unbounded in a second way. `a waiter resolves the artifact the builder stores`
had the builder hold the lock for a fixed 900 ms after writing `lock-ready`; the parent only spawns
the waiter once it sees that file, so the waiter had under 900 ms to boot Node and import
`build-lock.ts` before the lock was released. When it did not make it, the waiter acquired the lock,
printed `{ wonInstead: true }`, and the test failed on an assertion that says nothing about why. That
is the failure #379 attached from [PR #386, Node 22 attempt
1](https://github.com/appandflow/stim/actions/runs/33926866519/attempts/1). A raised vitest timeout
does not touch it, because the 900 ms window starts when `lock-ready` is written.

The machine cost that provokes the timeouts is environmental, and worth recording because it bounds
what this change can prove locally. #379 measured a child importing `node:http` at 4.18 s. On that
same machine now, the import takes 11 ms and the process then takes 30-230 s to *exit*: Node 22 reads
the macOS system trust store on teardown and `trustd` there is pegged at 100% CPU.
`node --use-openssl-ca` returns the same script to 0.03 s. Nothing in this repository controls that,
and no per-test timeout can cover a 230 s teardown.

## Solution

The seven live `describe` blocks and the one live `test` in `metro.test.ts` declare
`{ timeout: 30_000 }` -- an order of magnitude above what a healthy child costs, and well below the
120 s #160 gave the real-xcodebuild tests.

Every wait inside them now has a budget under that ceiling and a message naming what it wanted:

- `collector-run.test.ts`: `until` drops from 15 s to 6 s, and `exited` grows a 6 s budget instead of
  waiting forever for a child that may never exit. The longest test runs four of these in sequence,
  so the worst path is 24 s.
- `engine-build-lock.test.ts`: the builder waits for a `waiter-lost` marker the waiter writes once
  `acquireBuildLock` has returned `held`, then stores and releases. The waiter is therefore
  guaranteed to have lost the race, the startup window is gone, and the test no longer pays an
  unconditional 900 ms. The builder gives up on that marker after 10 s and reports the path it
  waited for. The wait for `lock-ready` was 100 attempts at 20 ms -- 2 s, which no real child start
  meets on a loaded machine; it is 8 s now, and the assertion names the path.
- `engine-build-slots.test.ts`: the test-local `waitFor` returned a boolean that an `expect` reported
  as `expected false to be truthy`. It is now a module-scope `waitForFile` that throws the path it
  waited for, with two tests covering that contract.
- `engine-build-lock.test.ts` and `engine-device-lease.test.ts`: the `execFile` budget for a child
  drops from 60 s to 20 s, so it expires inside the 30 s ceiling rather than after it. A killed child
  rejects with its script path and signal; previously the callback treated the kill as a normal exit
  (`err.code` is `null`, not `undefined`, on a timeout kill) and the test died in `JSON.parse` on
  empty stdout.

`engine-device-lease.test.ts` keeps its children blocked on a barrier file with no budget of their
own; bounding that would change what the test asserts, and the 20 s `execFile` budget now covers it.

No production code changes, and the pure suites keep the 5 s default.

## Test plan

Node 22.22.2, macOS 25.5, vitest 5.0.0, from the worktree root.

Before, on the four files named in #379 (`npx vitest run` on each of them):
`Tests 15 failed | 97 passed (112)`, every failure `Test timed out in 5000ms`. That reproduces the
issue exactly.

After, `pnpm test` on that machine: `Tests 15 failed | 3502 passed (3517)`. The same fifteen tests in
the same four files still fail, because of the 30-230 s teardown above, but they now report a cause
-- for example `.../racer.mjs was killed after 20000ms (SIGTERM)` -- instead of a bare vitest
timeout. With the teardown stall removed and nothing else changed,
`NODE_OPTIONS=--use-openssl-ca pnpm test` passes the whole suite: `Test Files 92 passed (92)`,
`Tests 3517 passed (3517)`, 22.93 s. The five touched files under that override run in 4.74 s, 128
passed, and `engine-build-lock.test.ts` alone passes 34/34 on five consecutive runs.

The local evidence is therefore bounded: this removes the 5 s ceiling and shows the suites pass at
30 s when a child process behaves like one. CI, where children exit normally, is the arbiter for the
timeout being sufficient.

Every new failure message was exercised by forcing it, since no passing run prints them:

```
Error: timed out after 300ms waiting for /var/folders/.../stim-slots-8T5yt1/never-written
AssertionError: the builder never wrote /var/folders/.../stim-ws-gEBBNM/builder/never-written
AssertionError: the builder gave up waiting for /var/folders/.../stim-ws-o7QfqN/builder/waiter-lost
Error: /var/folders/.../stim-ws-s62WV9/racer.mjs was killed after 300ms (SIGTERM)
Error: timed out after 1ms waiting for the collector (pid 47114) to exit
```

Also run: `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`,
`pnpm run knip` -- all clean.

Fixes #379
