### PR TITLE
fix: refuse a directory that is not a React Native or Expo app

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -73,7 +73,11 @@ beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'stim-android-'));
   writeFileSync(
     join(root, 'package.json'),
-    JSON.stringify({ name: 'app', scripts: { android: 'react-native run-android' } }),
+    JSON.stringify({
+      name: 'app',
+      dependencies: { 'react-native': '0.81.0' },
+      scripts: { android: 'react-native run-android' },
+    }),
   );
   mkdirSync(join(root, 'android', 'app'), { recursive: true });
   writeFileSync(join(root, 'android', 'app', 'build.gradle'), 'android {\n  namespace "com.example.app"\n}\n');
@@ -1362,6 +1366,19 @@ describe('metro is verified before any build work', () => {
 });
 
 describe('the other refusals', () => {
+  test('a directory that depends on neither react-native nor expo is refused before any workspace state', async () => {
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }));
+    const h = harness({ ensureDevice: never('the device'), build: never('the build') });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_NO_PROJECT');
+    expect(result.error?.message).toContain(join(root, 'package.json'));
+    expect(result.error?.message).toMatch(/neither react-native nor expo/);
+    expect(result.error?.remedy).toBeTruthy();
+    expect(h.calls.ensureStorage).toEqual([]);
+    expect(h.stdout).toEqual([]);
+  });
+
   test('a fingerprint with no hash refuses without a package-install remedy', async () => {
     const h = harness({
       fingerprint: async () => null,

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1379,6 +1379,20 @@ describe('the other refusals', () => {
     expect(h.stdout).toEqual([]);
   });
 
+  test('a package.json that does not parse is refused as unreadable, not as a missing app dependency', async () => {
+    writeFileSync(join(root, 'package.json'), '{ "name": "app", "dependencies": { "react-native": "0.81.0"');
+    const h = harness({ ensureDevice: never('the device'), build: never('the build') });
+    const result = await h.run();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('STIM_NO_PROJECT');
+    expect(result.error?.message).toContain(join(root, 'package.json'));
+    expect(result.error?.message).toMatch(/is not valid JSON/);
+    expect(result.error?.message).not.toMatch(/neither react-native nor expo/);
+    expect(result.error?.remedy).toMatch(/Fix the JSON/);
+    expect(h.calls.ensureStorage).toEqual([]);
+    expect(h.stdout).toEqual([]);
+  });
+
   test('a fingerprint with no hash refuses without a package-install remedy', async () => {
     const h = harness({
       fingerprint: async () => null,

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -623,6 +623,17 @@ describe('a directory that is not an app', () => {
     expect(reported.fix).toMatch(/app directory/);
   });
 
+  test('runDoctor reports a package.json that does not parse as its own finding', () => {
+    writeFileSync(join(project, 'package.json'), '{ "name": "app", "dependencies": { "react-native": "0.81.0"');
+    const reported = findings().find((f) => /does not parse/.test(f.title));
+    assert(reported);
+    expect(reported.level).toBe('cost');
+    expect(reported.detail).toContain(join(project, 'package.json'));
+    expect(reported.detail).not.toMatch(/neither react-native nor expo/);
+    expect(reported.fix).toMatch(/Fix the JSON/);
+    expect(findings().some((f) => /not a React Native or Expo app/.test(f.title))).toBe(false);
+  });
+
   test('runDoctor stays silent when the package.json depends on react-native', () => {
     writeFileSync(join(project, 'package.json'), JSON.stringify({ dependencies: { 'react-native': '0.81.0' } }));
     expect(findings().some((f) => /not a React Native or Expo app/.test(f.title))).toBe(false);

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -592,6 +592,43 @@ test('checkConcurrency echoes the caps and the current live count when set', () 
   expect(f.detail).toMatch(/1 /);
 });
 
+describe('a directory that is not an app', () => {
+  let home: string;
+  let project: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'stim-doc-home-'));
+    process.env.STIM_HOME = home;
+    project = mkdtempSync(join(tmpdir(), 'stim-doc-app-'));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+    delete process.env.STIM_HOME;
+  });
+
+  const findings = () => runDoctor(project, { concurrency: () => ({ maxBuilds: 0, maxDevices: 0 }) });
+
+  test('runDoctor reports a package.json that depends on neither react-native nor expo', () => {
+    writeFileSync(
+      join(project, 'package.json'),
+      JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }),
+    );
+    const reported = findings().find((f) => /not a React Native or Expo app/.test(f.title));
+    assert(reported);
+    expect(reported.level).toBe('cost');
+    expect(reported.detail).toContain(join(project, 'package.json'));
+    expect(reported.detail).toMatch(/STIM_NO_PROJECT/);
+    expect(reported.fix).toMatch(/app directory/);
+  });
+
+  test('runDoctor stays silent when the package.json depends on react-native', () => {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ dependencies: { 'react-native': '0.81.0' } }));
+    expect(findings().some((f) => /not a React Native or Expo app/.test(f.title))).toBe(false);
+  });
+});
+
 test('runDoctor stays silent about concurrency when nothing is set', () => {
   const project = mkdtempSync(join(tmpdir(), 'stim-doc-conc-'));
   writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -113,9 +113,9 @@ test('the errors topic states that the stale-carry line only prints on a real di
 test('the errors topic covers a directory that is not a React Native or Expo app', () => {
   const body = renderTopic('errors');
   assert(body);
-  expect(body).toMatch(/whose nearest package.json depends on\s+neither react-native nor expo/);
-  expect(body).toMatch(/the refusal\s+names that package.json/);
-  expect(body).toMatch(/`doctor` reports the same directory as a\s+finding/);
+  expect(body).toMatch(/whose nearest package.json does not\s+parse or depends on neither react-native nor expo/);
+  expect(body).toMatch(/the refusal names that package.json and says which of the two it\s+is/);
+  expect(body).toMatch(/`doctor` reports the same directory as a finding/);
   expect(body).toMatch(/These errors are caught before the port is reserved/);
 });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -110,6 +110,15 @@ test('the errors topic states that the stale-carry line only prints on a real di
   expect(body).toMatch(/a carry whose lockfile matches is\s+silent/);
 });
 
+test('the errors topic covers a directory that is not a React Native or Expo app', () => {
+  const body = renderTopic('errors');
+  assert(body);
+  expect(body).toMatch(/whose nearest package.json depends on\s+neither react-native nor expo/);
+  expect(body).toMatch(/the refusal\s+names that package.json/);
+  expect(body).toMatch(/`doctor` reports the same directory as a\s+finding/);
+  expect(body).toMatch(/These errors are caught before the port is reserved/);
+});
+
 test('an unknown topic renders nothing rather than throwing', () => {
   expect(renderTopic('nope')).toBe(null);
 });
@@ -977,6 +986,16 @@ test('the logs guide keeps Expo and bare React Native stack context on one human
   expect(logs).toMatch(/Expo error includes its immediately\s+following code frame and Call Stack lines/);
   expect(logs).toMatch(/Bare React Native symbolication is\s+shown as separate context/);
   expect(logs).toMatch(/Context does not change the error count or the raw error records\s+returned by --json/);
+});
+
+test('the agent guide tells the agent to run from the app directory', () => {
+  const agent = renderTopic('agent');
+  assert(agent);
+  expect(agent).toMatch(
+    /Run Stim from the app directory: the one whose package.json depends on\s+react-native or expo/,
+  );
+  expect(agent).toMatch(/start, ios and android refuse with STIM_NO_PROJECT naming that package.json/);
+  expect(agent).toMatch(/doctor reports it as a finding/);
 });
 
 test('the agent guide routes to every detailed topic', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -104,7 +104,10 @@ beforeEach(() => {
   tmpHome = mkdtempSync(join(tmpdir(), 'stim-test-'));
   process.env.STIM_HOME = tmpHome;
   root = realpathSync(mkdtempSync(join(tmpdir(), 'stim-ws-')));
-  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fixture' }));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', dependencies: { 'react-native': '0.81.0' } }),
+  );
 });
 
 afterEach(() => {
@@ -376,6 +379,22 @@ function buildRecords() {
   const file = buildLogFile(root);
   return existsSync(file) ? parseNdjsonText(readFileSync(file, 'utf-8')) : [];
 }
+
+describe('the project gate', () => {
+  test('a directory that depends on neither react-native nor expo is refused before any workspace state', async () => {
+    reserve();
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }));
+    const { exitCode, logs, errs, calls } = await run({ json: true });
+    expect(exitCode).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_NO_PROJECT');
+    expect(payload.message).toContain(join(root, 'package.json'));
+    expect(payload.message).toMatch(/neither react-native nor expo/);
+    expect(payload.remedy).toBeTruthy();
+    expect(calls.order).toEqual([]);
+    expect(errs.join('\n')).toMatch(/STIM_NO_PROJECT/);
+  });
+});
 
 describe('the Metro gate', () => {
   test('fires before the device, boot, and fingerprint: a dead port costs a second, not a build', async () => {
@@ -2009,7 +2028,7 @@ describe('Contract 6: the dev-client scheme', () => {
       join(root, 'package.json'),
       JSON.stringify({
         name: 'fixture',
-        dependencies: { 'expo-dev-client': '5.0.0' },
+        dependencies: { expo: '52.0.0', 'expo-dev-client': '5.0.0' },
       }),
     );
     const { calls } = await run({}, { devClientScheme });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -392,7 +392,23 @@ describe('the project gate', () => {
     expect(payload.message).toMatch(/neither react-native nor expo/);
     expect(payload.remedy).toBeTruthy();
     expect(calls.order).toEqual([]);
-    expect(errs.join('\n')).toMatch(/STIM_NO_PROJECT/);
+    expect(errs.join('\n')).toContain(phaseLine('error', payload.message as string));
+    expect(errs.join('\n')).toContain(phaseLine('failed', 'STIM_NO_PROJECT'));
+  });
+
+  test('a package.json that does not parse is refused as unreadable, not as a missing app dependency', async () => {
+    reserve();
+    writeFileSync(join(root, 'package.json'), '{ "name": "app", "dependencies": { "react-native": "0.81.0"');
+    const { exitCode, logs, errs, calls } = await run({ json: true });
+    expect(exitCode).toBe(1);
+    const payload = parseFirst(logs);
+    expect(payload.code).toBe('STIM_NO_PROJECT');
+    expect(payload.message).toContain(join(root, 'package.json'));
+    expect(payload.message).toMatch(/is not valid JSON/);
+    expect(payload.message).not.toMatch(/neither react-native nor expo/);
+    expect(payload.remedy).toMatch(/Fix the JSON/);
+    expect(calls.order).toEqual([]);
+    expect(errs.join('\n')).toContain(phaseLine('failed', 'STIM_NO_PROJECT'));
   });
 });
 

--- a/packages/stim-cli/src/__tests__/project.test.ts
+++ b/packages/stim-cli/src/__tests__/project.test.ts
@@ -2,9 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve, join } from 'path';
 import {
+  appProjectProblem,
   declaresAppDependency,
   findProjectRoot,
-  isAppProject,
   detectIsExpo,
   detectBundleId,
   detectAndroidPackage,
@@ -39,16 +39,36 @@ test('declaresAppDependency rejects a package.json that depends on neither', () 
   expect(declaresAppDependency('not an object')).toBe(false);
 });
 
-test('isAppProject reads the nearest package.json', () => {
-  expect(isAppProject(EXPO_PROJ)).toBe(true);
-  expect(isAppProject(BARE_PROJ)).toBe(true);
+test('appProjectProblem stays silent for an app, reading the nearest package.json', () => {
+  expect(appProjectProblem(EXPO_PROJ)).toBe(null);
+  expect(appProjectProblem(BARE_PROJ)).toBe(null);
 });
 
-test('isAppProject is false for a directory whose package.json is not an app', () => {
+test('appProjectProblem names the package.json of a directory that is not an app', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'stim-app-'));
   try {
     writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }));
-    expect(isAppProject(tmp)).toBe(false);
+    const problem = appProjectProblem(tmp);
+    expect(problem?.kind).toBe('not-an-app');
+    expect(problem?.message).toContain(join(tmp, 'package.json'));
+    expect(problem?.message).toMatch(/neither react-native nor expo/);
+    expect(problem?.remedy).toMatch(/app directory/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('appProjectProblem separates a package.json that does not parse from one with no app dependency', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'stim-app-'));
+  try {
+    writeFileSync(join(tmp, 'package.json'), '{ "name": "app", "dependencies": { "react-native": "0.81.0"');
+    const problem = appProjectProblem(tmp);
+    expect(problem?.kind).toBe('unreadable');
+    expect(problem?.message).toContain(join(tmp, 'package.json'));
+    expect(problem?.message).toMatch(/is not valid JSON/);
+    expect(problem?.message).not.toMatch(/neither react-native nor expo/);
+    expect(problem?.remedy).toMatch(/Fix the JSON/);
+    expect(problem?.remedy).not.toMatch(/app directory/);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/__tests__/project.test.ts
+++ b/packages/stim-cli/src/__tests__/project.test.ts
@@ -2,7 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve, join } from 'path';
 import {
+  declaresAppDependency,
   findProjectRoot,
+  isAppProject,
   detectIsExpo,
   detectBundleId,
   detectAndroidPackage,
@@ -22,6 +24,34 @@ test('findProjectRoot walks up from cwd to find package.json', () => {
 
 test('findProjectRoot returns null when no package.json found', () => {
   expect(findProjectRoot('/')).toBe(null);
+});
+
+test('declaresAppDependency accepts react-native or expo from either dependency block', () => {
+  expect(declaresAppDependency({ dependencies: { 'react-native': '0.81.0' } })).toBe(true);
+  expect(declaresAppDependency({ dependencies: { expo: '~54.0.0' } })).toBe(true);
+  expect(declaresAppDependency({ devDependencies: { 'react-native': '0.81.0' } })).toBe(true);
+});
+
+test('declaresAppDependency rejects a package.json that depends on neither', () => {
+  expect(declaresAppDependency({ name: 'monorepo', dependencies: { typescript: '5.9.3' } })).toBe(false);
+  expect(declaresAppDependency({ scripts: { ios: 'expo run:ios' } })).toBe(false);
+  expect(declaresAppDependency(null)).toBe(false);
+  expect(declaresAppDependency('not an object')).toBe(false);
+});
+
+test('isAppProject reads the nearest package.json', () => {
+  expect(isAppProject(EXPO_PROJ)).toBe(true);
+  expect(isAppProject(BARE_PROJ)).toBe(true);
+});
+
+test('isAppProject is false for a directory whose package.json is not an app', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'stim-app-'));
+  try {
+    writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }));
+    expect(isAppProject(tmp)).toBe(false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test('detectIsExpo true when expo deps + app.json has expo block', () => {

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -1786,6 +1786,22 @@ describe('the error contract', () => {
     expect(existsSync(workspaceMetadataFile(root))).toBe(false);
   });
 
+  test('a package.json that does not parse is refused as unreadable, not as a missing app dependency', async () => {
+    setExecutor(metroExecutor({ listeners: {} }));
+    writeFileSync(join(root, 'package.json'), '{ "name": "app", "dependencies": { "react-native": "0.81.0"');
+    const result = await runAction({ json: true });
+    expect(result.exitCode).toBe(1);
+    expect(result.logs.length).toBe(1);
+    const facts = JSON.parse(result.logs[0] ?? '');
+    expect(facts.code).toBe('STIM_NO_PROJECT');
+    expect(facts.message).toContain(join(root, 'package.json'));
+    expect(facts.message).toMatch(/is not valid JSON/);
+    expect(facts.message).not.toMatch(/neither react-native nor expo/);
+    expect(facts.remedy).toMatch(/Fix the JSON/);
+    expect(getProject(root)).toBeNull();
+    expect(existsSync(workspaceMetadataFile(root))).toBe(false);
+  });
+
   test('without --json a failure keeps stdout free of JSON and names the code', async () => {
     setExecutor(metroExecutor({ listeners: {} }));
     const result = await runAction({ wait: 'soon' });

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
   tmpHome = mkdtempSync(join(tmpdir(), 'stim-test-'));
   process.env.STIM_HOME = tmpHome;
   root = realpathSync(mkdtempSync(join(tmpdir(), 'stim-ws-')));
-  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws' }));
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', dependencies: { 'react-native': '0.81.0' } }));
 });
 
 afterEach(() => {
@@ -215,7 +215,10 @@ async function runSpawnedExpoStart({
   tunnelDelayMs?: number;
   exitAfterTunnel?: boolean;
 }) {
-  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+  );
   const exec = metroExecutor({ listeners: {} });
   const held: { server: Server | null } = { server: null };
   const childHandlers: Record<string, (...args: unknown[]) => void> = {};
@@ -512,7 +515,10 @@ describe('action: already running', () => {
   });
 
   test('start --remote refuses an external Expo server that has no public URL', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8169;
     const server = await metroListener(port);
     const exec = metroExecutor({ listeners: { [port]: DEAD_LISTENER_PID } });
@@ -532,7 +538,10 @@ describe('action: already running', () => {
   });
 
   test('start --remote accepts an external Expo server with an operator public URL', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8170;
     const server = await metroListener(port);
     const exec = metroExecutor({ listeners: { [port]: DEAD_LISTENER_PID } });
@@ -620,7 +629,10 @@ describe('action: already running', () => {
   });
 
   test('start --remote refuses when a healthy local Expo supervisor has no Expo tunnel', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8166;
     const server = await metroListener(port);
     const exec = metroExecutor({ listeners: { [port]: DEAD_LISTENER_PID } });
@@ -645,7 +657,10 @@ describe('action: already running', () => {
   });
 
   test('a concurrent remote start waits when an owned Expo server is already healthy before its tunnel', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8173;
     const server = await metroListener(port);
     const exec = metroExecutor({ listeners: { [port]: DEAD_LISTENER_PID } });
@@ -1756,6 +1771,21 @@ describe('the error contract', () => {
     expect(facts.remedy).toBeTruthy();
   });
 
+  test('a directory that depends on neither react-native nor expo is refused before the registry is touched', async () => {
+    setExecutor(metroExecutor({ listeners: {} }));
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'monorepo', devDependencies: { vitest: '5' } }));
+    const result = await runAction({ json: true });
+    expect(result.exitCode).toBe(1);
+    expect(result.logs.length).toBe(1);
+    const facts = JSON.parse(result.logs[0] ?? '');
+    expect(facts.code).toBe('STIM_NO_PROJECT');
+    expect(facts.message).toContain(join(root, 'package.json'));
+    expect(facts.message).toMatch(/neither react-native nor expo/);
+    expect(facts.remedy).toBeTruthy();
+    expect(getProject(root)).toBeNull();
+    expect(existsSync(workspaceMetadataFile(root))).toBe(false);
+  });
+
   test('without --json a failure keeps stdout free of JSON and names the code', async () => {
     setExecutor(metroExecutor({ listeners: {} }));
     const result = await runAction({ wait: 'soon' });
@@ -1891,7 +1921,10 @@ describe('action: an existing supervisor that is not answering', () => {
   });
 
   test('a remote start refuses after the local Expo supervisor begins answering without a tunnel', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8167;
     const exec = metroExecutor({ listeners: {} });
     const held: { server: Server | null } = { server: null };
@@ -1923,7 +1956,10 @@ describe('action: an existing supervisor that is not answering', () => {
   });
 
   test('a concurrent remote start waits when Metro becomes healthy before the Expo tunnel', async () => {
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'ws', scripts: { ios: 'expo run:ios' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'ws', dependencies: { expo: '54.0.0' }, scripts: { ios: 'expo run:ios' } }),
+    );
     const port = 8171;
     const exec = metroExecutor({ listeners: {} });
     const held: { server: Server | null } = { server: null };

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -47,7 +47,16 @@ import { acquireBuildSlot, releaseBuildSlot, type BuildSlotHandle } from '../eng
 import { createNdjsonWriter } from '../ndjson.ts';
 import { isPidAlive, resolveProjectMetro } from '../metro.ts';
 import { emulatorLogFile, workspaceDir, workspaceLogsDir } from '../paths.ts';
-import { detectAndroidPackage, detectBundleId, detectIsExpo, findProjectRoot, projectShortcut } from '../project.ts';
+import {
+  NOT_AN_APP_REMEDY,
+  detectAndroidPackage,
+  detectBundleId,
+  detectIsExpo,
+  findProjectRoot,
+  isAppProject,
+  notAnAppMessage,
+  projectShortcut,
+} from '../project.ts';
 import {
   devClientScheme as configuredDevClientScheme,
   ensureWorkspaceStorageSafely,
@@ -1761,6 +1770,13 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   } = resolveRunAndroidOptions(options);
   const started = now();
   const startedAt = new Date(started).toISOString();
+  if (!isAppProject(root)) {
+    const message = notAnAppMessage(root);
+    out(phaseLine('error', chalk.red(`STIM_NO_PROJECT: ${message}`)));
+    out(phaseLine('remedy', NOT_AN_APP_REMEDY));
+    if (json) emit(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY }));
+    return { ok: false, error: { code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY } };
+  }
   try {
     await ensureStorage(root, { note: out });
   } catch (error) {

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -48,13 +48,11 @@ import { createNdjsonWriter } from '../ndjson.ts';
 import { isPidAlive, resolveProjectMetro } from '../metro.ts';
 import { emulatorLogFile, workspaceDir, workspaceLogsDir } from '../paths.ts';
 import {
-  NOT_AN_APP_REMEDY,
+  appProjectProblem,
   detectAndroidPackage,
   detectBundleId,
   detectIsExpo,
   findProjectRoot,
-  isAppProject,
-  notAnAppMessage,
   projectShortcut,
 } from '../project.ts';
 import {
@@ -1770,12 +1768,13 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   } = resolveRunAndroidOptions(options);
   const started = now();
   const startedAt = new Date(started).toISOString();
-  if (!isAppProject(root)) {
-    const message = notAnAppMessage(root);
+  const projectProblem = appProjectProblem(root);
+  if (projectProblem) {
+    const { message, remedy } = projectProblem;
     out(phaseLine('error', chalk.red(`STIM_NO_PROJECT: ${message}`)));
-    out(phaseLine('remedy', NOT_AN_APP_REMEDY));
-    if (json) emit(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY }));
-    return { ok: false, error: { code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY } };
+    out(phaseLine('remedy', remedy));
+    if (json) emit(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy }));
+    return { ok: false, error: { code: 'STIM_NO_PROJECT', message, remedy } };
   }
   try {
     await ensureStorage(root, { note: out });

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -1374,11 +1374,11 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   android.avdConfig key or fragment, a malformed ios.signingIdentity,
   ios.signingIdentitySha1 or ios.lanHost value, \`--device\` with an empty
   serial or UDID, \`--device\` together with \`--remote\`, a working directory
-  with no package.json above it or whose nearest package.json depends on
-  neither react-native nor expo, so the directory is not an app (the refusal
-  names that package.json, and \`doctor\` reports the same directory as a
-  finding), an android/app/build.gradle that
-  declares product flavors with
+  with no package.json above it, or one whose nearest package.json does not
+  parse or depends on neither react-native nor expo, so the directory is not
+  an app (the refusal names that package.json and says which of the two it
+  is; \`doctor\` reports the same directory as a finding), an
+  android/app/build.gradle that declares product flavors with
   no variant selected (the refusal names the debug variants), or a
   \`--device-type\`, \`--runtime\` or \`--system-image\` name that is BLANK or
   is not installed on this machine. For the unknown-name case the installed

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -55,6 +55,10 @@ upstream gap.
 
 RULES DURING THE LOOP
 
+- Run Stim from the app directory: the one whose package.json depends on
+  react-native or expo. Anywhere else -- a monorepo root, a tools package --
+  start, ios and android refuse with STIM_NO_PROJECT naming that package.json,
+  and doctor reports it as a finding.
 - Run start before a debug ios or android build. If it returns STIM_NO_METRO,
   run stim start and retry.
 - Run ios or android again after a native input changes. A JavaScript-only
@@ -1370,7 +1374,10 @@ STIM_BAD_ARG / STIM_NO_PROJECT
   android.avdConfig key or fragment, a malformed ios.signingIdentity,
   ios.signingIdentitySha1 or ios.lanHost value, \`--device\` with an empty
   serial or UDID, \`--device\` together with \`--remote\`, a working directory
-  with no package.json above it, an android/app/build.gradle that
+  with no package.json above it or whose nearest package.json depends on
+  neither react-native nor expo, so the directory is not an app (the refusal
+  names that package.json, and \`doctor\` reports the same directory as a
+  finding), an android/app/build.gradle that
   declares product flavors with
   no variant selected (the refusal names the debug variants), or a
   \`--device-type\`, \`--runtime\` or \`--system-image\` name that is BLANK or

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -154,13 +154,11 @@ import { NOT_OURS_FOREIGN_CWD, isPidAlive, resolveProjectMetro } from '../metro.
 import { createNdjsonWriter, type NdjsonWriter } from '../ndjson.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceLogsDir } from '../paths.ts';
 import {
-  NOT_AN_APP_REMEDY,
+  appProjectProblem,
   detectBundleId,
   detectIsExpo,
   findProjectRoot,
-  isAppProject,
   isPackageResolvable,
-  notAnAppMessage,
   projectShortcut,
 } from '../project.ts';
 import {
@@ -1879,11 +1877,13 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return null;
   }
   const root = foundRoot;
-  if (!isAppProject(root)) {
-    const message = notAnAppMessage(root);
-    note(chalk.red(phaseLine('error', `STIM_NO_PROJECT: ${message}`)));
-    note(chalk.dim(phaseLine('remedy', NOT_AN_APP_REMEDY)));
-    if (json) console.log(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY }));
+  const projectProblem = appProjectProblem(root);
+  if (projectProblem) {
+    const { message, remedy } = projectProblem;
+    note(chalk.red(phaseLine('error', message)));
+    note(chalk.dim(phaseLine('remedy', remedy)));
+    note(chalk.red(phaseLine('failed', 'STIM_NO_PROJECT')));
+    if (json) console.log(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy }));
     process.exit(1);
     return null;
   }

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -153,7 +153,16 @@ import type { CacheHitLevel, CompilationCacheActivity, IosFacts, RemoteDeviceBac
 import { NOT_OURS_FOREIGN_CWD, isPidAlive, resolveProjectMetro } from '../metro.ts';
 import { createNdjsonWriter, type NdjsonWriter } from '../ndjson.ts';
 import { ensureWorkspaceStorage, workspaceDir, workspaceLogsDir } from '../paths.ts';
-import { detectBundleId, detectIsExpo, findProjectRoot, isPackageResolvable, projectShortcut } from '../project.ts';
+import {
+  NOT_AN_APP_REMEDY,
+  detectBundleId,
+  detectIsExpo,
+  findProjectRoot,
+  isAppProject,
+  isPackageResolvable,
+  notAnAppMessage,
+  projectShortcut,
+} from '../project.ts';
 import {
   cacheProviderSettingError,
   iosLanHostSetting,
@@ -1870,6 +1879,14 @@ export async function runIos(opts: IosCommandOptions = {}, overrides: Partial<Io
     return null;
   }
   const root = foundRoot;
+  if (!isAppProject(root)) {
+    const message = notAnAppMessage(root);
+    note(chalk.red(phaseLine('error', `STIM_NO_PROJECT: ${message}`)));
+    note(chalk.dim(phaseLine('remedy', NOT_AN_APP_REMEDY)));
+    if (json) console.log(JSON.stringify({ code: 'STIM_NO_PROJECT', message, remedy: NOT_AN_APP_REMEDY }));
+    process.exit(1);
+    return null;
+  }
 
   try {
     await d.ensureWorkspaceStorage(root, { note });

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -11,15 +11,7 @@ import type { MetroResolution } from '../metro.ts';
 import { queryLogs } from '../logs-query.ts';
 import { ensureWorkspaceStorage, supervisorLogFile, workspaceLogsDir } from '../paths.ts';
 import { reserveMetroPort } from '../ports.ts';
-import {
-  NOT_AN_APP_REMEDY,
-  detectAndroidPackage,
-  detectBundleId,
-  detectIsExpo,
-  findProjectRoot,
-  isAppProject,
-  notAnAppMessage,
-} from '../project.ts';
+import { appProjectProblem, detectAndroidPackage, detectBundleId, detectIsExpo, findProjectRoot } from '../project.ts';
 import {
   clearManagedMetroTunnel,
   readMetroTunnel,
@@ -321,11 +313,12 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           remedy: 'Run this from the app directory -- the one holding package.json.',
         });
       }
-      if (!isAppProject(root)) {
+      const projectProblem = appProjectProblem(root);
+      if (projectProblem) {
         return fail({
           code: 'STIM_NO_PROJECT',
-          message: notAnAppMessage(root),
-          remedy: NOT_AN_APP_REMEDY,
+          message: projectProblem.message,
+          remedy: projectProblem.remedy,
         });
       }
 

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -11,7 +11,15 @@ import type { MetroResolution } from '../metro.ts';
 import { queryLogs } from '../logs-query.ts';
 import { ensureWorkspaceStorage, supervisorLogFile, workspaceLogsDir } from '../paths.ts';
 import { reserveMetroPort } from '../ports.ts';
-import { detectAndroidPackage, detectBundleId, detectIsExpo, findProjectRoot } from '../project.ts';
+import {
+  NOT_AN_APP_REMEDY,
+  detectAndroidPackage,
+  detectBundleId,
+  detectIsExpo,
+  findProjectRoot,
+  isAppProject,
+  notAnAppMessage,
+} from '../project.ts';
 import {
   clearManagedMetroTunnel,
   readMetroTunnel,
@@ -311,6 +319,13 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           code: 'STIM_NO_PROJECT',
           message: 'Not in a React Native project (no package.json found).',
           remedy: 'Run this from the app directory -- the one holding package.json.',
+        });
+      }
+      if (!isAppProject(root)) {
+        return fail({
+          code: 'STIM_NO_PROJECT',
+          message: notAnAppMessage(root),
+          remedy: NOT_AN_APP_REMEDY,
         });
       }
 

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'fs'
 import { tmpdir } from 'os';
 import { dirname, join, relative, resolve } from 'path';
 import { getExecutor } from './exec.ts';
-import { detectIsExpo } from './project.ts';
+import { NOT_AN_APP_REMEDY, declaresAppDependency, detectIsExpo, notAnAppMessage } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
 import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
 import { dirtyFingerprintFiles, gitCommonDir, listWorktrees, repoRoot } from './worktree.ts';
@@ -689,6 +689,7 @@ export function runDoctor(
     .filter((remoteFinding): remoteFinding is Finding => remoteFinding !== null);
 
   return [
+    checkAppDependency(projectRoot, pkg),
     ...checkMainCheckout(projectRoot, { platform }),
     checkDevClient(pkg, isExpo),
     checkMetroCache(metroConfig),
@@ -701,6 +702,16 @@ export function runDoctor(
     ...remoteFindings,
     ...settingShapeFindings,
   ].filter((f): f is Finding => Boolean(f));
+}
+
+function checkAppDependency(projectRoot: string, pkg: AnyJson | null): Finding | null {
+  if (declaresAppDependency(pkg)) return null;
+  return finding(
+    'cost',
+    'This directory is not a React Native or Expo app',
+    `${notAnAppMessage(projectRoot)} \`stim start\`, \`stim ios\` and \`stim android\` refuse here with STIM_NO_PROJECT, so nothing below was measured against an app.`,
+    NOT_AN_APP_REMEDY,
+  );
 }
 
 function agentDeviceIsOnPath(): boolean {

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'fs'
 import { tmpdir } from 'os';
 import { dirname, join, relative, resolve } from 'path';
 import { getExecutor } from './exec.ts';
-import { NOT_AN_APP_REMEDY, declaresAppDependency, detectIsExpo, notAnAppMessage } from './project.ts';
+import { appProjectProblem, detectIsExpo } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
 import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
 import { dirtyFingerprintFiles, gitCommonDir, listWorktrees, repoRoot } from './worktree.ts';
@@ -689,7 +689,7 @@ export function runDoctor(
     .filter((remoteFinding): remoteFinding is Finding => remoteFinding !== null);
 
   return [
-    checkAppDependency(projectRoot, pkg),
+    checkAppProject(projectRoot),
     ...checkMainCheckout(projectRoot, { platform }),
     checkDevClient(pkg, isExpo),
     checkMetroCache(metroConfig),
@@ -704,13 +704,16 @@ export function runDoctor(
   ].filter((f): f is Finding => Boolean(f));
 }
 
-function checkAppDependency(projectRoot: string, pkg: AnyJson | null): Finding | null {
-  if (declaresAppDependency(pkg)) return null;
+function checkAppProject(projectRoot: string): Finding | null {
+  const problem = appProjectProblem(projectRoot);
+  if (!problem) return null;
   return finding(
     'cost',
-    'This directory is not a React Native or Expo app',
-    `${notAnAppMessage(projectRoot)} \`stim start\`, \`stim ios\` and \`stim android\` refuse here with STIM_NO_PROJECT, so nothing below was measured against an app.`,
-    NOT_AN_APP_REMEDY,
+    problem.kind === 'unreadable'
+      ? 'This package.json does not parse'
+      : 'This directory is not a React Native or Expo app',
+    `${problem.message} \`stim start\`, \`stim ios\` and \`stim android\` refuse here with STIM_NO_PROJECT, so nothing below was measured against an app.`,
+    problem.remedy,
   );
 }
 

--- a/packages/stim-cli/src/project.ts
+++ b/packages/stim-cli/src/project.ts
@@ -115,20 +115,27 @@ export function findProjectRoot(startDir: string): string | null {
   }
 }
 
-function readPackageJson(projectRoot: string): PackageJson | null {
+function loadPackageJson(projectRoot: string): { pkg: PackageJson | null; parseError: string | null } {
   const p = join(projectRoot, 'package.json');
-  if (!existsSync(p)) return null;
+  if (!existsSync(p)) return { pkg: null, parseError: null };
   try {
-    return JSON.parse(readFileSync(p, 'utf-8'));
-  } catch {
-    return null;
+    return { pkg: JSON.parse(readFileSync(p, 'utf-8')), parseError: null };
+  } catch (error) {
+    return { pkg: null, parseError: (error as Error)?.message || String(error) };
   }
+}
+
+function readPackageJson(projectRoot: string): PackageJson | null {
+  return loadPackageJson(projectRoot).pkg;
 }
 
 const APP_DEPENDENCIES = ['react-native', 'expo'];
 
-export const NOT_AN_APP_REMEDY =
-  'Run this from the app directory -- the one whose package.json depends on react-native or expo -- or from that directory inside a worktree.';
+export interface AppProjectProblem {
+  kind: 'not-an-app' | 'unreadable';
+  message: string;
+  remedy: string;
+}
 
 export function declaresAppDependency(pkg: unknown): boolean {
   if (!pkg || typeof pkg !== 'object') return false;
@@ -137,12 +144,22 @@ export function declaresAppDependency(pkg: unknown): boolean {
   return APP_DEPENDENCIES.some((name) => name in deps);
 }
 
-export function isAppProject(projectRoot: string): boolean {
-  return declaresAppDependency(readPackageJson(projectRoot));
-}
-
-export function notAnAppMessage(projectRoot: string): string {
-  return `${join(projectRoot, 'package.json')} depends on neither react-native nor expo, so this is not a React Native or Expo app.`;
+export function appProjectProblem(projectRoot: string): AppProjectProblem | null {
+  const file = join(projectRoot, 'package.json');
+  const { pkg, parseError } = loadPackageJson(projectRoot);
+  if (parseError)
+    return {
+      kind: 'unreadable',
+      message: `${file} is not valid JSON (${parseError}), so Stim cannot tell whether this is a React Native or Expo app.`,
+      remedy: `Fix the JSON in ${file} -- an unfinished edit or a merge conflict leaves it unparseable -- then run the command again.`,
+    };
+  if (declaresAppDependency(pkg)) return null;
+  return {
+    kind: 'not-an-app',
+    message: `${file} depends on neither react-native nor expo, so this is not a React Native or Expo app.`,
+    remedy:
+      'Run this from the app directory -- the one whose package.json depends on react-native or expo -- or from that directory inside a worktree.',
+  };
 }
 
 export function detectIsExpo(projectRoot: string): boolean {

--- a/packages/stim-cli/src/project.ts
+++ b/packages/stim-cli/src/project.ts
@@ -125,6 +125,26 @@ function readPackageJson(projectRoot: string): PackageJson | null {
   }
 }
 
+const APP_DEPENDENCIES = ['react-native', 'expo'];
+
+export const NOT_AN_APP_REMEDY =
+  'Run this from the app directory -- the one whose package.json depends on react-native or expo -- or from that directory inside a worktree.';
+
+export function declaresAppDependency(pkg: unknown): boolean {
+  if (!pkg || typeof pkg !== 'object') return false;
+  const { dependencies, devDependencies } = pkg as PackageJson;
+  const deps = { ...dependencies, ...devDependencies };
+  return APP_DEPENDENCIES.some((name) => name in deps);
+}
+
+export function isAppProject(projectRoot: string): boolean {
+  return declaresAppDependency(readPackageJson(projectRoot));
+}
+
+export function notAnAppMessage(projectRoot: string): string {
+  return `${join(projectRoot, 'package.json')} depends on neither react-native nor expo, so this is not a React Native or Expo app.`;
+}
+
 export function detectIsExpo(projectRoot: string): boolean {
   const pkg = readPackageJson(projectRoot);
   const iosScript = pkg?.scripts?.ios;


### PR DESCRIPTION
## Description

Project resolution walks up to the nearest `package.json` and stops there, so
any directory with a manifest counted as a React Native or Expo project. Run
in the Stim monorepo root itself, `stim start` registered the workspace,
reserved a Metro port and spawned the supervisor before the supervisor died
with `STIM_BARE_DEPS` ("metro is not resolvable ... run npm install") -- not
the real problem, and not a remedy that helps. The registry then held an
entry for a directory that is not an app, and the port stayed reserved until
`stim stop`. `stim doctor` reported `PASS` with 0 findings in that same
directory.

## Solution

`project.ts` gains the check the resolver never made: `declaresAppDependency`
is a pure predicate over parsed `package.json` content -- true when
`react-native` or `expo` appears in `dependencies` or `devDependencies` --
and `appProjectProblem` pairs it with a reader that separates a manifest that
does not parse from one that parses and declares neither, returning the
message and remedy the commands share.

`start`, `ios` and `android` refuse when there is a problem, each immediately
after its existing "no package.json above it" refusal and before the
workspace storage call, so no registry entry, port reservation, supervisor or
device work happens. The refusal reuses `STIM_NO_PROJECT` rather than adding
a code: `guide errors` already files "a working directory with no
package.json above it" under it as the refusal raised before anything runs,
and this is the same mistake with the same fix -- run the command somewhere
else. The message names the `package.json` that was read; the remedy is the
app directory, or that directory inside a worktree. `doctor` reports the same
directory as a "costs time" finding instead of `PASS`, since everything it
checks below is measured against a directory no run can use.

A `package.json` that does not parse is a separate refusal. Calling it "depends
on neither react-native nor expo" would be false for a real app whose manifest
is mid-edit or holds a merge conflict, and the remedy -- go to the app
directory -- is a dead end for someone already in it. That refusal names the
parse error and asks for the JSON to be fixed, and `doctor` reports it under
its own title.

The rule is the declared dependency, not a resolution probe, which keeps the
decision pure and cheap. A monorepo root that hoists `react-native` into its
`node_modules` without declaring it is still refused -- the app lives in a
package below it.

The iOS refusal follows that command's own failure shape: the message alone on
the `error` line, then the remedy, then the terminal `failed
STIM_NO_PROJECT` line. `android` keeps its own shape, which prints the code on
the `error` line and has no `failed` line.

`device lock` is not gated. Its lease file plus holder token is the one piece
of durable state a non-app directory can still leave behind, and it is outside
this issue, which names `start`, `ios`, `android` and `doctor`.

`guide agent` gains one rule (run Stim from the app directory) and the
`guide errors` entry names both new cases; both have contract tests.

## Test plan

Real runs of the built CLI, with `STIM_HOME` pointed at an empty scratch
directory:

```text
$ node packages/stim-cli/dist/cli.mjs start        # in a directory that is not an app
.../package.json depends on neither react-native nor expo, so this is not a React Native or Expo app.
Run this from the app directory -- the one whose package.json depends on react-native or expo -- or from that directory inside a worktree.
failed: STIM_NO_PROJECT   (exit 1)

$ node packages/stim-cli/dist/cli.mjs start        # package.json truncated mid-edit
.../package.json is not valid JSON (Expected ',' or '}' after property value in JSON at position 59 (line 1 column 60)), so Stim cannot tell whether this is a React Native or Expo app.
Fix the JSON in .../package.json -- an unfinished edit or a merge conflict leaves it unparseable -- then run the command again.
failed: STIM_NO_PROJECT   (exit 1)
```

`ios`, `ios --json` and `android --json` refuse the same way for both inputs,
with the payload as the single stdout line and the human lines on stderr, and
the iOS runs end on the `failed  STIM_NO_PROJECT` line. After those runs the
scratch `STIM_HOME` was still empty -- no `config.json`, no `workspaces/`.
`doctor` prints one finding for each input instead of `PASS`; in a temporary
directory whose `package.json` declares `react-native` the gate passes and
`android` goes on to its next gate (`STIM_NO_METRO`), so an app is not caught
by the new refusal.

Checks from the worktree root: `pnpm run format` then `pnpm run format:check`,
`pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip`
(clean; the one `pod` configuration hint is pre-existing on `main`),
`pnpm test` (3516 passed; the 15 failures are the pre-existing child-process
timeouts in `collector-run`, `engine-build-lock`, `engine-build-slots` and
`engine-device-lease` that issue #379 covers, unchanged by this branch), and
`pnpm run test:e2e` (20/20), because the change sits on the
`start`/`ios`/`android` entry points.

Fixes #378
