### PR TITLE
fix: restore physical Metro reload guidance

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -4090,7 +4090,7 @@ describe('--device (a physical Android device)', () => {
     expect(h.calls.resolveCached[0]).toEqual(['android', `${FINGERPRINT}-release-sim`]);
   });
 
-  test('a live physical-device error uses the existing automation session instead of a Metro reload', async () => {
+  test('a live physical-device error recommends Metro reload', async () => {
     const h = physicalHarness({
       verifyLaunched: async () => ({
         verified: true,
@@ -4100,13 +4100,8 @@ describe('--device (a physical Android device)', () => {
     });
     await h.run();
     const text = h.stderr.join('\n');
-    expect(text).toContain('existing agent-device automation session for com.example.app on RFCR7081Q9L');
-    expect(text).toContain('exact arguments and environment that identify that session');
-    expect(text).toContain('Run `agent-device snapshot -i` in that session');
-    expect(text).not.toContain('agent-device snapshot -i --platform android --serial RFCR7081Q9L');
-    expect(text).toMatch(/If Reload is visible on the error screen, press it by exact ref or label/);
-    expect(text).toMatch(/Otherwise open the React Native dev menu through that session/);
-    expect(text).not.toContain('agent-device metro reload');
+    expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).not.toContain('agent-device snapshot');
   });
 
   test('a physical run launches against localhost, not the emulator loopback', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1045,7 +1045,7 @@ test('the agent guide carries the normal workflow and safety rules', () => {
   expect(agent).toContain('No matching log records');
   expect(agent).toContain('stim reload');
   expect(normalWorkflow).not.toContain('stim reload');
-  expect(agent).not.toContain('agent-device metro reload --metro-port <reported-port>');
+  expect(normalWorkflow).not.toContain('agent-device metro reload');
   expect(agent).toMatch(/app error but also says the native process is alive,[\s\S]*app did not crash/);
   expect(agent).toMatch(/FATAL because the app process exited,[\s\S]*Metro cannot restart it/);
   expect(agent).toMatch(/Ordinary stim stop and an authorized clean\s+stim worktree remove do not need/);
@@ -1218,10 +1218,14 @@ test('the guide defines reload as a JavaScript-only live-app recovery', () => {
 
   expect(agent).toContain('stim reload');
   expect(agent).toMatch(/failed first bundle load[\s\S]*app restart/);
+  expect(agent).toMatch(/physical device that reached Metro[\s\S]*agent-device metro reload/);
+  expect(agent).toMatch(/iOS Local Network first-load remedy[\s\S]*never established a Metro connection/);
   expect(lifecycle).toMatch(/never builds, installs, boots, or cold-launches/);
   expect(lifecycle).toMatch(/owned local simulator or emulator/);
   expect(lifecycle).toMatch(/stim reload ios[\s\S]*stim reload android/);
   expect(lifecycle).toMatch(/^  reload\s+\[ios\|android\] --json$/m);
+  expect(lifecycle).toMatch(/physical device that reached Metro[\s\S]*agent-device metro reload/);
+  expect(lifecycle).toMatch(/iOS Local Network first-load[\s\S]*no Metro peer exists yet/);
   expect(facts).toContain('stim reload [ios|android] --json');
   expect(facts).toMatch(/platform[\s\S]*deviceId[\s\S]*metroPort[\s\S]*strategy/);
   expect(errors).toContain('STIM_RELOAD_AMBIGUOUS');

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -4127,7 +4127,7 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(text).not.toMatch(/opened on the dev-client URL/);
   });
 
-  test('a first-bundle failure on a live phone uses the existing automation session', async () => {
+  test('a Metro build failure on a live phone recommends Metro reload', async () => {
     reserve();
     const { errs, exitCode } = await run(
       { device: true },
@@ -4142,13 +4142,8 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     );
     const text = errs.join('\n');
     expect(exitCode).toBe(1);
-    expect(text).toContain(`existing agent-device automation session for com.example.app on ${PHONE}`);
-    expect(text).toContain('exact arguments and environment that identify that session');
-    expect(text).toContain('Run `agent-device snapshot -i` in that session');
-    expect(text).not.toContain(`agent-device snapshot -i --platform ios --udid ${PHONE}`);
-    expect(text).toMatch(/If Reload is visible on the error screen, press it by exact ref or label/);
-    expect(text).toMatch(/Otherwise open the React Native dev menu through that session/);
-    expect(text).not.toContain('agent-device metro reload');
+    expect(text).toContain('agent-device metro reload --metro-port 8082');
+    expect(text).not.toContain('agent-device snapshot');
   });
 
   test('the collector is the launch: it carries --physical and the run reads the device pid', async () => {

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -74,16 +74,6 @@ interface VerifyAndroidRunArgs {
   phase: (label: unknown, text: string) => void;
 }
 
-function physicalAndroidReloadRemedy(androidPackage: string, serial: string): string {
-  return (
-    `continue in your existing agent-device automation session for ${androidPackage} on ${serial}. ` +
-    'Keep the exact arguments and environment that identify that session on every command. ' +
-    'Run `agent-device snapshot -i` in that session. ' +
-    'If Reload is visible on the error screen, press it by exact ref or label. ' +
-    'Otherwise open the React Native dev menu through that session, inspect again, and press Reload.'
-  );
-}
-
 async function verifyAndroidRun({
   release,
   remoteRelease,
@@ -159,7 +149,7 @@ async function verifyAndroidRun({
       );
     } else if (verification.processAlive === true && metroPort !== null) {
       const reloadRemedy = physical
-        ? physicalAndroidReloadRemedy(androidPackage, serial)
+        ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
         : 'run `stim reload android`.';
       phase(
         'remedy',
@@ -183,7 +173,7 @@ async function verifyAndroidRun({
     for (const line of report.lines) phase('launch', chalk.yellow(line));
     if (report.lines.length > 0 && verification.processAlive === true && metroPort !== null) {
       const reloadRemedy = physical
-        ? physicalAndroidReloadRemedy(androidPackage, serial)
+        ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
         : 'run `stim reload android`.';
       phase(
         'remedy',

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -65,16 +65,6 @@ interface VerifyIosRunArgs {
   metroOrigin: string | null;
 }
 
-function physicalIosReloadRemedy(bundleId: string, udid: string): string {
-  return (
-    `continue in your existing agent-device automation session for ${bundleId} on ${udid}. ` +
-    'Keep the exact arguments and environment that identify that session on every command. ' +
-    'Run `agent-device snapshot -i` in that session. ' +
-    'If Reload is visible on the error screen, press it by exact ref or label. ' +
-    'Otherwise open the React Native dev menu through that session, inspect again, and press Reload.'
-  );
-}
-
 async function verifyIosRun({
   d,
   release,
@@ -165,9 +155,8 @@ async function verifyIosRun({
         ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
-      const reloadRemedy = physical
-        ? physicalIosReloadRemedy(bundleId, udid)
-        : remoteDevice
+      const reloadRemedy =
+        physical || remoteDevice
           ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
           : 'run `stim reload ios`.';
       note(
@@ -191,9 +180,8 @@ async function verifyIosRun({
     );
     const hasAppErrors = reportLaunchErrors(verification.errors ?? [], note);
     if (hasAppErrors && verification.processAlive === true && metroPort !== null) {
-      const reloadRemedy = physical
-        ? physicalIosReloadRemedy(bundleId, udid)
-        : remoteDevice
+      const reloadRemedy =
+        physical || remoteDevice
           ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
           : 'run `stim reload ios`.';
       note(

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -56,8 +56,10 @@ RULES DURING THE LOOP
   universal.
 - Reload is not part of the normal workflow. Use stim reload on an owned local
   simulator or emulator after a failed first bundle load, when an error screen
-  remains after the fix, or when you explicitly need an app restart. On a
-  physical device, follow the printed agent-device UI automation remedy.
+  remains after the fix, or when you explicitly need an app restart. For a
+  physical device that reached Metro, use agent-device metro reload with the
+  reported port. The detected iOS Local Network first-load remedy uses UI
+  automation instead because that app never established a Metro connection.
 - If launch reports an app error but also says the native process is alive,
   the app did not crash. Fix JavaScript or TypeScript and use Fast Refresh. If
   the error screen remains, follow the printed reload remedy instead of

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -52,6 +52,9 @@ not part of the normal workflow. It is the explicit recovery path after a
 failed first bundle load, when Fast Refresh cannot clear the current screen,
 or when you explicitly need an app restart. Use \`stim reload ios\` or
 \`stim reload android\` to select a platform when both owned apps are live.
+For a physical device that reached Metro, use \`agent-device metro reload
+--metro-port <reported-port>\`. The detected iOS Local Network first-load
+remedy uses agent-device UI automation because no Metro peer exists yet.
 It never builds, installs, boots, or cold-launches. It acts only on a live app
 on this workspace's owned local simulator or emulator, and refuses release
 builds, stopped or unowned devices, a missing or foreign Metro, and an


### PR DESCRIPTION
## Description

#396 applied an iOS no-Metro-peer recovery constraint to every physical-device JavaScript error. Connected iOS and Android paths already observed a Metro bundle failure or a loaded bundle, so UI automation is unnecessary there. This follow-up changes only printed remedies and version-matched guidance.

The UI exception is narrower: the detected iOS Local Network first-load failure never establishes a Metro connection, so granting permission must be followed by pressing the visible Reload control. The behavior being corrected was introduced deliberately in [44d1ae2](https://github.com/appandflow/stim/commit/44d1ae28b54fa08f2c7252581ba70a180d15f9af), but its premise only applies to that existing routed failure.

## Solution

Connected physical iOS and Android remedies again use `agent-device metro reload --metro-port <port>`. The detected iOS Local Network first-load remedy keeps its existing alert, snapshot, and UI Reload sequence. Reload remains absent from successful common workflows.

No child-process invocation or device ownership behavior changes.

## Test plan

- Targeted iOS and Android tests verify Metro reload for connected physical apps and UI Reload for the detected iOS Local Network first-load failure (3 passed).
- The complete guide contract verifies the physical-device distinction and that common workflows still omit reload (95 passed).
- `format:check`, `lint`, `build`, and `typecheck` pass. The sandboxed full suite reached 3,471 passing tests with 130 unrelated environment-dependent failures.

Fixes #401
