### PR TITLE
fix: build Android debug artifacts for the target ABI

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -176,6 +176,7 @@ export function sharedStoreRoot(store: unknown): string | null {
 
 export interface BuildRunOptions {
   variant?: string;
+  abi?: string;
   configuration?: string;
   buildConfiguration?: string;
   isSimulator?: boolean;
@@ -210,7 +211,8 @@ function buildTarget(options: BuildRunOptions): string {
 
 export function buildCacheKey(platform: string, fingerprintHash: string, options: unknown = {}): string {
   const opts = (options && typeof options === 'object' ? options : {}) as BuildRunOptions;
-  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}`;
+  const abi = platform === 'android' && typeof opts.abi === 'string' ? slug(opts.abi) : '';
+  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}${abi ? `-${abi}` : ''}`;
 }
 
 export interface RegisterOptions {

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -139,6 +139,7 @@ interface BuildArgs {
   root?: string;
   logWriter?: unknown;
   variant?: string | null;
+  abi?: string | null;
 }
 interface InstallArgs {
   apkPath?: string | null;
@@ -252,6 +253,7 @@ function harness(overrides = {}) {
   const stdout: string[] = [];
   const options = {
     root,
+    deviceAbi: () => null,
     ensureDevice: async (args: unknown = {}) => {
       calls.ensureDevice.push(args);
       return { avdName: 'stim-app-412', consolePort: 5584, owned: true };
@@ -1055,6 +1057,59 @@ describe('a cache miss', () => {
     expect(labelled(h.stderr, 'build')[1]).toMatch(/^  build {7}ok \(2m41s\)$/);
     assert(result.facts);
     expect(result.facts.cacheHit).toBe(false);
+  });
+
+  test('builds only the ABI selected for an owned emulator and scopes the cache key', async () => {
+    const abiKey = `${FINGERPRINT}-debug-sim-arm64-v8a`;
+    const h = harness({
+      deviceAbi: never('the owned emulator ABI query'),
+      ensureDevice: async () => ({
+        avdName: 'stim-app-412',
+        consolePort: 5584,
+        owned: true,
+        systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+      }),
+      loadProvider: async () => ({ provider: { plugin: {}, options: {} }, name: 'eas' }),
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBe('arm64-v8a');
+    expect(h.calls.resolveCached[0]).toEqual(['android', abiKey]);
+    expect(h.calls.storeCached[0]?.slice(0, 2)).toEqual(['android', abiKey]);
+    expect(h.calls.resolveRemoteBuild[0]?.runOptions).toEqual({ abi: 'arm64-v8a' });
+    expect(h.calls.uploadRemoteBuild[0]?.runOptions).toEqual({ abi: 'arm64-v8a' });
+  });
+
+  test('keeps a universal Debug build when the owned emulator ABI is unknown', async () => {
+    const h = harness({
+      ensureDevice: async () => ({
+        avdName: 'stim-app-412',
+        consolePort: 5584,
+        owned: true,
+        systemImage: null,
+      }),
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBeNull();
+    expect(h.calls.resolveCached[0]).toEqual(['android', CACHE_KEY]);
+  });
+
+  test('keeps Release builds universal even when the target ABI is known', async () => {
+    const releaseKey = `${FINGERPRINT}-release-sim`;
+    const h = harness({
+      variant: 'release',
+      ensureDevice: async () => ({
+        avdName: 'stim-app-412',
+        consolePort: 5584,
+        owned: true,
+        systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+      }),
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBeNull();
+    expect(h.calls.resolveCached[0]).toEqual(['android', releaseKey]);
   });
 
   test('a cache that cannot be written is a warning, not a failed run', async () => {
@@ -3907,6 +3962,14 @@ describe('--device (a physical Android device)', () => {
     expect(result.ok).toBe(true);
     expect(h.calls.install[0]?.serial).toBe('RFCR7081Q9L');
     expect(h.calls.launch[0]?.serial).toBe('RFCR7081Q9L');
+  });
+
+  test('a physical Debug run builds for the device primary ABI', async () => {
+    const h = physicalHarness({ deviceAbi: () => 'arm64-v8a' });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBe('arm64-v8a');
+    expect(h.calls.resolveCached[0]).toEqual(['android', `${FINGERPRINT}-debug-sim-arm64-v8a`]);
   });
 
   test('a physical run launches against localhost, not the emulator loopback', async () => {

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1062,6 +1062,7 @@ describe('a cache miss', () => {
   test('builds only the ABI selected for an owned emulator and scopes the cache key', async () => {
     const abiKey = `${FINGERPRINT}-debug-sim-arm64-v8a`;
     const h = harness({
+      json: true,
       deviceAbi: never('the owned emulator ABI query'),
       ensureDevice: async () => ({
         avdName: 'stim-app-412',
@@ -1069,15 +1070,17 @@ describe('a cache miss', () => {
         owned: true,
         systemImage: 'system-images;android-36;google_apis;arm64-v8a',
       }),
-      loadProvider: async () => ({ provider: { plugin: {}, options: {} }, name: 'eas' }),
+      loadProvider: never('the Expo build cache provider'),
     });
 
-    expect((await h.run()).ok).toBe(true);
+    const result = await h.run();
+    expect(result.ok).toBe(true);
     expect(h.calls.build[0]?.abi).toBe('arm64-v8a');
     expect(h.calls.resolveCached[0]).toEqual(['android', abiKey]);
     expect(h.calls.storeCached[0]?.slice(0, 2)).toEqual(['android', abiKey]);
-    expect(h.calls.resolveRemoteBuild[0]?.runOptions).toEqual({ abi: 'arm64-v8a' });
-    expect(h.calls.uploadRemoteBuild[0]?.runOptions).toEqual({ abi: 'arm64-v8a' });
+    expect(result.facts?.cacheKey).toBe(abiKey);
+    expect(JSON.parse(h.stdout[0] ?? '{}').cacheKey).toBe(abiKey);
+    expect(readState().lastBuild.cacheKey).toBe(abiKey);
   });
 
   test('keeps a universal Debug build when the owned emulator ABI is unknown', async () => {
@@ -3870,6 +3873,38 @@ describe('the project cache provider', () => {
     expect(labelled(h.stderr, 'cache').some((line) => line.includes('uploaded (./cache.cjs)'))).toBe(true);
   });
 
+  test('an ABI-targeted build uses the key-based provider and skips the Expo provider', async () => {
+    const abiKey = `${FINGERPRINT}-debug-sim-arm64-v8a`;
+    const providerCalls: unknown[] = [];
+    const h = harness(
+      providerOptions(
+        {
+          resolve: (input: unknown) => {
+            providerCalls.push(input);
+            return null;
+          },
+          store: (input: unknown) => {
+            providerCalls.push(input);
+          },
+        },
+        {
+          ensureDevice: async () => ({
+            avdName: 'stim-app-412',
+            consolePort: 5584,
+            owned: true,
+            systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+          }),
+          loadProvider: never('the Expo build cache provider'),
+        },
+      ),
+    );
+
+    expect((await h.run()).ok).toBe(true);
+    expect(providerCalls).toHaveLength(2);
+    expect(providerCalls[0]).toMatchObject({ platform: 'android', key: abiKey });
+    expect(providerCalls[1]).toMatchObject({ platform: 'android', key: abiKey });
+  });
+
   test('an unusable provider reports once and the build still succeeds', async () => {
     const h = harness({
       resolveCacheProvider: () => providerConfig(),
@@ -3965,11 +4000,37 @@ describe('--device (a physical Android device)', () => {
   });
 
   test('a physical Debug run builds for the device primary ABI', async () => {
-    const h = physicalHarness({ deviceAbi: () => 'arm64-v8a' });
+    const serials: string[] = [];
+    const h = physicalHarness({
+      deviceAbi: (serial: string) => {
+        serials.push(serial);
+        return 'arm64-v8a';
+      },
+    });
 
     expect((await h.run()).ok).toBe(true);
+    expect(serials).toEqual(['RFCR7081Q9L']);
     expect(h.calls.build[0]?.abi).toBe('arm64-v8a');
     expect(h.calls.resolveCached[0]).toEqual(['android', `${FINGERPRINT}-debug-sim-arm64-v8a`]);
+  });
+
+  test('a physical Debug run stays universal when the device ABI is unknown', async () => {
+    const h = physicalHarness({ deviceAbi: () => null });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBeNull();
+    expect(h.calls.resolveCached[0]).toEqual(['android', CACHE_KEY]);
+  });
+
+  test('a physical Release run stays universal without querying the device ABI', async () => {
+    const h = physicalHarness({
+      variant: 'release',
+      deviceAbi: never('the device ABI'),
+    });
+
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.build[0]?.abi).toBeNull();
+    expect(h.calls.resolveCached[0]).toEqual(['android', `${FINGERPRINT}-release-sim`]);
   });
 
   test('a physical run launches against localhost, not the emulator loopback', async () => {

--- a/packages/stim-cli/src/__tests__/build-cache.test.ts
+++ b/packages/stim-cli/src/__tests__/build-cache.test.ts
@@ -246,6 +246,14 @@ test('android keys on the gradle variant rather than the Xcode configuration', (
   expect(buildCacheKey('android', hash, { configuration: 'Release' })).toBe(`${hash}-debug-sim`);
 });
 
+test('android cache keys separate target ABIs while preserving the universal key', () => {
+  const hash = 'abc123';
+  expect(buildCacheKey('android', hash, { abi: 'arm64-v8a' })).toBe(`${hash}-debug-sim-arm64-v8a`);
+  expect(buildCacheKey('android', hash, { abi: 'x86_64' })).toBe(`${hash}-debug-sim-x86-64`);
+  expect(buildCacheKey('android', hash, {})).toBe(`${hash}-debug-sim`);
+  expect(buildCacheKey('ios', hash, { abi: 'arm64-v8a' })).toBe(`${hash}-debug-sim`);
+});
+
 test('the CLI and the Expo provider compute the same key', () => {
   for (const [platform, options] of [
     ['ios', {}],
@@ -253,7 +261,7 @@ test('the CLI and the Expo provider compute the same key', () => {
     ['ios', { device: 'generic' }],
     ['ios', { device: 'Janic iPhone' }],
     ['ios', { device: true }],
-    ['android', { variant: 'release', device: 'emulator-5554' }],
+    ['android', { variant: 'release', device: 'emulator-5554', abi: 'arm64-v8a' }],
   ] as [string, Record<string, unknown>][]) {
     expect(buildCacheKey(platform, 'hash', options)).toBe(providerKey(platform, 'hash', options));
   }

--- a/packages/stim-cli/src/__tests__/cache-packages.test.ts
+++ b/packages/stim-cli/src/__tests__/cache-packages.test.ts
@@ -44,6 +44,53 @@ test('the Expo build cache provider registers itself on this Node, at the right 
   }
 });
 
+test('the standalone Expo build cache provider separates Android ABIs', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'stim-pkg-home-'));
+  const cacheRoot = mkdtempSync(join(tmpdir(), 'stim-pkg-bc-'));
+  const universalApk = join(home, 'universal.apk');
+  const arm64Apk = join(home, 'arm64.apk');
+  process.env.STIM_HOME = home;
+  process.env.STIM_BUILD_CACHE = cacheRoot;
+  writeFileSync(universalApk, 'universal');
+  writeFileSync(arm64Apk, 'arm64');
+  try {
+    const provider = await import('@stim-cli/expo-build-cache');
+    await provider.uploadBuildCache({
+      platform: 'android',
+      fingerprintHash: 'fingerprint',
+      buildPath: universalApk,
+      runOptions: { variant: 'debug' },
+    });
+    await provider.uploadBuildCache({
+      platform: 'android',
+      fingerprintHash: 'fingerprint',
+      buildPath: arm64Apk,
+      runOptions: { variant: 'debug', abi: 'arm64-v8a' },
+    });
+
+    const universal = await provider.resolveBuildCache({
+      platform: 'android',
+      fingerprintHash: 'fingerprint',
+      runOptions: { variant: 'debug' },
+    });
+    const arm64 = await provider.resolveBuildCache({
+      platform: 'android',
+      fingerprintHash: 'fingerprint',
+      runOptions: { variant: 'debug', abi: 'arm64-v8a' },
+    });
+    assert(universal);
+    assert(arm64);
+    expect(universal).not.toBe(arm64);
+    expect(readFileSync(universal, 'utf8')).toBe('universal');
+    expect(readFileSync(arm64, 'utf8')).toBe('arm64');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cacheRoot, { recursive: true, force: true });
+    delete process.env.STIM_HOME;
+    delete process.env.STIM_BUILD_CACHE;
+  }
+});
+
 test('the Metro cache store registers itself on this Node, at the shard depth', async () => {
   const home = mkdtempSync(join(tmpdir(), 'stim-pkg-home2-'));
   const cacheRoot = join(tmpdir(), `stim-pkg-metro-${process.pid}`);

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -349,6 +349,14 @@ describe('gradleArgs', () => {
   test('a caller can turn it off, and then the argv is exactly the task', () => {
     expect(gradleArgs('assembleDebug', { buildCache: false })).toEqual(['assembleDebug']);
   });
+
+  test('limits React Native native compilation to a proven target ABI', () => {
+    expect(gradleArgs('assembleDebug', { abi: 'arm64-v8a' })).toEqual([
+      'assembleDebug',
+      '--build-cache',
+      '-PreactNativeArchitectures=arm64-v8a',
+    ]);
+  });
 });
 
 describe('buildAndroid', () => {

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -407,13 +407,20 @@ describe('buildAndroid', () => {
     }
   });
 
-  test('writes a build_start record carrying the resolved gradlew path and its full argv', async () => {
+  test('forwards the target ABI to Gradle and records it in the full argv', async () => {
     makeAndroidProject();
     const writer = recordingWriter();
+    const calls: string[][] = [];
     await buildAndroid(
-      { root, logWriter: writer },
-      { spawnFn: () => fakeChild({ lines: ['BUILD SUCCESSFUL in 1s'], onExit: () => writeApk() }) },
+      { root, logWriter: writer, abi: 'arm64-v8a' },
+      {
+        spawnFn: (_cmd, args) => {
+          calls.push(args);
+          return fakeChild({ lines: ['BUILD SUCCESSFUL in 1s'], onExit: () => writeApk() });
+        },
+      },
     );
+    expect(calls).toEqual([['assembleDebug', '--build-cache', '-PreactNativeArchitectures=arm64-v8a']]);
     const starts = writer.records.filter((r) => r.event === 'build_start');
     expect(starts.length).toBe(1);
     const start = starts[0];
@@ -421,7 +428,9 @@ describe('buildAndroid', () => {
     expect(start.src).toBe('build');
     expect(start.level).toBe('info');
     expect(start.raw).toBe(undefined);
-    expect(start.msg).toBe(`${join(root, 'android', 'gradlew')} assembleDebug --build-cache`);
+    expect(start.msg).toBe(
+      `${join(root, 'android', 'gradlew')} assembleDebug --build-cache -PreactNativeArchitectures=arm64-v8a`,
+    );
   });
 
   test('the build_start record shows the argv WITHOUT --build-cache when the cache is off', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -200,6 +200,12 @@ test('the facts topic says Android artifacts use the post-Gradle fingerprint', (
   expect(body).toMatch(/fingerprint and cacheKey are null/);
 });
 
+test('the guides document Android target-ABI builds and universal fallbacks', () => {
+  expect(renderTopic('facts')).toMatch(/debug-sim-arm64-v8a/);
+  expect(renderTopic('lifecycle')).toMatch(/-PreactNativeArchitectures=<target ABI>/);
+  expect(renderTopic('agent')).toMatch(/Unknown targets and Release builds stay\s+universal/);
+});
+
 test('the one-line JSON sentence names every command whose --json payload is a single line', () => {
   const body = renderTopic('facts');
   assert(body);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -203,6 +203,7 @@ test('the facts topic says Android artifacts use the post-Gradle fingerprint', (
 test('the guides document Android target-ABI builds and universal fallbacks', () => {
   expect(renderTopic('facts')).toMatch(/debug-sim-arm64-v8a/);
   expect(renderTopic('lifecycle')).toMatch(/-PreactNativeArchitectures=<target ABI>/);
+  expect(renderTopic('lifecycle')).toMatch(/ABI-targeted Android Debug build skips this Expo\s+tier/);
   expect(renderTopic('agent')).toMatch(/Unknown targets and Release builds stay\s+universal/);
 });
 

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -15,6 +15,8 @@ import { join } from 'path';
 import { setExecutor, resetExecutor } from '../exec.ts';
 import {
   MAX_EMULATOR_FAILURE_LINES,
+  androidDeviceAbi,
+  androidSystemImageAbi,
   androidToolPath,
   androidPoolNoCandidatesRefusal,
   buildToolsMajor,
@@ -872,6 +874,30 @@ test('physicalDeviceModel returns null when adb cannot answer', () => {
   } as never);
   expect(physicalDeviceModel('RFCR7081Q9L')).toBeNull();
   resetExecutor();
+});
+
+test('androidDeviceAbi reads the device primary ABI', () => {
+  const calls: string[][] = [];
+  setExecutor({
+    runFile: (_file: string, args: string[] = []) => {
+      calls.push(args);
+      return 'arm64-v8a\n';
+    },
+  } as never);
+  expect(androidDeviceAbi('RFCR7081Q9L')).toBe('arm64-v8a');
+  expect(calls).toEqual([['-s', 'RFCR7081Q9L', 'shell', 'getprop', 'ro.product.cpu.abi']]);
+});
+
+test('Android ABI detection falls back when the value is not supported', () => {
+  setExecutor({ runFile: () => 'unknown' } as never);
+  expect(androidDeviceAbi('RFCR7081Q9L')).toBeNull();
+  expect(androidSystemImageAbi('system-images;android-36;google_apis;unknown')).toBeNull();
+  expect(androidSystemImageAbi(null)).toBeNull();
+});
+
+test('androidSystemImageAbi uses the architecture selected for an owned emulator', () => {
+  expect(androidSystemImageAbi('system-images;android-36;google_apis;arm64-v8a')).toBe('arm64-v8a');
+  expect(androidSystemImageAbi('system-images;android-35;google_apis;x86_64')).toBe('x86_64');
 });
 
 test('resolvePhysicalDevice refuses a network-attached emulator that adb reports as physical', () => {

--- a/packages/stim-cli/src/build-cache.ts
+++ b/packages/stim-cli/src/build-cache.ts
@@ -11,6 +11,7 @@ import { sharedBuildCache } from './paths.ts';
 
 export interface BuildRunOptions {
   variant?: string;
+  abi?: string;
   configuration?: string;
   buildConfiguration?: string;
   isSimulator?: boolean;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -117,9 +117,11 @@ import {
   verifyLaunch,
 } from '../engine/app-install.ts';
 import {
+  androidDeviceAbi,
   androidHome,
   androidPoolCandidates,
   androidPoolNoCandidatesRefusal,
+  androidSystemImageAbi,
   memoizeEmulatorProbe,
   emulatorDiskSpaceRemedy,
   emulatorFailureRemedy,
@@ -796,6 +798,7 @@ interface RunAndroidOptions {
   onLeaseSignal?: typeof releaseLeaseOnSignal;
   listDevices?: typeof listAdbDevices;
   deviceModel?: typeof physicalDeviceModel;
+  deviceAbi?: typeof androidDeviceAbi;
   isEmulatorDevice?: typeof probeEmulatorSerial;
   readApkPackage?: (apkPath: string | null) => string | null;
   remoteDevice?: RemoteDeviceBackend | null;
@@ -1564,6 +1567,34 @@ async function pooledAndroidDevice({
   };
 }
 
+function androidBuildOptions({
+  release,
+  physical,
+  device,
+  variant,
+  deviceAbi,
+}: {
+  release: boolean;
+  physical: boolean;
+  device: OwnedDeviceRecord;
+  variant: string | null;
+  deviceAbi: typeof androidDeviceAbi;
+}) {
+  let abi: string | null = null;
+  if (!release && physical && device.serial) abi = deviceAbi(device.serial);
+  if (!release && !physical) abi = androidSystemImageAbi(device.systemImage);
+
+  const runOptions: { variant?: string; abi?: string } = {};
+  if (variant) runOptions.variant = variant;
+  if (abi) runOptions.abi = abi;
+
+  return {
+    abi,
+    runOptions,
+    remoteRunOptions: Object.keys(runOptions).length === 0 ? null : runOptions,
+  };
+}
+
 function resolveRunAndroidOptions(
   {
     root,
@@ -1589,6 +1620,7 @@ function resolveRunAndroidOptions(
     onLeaseSignal = releaseLeaseOnSignal,
     listDevices = listAdbDevices,
     deviceModel = physicalDeviceModel,
+    deviceAbi = androidDeviceAbi,
     isEmulatorDevice = probeEmulatorSerial,
     readApkPackage = (apkPath: string | null) => apkPackage(dumpApkManifest(apkPath)),
     getLimits = getConcurrencyLimits,
@@ -1665,6 +1697,7 @@ function resolveRunAndroidOptions(
     onLeaseSignal,
     listDevices,
     deviceModel,
+    deviceAbi,
     isEmulatorDevice,
     readApkPackage,
     getLimits,
@@ -1743,6 +1776,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     onLeaseSignal,
     listDevices,
     deviceModel,
+    deviceAbi,
     isEmulatorDevice,
     readApkPackage,
     getLimits,
@@ -2218,6 +2252,17 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   record.avdName = device.avdName ?? null;
   record.deviceName = device.deviceName ?? device.avdName ?? null;
   record.systemImage = device.systemImage;
+  const {
+    abi: buildAbi,
+    runOptions: buildRunOptions,
+    remoteRunOptions,
+  } = androidBuildOptions({
+    release,
+    physical,
+    device,
+    variant,
+    deviceAbi,
+  });
 
   let hash = '';
   let providerUpload: Promise<ProviderCallResult<void>> | null = null;
@@ -2257,7 +2302,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       return false;
     }
     record.fingerprint = hash;
-    cacheKey = buildCacheKey(PLATFORM, hash, variant ? { variant } : {});
+    cacheKey = buildCacheKey(PLATFORM, hash, buildRunOptions);
     stats.setCacheKey(cacheKey);
     record.cacheKey = cacheKey;
     storeHash = hash;
@@ -2337,7 +2382,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
           platform: PLATFORM,
           projectRoot: root,
           fingerprintHash: hash,
-          runOptions: variant ? { variant } : null,
+          runOptions: remoteRunOptions,
         });
         if (hit?.appPath) {
           let stored = null;
@@ -2526,7 +2571,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
             if (after?.moved) {
               storeHash = after.hash;
               storeSources = after.sources;
-              storeKey = buildCacheKey(PLATFORM, after.hash, variant ? { variant } : {});
+              storeKey = buildCacheKey(PLATFORM, after.hash, buildRunOptions);
               record.fingerprint = storeHash;
               record.cacheKey = storeKey;
               phase('fingerprint', chalk.dim(`${shortHash(hash)} -> ${shortHash(storeHash)} (after prebuild)`));
@@ -2546,7 +2591,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
           if (!apkPath) {
             phase('build', `compiling ${variant || 'debug'} with Gradle`);
             const built: BuildAndroidResultLike = await build(
-              { root, logWriter: writer, variant },
+              { root, logWriter: writer, variant, abi: buildAbi },
               { estimateMs: estimates().coldBuildMs },
             );
             if (built.failed) {
@@ -2594,7 +2639,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
               if (afterBuild.moved) {
                 storeHash = afterBuild.hash;
                 storeSources = afterBuild.sources;
-                storeKey = buildCacheKey(PLATFORM, afterBuild.hash, variant ? { variant } : {});
+                storeKey = buildCacheKey(PLATFORM, afterBuild.hash, buildRunOptions);
                 record.fingerprint = storeHash;
                 record.cacheKey = storeKey;
                 phase(
@@ -2632,7 +2677,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
                   projectRoot: root,
                   fingerprintHash: storeHash,
                   buildPath: apkPath!,
-                  runOptions: variant ? { variant } : null,
+                  runOptions: remoteRunOptions,
                 });
               }
             }

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -2359,6 +2359,9 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     let uploadPending: Promise<RemoteUploadLike> | null = null;
 
     async function resolveRemoteArtifact(): Promise<void> {
+      // Expo buildCacheProvider run options cannot key Android ABIs, so targeted APKs are unsafe in this tier.
+      if (buildAbi) return;
+
       if (!apkPath) {
         const loaded: LoadProjectProviderResult = await loadProvider(root, { isExpo });
         if (loaded?.unavailable) {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -2004,7 +2004,9 @@ THE BUILD CACHE HAS THREE LEVELS
      remote cannot stall the loop, and a hit is copied into level one on the
      way past so the next workspace on this machine gets it for free. After a
      build, the result is stored locally AND handed to both providers, which
-     run independently.
+     run independently. An ABI-targeted Android Debug build skips this Expo
+     tier because its run-options contract cannot distinguish ABIs; levels one
+     and two remain ABI-keyed and active.
 
   Stim never configures a provider and never suggests changing one: a
   project without one is a perfectly ordinary local-only project (doctor does

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -63,6 +63,9 @@ RULES DURING THE LOOP
   run stim start and retry.
 - Run ios or android again after a native input changes. A JavaScript-only
   change does not need one.
+- Android Debug builds target the owned emulator system-image ABI or the
+  physical device's primary ABI. Unknown targets and Release builds stay
+  universal.
 - If launch reports an app error but also says the native process is alive,
   the app did not crash. Fix JavaScript or TypeScript and use Fast Refresh; if
   the error screen remains, use stim reload. Do not run ios or android again.
@@ -402,8 +405,9 @@ line by design (see \`guide logs\`), not this single-payload contract.
   fingerprint / cacheKey / cacheHit / cacheSkipped / waitedForBuild /
   appPath / installSkipped / launched
                   as above -- cacheKey keys on the VARIANT here
-                  (<fingerprint>-productionrelease-sim) the way the iOS one
-                  keys on the configuration
+                  (<fingerprint>-productionrelease-sim). A Debug artifact for
+                  a proven target ABI also ends in that ABI
+                  (<fingerprint>-debug-sim-arm64-v8a)
   variant         the gradle variant that was built ("productionDebug" from
                   --variant or the android.variant setting); null for the
                   default assembleDebug. A variant whose name ENDS IN Release
@@ -1964,7 +1968,9 @@ lines Stim composes rather than on files the project owns:
            Podfile post_install block. Xcode 26+ only, and skipped entirely
            when the project configured ccache (the two defeat each other).
   android  gradlew carries --build-cache, so task outputs cross worktrees with
-           no org.gradle.caching=true in gradle.properties.
+           no org.gradle.caching=true in gradle.properties. Debug builds also
+           carry -PreactNativeArchitectures=<target ABI> when Stim can prove
+           the emulator or physical-device ABI; otherwise they stay universal.
   start    the dev server gets a shared Metro FileStore APPENDED to whatever
            the project configured -- in-process on a bare project, and through
            Expo's config override on SDK 54+. Expo SDK 53 and older use their
@@ -2966,7 +2972,10 @@ be setup steps are supplied by Stim on the command lines it composes itself:
                (Xcode 26+ only, and skipped when the project configured ccache,
                which defeats it)
   gradlew      --build-cache -- so no org.gradle.caching=true in a committed
-               gradle.properties
+               gradle.properties. Debug builds add
+               -PreactNativeArchitectures=<target ABI> when the owned
+               emulator system image or physical device proves the ABI;
+               unknown targets and Release builds stay universal.
   start        a shared Metro FileStore, APPENDED to whatever the project
                configured -- so no metro.config.js. On a bare project Stim
                hosts Metro itself and adds it to the config it loaded; on Expo

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -423,12 +423,20 @@ export type BuildAndroidResult = {
   durationMs: number;
 };
 
-export function gradleArgs(task: string, { buildCache = true }: { buildCache?: boolean } = {}): string[] {
-  return buildCache ? [task, '--build-cache'] : [task];
+export function gradleArgs(
+  task: string,
+  { buildCache = true, abi = null }: { buildCache?: boolean; abi?: string | null } = {},
+): string[] {
+  return [task, ...(buildCache ? ['--build-cache'] : []), ...(abi ? [`-PreactNativeArchitectures=${abi}`] : [])];
 }
 
 export async function buildAndroid(
-  { root, logWriter, variant = null }: { root: string; logWriter?: NdjsonWriter | null; variant?: string | null },
+  {
+    root,
+    logWriter,
+    variant = null,
+    abi = null,
+  }: { root: string; logWriter?: NdjsonWriter | null; variant?: string | null; abi?: string | null },
   {
     spawnFn = null,
     now = Date.now,
@@ -463,7 +471,7 @@ export async function buildAndroid(
 
   const spawn: SpawnFn = spawnFn || ((cmd, args, opts) => getExecutor().spawn(cmd, args, opts));
   const task = assembleTaskFor(variant);
-  const args = gradleArgs(task, { buildCache });
+  const args = gradleArgs(task, { buildCache, abi });
   if (buildCache) {
     onNote(chalk.dim(phaseLine('cache', 'gradle build cache on (--build-cache, shared under the Gradle user home)')));
   }

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -22,6 +22,8 @@ export interface SystemImage {
   pkg: string;
 }
 
+const ANDROID_ABIS = new Set(['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64']);
+
 interface AdbEmulatorEntry {
   serial: string;
   consolePort: number;
@@ -317,6 +319,19 @@ function adbProp(serial: string, name: string): string | null {
 
 export function physicalDeviceModel(serial: string): string | null {
   return adbProp(serial, 'ro.product.model');
+}
+
+export function androidDeviceAbi(serial: string): string | null {
+  const abi = adbProp(serial, 'ro.product.cpu.abi');
+  return abi && ANDROID_ABIS.has(abi) ? abi : null;
+}
+
+export function androidSystemImageAbi(systemImage: string | null | undefined): string | null {
+  const abi =
+    String(systemImage ?? '')
+      .split(';')
+      .at(-1) ?? '';
+  return ANDROID_ABIS.has(abi) ? abi : null;
 }
 
 function looksLikeEmulator({


### PR DESCRIPTION
## Description

`stim android` currently lets Gradle build every React Native ABI declared by the project even though the run targets one emulator or physical device. That adds avoidable native compilation, and the shared cache cannot distinguish artifacts built for different ABIs.

## Solution

For Debug runs, Stim uses the owned emulator's selected system image or the physical device's reported primary ABI and passes it as `-PreactNativeArchitectures=<abi>`. Unknown targets fall back to the existing universal build, and Release variants remain universal. The proven ABI is also part of the local cache and key-based project-provider identity so an artifact cannot be reused for a different architecture. ABI-targeted builds skip Expo's legacy `buildCacheProvider` tier because that contract cannot distinguish ABIs.

## Test plan

- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, and `pnpm run typecheck` pass.
- `pnpm test` passes 3,581 tests; `pnpm run test:e2e` passes 20 tests.
- On a bare React Native 0.85.3 app, `./gradlew assembleDebug --build-cache -PreactNativeArchitectures=arm64-v8a` completed successfully. The APK contained native libraries only under `lib/arm64-v8a`.

Fixes #394
