### PR TITLE
fix: correct reload recovery guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ logs.
 The normal flow is:
 
 ```text
-worktree create -> start -> ios|android -> reload -> logs --errors -> stop -> worktree remove
+worktree create -> start -> ios|android -> logs --errors -> stop -> worktree remove
 ```
 
 The command surface is `doctor`, `worktree create|remove`, `start`, `stop`,

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Then ask your coding agent to build and run the app. The normal loop is:
 stim doctor
 stim start
 stim ios                  # or: stim android
-stim reload               # after a JS-only edit when Fast Refresh needs help
 stim logs --errors
 stim stop
 ```
+
+`stim reload [ios|android]` is a recovery or explicit restart command. Use it
+after a failed first bundle load or when an error screen remains after a fix,
+not after every JavaScript edit.
 
 Stim needs no project initialization. Runtime state stays under `~/.stim` by
 default.

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -27,7 +27,6 @@ Node 20.19.4 or later on Node 20, or Node 22.12.0 or later, is required.
 stim doctor
 stim start
 stim ios                  # or: stim android
-stim reload               # after a JS-only edit when Fast Refresh needs help
 stim logs --errors
 stim stop
 ```
@@ -50,8 +49,10 @@ readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.
 
 `stim reload [ios|android]` reloads JavaScript in the live app on this
-workspace's owned local device. It does not build, install, boot, or launch an
-app. The platform is optional when only one app is live.
+workspace's owned local device. Use it after a failed first bundle load, when
+an error screen remains after a fix, or when you explicitly need an app
+restart. It is not part of the normal workflow and does not build, install,
+boot, or launch an app. The platform is optional when only one app is live.
 
 ## Reference
 

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -4033,6 +4033,25 @@ describe('--device (a physical Android device)', () => {
     expect(h.calls.resolveCached[0]).toEqual(['android', `${FINGERPRINT}-release-sim`]);
   });
 
