### PR TITLE
feat(website): separate benchmark model and platform pickers

### DIFF
--- a/website/src/components/benchmarkCatalog.ts
+++ b/website/src/components/benchmarkCatalog.ts
@@ -1,4 +1,5 @@
 import type { BenchmarkData, BenchmarkRun } from './benchmarkData';
+export { defaultRun } from './benchmarkSelection';
 import benchmarkJson from '@site/src/data/benchmarks/luna-rc12.json';
 import lunaAndroidBenchmarkJson from '@site/src/data/benchmarks/luna-android.json';
 import opusBenchmarkJson from '@site/src/data/benchmarks/opus-rc12.json';
@@ -22,10 +23,6 @@ export const benchmarks = (
     solLaunchCrashJson,
   ] as BenchmarkData[]
 ).filter((benchmark) => benchmark.runs.some((run) => run.valid));
-
-export function defaultRun(benchmark: BenchmarkData | undefined): BenchmarkRun | undefined {
-  return benchmark?.runs.find((run) => run.valid);
-}
 
 export function displayVariant(variant: BenchmarkRun['variant']): string {
   if (variant === 'javascript') return 'JavaScript change';

--- a/website/src/components/benchmarkSelection.test.ts
+++ b/website/src/components/benchmarkSelection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { benchmarkDimensions, benchmarkForDimensions, benchmarkModelLabel, defaultRun } from './benchmarkSelection';
+import type { BenchmarkData } from './benchmarkData';
+
+function benchmark(
+  stage: string,
+  model: string,
+  platform: 'ios' | 'android' | undefined,
+  suite: 'readiness' | 'launch-crash' | undefined,
+): BenchmarkData {
+  return {
+    stage,
+    title: stage,
+    platform,
+    suite,
+    pricing: model.startsWith('gpt-') ? { model } : null,
+    environment: { simulator: platform === 'android' ? 'Android emulator' : 'iPhone Simulator' },
+    runs: [
+      { id: 'javascript-stim', model, platform, valid: true },
+      { id: 'native-stim', model, platform, valid: true },
+    ],
+  } as BenchmarkData;
+}
+
+describe('benchmark catalog selection', () => {
+  const readinessIos = benchmark('sol-ios', 'gpt-5.6-sol', 'ios', 'readiness');
+  const readinessAndroid = benchmark('sol-android', 'gpt-5.6-sol', 'android', 'readiness');
+  const crashIos = benchmark('sol-crash', 'gpt-5.6-sol', 'ios', 'launch-crash');
+  const lunaIos = benchmark('luna-ios', 'gpt-5.6-luna', undefined, undefined);
+  const catalog = [lunaIos, readinessIos, readinessAndroid, crashIos];
+
+  it('derives missing legacy dimensions from the run and environment', () => {
+    expect(benchmarkDimensions(lunaIos)).toEqual({
+      model: 'gpt-5.6-luna',
+      platform: 'ios',
+      suite: 'readiness',
+    });
+  });
+
+  it('selects model, platform, and suite independently', () => {
+    expect(
+      benchmarkForDimensions(catalog, { model: 'gpt-5.6-sol', platform: 'ios', suite: 'launch-crash' })?.stage,
+    ).toBe('sol-crash');
+    expect(
+      benchmarkForDimensions(catalog, { model: 'gpt-5.6-sol', platform: 'android', suite: 'launch-crash' })?.stage,
+    ).toBe('sol-android');
+  });
+
+  it('preserves a run when the destination provides it', () => {
+    expect(defaultRun(readinessAndroid, 'native-stim')?.id).toBe('native-stim');
+    expect(defaultRun(readinessAndroid, 'missing')?.id).toBe('javascript-stim');
+  });
+
+  it('formats the catalog model identifiers for picker labels', () => {
+    expect(benchmarkModelLabel('gpt-5.6-luna')).toBe('Luna');
+    expect(benchmarkModelLabel('sonnet')).toBe('Sonnet');
+  });
+});

--- a/website/src/components/benchmarkSelection.ts
+++ b/website/src/components/benchmarkSelection.ts
@@ -1,0 +1,47 @@
+import type { BenchmarkData, BenchmarkRun } from './benchmarkData';
+
+export type BenchmarkDimensions = {
+  model: string;
+  platform: 'ios' | 'android';
+  suite: 'readiness' | 'launch-crash';
+};
+
+export function defaultRun(benchmark: BenchmarkData | undefined, preferredId?: string): BenchmarkRun | undefined {
+  return benchmark?.runs.find((run) => run.valid && run.id === preferredId) ?? benchmark?.runs.find((run) => run.valid);
+}
+
+export function benchmarkDimensions(benchmark: BenchmarkData): BenchmarkDimensions {
+  const firstValidRun = benchmark.runs.find((run) => run.valid);
+  return {
+    model: benchmark.pricing?.model ?? firstValidRun?.model ?? benchmark.title,
+    platform:
+      benchmark.platform ??
+      firstValidRun?.platform ??
+      (/android/i.test(benchmark.environment.simulator) ? 'android' : 'ios'),
+    suite: benchmark.suite ?? 'readiness',
+  };
+}
+
+export function benchmarkModelLabel(model: string): string {
+  const knownName = model.match(/(?:^|[-_/])(luna|sol|sonnet|opus)$/i)?.[1];
+  const name = knownName ?? model;
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+}
+
+export function benchmarkForDimensions(
+  catalog: BenchmarkData[],
+  requested: BenchmarkDimensions,
+): BenchmarkData | undefined {
+  const modelMatches = catalog.filter((candidate) => benchmarkDimensions(candidate).model === requested.model);
+  const platformMatches = modelMatches.filter(
+    (candidate) => benchmarkDimensions(candidate).platform === requested.platform,
+  );
+  return (
+    platformMatches.find((candidate) => benchmarkDimensions(candidate).suite === requested.suite) ??
+    platformMatches.find((candidate) => benchmarkDimensions(candidate).suite === 'readiness') ??
+    platformMatches[0] ??
+    modelMatches.find((candidate) => benchmarkDimensions(candidate).suite === requested.suite) ??
+    modelMatches.find((candidate) => benchmarkDimensions(candidate).suite === 'readiness') ??
+    modelMatches[0]
+  );
+}

--- a/website/src/pages/benchmarks.module.css
+++ b/website/src/pages/benchmarks.module.css
@@ -248,23 +248,33 @@
   flex: none;
 }
 
