### PR TITLE
feat(website): keep unavailable benchmark choices visible

### DIFF
--- a/website/src/components/benchmarkSelection.test.ts
+++ b/website/src/components/benchmarkSelection.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { benchmarkDimensions, benchmarkForDimensions, benchmarkModelLabel, defaultRun } from './benchmarkSelection';
+import {
+  benchmarkDimensions,
+  benchmarkForDimensions,
+  benchmarkModelLabel,
+  benchmarkPlatforms,
+  benchmarkSuites,
+  defaultRun,
+  exactBenchmarkForDimensions,
+} from './benchmarkSelection';
 import type { BenchmarkData } from './benchmarkData';
 
 function benchmark(
@@ -44,6 +52,20 @@ describe('benchmark catalog selection', () => {
     expect(
       benchmarkForDimensions(catalog, { model: 'gpt-5.6-sol', platform: 'android', suite: 'launch-crash' })?.stage,
     ).toBe('sol-android');
+  });
+
+  it('distinguishes an exact published combination from a fallback', () => {
+    expect(
+      exactBenchmarkForDimensions(catalog, { model: 'gpt-5.6-sol', platform: 'ios', suite: 'launch-crash' })?.stage,
+    ).toBe('sol-crash');
+    expect(
+      exactBenchmarkForDimensions(catalog, { model: 'gpt-5.6-sol', platform: 'android', suite: 'launch-crash' }),
+    ).toBeUndefined();
+  });
+
+  it('keeps every known platform and scenario available to render', () => {
+    expect(benchmarkPlatforms).toEqual(['ios', 'android']);
+    expect(benchmarkSuites).toEqual(['readiness', 'launch-crash']);
   });
 
   it('preserves a run when the destination provides it', () => {

--- a/website/src/components/benchmarkSelection.ts
+++ b/website/src/components/benchmarkSelection.ts
@@ -6,6 +6,9 @@ export type BenchmarkDimensions = {
   suite: 'readiness' | 'launch-crash';
 };
 
+export const benchmarkPlatforms: BenchmarkDimensions['platform'][] = ['ios', 'android'];
+export const benchmarkSuites: BenchmarkDimensions['suite'][] = ['readiness', 'launch-crash'];
+
 export function defaultRun(benchmark: BenchmarkData | undefined, preferredId?: string): BenchmarkRun | undefined {
   return benchmark?.runs.find((run) => run.valid && run.id === preferredId) ?? benchmark?.runs.find((run) => run.valid);
 }
@@ -28,6 +31,20 @@ export function benchmarkModelLabel(model: string): string {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
 }
 
+export function exactBenchmarkForDimensions(
+  catalog: BenchmarkData[],
+  requested: BenchmarkDimensions,
+): BenchmarkData | undefined {
+  return catalog.find((candidate) => {
+    const dimensions = benchmarkDimensions(candidate);
+    return (
+      dimensions.model === requested.model &&
+      dimensions.platform === requested.platform &&
+      dimensions.suite === requested.suite
+    );
+  });
+}
+
 export function benchmarkForDimensions(
   catalog: BenchmarkData[],
   requested: BenchmarkDimensions,
@@ -37,7 +54,7 @@ export function benchmarkForDimensions(
     (candidate) => benchmarkDimensions(candidate).platform === requested.platform,
   );
   return (
-    platformMatches.find((candidate) => benchmarkDimensions(candidate).suite === requested.suite) ??
+    exactBenchmarkForDimensions(catalog, requested) ??
     platformMatches.find((candidate) => benchmarkDimensions(candidate).suite === 'readiness') ??
     platformMatches[0] ??
     modelMatches.find((candidate) => benchmarkDimensions(candidate).suite === requested.suite) ??

--- a/website/src/pages/benchmarks.module.css
+++ b/website/src/pages/benchmarks.module.css
@@ -289,6 +289,14 @@
   color: var(--ifm-color-primary-contrast-background);
 }
 
+.benchmarkPicker button:disabled {
+  border-color: var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-600);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .comparison {
   margin-bottom: 3rem;
 }

--- a/website/src/pages/benchmarks/details.tsx
+++ b/website/src/pages/benchmarks/details.tsx
@@ -10,7 +10,10 @@ import {
   benchmarkDimensions,
   benchmarkForDimensions,
   benchmarkModelLabel,
+  benchmarkPlatforms,
+  benchmarkSuites,
   defaultRun,
+  exactBenchmarkForDimensions,
   type BenchmarkDimensions,
 } from '@site/src/components/benchmarkSelection';
 import BenchmarkTimeline from '@site/src/components/BenchmarkTimeline';
@@ -107,31 +110,8 @@ export default function BenchmarkDetails(): ReactNode {
       ),
     [],
   );
-  const platformOptions = useMemo(
-    () =>
-      dimensions
-        ? benchmarks
-            .filter((candidate) => benchmarkDimensions(candidate).model === dimensions.model)
-            .map((candidate) => benchmarkDimensions(candidate).platform)
-            .filter((platform, index, values) => values.indexOf(platform) === index)
-        : [],
-    [dimensions?.model],
-  );
-  const suiteOptions = useMemo(
-    () =>
-      dimensions
-        ? benchmarks
-            .filter((candidate) => {
-              const candidateDimensions = benchmarkDimensions(candidate);
-              return (
-                candidateDimensions.model === dimensions.model && candidateDimensions.platform === dimensions.platform
-              );
-            })
-            .map((candidate) => benchmarkDimensions(candidate).suite)
-            .filter((suite, index, values) => values.indexOf(suite) === index)
-        : [],
-    [dimensions?.model, dimensions?.platform],
-  );
+  const isAvailable = (next: Partial<BenchmarkDimensions>) =>
+    dimensions ? Boolean(exactBenchmarkForDimensions(benchmarks, { ...dimensions, ...next })) : false;
   const navigateTo = (nextStage: string, nextRunId: string) => {
     history.push({
       pathname: location.pathname,
@@ -196,11 +176,14 @@ export default function BenchmarkDetails(): ReactNode {
               <div className={styles.pickerOptions}>
                 {modelOptions.map((candidate) => {
                   const model = benchmarkDimensions(candidate).model;
+                  const available = isAvailable({ model });
                   return (
                     <button
                       key={model}
                       type="button"
                       aria-pressed={model === dimensions?.model}
+                      disabled={!available}
+                      title={available ? undefined : 'No published benchmark for this combination'}
                       onClick={() => selectDimensions({ model })}
                     >
                       {benchmarkModelLabel(model)}
@@ -213,36 +196,44 @@ export default function BenchmarkDetails(): ReactNode {
             <nav className={styles.benchmarkPicker} aria-label="Benchmark platform">
               <span>Platform</span>
               <div className={styles.pickerOptions}>
-                {platformOptions.map((platform) => (
-                  <button
-                    key={platform}
-                    type="button"
-                    aria-pressed={platform === dimensions?.platform}
-                    onClick={() => selectDimensions({ platform })}
-                  >
-                    {platform === 'ios' ? 'iOS' : 'Android'}
-                  </button>
-                ))}
+                {benchmarkPlatforms.map((platform) => {
+                  const available = isAvailable({ platform });
+                  return (
+                    <button
+                      key={platform}
+                      type="button"
+                      aria-pressed={platform === dimensions?.platform}
+                      disabled={!available}
+                      title={available ? undefined : 'No published benchmark for this combination'}
+                      onClick={() => selectDimensions({ platform })}
+                    >
+                      {platform === 'ios' ? 'iOS' : 'Android'}
+                    </button>
+                  );
+                })}
               </div>
             </nav>
 
-            {suiteOptions.length > 1 ? (
-              <nav className={styles.benchmarkPicker} aria-label="Benchmark scenario">
-                <span>Scenario</span>
-                <div className={styles.pickerOptions}>
-                  {suiteOptions.map((suite) => (
+            <nav className={styles.benchmarkPicker} aria-label="Benchmark scenario">
+              <span>Scenario</span>
+              <div className={styles.pickerOptions}>
+                {benchmarkSuites.map((suite) => {
+                  const available = isAvailable({ suite });
+                  return (
                     <button
                       key={suite}
                       type="button"
                       aria-pressed={suite === dimensions?.suite}
+                      disabled={!available}
+                      title={available ? undefined : 'No published benchmark for this combination'}
                       onClick={() => selectDimensions({ suite })}
                     >
                       {suite === 'readiness' ? 'App readiness' : 'Launch crash'}
                     </button>
-                  ))}
-                </div>
-              </nav>
-            ) : null}
+                  );
+                })}
+              </div>
+            </nav>
           </div>
 
           <section className={styles.comparison} aria-labelledby="comparison-title">


### PR DESCRIPTION
## Description

The benchmark detail page currently hides platform and scenario choices that have no published dataset for the active model. That makes “not benchmarked yet” look like the capability does not exist and causes the picker rows to change shape as readers switch results.

## Solution

Keep the known platform and scenario choices visible, and disable any model/platform/scenario option whose exact combination has no published benchmark. Disabled controls use native button semantics and a distinct muted state. Available choices continue to preserve the selected run, and existing benchmark/run query links are unchanged.

## Test plan

- Run the benchmark selection and URL suites; all 28 tests pass, including exact-match availability and fallback coverage.
- Build the Docusaurus site and open a benchmark detail route; the route returns HTTP 200 with the stable picker rows.
- Run the full repository suite; all 3,607 tests pass.

Fixes #402