+  test('a live physical-device error uses the existing automation session instead of a Metro reload', async () => {
+    const h = physicalHarness({
+      verifyLaunched: async () => ({
+        verified: true,
+        processAlive: true,
+        errors: [{ src: 'client', msg: 'a redbox from the app' }],
+      }),
+    });
+    await h.run();
+    const text = h.stderr.join('\n');
+    expect(text).toContain('existing agent-device automation session for com.example.app on RFCR7081Q9L');
+    expect(text).toContain('exact arguments and environment that identify that session');
+    expect(text).toContain('Run `agent-device snapshot -i` in that session');
+    expect(text).not.toContain('agent-device snapshot -i --platform android --serial RFCR7081Q9L');
+    expect(text).toMatch(/If Reload is visible on the error screen, press it by exact ref or label/);
+    expect(text).toMatch(/Otherwise open the React Native dev menu through that session/);
+    expect(text).not.toContain('agent-device metro reload');
+  });
+
   test('a physical run launches against localhost, not the emulator loopback', async () => {
     const h = physicalHarness();
     await h.run();

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1000,6 +1000,8 @@ test('the website offers copyable outcome prompts and explains skill activation'
 test('the agent guide carries the normal workflow and safety rules', () => {
   const agent = renderTopic('agent');
   assert(agent);
+  const normalWorkflow = agent.match(/NORMAL WORKFLOW([\s\S]*?)RULES DURING THE LOOP/)?.[1];
+  assert(normalWorkflow);
   expect(agent).toContain('stim doctor --platform ios');
   expect(agent).toContain('stim worktree create <name> --carry-ignored');
   expect(agent).toMatch(/ios and android install the app, launch it, and check readiness/);
@@ -1009,6 +1011,7 @@ test('the agent guide carries the normal workflow and safety rules', () => {
   expect(agent).toMatch(/Exit code 0 from logs --errors is the pass condition/);
   expect(agent).toContain('No matching log records');
   expect(agent).toContain('stim reload');
+  expect(normalWorkflow).not.toContain('stim reload');
   expect(agent).not.toContain('agent-device metro reload --metro-port <reported-port>');
   expect(agent).toMatch(/app error but also says the native process is alive,[\s\S]*app did not crash/);
   expect(agent).toMatch(/FATAL because the app process exited,[\s\S]*Metro cannot restart it/);
@@ -1153,15 +1156,34 @@ test('the guide defines reload as a JavaScript-only live-app recovery', () => {
   assert(errors);
 
   expect(agent).toContain('stim reload');
+  expect(agent).toMatch(/failed first bundle load[\s\S]*app restart/);
   expect(lifecycle).toMatch(/never builds, installs, boots, or cold-launches/);
   expect(lifecycle).toMatch(/owned local simulator or emulator/);
-  expect(lifecycle).toMatch(/stim reload ios \/ stim reload android/);
+  expect(lifecycle).toMatch(/stim reload ios[\s\S]*stim reload android/);
   expect(facts).toContain('stim reload [ios|android] --json');
   expect(facts).toMatch(/platform[\s\S]*deviceId[\s\S]*metroPort[\s\S]*strategy/);
   expect(errors).toContain('STIM_RELOAD_AMBIGUOUS');
   expect(errors).toContain('STIM_RELOAD_RELEASE');
   expect(errors).toContain('STIM_RELOAD_FAILED');
   expect(lifecycle).toMatch(/does not\s+take over\s+that stateful session/);
+});
+
+test('the documented common workflows leave reload to recovery', () => {
+  const rootReadme = readFileSync(new URL('../../../../README.md', import.meta.url), 'utf-8');
+  const packageReadme = readFileSync(new URL('../../README.md', import.meta.url), 'utf-8');
+  const website = readFileSync(new URL('../../../../website/docs/commands.md', import.meta.url), 'utf-8');
+  const agents = readFileSync(new URL('../../../../AGENTS.md', import.meta.url), 'utf-8');
+  const rootWorkflow = rootReadme.match(/The normal loop is:\n\n```bash([\s\S]*?)```/)?.[1];
+  const packageWorkflow = packageReadme.match(/## Normal workflow\n\n```bash([\s\S]*?)```/)?.[1];
+  const websiteWorkflow = website.match(/code=\{`stim doctor([\s\S]*?)stim stop`\}/)?.[0];
+  const repositoryWorkflow = agents.match(/The normal flow is:\n\n```text([\s\S]*?)```/)?.[1];
+  assert(rootWorkflow);
+  assert(packageWorkflow);
+  assert(websiteWorkflow);
+  assert(repositoryWorkflow);
+  for (const workflow of [rootWorkflow, packageWorkflow, websiteWorkflow, repositoryWorkflow]) {
+    expect(workflow).not.toContain('reload');
+  }
 });
 
 test('the guide documents the project cache provider as the tier between local and Expo', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -4007,6 +4007,30 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(text).not.toMatch(/opened on the dev-client URL/);
   });
 
+  test('a first-bundle failure on a live phone uses the existing automation session', async () => {
+    reserve();
+    const { errs, exitCode } = await run(
+      { device: true },
+      {
+        ...connected(),
+        verifyLaunch: async () => ({
+          fatal: true,
+          processAlive: true,
+          errors: [{ src: 'metro', msg: 'Unable to resolve module ./missing' }],
+        }),
+      },
+    );
+    const text = errs.join('\n');
+    expect(exitCode).toBe(1);
+    expect(text).toContain(`existing agent-device automation session for com.example.app on ${PHONE}`);
+    expect(text).toContain('exact arguments and environment that identify that session');
+    expect(text).toContain('Run `agent-device snapshot -i` in that session');
+    expect(text).not.toContain(`agent-device snapshot -i --platform ios --udid ${PHONE}`);
+    expect(text).toMatch(/If Reload is visible on the error screen, press it by exact ref or label/);
+    expect(text).toMatch(/Otherwise open the React Native dev menu through that session/);
+    expect(text).not.toContain('agent-device metro reload');
+  });
+
   test('the collector is the launch: it carries --physical and the run reads the device pid', async () => {
     reserve();
     const { calls } = await run({ device: true }, connected());

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -893,6 +893,16 @@ interface VerifyAndroidRunArgs {
   phase: (label: unknown, text: string) => void;
 }
 
+function physicalAndroidReloadRemedy(androidPackage: string, serial: string): string {
+  return (
+    `continue in your existing agent-device automation session for ${androidPackage} on ${serial}. ` +
+    'Keep the exact arguments and environment that identify that session on every command. ' +
+    'Run `agent-device snapshot -i` in that session. ' +
+    'If Reload is visible on the error screen, press it by exact ref or label. ' +
+    'Otherwise open the React Native dev menu through that session, inspect again, and press Reload.'
+  );
+}
+
 async function verifyAndroidRun({
   release,
   remoteRelease,
@@ -967,10 +977,13 @@ async function verifyAndroidRun({
         chalk.yellow('Fix the crash, then run `stim android` again. A Metro reload cannot restart an exited app.'),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
+      const reloadRemedy = physical
+        ? physicalAndroidReloadRemedy(androidPackage, serial)
+        : 'run `stim reload android`.';
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error, then run ${physical ? `\`agent-device metro reload --metro-port ${metroPort}\`` : '`stim reload android`'}. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. Fix the JavaScript or TypeScript error, then ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
         ),
       );
     }
@@ -988,10 +1001,13 @@ async function verifyAndroidRun({
     if (report.summary) phase('launch', chalk.dim(report.summary));
     for (const line of report.lines) phase('launch', chalk.yellow(line));
     if (report.lines.length > 0 && verification.processAlive === true && metroPort !== null) {
+      const reloadRemedy = physical
+        ? physicalAndroidReloadRemedy(androidPackage, serial)
+        : 'run `stim reload android`.';
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run ${physical ? `\`agent-device metro reload --metro-port ${metroPort}\`` : '`stim reload android`'}. Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
         ),
       );
     }

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -45,11 +45,6 @@ upstream gap.
   stim ios                             # or: stim android
   stim logs --errors
 
-  # JavaScript and TypeScript edits use Fast Refresh. If an error screen stays
-  # after the edit, reload the running app without rebuilding it.
-  stim reload                            # add ios or android when both are live
-  stim logs --since 30s --level error
-
   stim stop
   stim worktree remove
 
@@ -66,10 +61,14 @@ RULES DURING THE LOOP
 - Android Debug builds target the owned emulator system-image ABI or the
   physical device's primary ABI. Unknown targets and Release builds stay
   universal.
+- Reload is not part of the normal workflow. Use stim reload on an owned local
+  simulator or emulator after a failed first bundle load, when an error screen
+  remains after the fix, or when you explicitly need an app restart. On a
+  physical device, follow the printed agent-device UI automation remedy.
 - If launch reports an app error but also says the native process is alive,
-  the app did not crash. Fix JavaScript or TypeScript and use Fast Refresh; if
-  the error screen remains, use stim reload. Do not run ios or android again.
-  If launch says FATAL because the app process exited,
+  the app did not crash. Fix JavaScript or TypeScript and use Fast Refresh. If
+  the error screen remains, follow the printed reload remedy instead of
+  running ios or android again. If launch says FATAL because the app process exited,
   fix the crash and run the platform command again; Metro cannot restart it.
 - A cold native build can outlive a shell timeout. Run the same command again:
   the second call joins the active build or returns its result.
@@ -1719,10 +1718,6 @@ STIM_CONFIG_CORRUPT  ("Stim config at <path> is not valid JSON")
   stim logs --errors
 
   # 5. Edit the JS. Fast Refresh applies it; no Stim command is involved.
-  #    If a startup or error overlay stays, reload without rebuilding. The
-  #    platform is optional unless both owned apps are live. Then ask again.
-  stim reload          # or: stim reload ios / stim reload android
-  stim logs --since 30s --level error
 
   # 6. Pausing: supervisor halted, collectors reaped, owned device SHUT DOWN
   #    (never deleted), port freed. Coming back costs a boot, not a create.
@@ -1739,7 +1734,10 @@ and produces an app that cannot load a bundle.
 
 Repeat step 3 whenever a NATIVE input changes. A JS-only edit needs nothing --
 that is what Fast Refresh over the running dev server is for. \`stim reload\` is
-the explicit recovery path when Fast Refresh cannot clear the current screen.
+not part of the normal workflow. It is the explicit recovery path after a
+failed first bundle load, when Fast Refresh cannot clear the current screen,
+or when you explicitly need an app restart. Use \`stim reload ios\` or
+\`stim reload android\` to select a platform when both owned apps are live.
 It never builds, installs, boots, or cold-launches. It acts only on a live app
 on this workspace's owned local simulator or emulator, and refuses release
 builds, stopped or unowned devices, a missing or foreign Metro, and an

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1109,6 +1109,16 @@ interface VerifyIosRunArgs {
   metroOrigin: string | null;
 }
 
+function physicalIosReloadRemedy(bundleId: string, udid: string): string {
+  return (
+    `continue in your existing agent-device automation session for ${bundleId} on ${udid}. ` +
+    'Keep the exact arguments and environment that identify that session on every command. ' +
+    'Run `agent-device snapshot -i` in that session. ' +
+    'If Reload is visible on the error screen, press it by exact ref or label. ' +
+    'Otherwise open the React Native dev menu through that session, inspect again, and press Reload.'
+  );
+}
+
 async function verifyIosRun({
   d,
   release,
@@ -1199,11 +1209,16 @@ async function verifyIosRun({
         ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
+      const reloadRemedy = physical
+        ? physicalIosReloadRemedy(bundleId, udid)
+        : remoteDevice
+          ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
+          : 'run `stim reload ios`.';
       note(
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error, then run ${physical || remoteDevice ? `\`agent-device metro reload --metro-port ${metroPort}\`` : '`stim reload ios`'}. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. Fix the JavaScript or TypeScript error, then ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );
@@ -1220,11 +1235,16 @@ async function verifyIosRun({
     );
     const hasAppErrors = reportLaunchErrors(verification.errors ?? [], note);
     if (hasAppErrors && verification.processAlive === true && metroPort !== null) {
+      const reloadRemedy = physical
+        ? physicalIosReloadRemedy(bundleId, udid)
+        : remoteDevice
+          ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
+          : 'run `stim reload ios`.';
       note(
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, run ${physical || remoteDevice ? `\`agent-device metro reload --metro-port ${metroPort}\`` : '`stim reload ios`'}. Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -18,13 +18,16 @@ reference that ships with the installed version.
 code={`stim doctor
 stim start
 stim ios                 # or: stim android
-stim reload              # after a JS-only edit when Fast Refresh needs help
 stim logs --errors
 stim stop`}
 />
 
 `ios` and `android` require a running dev server for a Debug build. Release
 builds embed the JavaScript bundle and skip that requirement.
+
+`reload` is a recovery or explicit restart command. Use it after a failed first
+bundle load or when an error screen remains after a fix, not after every
+JavaScript edit.
 
 ## `doctor`
 


### PR DESCRIPTION
## Description

Physical `--device` launch remedies currently suggest `agent-device metro reload` after a failed first bundle load or a persistent error overlay. That Metro broadcast cannot recover an app that never connected to Metro. The reload command also appears in the common workflow even though Fast Refresh handles normal JavaScript edits. These choices came from [the first-class reload command](https://github.com/appandflow/stim/commit/43da17e5e94fc920fdce65492432ee9f67411b28); this corrects the recovery boundary without changing the command itself.

## Solution

Physical-device recovery now uses the exact existing `agent-device` UI session to press Reload from the error screen or React Native dev menu. The printed remedy names the selected UDID or serial and requires every command to preserve the exact arguments and environment that identify that session. Owned local simulator/emulator and remote-device recovery behavior is unchanged.

The common workflows now leave reload out of successful runs. The detailed guidance presents it only for a failed first bundle load, an error screen that remains after a fix, or an explicit app restart.

## Test plan

- `pnpm exec vitest run packages/stim-cli/src/__tests__/ios-command.test.ts packages/stim-cli/src/__tests__/android-command.test.ts -t 'launch verification|--device \(a physical Android device\)|ios --device: selecting a phone'` (80 passed)
- `pnpm exec vitest run packages/stim-cli/src/__tests__/guide.test.ts` (90 passed)
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, and `pnpm run typecheck`
- `pnpm test` in the Codex sandbox reached 3,439 passing tests; 131 environment-dependent tests could not access localhost listeners, process inspection, GPG/keychain services, or the machine-global EAS lock. The changed suites above pass in that same sandbox.

Fixes #395