-.modelPicker {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
+.benchmarkPickers {
+  display: grid;
+  gap: 0.65rem;
   margin: -1rem 0 2.5rem;
 }
 
-.modelPicker > span {
-  margin-right: 0.25rem;
+.benchmarkPicker {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.benchmarkPicker > span {
   color: var(--ifm-color-emphasis-700);
   font-size: 0.78rem;
   font-weight: 700;
   text-transform: uppercase;
 }
 
-.modelPicker button {
+.pickerOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.benchmarkPicker button {
   padding: 0.55rem 0.9rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 999px;
@@ -273,7 +283,7 @@
   cursor: pointer;
 }
 
-.modelPicker button[aria-pressed='true'] {
+.benchmarkPicker button[aria-pressed='true'] {
   border-color: var(--ifm-color-primary);
   background: var(--ifm-color-primary);
   color: var(--ifm-color-primary-contrast-background);
@@ -508,6 +518,11 @@
 }
 
 @media (max-width: 520px) {
+  .benchmarkPicker {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
   .overviewModel {
     grid-template-columns: 1fr;
     gap: 0.35rem;

--- a/website/src/pages/benchmarks/details.tsx
+++ b/website/src/pages/benchmarks/details.tsx
@@ -5,7 +5,14 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import { benchmarks, defaultRun, displayVariant } from '@site/src/components/benchmarkCatalog';
+import { benchmarks, displayVariant } from '@site/src/components/benchmarkCatalog';
+import {
+  benchmarkDimensions,
+  benchmarkForDimensions,
+  benchmarkModelLabel,
+  defaultRun,
+  type BenchmarkDimensions,
+} from '@site/src/components/benchmarkSelection';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
 import {
   benchmarkDisplayTitle,
@@ -90,12 +97,53 @@ export default function BenchmarkDetails(): ReactNode {
   const benchmark = benchmarks.find((candidate) => candidate.stage === selection.stage) ?? benchmarks[0];
   const publishedRuns = useMemo(() => benchmark?.runs.filter((run) => run.valid) ?? [], [benchmark]);
   const activeRun = publishedRuns.find((run) => run.id === selection.runId) ?? defaultRun(benchmark);
+  const dimensions = benchmark ? benchmarkDimensions(benchmark) : null;
+  const modelOptions = useMemo(
+    () =>
+      benchmarks.filter(
+        (candidate, index) =>
+          benchmarks.findIndex((other) => benchmarkDimensions(other).model === benchmarkDimensions(candidate).model) ===
+          index,
+      ),
+    [],
+  );
+  const platformOptions = useMemo(
+    () =>
+      dimensions
+        ? benchmarks
+            .filter((candidate) => benchmarkDimensions(candidate).model === dimensions.model)
+            .map((candidate) => benchmarkDimensions(candidate).platform)
+            .filter((platform, index, values) => values.indexOf(platform) === index)
+        : [],
+    [dimensions?.model],
+  );
+  const suiteOptions = useMemo(
+    () =>
+      dimensions
+        ? benchmarks
+            .filter((candidate) => {
+              const candidateDimensions = benchmarkDimensions(candidate);
+              return (
+                candidateDimensions.model === dimensions.model && candidateDimensions.platform === dimensions.platform
+              );
+            })
+            .map((candidate) => benchmarkDimensions(candidate).suite)
+            .filter((suite, index, values) => values.indexOf(suite) === index)
+        : [],
+    [dimensions?.model, dimensions?.platform],
+  );
   const navigateTo = (nextStage: string, nextRunId: string) => {
     history.push({
       pathname: location.pathname,
       search: benchmarkSelectionSearch({ stage: nextStage, runId: nextRunId }, benchmarks),
       hash: location.hash,
     });
+  };
+  const selectDimensions = (next: Partial<BenchmarkDimensions>) => {
+    if (!dimensions) return;
+    const candidate = benchmarkForDimensions(benchmarks, { ...dimensions, ...next });
+    if (!candidate) return;
+    navigateTo(candidate.stage, defaultRun(candidate, activeRun?.id)?.id ?? '');
   };
   const grouped = useMemo(() => {
     const variants: BenchmarkRun['variant'][] =
@@ -136,22 +184,66 @@ export default function BenchmarkDetails(): ReactNode {
             <Link to="/benchmarks">Benchmark overview</Link>
             <span className={styles.eyebrow}>Detailed audit</span>
             <Heading as="h1">{benchmarkDisplayTitle(benchmark.title)}: Stim vs local toolchain</Heading>
-            <p>Select a model and run to inspect its timing, commands, terminal output, and Settings-screen proof.</p>
+            <p>
+              Select a model, platform, and run to inspect its timing, commands, terminal output, and Settings-screen
+              proof.
+            </p>
           </header>
 
-          <nav className={styles.modelPicker} aria-label="Benchmark model">
-            <span>Model</span>
-            {benchmarks.map((candidate) => (
-              <button
-                key={candidate.stage}
-                type="button"
-                aria-pressed={candidate.stage === benchmark.stage}
-                onClick={() => navigateTo(candidate.stage, defaultRun(candidate)?.id ?? '')}
-              >
-                {benchmarkDisplayTitle(candidate.title)}
-              </button>
-            ))}
-          </nav>
+          <div className={styles.benchmarkPickers}>
+            <nav className={styles.benchmarkPicker} aria-label="Benchmark model">
+              <span>Model</span>
+              <div className={styles.pickerOptions}>
+                {modelOptions.map((candidate) => {
+                  const model = benchmarkDimensions(candidate).model;
+                  return (
+                    <button
+                      key={model}
+                      type="button"
+                      aria-pressed={model === dimensions?.model}
+                      onClick={() => selectDimensions({ model })}
+                    >
+                      {benchmarkModelLabel(model)}
+                    </button>
+                  );
+                })}
+              </div>
+            </nav>
+
+            <nav className={styles.benchmarkPicker} aria-label="Benchmark platform">
+              <span>Platform</span>
+              <div className={styles.pickerOptions}>
+                {platformOptions.map((platform) => (
+                  <button
+                    key={platform}
+                    type="button"
+                    aria-pressed={platform === dimensions?.platform}
+                    onClick={() => selectDimensions({ platform })}
+                  >
+                    {platform === 'ios' ? 'iOS' : 'Android'}
+                  </button>
+                ))}
+              </div>
+            </nav>
+
+            {suiteOptions.length > 1 ? (
+              <nav className={styles.benchmarkPicker} aria-label="Benchmark scenario">
+                <span>Scenario</span>
+                <div className={styles.pickerOptions}>
+                  {suiteOptions.map((suite) => (
+                    <button
+                      key={suite}
+                      type="button"
+                      aria-pressed={suite === dimensions?.suite}
+                      onClick={() => selectDimensions({ suite })}
+                    >
+                      {suite === 'readiness' ? 'App readiness' : 'Launch crash'}
+                    </button>
+                  ))}
+                </div>
+              </nav>
+            ) : null}
+          </div>
 
           <section className={styles.comparison} aria-labelledby="comparison-title">
             <div className={styles.sectionHeading}>


### PR DESCRIPTION
## Description

The benchmark detail page presents every model/platform dataset as one flat list. Labels such as “Luna Android” mix two independent choices, make the selector harder to scan, and do not leave a clear place for task-specific suites such as launch-crash diagnosis.

## Solution

Derive model, platform, and scenario dimensions from the benchmark catalog and render each as its own picker. The selected run is preserved when the destination dataset contains it, existing `benchmark` and `run` query links remain valid, and the scenario row appears only when the selected model/platform has more than one suite.

Legacy benchmark JSON without explicit platform or suite metadata continues to resolve from its run/environment data and defaults to the readiness suite.

## Test plan

- `pnpm exec vitest run website/src/components/benchmarkSelection.test.ts website/src/components/benchmarkData.test.ts` (26 tests passed)
- `pnpm --dir website run typecheck`
- `pnpm --dir website run build`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm test -- --maxWorkers=1 --no-file-parallelism --reporter=dot` (3,589 tests passed)

Fixes #399
