### PR TITLE
perf: route Android CMake compiles through ccache

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -342,8 +342,15 @@ function harness(overrides = {}) {
     build: async (args: BuildArgs = {}) => {
       calls.order.push('build');
       calls.build.push(args);
-      return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      return {
+        ok: true,
+        apkPath: fakeApk(),
+        durationMs: 161000,
+        lastLines: [],
+        ccache: { status: 'reported' as const, hits: 176, misses: 204, hitRatePercent: 46.3 },
+      };
     },
+    ccacheFor: () => null,
     install: (args: InstallArgs = {}) => {
       calls.install.push(args);
       return { ok: true, apkPath: args.apkPath ?? '' };
@@ -1030,6 +1037,7 @@ describe('a cache hit', () => {
       bundleId: 'com.example.app',
       installSkipped: false,
       launched: true,
+      ccache: { status: 'not-run', hits: null, misses: null, hitRatePercent: null },
       debugHttpHost: '10.0.2.2:8082',
       debugHttpHostNote: null,
       devClientUrl: null,
@@ -1057,6 +1065,34 @@ describe('a cache miss', () => {
     expect(labelled(h.stderr, 'build')[1]).toMatch(/^  build {7}ok \(2m41s\)$/);
     assert(result.facts);
     expect(result.facts.cacheHit).toBe(false);
+  });
+
+  test('hands the resolved ccache environment to Gradle and reports its counts', async () => {
+    const setup = {
+      dir: join(home, 'ccache'),
+      statsLog: join(home, 'ccache-stats.log'),
+      env: { CMAKE_CXX_COMPILER_LAUNCHER: '/opt/homebrew/bin/ccache' },
+    };
+    const options: Record<string, unknown>[] = [];
+    const h = harness({
+      ccacheFor: () => setup,
+      build: async (_args: BuildArgs = {}, opts: Record<string, unknown> = {}) => {
+        options.push(opts);
+        return {
+          ok: true,
+          apkPath: fakeApk(),
+          durationMs: 161000,
+          lastLines: [],
+          ccache: { status: 'reported' as const, hits: 176, misses: 204, hitRatePercent: 46.3 },
+        };
+      },
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(options[0]?.ccache).toBe(setup);
+    assert(result.facts);
+    expect(result.facts.ccache).toEqual({ status: 'reported', hits: 176, misses: 204, hitRatePercent: 46.3 });
+    expect(h.stdout.join('\n')).toMatch(/^ {2}compilation cache 176 hits \/ 204 misses \(46\.3%\)$/m);
   });
 
   test('builds only the ABI selected for an owned emulator and scopes the cache key', async () => {
@@ -2461,6 +2497,7 @@ describe('the pure parts', () => {
       bundleId: null,
       installSkipped: false,
       launched: false,
+      ccache: { status: 'unavailable', hits: null, misses: null, hitRatePercent: null },
       debugHttpHost: null,
       debugHttpHostNote: null,
       devClientUrl: null,

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -397,6 +397,35 @@ describe('checkCxxCompilerLauncher', () => {
     ).toBe(null);
   });
 
+  test('a launcher CMake resolves through PATH is not read as a filesystem path', () => {
+    for (const ccacheOnPath of [true, false]) {
+      expect(
+        checkCxxCompilerLauncher({
+          states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: 'ccache' }],
+          ccacheOnPath,
+          launcherExists: onDisk,
+        }),
+      ).toBe(null);
+      expect(
+        checkCxxCompilerLauncher({
+          states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: 'ccache;--some-flag' }],
+          ccacheOnPath,
+          launcherExists: onDisk,
+        }),
+      ).toBe(null);
+    }
+  });
+
+  test('a launcher list whose absolute command is gone is still a cost', () => {
+    const f = checkCxxCompilerLauncher({
+      states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: '/usr/local/bin/ccache;--some-flag' }],
+      ccacheOnPath: true,
+      launcherExists: onDisk,
+    });
+    assert(f);
+    expect(f.detail).toMatch(/\/usr\/local\/bin\/ccache/);
+  });
+
   test('a .cxx already routed through an installed launcher, or none at all, is clean', () => {
     expect(
       checkCxxCompilerLauncher({

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -8,6 +8,9 @@ import {
   checkBuildCacheProvider,
   checkCompilationCache,
   checkCcacheConflict,
+  checkCcacheInstalled,
+  checkCxxCompilerLauncher,
+  parseCmakeCacheLauncher,
   checkDevClient,
   checkEasAuth,
   checkFingerprintParity,
@@ -303,6 +306,145 @@ test('a project with no ccache is reported as nothing, with or without caching i
   );
   expect(checkCcacheConflict('post_install', null)).toBe(null);
   expect(checkCcacheConflict(null, { 'apple.ccacheEnabled': 'true' })).toBe(null);
+});
+
+test('the iOS ccache finding no longer claims ccache cannot cross worktrees at all', () => {
+  const f = checkCcacheConflict('post_install', { 'apple.ccacheEnabled': 'true' });
+  assert(f);
+  expect(f.detail).not.toMatch(/misses across worktrees anyway/);
+  expect(f.detail).toMatch(/default configuration/);
+});
+
+test('ccache on PATH is silent, and ccache absent costs time with a full remedy', () => {
+  expect(checkCcacheInstalled(true)).toBe(null);
+  const f = checkCcacheInstalled(false);
+  assert(f);
+  expect(f.level).toBe('cost');
+  expect(f.title).toMatch(/ccache is not on PATH, so Android C\+\+ recompiles in every worktree/);
+  expect(f.detail).toMatch(/command -v ccache/);
+  expect(f.detail).toMatch(/CMAKE_CXX_COMPILER_LAUNCHER/);
+  expect(f.detail).toMatch(/49\.6s.*34\.2s/);
+  expect(f.fix).toMatch(/brew install ccache/);
+  expect(f.fix).toMatch(/android\/app\/\.cxx/);
+  expect(f.fix).toMatch(/node_modules\/\*\*\/android\/\.cxx/);
+  expect(f.fix).toMatch(/\/opt\/homebrew\/bin/);
+});
+
+test('the ccache finding belongs to the Android group and is filtered out by --platform ios', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-ccache-platform-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    mkdirSync(join(project, 'android'), { recursive: true });
+    const options = { concurrency: { maxBuilds: 0, maxDevices: 0 }, lookupCcache: () => false };
+    const android = runDoctor(project, { ...options, platform: 'android' as const });
+    const ios = runDoctor(project, { ...options, platform: 'ios' as const });
+    expect(android.some((f) => /ccache is not on PATH/.test(f.title))).toBe(true);
+    expect(ios.some((f) => /ccache is not on PATH/.test(f.title))).toBe(false);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('parseCmakeCacheLauncher reads the launcher a configure wrote into CMakeCache.txt', () => {
+  const cache = [
+    '//Compiler launcher for CXX.',
+    'CMAKE_CXX_COMPILER_LAUNCHER:STRING=/opt/homebrew/bin/ccache',
+    'CMAKE_BUILD_TYPE:STRING=Debug',
+  ].join('\n');
+  expect(parseCmakeCacheLauncher(cache)).toBe('/opt/homebrew/bin/ccache');
+  expect(parseCmakeCacheLauncher('CMAKE_CXX_COMPILER_LAUNCHER:STRING=')).toBe(null);
+  expect(parseCmakeCacheLauncher('CMAKE_BUILD_TYPE:STRING=Debug')).toBe(null);
+  expect(parseCmakeCacheLauncher(null)).toBe(null);
+});
+
+describe('checkCxxCompilerLauncher', () => {
+  const onDisk = (path: string) => path === '/opt/homebrew/bin/ccache';
+
+  test('a CMake cache naming a launcher that is gone is a cost, ccache installed or not', () => {
+    for (const ccacheOnPath of [true, false]) {
+      const f = checkCxxCompilerLauncher({
+        states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: '/usr/local/bin/ccache' }],
+        ccacheOnPath,
+        launcherExists: onDisk,
+      });
+      assert(f);
+      expect(f.level).toBe('cost');
+      expect(f.title).toMatch(/names a compiler launcher that is not on this machine/);
+      expect(f.detail).toMatch(/\/usr\/local\/bin\/ccache/);
+      expect(f.fix).toMatch(/\.cxx/);
+    }
+  });
+
+  test('a configured .cxx with no launcher costs the C++ cache until it is deleted once', () => {
+    const f = checkCxxCompilerLauncher({
+      states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: null }],
+      ccacheOnPath: true,
+      launcherExists: onDisk,
+    });
+    assert(f);
+    expect(f.level).toBe('cost');
+    expect(f.title).toMatch(/predates/);
+    expect(f.fix).toMatch(/\.cxx/);
+  });
+
+  test('nothing is said about a .cxx with no launcher when ccache is not installed either', () => {
+    expect(
+      checkCxxCompilerLauncher({
+        states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: null }],
+        ccacheOnPath: false,
+        launcherExists: onDisk,
+      }),
+    ).toBe(null);
+  });
+
+  test('a .cxx already routed through an installed launcher, or none at all, is clean', () => {
+    expect(
+      checkCxxCompilerLauncher({
+        states: [{ path: 'android/app/.cxx/Debug/a1/arm64-v8a', launcher: '/opt/homebrew/bin/ccache' }],
+        ccacheOnPath: true,
+        launcherExists: onDisk,
+      }),
+    ).toBe(null);
+    expect(checkCxxCompilerLauncher({ states: [], ccacheOnPath: true, launcherExists: onDisk })).toBe(null);
+  });
+});
+
+test('runDoctor reads the real .cxx of an Android project and reports it only for Android', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-cxx-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    const abiDir = join(project, 'android', 'app', '.cxx', 'Debug', '3q1r2w4t', 'arm64-v8a');
+    mkdirSync(abiDir, { recursive: true });
+    writeFileSync(join(abiDir, 'CMakeCache.txt'), 'CMAKE_BUILD_TYPE:STRING=Debug\n');
+    const options = { concurrency: { maxBuilds: 0, maxDevices: 0 }, lookupCcache: () => true };
+    const android = runDoctor(project, { ...options, platform: 'android' as const });
+    const ios = runDoctor(project, { ...options, platform: 'ios' as const });
+    expect(android.some((f) => /predates/.test(f.title))).toBe(true);
+    expect(ios.some((f) => /predates/.test(f.title))).toBe(false);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('an iOS-only checkout is not told about the Android C++ cache', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-noandroid-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    const findings = runDoctor(project, {
+      concurrency: { maxBuilds: 0, maxDevices: 0 },
+      lookupCcache: () => false,
+    });
+    expect(findings.some((f) => /ccache is not on PATH/.test(f.title))).toBe(false);
+    expect(
+      runDoctor(project, {
+        concurrency: { maxBuilds: 0, maxDevices: 0 },
+        lookupCcache: () => false,
+        platform: 'android' as const,
+      }).some((f) => /ccache is not on PATH/.test(f.title)),
+    ).toBe(true);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
 });
 
 test('a bare React Native project is not told to install expo-dev-client', () => {
@@ -1009,6 +1151,7 @@ test('runDoctor keeps shared checks and filters native checks and remote backend
       lookupAgentDevice: () => true,
       lookupEasCli: () => false,
       lookupSimSlim: () => false,
+      lookupCcache: () => true,
     };
 
     const ios = runDoctor(project, { ...options, platform: 'ios', xcodeMajor: 26 });
@@ -1017,12 +1160,12 @@ test('runDoctor keeps shared checks and filters native checks and remote backend
     for (const findings of [ios, android]) {
       expect(findings.some((finding) => finding.title.includes('metro.config.js'))).toBe(true);
     }
-    expect(ios.some((finding) => finding.title.includes('ccache'))).toBe(true);
+    expect(ios.some((finding) => finding.title.includes('Stim leaves Xcode compilation caching off'))).toBe(true);
     expect(ios.some((finding) => finding.title.includes('SimSlim'))).toBe(true);
     expect(ios.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(true);
     expect(ios.some((finding) => finding.title.includes('simulator pool bound'))).toBe(true);
     expect(ios.some((finding) => finding.title.includes('no eas-cli'))).toBe(false);
-    expect(android.some((finding) => finding.title.includes('ccache'))).toBe(false);
+    expect(android.some((finding) => finding.title.includes('Stim leaves Xcode compilation caching off'))).toBe(false);
     expect(android.some((finding) => finding.title.includes('SimSlim'))).toBe(false);
     expect(android.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(false);
     expect(android.some((finding) => finding.title.includes('simulator pool bound'))).toBe(false);
@@ -1157,7 +1300,7 @@ test('doctor success output scopes native checks to Android', () => {
   expect(output).toContain('Doctor (Android)');
   expect(output).toContain('Android');
   expect(output).toContain('setup       warm state, dev client');
-  expect(output).toContain('caches      Metro, Gradle build provider');
+  expect(output).toContain('caches      Metro, Gradle, ccache, build provider');
   expect(output).not.toContain('Xcode compilation');
   expect(output).not.toContain('SimSlim');
 });

--- a/packages/stim-cli/src/__tests__/engine-ccache.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ccache.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CCACHE_MAX_SIZE,
+  CCACHE_SLOPPINESS,
+  CCACHE_UNAVAILABLE,
+  ccacheActivityLine,
+  ccacheEnvironment,
+  ccacheStatsLog,
+  parseCcacheBinary,
+  parseCcacheStatsLog,
+  projectCmakeLauncher,
+  resolveCcache,
+} from '../engine/ccache.ts';
+import { readManifest } from '../cache-manifest.ts';
+
+let home: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-ccache-home-'));
+  savedHome = process.env.STIM_HOME;
+  process.env.STIM_HOME = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (savedHome === undefined) delete process.env.STIM_HOME;
+  else process.env.STIM_HOME = savedHome;
+});
+
+describe('ccacheEnvironment', () => {
+  test('names every variable a relocatable Android CMake compile needs', () => {
+    expect(
+      ccacheEnvironment({
+        binary: '/opt/homebrew/bin/ccache',
+        dir: '/home/.stim/ccache',
+        workspaceRoot: '/w/app',
+        statsLog: '/home/.stim/workspaces/app/logs/ccache-stats.log',
+      }),
+    ).toEqual({
+      CMAKE_C_COMPILER_LAUNCHER: '/opt/homebrew/bin/ccache',
+      CMAKE_CXX_COMPILER_LAUNCHER: '/opt/homebrew/bin/ccache',
+      CCACHE_DIR: '/home/.stim/ccache',
+      CCACHE_BASEDIR: '/w/app',
+      CCACHE_NOHASHDIR: 'true',
+      CCACHE_SLOPPINESS: CCACHE_SLOPPINESS,
+      CCACHE_MAXSIZE: CCACHE_MAX_SIZE,
+      CCACHE_STATSLOG: '/home/.stim/workspaces/app/logs/ccache-stats.log',
+    });
+  });
+
+  test('the launcher is always an absolute path, and the sloppiness covers precompiled headers', () => {
+    const env = ccacheEnvironment({
+      binary: '/usr/local/bin/ccache',
+      dir: '/c',
+      workspaceRoot: '/w',
+      statsLog: '/l',
+    });
+    expect(String(env.CMAKE_CXX_COMPILER_LAUNCHER).startsWith('/')).toBe(true);
+    expect(CCACHE_SLOPPINESS.split(',')).toEqual(['pch_defines', 'time_macros']);
+    expect(CCACHE_MAX_SIZE).toBe('5G');
+  });
+});
+
+describe('parseCcacheBinary', () => {
+  test('takes the first line of `command -v ccache` and nothing else', () => {
+    expect(parseCcacheBinary('/opt/homebrew/bin/ccache\n')).toBe('/opt/homebrew/bin/ccache');
+    expect(parseCcacheBinary('/opt/homebrew/bin/ccache\n/usr/bin/ccache\n')).toBe('/opt/homebrew/bin/ccache');
+  });
+
+  test('a relative path or empty output is not a launcher', () => {
+    expect(parseCcacheBinary('ccache')).toBe(null);
+    expect(parseCcacheBinary('./ccache')).toBe(null);
+    expect(parseCcacheBinary('')).toBe(null);
+    expect(parseCcacheBinary(null)).toBe(null);
+    expect(parseCcacheBinary(undefined)).toBe(null);
+  });
+});
+
+describe('projectCmakeLauncher', () => {
+  test('finds a launcher the project already passes to CMake', () => {
+    const source = `
+android {
+  defaultConfig {
+    externalNativeBuild {
+      cmake {
+        arguments "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache", "-DANDROID_STL=c++_shared"
+      }
+    }
+  }
+}
+`;
+    expect(projectCmakeLauncher(source)).toBe('CMAKE_CXX_COMPILER_LAUNCHER');
+    expect(projectCmakeLauncher('arguments "-DCMAKE_C_COMPILER_LAUNCHER=sccache"')).toBe('CMAKE_C_COMPILER_LAUNCHER');
+  });
+
+  test('an ordinary app build.gradle defines none', () => {
+    expect(projectCmakeLauncher('apply plugin: "com.android.application"')).toBe(null);
+    expect(projectCmakeLauncher(null)).toBe(null);
+  });
+});
+
+describe('parseCcacheStatsLog', () => {
+  test('counts hits and misses from a real ccache 4 stats log', () => {
+    const log = readFileSync(join(import.meta.dirname, 'fixtures', 'ccache-stats-log.txt'), 'utf-8');
+    expect(parseCcacheStatsLog(log)).toEqual({
+      status: 'reported',
+      hits: 2,
+      misses: 1,
+      hitRatePercent: 66.7,
+    });
+  });
+
+  test('a miss bumps three counters and still counts once', () => {
+    const log = ['# a.cpp', 'cache_miss', 'direct_cache_miss', 'preprocessed_cache_miss', 'local_storage_write'].join(
+      '\n',
+    );
+    expect(parseCcacheStatsLog(log)).toEqual({ status: 'reported', hits: 0, misses: 1, hitRatePercent: 0 });
+  });
+
+  test('no cacheable compile at all reports nothing rather than a zero rate', () => {
+    expect(parseCcacheStatsLog('')).toBe(null);
+    expect(parseCcacheStatsLog('# a.cpp\ncalled_for_link\n')).toBe(null);
+    expect(parseCcacheStatsLog(null)).toBe(null);
+  });
+});
+
+describe('ccacheActivityLine', () => {
+  test('states the counts for a reported build and the reason otherwise', () => {
+    expect(ccacheActivityLine({ status: 'reported', hits: 176, misses: 204, hitRatePercent: 46.3 })).toBe(
+      '176 hits / 204 misses (46.3%)',
+    );
+    expect(ccacheActivityLine({ status: 'not-run', hits: null, misses: null, hitRatePercent: null })).toBe(
+      'not run; artifact cache supplied the app',
+    );
+    expect(ccacheActivityLine(CCACHE_UNAVAILABLE)).toBe('unavailable; no C++ compile went through ccache');
+  });
+});
+
+describe('resolveCcache', () => {
+  function project(root: string, buildGradle = 'apply plugin: "com.android.application"\n'): void {
+    mkdirSync(join(root, 'android', 'app'), { recursive: true });
+    writeFileSync(join(root, 'android', 'app', 'build.gradle'), buildGradle);
+  }
+
+  test('sets the launcher, registers the cache for gc, and says so once', () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-ccache-root-'));
+    project(root);
+    const notes: string[] = [];
+    const resolved = resolveCcache({
+      root,
+      lookup: () => '/opt/homebrew/bin/ccache',
+      onNote: (line) => notes.push(line),
+    });
+    assert(resolved);
+    expect(resolved.env.CMAKE_CXX_COMPILER_LAUNCHER).toBe('/opt/homebrew/bin/ccache');
+    expect(resolved.dir).toBe(join(home, 'ccache'));
+    expect(resolved.env.CCACHE_BASEDIR).toBe(realpathSync(root));
+    expect(resolved.statsLog).toBe(ccacheStatsLog(root));
+    expect(notes.length).toBe(1);
+    expect(notes[0]).toMatch(/^ {2}cache {7}ccache on \(/);
+    const entry = readManifest().caches.find((c) => c.dir === join(home, 'ccache'));
+    assert(entry);
+    expect(entry.name).toBe('ccache');
+    expect(entry.prune).toBe('atomic');
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('sets nothing when ccache is not installed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-ccache-root-'));
+    project(root);
+    const notes: string[] = [];
+    expect(resolveCcache({ root, lookup: () => null, onNote: (line) => notes.push(line) })).toBe(null);
+    expect(notes.length).toBe(1);
+    expect(notes[0]).toMatch(/ccache off \(not installed/);
+    expect(readManifest().caches.length).toBe(0);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('leaves a project that passes its own CMake launcher alone', () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-ccache-root-'));
+    project(root, 'arguments "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"\n');
+    const notes: string[] = [];
+    expect(resolveCcache({ root, lookup: () => '/opt/homebrew/bin/ccache', onNote: (line) => notes.push(line) })).toBe(
+      null,
+    );
+    expect(notes.length).toBe(1);
+    expect(notes[0]).toMatch(/ccache off \(android\/app\/build\.gradle sets CMAKE_CXX_COMPILER_LAUNCHER/);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('the stats log lives beside this workspace logs, not in the shared cache', () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-ccache-root-'));
+    project(root);
+    const resolved = resolveCcache({ root, lookup: () => '/opt/homebrew/bin/ccache', onNote: () => {} });
+    assert(resolved);
+    expect(resolved.statsLog.startsWith(join(home, 'workspaces'))).toBe(true);
+    expect(resolved.statsLog.startsWith(resolved.dir)).toBe(false);
+    expect(existsSync(resolved.dir)).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -1,7 +1,16 @@
 import assert from 'node:assert';
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { NdjsonRecord, NdjsonWriter } from '../ndjson.ts';
@@ -707,6 +716,79 @@ describe('buildAndroid', () => {
     const settled = beats.length;
     await new Promise((r) => setTimeout(r, 40));
     expect(beats.length).toBe(settled);
+  });
+
+  test('the ccache environment reaches the Gradle child, and its stats log is read back', async () => {
+    makeAndroidProject();
+    const statsLog = join(root, 'logs', 'ccache-stats.log');
+    mkdirSync(join(root, 'logs'), { recursive: true });
+    writeFileSync(statsLog, 'stale run\ncache_miss\n');
+    const notes: string[] = [];
+    const envs: NodeJS.ProcessEnv[] = [];
+    const result = await buildAndroid(
+      { root, logWriter: recordingWriter() },
+      {
+        ccache: {
+          dir: join(root, 'ccache'),
+          statsLog,
+          env: { CMAKE_CXX_COMPILER_LAUNCHER: '/opt/homebrew/bin/ccache', CCACHE_DIR: join(root, 'ccache') },
+        },
+        spawnFn: (_cmd, _args, opts) => {
+          envs.push(opts.env as NodeJS.ProcessEnv);
+          expect(existsSync(statsLog)).toBe(false);
+          return fakeChild({
+            lines: ['BUILD SUCCESSFUL in 3s'],
+            onExit: () => {
+              writeFileSync(statsLog, ['# a.cpp', 'direct_cache_hit', '# b.cpp', 'cache_miss'].join('\n'));
+              writeApk();
+            },
+          });
+        },
+        onNote: (line) => notes.push(line),
+      },
+    );
+    expect((result as BuildAndroidResultLike).ok).toBe(true);
+    const spawnEnv = envs[0];
+    assert(spawnEnv);
+    expect(spawnEnv.CMAKE_CXX_COMPILER_LAUNCHER).toBe('/opt/homebrew/bin/ccache');
+    expect(spawnEnv.CCACHE_DIR).toBe(join(root, 'ccache'));
+    expect(spawnEnv.TERM).toBe('dumb');
+    expect(result.ccache).toEqual({ status: 'reported', hits: 1, misses: 1, hitRatePercent: 50 });
+    expect(notes.filter((line) => line.includes('ccache'))).toEqual([]);
+  });
+
+  test('without ccache the Gradle argv and environment are unchanged and no statistics are claimed', async () => {
+    makeAndroidProject();
+    const calls: { args: string[]; env: NodeJS.ProcessEnv }[] = [];
+    const result = await buildAndroid(
+      { root, logWriter: recordingWriter() },
+      {
+        spawnFn: (_cmd, args, opts) => {
+          calls.push({ args, env: opts.env as NodeJS.ProcessEnv });
+          return fakeChild({ lines: ['BUILD SUCCESSFUL in 1s'], onExit: () => writeApk() });
+        },
+      },
+    );
+    expect((result as BuildAndroidResultLike).ok).toBe(true);
+    const call = calls[0];
+    assert(call);
+    expect(call.args).toEqual(['assembleDebug', '--build-cache']);
+    expect(call.env.CMAKE_CXX_COMPILER_LAUNCHER).toBe(undefined);
+    expect(call.env.CCACHE_DIR).toBe(undefined);
+    expect(result.ccache).toEqual({ status: 'unavailable', hits: null, misses: null, hitRatePercent: null });
+  });
+
+  test('a build that compiled no C++ reports unavailable rather than a zero hit rate', async () => {
+    makeAndroidProject();
+    const statsLog = join(root, 'logs', 'ccache-stats.log');
+    const result = await buildAndroid(
+      { root, logWriter: recordingWriter() },
+      {
+        ccache: { dir: join(root, 'ccache'), statsLog, env: { CCACHE_DIR: join(root, 'ccache') } },
+        spawnFn: () => fakeChild({ lines: ['BUILD SUCCESSFUL in 1s'], onExit: () => writeApk() }),
+      },
+    );
+    expect(result.ccache).toEqual({ status: 'unavailable', hits: null, misses: null, hitRatePercent: null });
   });
 
   test('android/local.properties satisfies the SDK check on its own', async () => {

--- a/packages/stim-cli/src/__tests__/fixtures/ccache-stats-log.txt
+++ b/packages/stim-cli/src/__tests__/fixtures/ccache-stats-log.txt
@@ -1,0 +1,19 @@
+# a.c
+cache_miss
+direct_cache_miss
+local_storage_miss
+local_storage_read_miss
+local_storage_read_miss
+local_storage_write
+local_storage_write
+preprocessed_cache_miss
+# a.c
+direct_cache_hit
+local_storage_hit
+local_storage_read_hit
+local_storage_read_hit
+# a.c
+direct_cache_hit
+local_storage_hit
+local_storage_read_hit
+local_storage_read_hit

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -515,6 +515,38 @@ test('the cleanup guide documents that the shared Gradle build cache is report-o
   expect(cleanup).toMatch(/never[^.]*prunes[^.]*empties/i);
 });
 
+test('the cleanup guide lists the shared ccache directory and who bounds it', () => {
+  const cleanup = renderTopic('cleanup');
+  assert(cleanup);
+
+  expect(cleanup).toMatch(/\$STIM_HOME\/ccache \(default ~\/\.stim\/ccache\)/);
+  expect(cleanup).toMatch(/ccache keeps it under CCACHE_MAXSIZE\s+on its own/);
+  expect(cleanup).toMatch(/--older-than\s+skips it/);
+});
+
+test('the lifecycle guide states what Stim sets for Android C++ and what it costs', () => {
+  const lifecycle = renderTopic('lifecycle');
+  assert(lifecycle);
+
+  expect(lifecycle).toMatch(/CMAKE_C_COMPILER_LAUNCHER \/ CMAKE_CXX_COMPILER_LAUNCHER/);
+  expect(lifecycle).toMatch(/CCACHE_DIR, CCACHE_BASEDIR, CCACHE_NOHASHDIR, CCACHE_SLOPPINESS/);
+  expect(lifecycle).toMatch(/Nothing is set when ccache is\s+absent/);
+  expect(lifecycle).toMatch(/\$STIM_HOME\/ccache \(default ~\/\.stim\/ccache\)/);
+  expect(lifecycle).toMatch(/DWARF comp_dir/);
+  expect(lifecycle).toMatch(/reanimated, worklets and\s+expo-modules-core use target_precompile_headers/);
+  expect(lifecycle).toMatch(/\.cxx\/\*\*\/CMakeCache\.txt on the first configure/);
+  expect(lifecycle).toMatch(/keeps compiling without them until it is deleted once/);
+});
+
+test('the settings guide names the ccache variables among the fixed invocations', () => {
+  const settings = renderTopic('settings');
+  assert(settings);
+
+  expect(settings).toMatch(
+    /carries the ccache launcher and CCACHE_BASEDIR \/\s+CCACHE_NOHASHDIR when ccache is on PATH/,
+  );
+});
+
 test('the settings guide defines Metro overrides as parent roots and preserves legacy files', () => {
   const settings = renderTopic('settings');
   assert(settings);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -181,6 +181,7 @@ test('the facts topic documents the fields each --json payload actually carries'
       'launched',
       'durationMs',
       'systemImage',
+      'ccache',
     ],
   };
   for (const [command, names] of Object.entries(fields)) {
@@ -522,6 +523,7 @@ test('the cleanup guide lists the shared ccache directory and who bounds it', ()
   expect(cleanup).toMatch(/\$STIM_HOME\/ccache \(default ~\/\.stim\/ccache\)/);
   expect(cleanup).toMatch(/ccache keeps it under CCACHE_MAXSIZE\s+on its own/);
   expect(cleanup).toMatch(/--older-than\s+skips it/);
+  expect(cleanup).toMatch(/it sets CCACHE_MAXSIZE on the Gradle run, which wins over\s+a max_size/);
 });
 
 test('the lifecycle guide states what Stim sets for Android C++ and what it costs', () => {
@@ -533,7 +535,9 @@ test('the lifecycle guide states what Stim sets for Android C++ and what it cost
   expect(lifecycle).toMatch(/Nothing is set when ccache is\s+absent/);
   expect(lifecycle).toMatch(/\$STIM_HOME\/ccache \(default ~\/\.stim\/ccache\)/);
   expect(lifecycle).toMatch(/DWARF comp_dir/);
-  expect(lifecycle).toMatch(/reanimated, worklets and\s+expo-modules-core use target_precompile_headers/);
+  expect(lifecycle).toMatch(/worklets and\s+expo-modules-core precompile a header without\s+-fno-pch-timestamp/);
+  expect(lifecycle).toMatch(/reanimated passes\s+-Xclang -fno-pch-timestamp and hits across worktrees/);
+  expect(lifecycle).toMatch(/No stale \.pch is ever served/);
   expect(lifecycle).toMatch(/\.cxx\/\*\*\/CMakeCache\.txt on the first configure/);
   expect(lifecycle).toMatch(/keeps compiling without them until it is deleted once/);
 });

--- a/packages/stim-cli/src/__tests__/paths.test.ts
+++ b/packages/stim-cli/src/__tests__/paths.test.ts
@@ -16,6 +16,7 @@ import {
   workspaceStateFile,
   sharedMetroCache,
   sharedBuildCache,
+  sharedCcache,
   sharedCompilationCache,
   sharedGradle,
   sharedPods,
@@ -95,6 +96,7 @@ describe('shared paths', () => {
     expect(sharedMetroCache()).toBe(join(tmpHome, 'metro-cache'));
     expect(sharedBuildCache()).toBe(join(tmpHome, 'build-cache'));
     expect(sharedCompilationCache()).toBe(join(tmpHome, 'compilation-cache'));
+    expect(sharedCcache()).toBe(join(tmpHome, 'ccache'));
     expect(sharedGradle()).toBe(join(tmpHome, 'gradle'));
     expect(sharedPods()).toBe(join(tmpHome, 'pods'));
   });
@@ -103,10 +105,12 @@ describe('shared paths', () => {
     sharedMetroCache();
     sharedBuildCache();
     sharedCompilationCache();
+    sharedCcache();
     sharedGradle();
     sharedPods();
     expect(existsSync(join(tmpHome, 'metro-cache'))).toBe(false);
     expect(existsSync(join(tmpHome, 'build-cache'))).toBe(false);
+    expect(existsSync(join(tmpHome, 'ccache'))).toBe(false);
   });
 });
 

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -12,7 +12,7 @@ import {
 } from '@stim-cli/cache';
 import type { FingerprintSource } from '@expo/fingerprint';
 import { formatDuration, phaseLine, shortHash, SLOW_STEP_MS, stepClock, stepTimer } from '../command-output.ts';
-import type { RemoteDeviceBackend, WaitedForBuild } from '../types.ts';
+import type { CcacheActivity, RemoteDeviceBackend, WaitedForBuild } from '../types.ts';
 import {
   appProjectProblem,
   findProjectRoot,
@@ -119,6 +119,7 @@ import { detectProviders } from '../engine/metro-reach.ts';
 import { selectFromPool } from '../engine/device-pool.ts';
 import { needsPrebuild, runPrebuild } from '../engine/prebuild.ts';
 import { buildAndroid, productFlavorRefusal, readProductFlavors } from '../engine/gradle.ts';
+import { CCACHE_NOT_RUN, CCACHE_UNAVAILABLE, resolveCcache } from '../engine/ccache.ts';
 import { swapApkBundle, resolveKeystore } from '../engine/apk-swap.ts';
 import { captureAssetManifest } from '../engine/asset-manifest.ts';
 import {
@@ -338,6 +339,7 @@ interface RunAndroidOptions {
   needsPrebuildFor?: typeof needsPrebuild;
   prebuild?: typeof runPrebuild;
   build?: typeof buildAndroid;
+  ccacheFor?: typeof resolveCcache;
   install?: typeof installAndroidApp;
   launch?: typeof launchAndroidApp;
   launchRelease?: typeof launchAndroidReleaseApp;
@@ -416,6 +418,7 @@ function resolveRunAndroidOptions(
     needsPrebuildFor = needsPrebuild,
     prebuild = runPrebuild,
     build = buildAndroid,
+    ccacheFor = resolveCcache,
     install = installAndroidApp,
     launch = launchAndroidApp,
     launchRelease = launchAndroidReleaseApp,
@@ -493,6 +496,7 @@ function resolveRunAndroidOptions(
     needsPrebuildFor,
     prebuild,
     build,
+    ccacheFor,
     install,
     launch,
     launchRelease,
@@ -572,6 +576,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     needsPrebuildFor,
     prebuild,
     build,
+    ccacheFor,
     install,
     launch,
     launchRelease,
@@ -1039,6 +1044,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let storeKey = '';
   let storeSources: FingerprintSource[] = [];
   let apkPath: string | null = null;
+  let ccacheActivity: CcacheActivity = CCACHE_NOT_RUN;
 
   async function resolveInitialFingerprint(): Promise<boolean> {
     const fingerprintTimer = stepTimer(now);
@@ -1373,8 +1379,9 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
             phase('build', `compiling ${variant || 'debug'} with Gradle`);
             const built: BuildAndroidResultLike = await build(
               { root, logWriter: writer, variant, abi: buildAbi },
-              { estimateMs: estimates().coldBuildMs },
+              { estimateMs: estimates().coldBuildMs, ccache: ccacheFor({ root, onNote: out }) },
             );
+            ccacheActivity = built.ccache ?? CCACHE_UNAVAILABLE;
             if (built.failed) {
               const diagnostics = built.diagnostics || [];
               for (const diag of diagnostics) {
@@ -1548,6 +1555,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         swapDir,
         record,
         waitedForBuild,
+        ccache: ccacheActivity,
         uploadPending,
         providerUpload,
         providerName,

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -42,7 +42,7 @@ import {
   noDeviceDiagnostic,
   displayPath,
 } from './support.ts';
-import type { WaitedForBuild } from '../../types.ts';
+import type { CcacheActivity, WaitedForBuild } from '../../types.ts';
 import { verifyCollectorOwnership } from '../../collector/ownership.ts';
 import { isPidAlive } from '../../metro.ts';
 import type { OwnedDeviceRecord } from '../../engine/device.ts';
@@ -248,6 +248,7 @@ interface FinishAndroidRunArgs {
   swapDir: string | null;
   record: AndroidRecord;
   waitedForBuild: WaitedForBuild | null;
+  ccache: CcacheActivity;
   uploadPending: Promise<RemoteUploadLike> | null;
   providerUpload: Promise<ProviderCallResult<void>> | null;
   providerName: string | null;
@@ -305,6 +306,7 @@ export async function finishAndroidRun({
   swapDir,
   record,
   waitedForBuild,
+  ccache,
   uploadPending,
   providerUpload,
   providerName,
@@ -569,6 +571,7 @@ export async function finishAndroidRun({
     providerName,
     launchState,
     launched,
+    ccache,
     durationMs: now() - started,
     writer,
     emit,

--- a/packages/stim-cli/src/commands/android/result.ts
+++ b/packages/stim-cli/src/commands/android/result.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { AndroidFacts, WaitedForBuild } from '../../types.ts';
+import type { AndroidFacts, CcacheActivity, WaitedForBuild } from '../../types.ts';
 import { LAUNCH_BUNDLING, LAUNCH_UNVERIFIED } from '../../engine/app-install.ts';
 import {
   cacheLevel,
@@ -8,6 +8,7 @@ import {
   isEasAuthFailureText,
   type LoadProjectProviderResult,
 } from '../../engine/remote-cache.ts';
+import { CCACHE_UNAVAILABLE, ccacheActivityLine } from '../../engine/ccache.ts';
 import { PLATFORM } from './support.ts';
 import { formatDuration, phaseLine } from '../../command-output.ts';
 import type { RemoteUploadLike, LaunchResultLike, AndroidRecord, AndroidWriter } from './types.ts';
@@ -30,6 +31,7 @@ export function androidFacts({
   bundleId,
   installSkipped = false,
   launched,
+  ccache = CCACHE_UNAVAILABLE,
   logs,
   debugHttpHost = null,
   debugHttpHostNote = null,
@@ -52,6 +54,7 @@ export function androidFacts({
   bundleId?: string | null;
   installSkipped?: boolean;
   launched?: boolean | string;
+  ccache?: CcacheActivity;
   logs?: string | null;
   debugHttpHost?: string | null;
   debugHttpHostNote?: string | null;
@@ -76,6 +79,7 @@ export function androidFacts({
     bundleId: bundleId ?? null,
     installSkipped: Boolean(installSkipped),
     launched: launched === LAUNCH_UNVERIFIED || launched === LAUNCH_BUNDLING ? launched : Boolean(launched),
+    ccache,
     debugHttpHost: debugHttpHost ?? null,
     debugHttpHostNote: debugHttpHostNote ?? null,
     devClientUrl: devClientUrl ?? null,
@@ -174,6 +178,7 @@ export interface ReportAndroidResultArgs {
   providerName: string | null;
   launchState: boolean | string;
   launched: LaunchResultLike;
+  ccache: CcacheActivity;
   durationMs: number;
   writer: AndroidWriter;
   emit: (line: string) => void;
@@ -198,6 +203,7 @@ export function reportAndroidResult({
   providerName,
   launchState,
   launched,
+  ccache,
   durationMs,
   writer,
   emit,
@@ -224,6 +230,7 @@ export function reportAndroidResult({
     bundleId: androidPackage,
     installSkipped,
     launched: launchState,
+    ccache,
     logs: logsDir,
     durationMs,
     lease,
@@ -259,6 +266,7 @@ export function reportAndroidResult({
         phaseLine('app', androidPackage),
         phaseLine('metro', metroResult),
         phaseLine('cache', cacheResult),
+        phaseLine('compilation cache', ccacheActivityLine(ccache)),
         phaseLine('logs', logsDir || 'unavailable (remote device)'),
       ].join('\n'),
     );

--- a/packages/stim-cli/src/commands/android/types.ts
+++ b/packages/stim-cli/src/commands/android/types.ts
@@ -1,7 +1,7 @@
 import type { Diagnostic } from '../../engine/errors-gradle.ts';
 import type { LaunchErrorRecord } from '../../command-output.ts';
 import type { LeaseFacts } from '../../engine/device-lease-run.ts';
-import type { AndroidFacts } from '../../types.ts';
+import type { AndroidFacts, CcacheActivity } from '../../types.ts';
 import type { createNdjsonWriter } from '../../ndjson.ts';
 
 export interface SupervisorLike {
@@ -36,6 +36,7 @@ export interface BuildAndroidResultLike {
   durationMs?: number;
   apkPath?: string;
   apkNote?: string | null;
+  ccache?: CcacheActivity;
 }
 
 export interface InstallResultLike {

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -52,7 +52,7 @@ export function doctorSuccessLines(platform?: DoctorPlatform): string[] {
   if (platform !== 'ios') {
     lines.push('', 'Android');
     lines.push(phaseLine('setup', 'warm state, dev client'));
-    lines.push(phaseLine('caches', 'Metro, Gradle build provider'));
+    lines.push(phaseLine('caches', 'Metro, Gradle, ccache, build provider'));
     lines.push(phaseLine('devices', 'remote device'));
   }
 
@@ -64,8 +64,8 @@ export function doctorSuccessLines(platform?: DoctorPlatform): string[] {
     platform === 'ios'
       ? 'Metro transform store, Xcode compilation cache'
       : platform === 'android'
-        ? 'Metro transform store, Gradle build cache'
-        : 'Metro transform store, Xcode compilation cache, Gradle build cache';
+        ? 'Metro transform store, Gradle build cache, ccache'
+        : 'Metro transform store, Xcode compilation cache, Gradle build cache, ccache';
   lines.push(phaseLine('caches', suppliedCaches));
   lines.push(phaseLine('meaning', 'missing project cache settings are healthy'));
   return lines;

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, relative, resolve } from 'path';
+import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
 import { appProjectProblem, detectIsExpo } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
@@ -344,9 +345,106 @@ export function checkCcacheConflict(podfileSource: string | null, podfilePropert
   return finding(
     'cost',
     'ccache is enabled, so Stim leaves Xcode compilation caching off',
-    'The ccache launcher script is what disables explicitly built modules, which compilation caching requires -- so enabling both tends to mean neither works. Stim will not add its compilation-cache settings to a build whose project has apple.ccacheEnabled=true, and ccache itself keys on absolute paths, so it misses across worktrees anyway.',
+    "The ccache launcher script is what disables explicitly built modules, which compilation caching requires -- so enabling both tends to mean neither works. Stim will not add its compilation-cache settings to a build whose project has apple.ccacheEnabled=true, and in its default configuration ccache hashes the working directory and every absolute include path, so it misses across worktrees. (Stim relocates ccache itself on Android, where it drives the compile and can set CCACHE_BASEDIR and CCACHE_NOHASHDIR; the Podfile launcher script here is the project's, not Stim's.)",
     'Pick one, and on Xcode 26 the compilation cache is the one that survives a different workspace path -- Stim supplies it on its own builds as soon as ccache is off. Turn it off where the value comes FROM: on Expo that is the expo-build-properties plugin in the app config (ios.ccacheEnabled), because prebuild rewrites ios/Podfile.properties.json from it; on a bare project edit ios/Podfile.properties.json directly. Then re-run pod install (or let `stim ios` do it).',
   );
+}
+
+export function checkCcacheInstalled(onPath: boolean): Finding | null {
+  if (onPath) return null;
+  return finding(
+    'cost',
+    'ccache is not on PATH, so Android C++ recompiles in every worktree',
+    'Stim resolves the launcher with `command -v ccache` -- the same PATH lookup the build itself uses -- and found nothing, so it passes no CMAKE_C_COMPILER_LAUNCHER / CMAKE_CXX_COMPILER_LAUNCHER to Gradle and every AGP CMake task compiles without one. Those tasks are uncacheable by Gradle, so not one C++ object crosses a worktree. Measured on trailhead (arm64, fresh worktree): 49.6s without the launcher against 34.2s with it.',
+    'brew install ccache, then delete android/app/.cxx and node_modules/**/android/.cxx once so CMake reconfigures with the launcher. The shell that runs Stim must have the install location on PATH -- agent shells often lack /opt/homebrew/bin.',
+  );
+}
+
+export interface CxxLauncherState {
+  path: string;
+  launcher: string | null;
+}
+
+export function parseCmakeCacheLauncher(source: unknown): string | null {
+  if (typeof source !== 'string') return null;
+  const match = /^CMAKE_CXX_COMPILER_LAUNCHER(?::[A-Z]+)?=(.*)$/m.exec(source);
+  const value = match?.[1]?.trim();
+  return value ? value : null;
+}
+
+export function checkCxxCompilerLauncher({
+  states,
+  ccacheOnPath,
+  launcherExists = existsSync,
+}: {
+  states: CxxLauncherState[];
+  ccacheOnPath: boolean;
+  launcherExists?: (path: string) => boolean;
+}): Finding | null {
+  const missing = states.filter((state) => state.launcher !== null && !launcherExists(state.launcher));
+  if (missing.length > 0) {
+    const named = [...new Set(missing.map((state) => state.launcher as string))].join(', ');
+    return finding(
+      'cost',
+      'A configured CMake cache names a compiler launcher that is not on this machine',
+      `${plural(missing.length, 'CMakeCache.txt file')} under this project name ${named}, and CMake runs that path for every C++ compile. Until the cache is reconfigured the build fails there rather than falling back: ${missing[0]?.path}.`,
+      'Delete the configured CMake directories once so the next build reconfigures: `rm -rf android/app/.cxx android/app/build` (and node_modules/*/android/.cxx for library modules).',
+    );
+  }
+  if (!ccacheOnPath) return null;
+  if (states.length === 0) return null;
+  if (states.some((state) => state.launcher !== null)) return null;
+  return finding(
+    'cost',
+    'The configured CMake cache predates the ccache launcher, so C++ compiles still bypass it',
+    `CMake seeds CMAKE_CXX_COMPILER_LAUNCHER from the environment on a FRESH configure only, so a .cxx directory written before Stim set the variable keeps compiling without it and the shared cache stays empty. ${plural(states.length, 'CMakeCache.txt file')} here names no launcher: ${states[0]?.path}.`,
+    'Delete the configured CMake directories once: `rm -rf android/app/.cxx android/app/build` (and node_modules/*/android/.cxx for library modules). The next `stim android` reconfigures with the launcher and every later build keeps it.',
+  );
+}
+
+const CXX_SCAN_DEPTH = 4;
+
+function readCxxLauncherStates(projectRoot: string): CxxLauncherState[] {
+  const base = join(projectRoot, 'android', 'app', '.cxx');
+  const states: CxxLauncherState[] = [];
+  const walk = (dir: string, depth: number): void => {
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      const path = join(dir, name);
+      if (name === 'CMakeCache.txt') {
+        let source: string | null = null;
+        try {
+          source = readFileSync(path, 'utf-8');
+        } catch {
+          continue;
+        }
+        states.push({ path: relative(projectRoot, path), launcher: parseCmakeCacheLauncher(source) });
+        continue;
+      }
+      if (depth >= CXX_SCAN_DEPTH) continue;
+      try {
+        if (!statSync(path).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      walk(path, depth + 1);
+    }
+  };
+  walk(base, 0);
+  return states;
+}
+
+function ccacheIsOnPath(): boolean {
+  try {
+    return Boolean(getExecutor().runQuiet('command -v ccache', { timeoutMs: 5000 }));
+  } catch {
+    return false;
+  }
 }
 
 export function checkBuildCacheProvider(
@@ -564,6 +662,7 @@ export function runDoctor(
     lookupAgentDevice = null,
     lookupEasCli = null,
     lookupSimSlim = null,
+    lookupCcache = null,
     platform,
   }: {
     readFile?: typeof readFileSync;
@@ -576,6 +675,7 @@ export function runDoctor(
     lookupAgentDevice?: (() => boolean) | null;
     lookupEasCli?: (() => boolean) | null;
     lookupSimSlim?: (() => boolean) | null;
+    lookupCcache?: (() => boolean) | null;
     platform?: DoctorPlatform;
   } = {},
 ): Finding[] {
@@ -695,6 +795,7 @@ export function runDoctor(
     checkMetroCache(metroConfig),
     platform === 'android' ? null : checkCompilationCache(podfile, xcodeMajor),
     platform === 'android' ? null : checkCcacheConflict(podfile, podfileProperties),
+    ...(platform === 'ios' ? [] : androidCcacheFindings(projectRoot, platform, lookupCcache)),
     checkBuildCacheProvider(appConfig, sdkMajor, isExpo, dynamicConfig),
     easFinding,
     concurrencyFinding,
@@ -702,6 +803,19 @@ export function runDoctor(
     ...remoteFindings,
     ...settingShapeFindings,
   ].filter((f): f is Finding => Boolean(f));
+}
+
+function androidCcacheFindings(
+  projectRoot: string,
+  platform: DoctorPlatform | undefined,
+  lookupCcache: (() => boolean) | null,
+): (Finding | null)[] {
+  if (platform !== 'android' && !existsSync(join(projectRoot, 'android'))) return [];
+  const onPath = lookupCcache ? lookupCcache() : ccacheIsOnPath();
+  return [
+    checkCcacheInstalled(onPath),
+    checkCxxCompilerLauncher({ states: readCxxLauncherStates(projectRoot), ccacheOnPath: onPath }),
+  ];
 }
 
 function checkAppProject(projectRoot: string): Finding | null {

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
 import { tmpdir } from 'os';
-import { dirname, join, relative, resolve } from 'path';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
 import { appProjectProblem, detectIsExpo } from './project.ts';
@@ -372,6 +372,14 @@ export function parseCmakeCacheLauncher(source: unknown): string | null {
   return value ? value : null;
 }
 
+// CMake docs, CMAKE_<LANG>_COMPILER_LAUNCHER: the value is a ;-separated
+// command line whose first word is resolved through PATH unless it is
+// absolute, so only an absolute one is a path this machine must hold.
+function launcherPath(launcher: string | null): string | null {
+  const command = launcher?.split(';')[0]?.trim();
+  return command && isAbsolute(command) ? command : null;
+}
+
 export function checkCxxCompilerLauncher({
   states,
   ccacheOnPath,
@@ -381,9 +389,13 @@ export function checkCxxCompilerLauncher({
   ccacheOnPath: boolean;
   launcherExists?: (path: string) => boolean;
 }): Finding | null {
-  const missing = states.filter((state) => state.launcher !== null && !launcherExists(state.launcher));
+  const missing = states
+    .map((state) => ({ path: state.path, command: launcherPath(state.launcher) }))
+    .filter(
+      (state): state is { path: string; command: string } => state.command !== null && !launcherExists(state.command),
+    );
   if (missing.length > 0) {
-    const named = [...new Set(missing.map((state) => state.launcher as string))].join(', ');
+    const named = [...new Set(missing.map((state) => state.command))].join(', ');
     return finding(
       'cost',
       'A configured CMake cache names a compiler launcher that is not on this machine',

--- a/packages/stim-cli/src/engine/ccache.ts
+++ b/packages/stim-cli/src/engine/ccache.ts
@@ -1,0 +1,183 @@
+import { readFileSync, realpathSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import chalk from 'chalk';
+import { phaseLine } from '../command-output.ts';
+import { register } from '../cache-manifest.ts';
+import { getExecutor } from '../exec.ts';
+import { sharedCcache, workspaceLogsDir } from '../paths.ts';
+import type { CcacheActivity } from '../types.ts';
+
+export const CCACHE_MAX_SIZE = '5G';
+
+// ccache manual, "SLOPPINESS": pch_defines is required for a precompiled
+// header to be reusable at all, and time_macros lets a translation unit that
+// expands __DATE__ or __TIME__ be cached.
+export const CCACHE_SLOPPINESS = 'pch_defines,time_macros';
+
+const STATS_LOG_FILE = 'ccache-stats.log';
+
+export const CCACHE_UNAVAILABLE: CcacheActivity = {
+  status: 'unavailable',
+  hits: null,
+  misses: null,
+  hitRatePercent: null,
+};
+
+export const CCACHE_NOT_RUN: CcacheActivity = {
+  status: 'not-run',
+  hits: null,
+  misses: null,
+  hitRatePercent: null,
+};
+
+export interface CcacheSetup {
+  dir: string;
+  statsLog: string;
+  env: Record<string, string>;
+}
+
+export function ccacheStatsLog(root: string): string {
+  return join(workspaceLogsDir(root), STATS_LOG_FILE);
+}
+
+export function ccacheEnvironment({
+  binary,
+  dir,
+  workspaceRoot,
+  statsLog,
+}: {
+  binary: string;
+  dir: string;
+  workspaceRoot: string;
+  statsLog: string;
+}): Record<string, string> {
+  return {
+    CMAKE_C_COMPILER_LAUNCHER: binary,
+    CMAKE_CXX_COMPILER_LAUNCHER: binary,
+    CCACHE_DIR: dir,
+    CCACHE_BASEDIR: workspaceRoot,
+    // ccache manual, "CCACHE_NOHASHDIR": the boolean is read from this
+    // spelling only; CCACHE_HASHDIR=false is not honored.
+    CCACHE_NOHASHDIR: 'true',
+    CCACHE_SLOPPINESS,
+    CCACHE_MAXSIZE: CCACHE_MAX_SIZE,
+    CCACHE_STATSLOG: statsLog,
+  };
+}
+
+export function parseCcacheBinary(output: unknown): string | null {
+  const first = String(output ?? '')
+    .split('\n')[0]
+    ?.trim();
+  if (!first || !isAbsolute(first)) return null;
+  return first;
+}
+
+const CMAKE_LAUNCHER = /CMAKE_(C|CXX)_COMPILER_LAUNCHER\b/;
+
+export function projectCmakeLauncher(source: unknown): string | null {
+  if (typeof source !== 'string') return null;
+  const match = CMAKE_LAUNCHER.exec(source);
+  return match ? `CMAKE_${match[1]}_COMPILER_LAUNCHER` : null;
+}
+
+const HIT_COUNTERS = new Set(['direct_cache_hit', 'preprocessed_cache_hit']);
+
+export function parseCcacheStatsLog(text: unknown): CcacheActivity | null {
+  if (typeof text !== 'string') return null;
+  let hits = 0;
+  let misses = 0;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (HIT_COUNTERS.has(line)) hits += 1;
+    else if (line === 'cache_miss') misses += 1;
+  }
+  const total = hits + misses;
+  if (total === 0) return null;
+  return {
+    status: 'reported',
+    hits,
+    misses,
+    hitRatePercent: Math.round((hits / total) * 1000) / 10,
+  };
+}
+
+export function readCcacheActivity(statsLog: string): CcacheActivity {
+  let text: string;
+  try {
+    text = readFileSync(statsLog, 'utf-8');
+  } catch {
+    return CCACHE_UNAVAILABLE;
+  }
+  return parseCcacheStatsLog(text) ?? CCACHE_UNAVAILABLE;
+}
+
+export function ccacheActivityLine(activity: CcacheActivity): string {
+  if (activity.status === 'reported') {
+    return `${activity.hits} hits / ${activity.misses} misses (${activity.hitRatePercent}%)`;
+  }
+  if (activity.status === 'not-run') return 'not run; artifact cache supplied the app';
+  return 'unavailable; no C++ compile went through ccache';
+}
+
+function lookupCcache(): string | null {
+  try {
+    return parseCcacheBinary(getExecutor().runQuiet('command -v ccache', { timeoutMs: 5000 }));
+  } catch {
+    return null;
+  }
+}
+
+function readOrNull(file: string): string | null {
+  try {
+    return readFileSync(file, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function canonical(root: string): string {
+  try {
+    return realpathSync(root);
+  } catch {
+    return root;
+  }
+}
+
+export function resolveCcache({
+  root,
+  dir = sharedCcache(),
+  lookup = lookupCcache,
+  onNote = (line: string) => console.error(line),
+}: {
+  root: string;
+  dir?: string;
+  lookup?: () => string | null;
+  onNote?: (line: string) => void;
+}): CcacheSetup | null {
+  const binary = lookup();
+  if (!binary) {
+    onNote(chalk.dim(phaseLine('cache', 'ccache off (not installed; brew install ccache)')));
+    return null;
+  }
+
+  const declared = projectCmakeLauncher(readOrNull(join(root, 'android', 'app', 'build.gradle')));
+  if (declared) {
+    onNote(chalk.dim(phaseLine('cache', `ccache off (android/app/build.gradle sets ${declared} itself)`)));
+    return null;
+  }
+
+  const statsLog = ccacheStatsLog(root);
+  register({
+    dir,
+    name: 'ccache',
+    prune: 'atomic',
+    note: 'ccache keeps itself under CCACHE_MAXSIZE, so it is emptied whole or not at all',
+  });
+  onNote(chalk.dim(phaseLine('cache', `ccache on (${dir})`)));
+  return {
+    dir,
+    statsLog,
+    env: ccacheEnvironment({ binary, dir, workspaceRoot: canonical(root), statsLog }),
+  };
+}

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 import chalk from 'chalk';
 import { phaseLine } from '../command-output.ts';
 import { getExecutor } from '../exec.ts';
@@ -8,7 +8,9 @@ import type { NdjsonWriter } from '../ndjson.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
 import { androidHome } from '../sim/android.ts';
 import { capDiagnostics, type Diagnostic, extractGradleDiagnostics } from './errors-gradle.ts';
+import { CCACHE_UNAVAILABLE, type CcacheSetup, readCcacheActivity } from './ccache.ts';
 import { HEARTBEAT_INTERVAL_MS, startBuildHeartbeat } from './xcode.ts';
+import type { CcacheActivity } from '../types.ts';
 
 export const BUILD_ERROR = 'STIM_BUILD_FAILED';
 
@@ -421,6 +423,7 @@ export type BuildAndroidResult = {
   truncated?: number;
   lastLines: string[];
   durationMs: number;
+  ccache?: CcacheActivity;
 };
 
 export function gradleArgs(
@@ -442,6 +445,7 @@ export async function buildAndroid(
     now = Date.now,
     env = process.env,
     buildCache = true,
+    ccache = null,
     heartbeatMs = HEARTBEAT_INTERVAL_MS,
     estimateMs = null,
     onHeartbeat = (line: string) => console.error(line),
@@ -451,6 +455,7 @@ export async function buildAndroid(
     now?: () => number;
     env?: NodeJS.ProcessEnv;
     buildCache?: boolean;
+    ccache?: CcacheSetup | null;
     heartbeatMs?: number;
     estimateMs?: number | null;
     onHeartbeat?: (line: string) => void;
@@ -496,12 +501,14 @@ export async function buildAndroid(
     logWriter?.write?.({ src: 'build', level: 'debug', msg, raw: true, event: 'gradle' });
   };
 
+  if (ccache) resetStatsLog(ccache.statsLog);
+
   let child: ChildProcess;
   try {
     child = spawn(project.gradlew as string, args, {
       cwd: project.androidDir,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...env, TERM: 'dumb', FORCE_COLOR: '0' },
+      env: { ...env, ...ccache?.env, TERM: 'dumb', FORCE_COLOR: '0' },
     });
   } catch (err) {
     return spawnFailure(err, project, now() - startedAt);
@@ -527,6 +534,7 @@ export async function buildAndroid(
   errReader.flush();
   const durationMs = now() - startedAt;
   const transcript = window.join('\n');
+  const ccacheActivity = ccache ? readCcacheActivity(ccache.statsLog) : CCACHE_UNAVAILABLE;
 
   if (result.error) return { ...spawnFailure(result.error, project, durationMs), lastLines: tail.slice() };
 
@@ -575,7 +583,21 @@ export async function buildAndroid(
   }
   const apkPath = located.apkPath;
 
-  return { ok: true, apkPath, apkNote: located.note ?? null, durationMs, lastLines: tail.slice() };
+  return {
+    ok: true,
+    apkPath,
+    apkNote: located.note ?? null,
+    durationMs,
+    lastLines: tail.slice(),
+    ccache: ccacheActivity,
+  };
+}
+
+function resetStatsLog(statsLog: string): void {
+  try {
+    mkdirSync(dirname(statsLog), { recursive: true });
+    rmSync(statsLog, { force: true });
+  } catch {}
 }
 
 function spawnFailure(err: unknown, project: AndroidProjectResult, durationMs: number) {

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -208,7 +208,9 @@ SHARED BUILD CACHES
   $STIM_HOME/ccache (default ~/.stim/ccache) holds the Android C++ objects
   \`stim android\` compiles through ccache. ccache keeps it under CCACHE_MAXSIZE
   on its own, so \`gc\` reports its size and leaves it alone; --older-than
-  skips it, and \`--cache all\` empties it whole like the Xcode CAS.
+  skips it, and \`--cache all\` empties it whole like the Xcode CAS. That
+  bound is Stim's: it sets CCACHE_MAXSIZE on the Gradle run, which wins over
+  a max_size written into the cache directory's own ccache.conf.
 
   The Gradle build cache under GRADLE_USER_HOME (default ~/.gradle) is
   report-only because every Gradle build shares it. Stim reports its size

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -205,6 +205,11 @@ SHARED BUILD CACHES
     stim gc --delete --older-than 30   # trim entries nothing has used
     stim gc --delete --cache all       # empty them whole, index-backed ones
                                          # (the Xcode CAS) included
+  $STIM_HOME/ccache (default ~/.stim/ccache) holds the Android C++ objects
+  \`stim android\` compiles through ccache. ccache keeps it under CCACHE_MAXSIZE
+  on its own, so \`gc\` reports its size and leaves it alone; --older-than
+  skips it, and \`--cache all\` empties it whole like the Xcode CAS.
+
   The Gradle build cache under GRADLE_USER_HOME (default ~/.gradle) is
   report-only because every Gradle build shares it. Stim reports its size
   but never prunes or empties it, including with --older-than or --cache all.

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -280,6 +280,15 @@ line by design (see \`guide logs\`), not this single-payload contract.
   devClientUrl    the expo-dev-client deep link that was opened, or null for
                   a plain launcher start. This is the command that puts the
                   app back on THIS workspace's bundle
+  ccache          the Android C++ compilation cache, the counterpart of the
+                  iOS compilationCache field:
+                    { status: "reported", hits, misses, hitRatePercent }
+                  status is "not-run" when the artifact cache supplied the
+                  APK. status is "unavailable" when no C++ compile went
+                  through ccache -- ccache absent from PATH, a project that
+                  sets its own CMake compiler launcher, or a Gradle run whose
+                  native work was all up to date. None of the three is an
+                  error, and this field is separate from cacheHit
   logs            the workspace log directory
   durationMs      wall time for the whole run
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -319,11 +319,14 @@ The trade-off is the same class as the iOS CAS one: an object reused from
 worktree A carries A's directory as its DWARF comp_dir, so a debugger stepping
 into reused C++ resolves sources against that path.
 
-Three modules miss by construction. reanimated, worklets and
-expo-modules-core use target_precompile_headers, CMake writes an absolute
-include into cmake_pch.hxx, and the precompiled header embeds the worktree
-path -- so their hash cannot match across paths and they recompile in every
-workspace. Everything else hits.
+Precompiled headers are where the misses are, and the cause is mtime, not
+paths. worklets and expo-modules-core precompile a header without
+-fno-pch-timestamp, so ccache re-checks the mtime of the PCH inputs
+(\`Precompiled header includes ..., which has a new mtime\`), rebuilds the
+header, and every translation unit that includes it misses too -- 5 to 11
+seconds per module, paid again after anything that rewrites those mtimes,
+a fresh npm ci included. No stale .pch is ever served. reanimated passes
+-Xclang -fno-pch-timestamp and hits across worktrees like everything else.
 
 The launcher persists in the project. AGP writes it into each
 .cxx/**/CMakeCache.txt on the first configure, so a plain \`./gradlew\` in that

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -283,6 +283,13 @@ committing. The shared caches need no project-file edits:
            no org.gradle.caching=true in gradle.properties. Debug builds also
            carry -PreactNativeArchitectures=<target ABI> when Stim can prove
            the emulator or physical-device ABI; otherwise they stay universal.
+  ccache   the same gradlew run carries an absolute
+           CMAKE_C_COMPILER_LAUNCHER / CMAKE_CXX_COMPILER_LAUNCHER plus
+           CCACHE_DIR, CCACHE_BASEDIR, CCACHE_NOHASHDIR, CCACHE_SLOPPINESS
+           and CCACHE_MAXSIZE whenever a ccache binary is on PATH, so the C++
+           objects cross worktrees as well. Nothing is set when ccache is
+           absent, or when the project passes a CMake compiler launcher of
+           its own.
   start    the dev server gets a shared Metro FileStore APPENDED to whatever
            the project configured -- in-process on a bare project, and through
            Expo's config override on SDK 54+. Expo SDK 53 and older use their
@@ -294,8 +301,35 @@ committing. The shared caches need no project-file edits:
 
 Each reports its cache setup. \`stim doctor\` checks missing or stale setup
 when a build is blocked or slow. It reports what Stim cannot handle itself
-(a missing dev client, ccache, a fingerprint no fresh worktree reproduces, a
-provider on a key this SDK ignores) and settings for builds outside Stim.
+(a missing dev client, ccache absent from PATH or a .cxx that predates the
+launcher, a fingerprint no fresh worktree reproduces, a provider on a key this
+SDK ignores) and settings for builds outside Stim.
+
+WHY ANDROID NEEDS CCACHE, AND WHAT IT COSTS
+Every AGP CMake task is uncacheable by Gradle, so --build-cache serves not one
+C++ compile. Without a launcher a fresh worktree recompiles every translation
+unit, which on a React Native app with native modules is most of a first build.
+The shared objects live at $STIM_HOME/ccache (default ~/.stim/ccache), which is
+registered for \`gc\` and prunes itself at CCACHE_MAXSIZE.
+
+CCACHE_BASEDIR rewrites paths under the workspace root relative to the compile
+directory and CCACHE_NOHASHDIR keeps the working directory out of the hash;
+together they are what lets an object built in one worktree match in another.
+The trade-off is the same class as the iOS CAS one: an object reused from
+worktree A carries A's directory as its DWARF comp_dir, so a debugger stepping
+into reused C++ resolves sources against that path.
+
+Three modules miss by construction. reanimated, worklets and
+expo-modules-core use target_precompile_headers, CMake writes an absolute
+include into cmake_pch.hxx, and the precompiled header embeds the worktree
+path -- so their hash cannot match across paths and they recompile in every
+workspace. Everything else hits.
+
+The launcher persists in the project. AGP writes it into each
+.cxx/**/CMakeCache.txt on the first configure, so a plain \`./gradlew\` in that
+checkout also compiles through ccache -- and a .cxx configured BEFORE the
+variables existed keeps compiling without them until it is deleted once.
+\`stim doctor\` reports both.
 
 THE BUILD CACHE HAS THREE LEVELS
   1. Stim's own, on this machine: a directory under ~/.stim shared by

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -274,7 +274,11 @@ be setup steps are supplied by Stim on the command lines it composes itself:
                gradle.properties. Debug builds add
                -PreactNativeArchitectures=<target ABI> when the owned
                emulator system image or physical device proves the ABI;
-               unknown targets and Release builds stay universal.
+               unknown targets and Release builds stay universal. The same run
+               carries the ccache launcher and CCACHE_BASEDIR /
+               CCACHE_NOHASHDIR when ccache is on PATH -- so no
+               externalNativeBuild cmake arguments in a committed
+               build.gradle.
   start        a shared Metro FileStore, APPENDED to whatever the project
                configured -- so no metro.config.js. On a bare project Stim
                hosts Metro itself and adds it to the config it loaded; on Expo

--- a/packages/stim-cli/src/paths.ts
+++ b/packages/stim-cli/src/paths.ts
@@ -117,6 +117,10 @@ export function sharedCompilationCache(): string {
   return join(getConfigDir(), 'compilation-cache');
 }
 
+export function sharedCcache(): string {
+  return join(getConfigDir(), 'ccache');
+}
+
 export function sharedGradle(): string {
   return join(getConfigDir(), 'gradle');
 }

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -103,6 +103,13 @@ export interface CompilationCacheActivity {
   hitRatePercent: number | null;
 }
 
+export interface CcacheActivity {
+  status: 'reported' | 'unavailable' | 'not-run';
+  hits: number | null;
+  misses: number | null;
+  hitRatePercent: number | null;
+}
+
 interface RunLeaseFacts {
   kind: string;
   expiresAt: string;
@@ -149,6 +156,7 @@ export interface AndroidFacts {
   bundleId: string | null;
   installSkipped: boolean;
   launched: LaunchStatus;
+  ccache: CcacheActivity;
   debugHttpHost: string | null;
   debugHttpHostNote: string | null;
   devClientUrl: string | null;


### PR DESCRIPTION
## Description

`stim android` never reused a C++ object across worktrees. Every AGP CMake task
(`configureCMakeDebug[abi]`, `buildCMakeDebug[abi]`) is uncacheable by Gradle, so
`--build-cache` serves none of them, and `engine/gradle.ts` spawned `gradlew` with
the inherited environment plus `TERM` and `FORCE_COLOR` -- nothing selected a
compiler launcher. On a React Native app with native modules that leaves a fresh
worktree recompiling every C++ translation unit, which is the bulk of its first
Android build. iOS has had the Xcode compilation cache under
`~/.stim/compilation-cache` since Xcode 26; Android had no counterpart.

React Native's own `ReactNative-application.cmake` already routes the `:app` CMake
project through ccache when it is on PATH, but with ccache's defaults
(`hash_dir=true`, no `base_dir`) the working directory and every absolute include
path enter the hash, so a second worktree gets no hits -- and the library CMake
projects get no launcher at all.

## Solution

When a `ccache` binary resolves on PATH, `buildAndroid` spawns Gradle with a
computed environment, and **nothing else changes**: same argument list, same cache
key, no Gradle init script, no new command or flag.

The new `engine/ccache.ts` keeps the pure part separate. `ccacheEnvironment()`
returns the eight variables (they are printed verbatim in the evidence below);
`resolveCcache()` is the thin I/O wrapper that resolves the binary through the
single exec wrapper, declines to fight a project that passes its own
`CMAKE_*_COMPILER_LAUNCHER` in `android/app/build.gradle`, registers
`$STIM_HOME/ccache` in the cache manifest so `gc` reports it, and prints one dim
`cache  ccache on (<dir>)` line the way `xcode.ts` does for the CAS. After the
build the per-workspace `CCACHE_STATSLOG` is parsed into hits and misses -- a
per-build count that does not zero the shared statistics -- and reported as the
existing `compilation cache` label in the run summary and as `ccache` in the
`--json` facts, so the closed label vocabulary in `command-output.ts` is unchanged.

**Two costs, both deliberate and both documented in `guide lifecycle`.**
`CCACHE_NOHASHDIR` is what lets an object cross paths at all, and it means an
object reused from worktree A carries A's directory as its DWARF `comp_dir` --
the same class of trade-off doctor already explains for the iOS CAS. And the
modules that precompile a header without `-fno-pch-timestamp` -- worklets and
expo-modules-core -- recompile whenever the mtime of a PCH input changes, which
a fresh `npm ci` in a new worktree does: ccache rebuilds the header and every
translation unit including it misses, 5 to 11 seconds per module. No stale
`.pch` is served. reanimated passes `-Xclang -fno-pch-timestamp` and hits
across worktrees.

`CCACHE_SLOPPINESS` is `pch_defines,time_macros`, the value the issue's
"Verification results" comment measured: dropping `include_file_mtime,
include_file_ctime` lost no hits (380 of 380 direct hits against entries stored
under the wider setting), and PCH reuse under it was confirmed safe.

The launcher persists in the checkout: AGP writes it into every
`.cxx/**/CMakeCache.txt` on the first configure, so a plain `./gradlew` there also
compiles through ccache, and a `.cxx` written before the variables existed keeps
compiling without them. `doctor` reports both, as Android findings that honor
`--platform`: a "costs time" finding when ccache is not on PATH (with the measured
cost and the delete-`.cxx` remedy, per the maintainer requirement on the issue),
and one when a `CMakeCache.txt` names an absolute launcher that is not on this
machine, or names none at all (a bare name is CMake's own PATH lookup, so it is
left alone). The iOS `checkCcacheConflict` detail no longer claims ccache misses across
worktrees unconditionally -- that is true of its default configuration.

## Test plan

**Result first:** a second worktree of a real app built in **35s against the
producer's 55s**, with **176 of 380 C++ compiles served from the other worktree's
objects**.

### Real tool verification (invariant 9)

Two throwaway `git worktree` checkouts of an Expo SDK 57 / RN 0.86 app with nine
CMake modules (trailhead at `b0e4f23`), `npm ci` in each, a temporary `STIM_HOME`
so `~/.stim` was untouched, and the environment read out of the built
`resolveCcache()` rather than retyped. Same command in both:

```
./gradlew assembleDebug --build-cache --console=plain -PreactNativeArchitectures=arm64-v8a
```

**Producer** (`ccache-a`, empty cache). What Stim set:

```
CMAKE_C_COMPILER_LAUNCHER=/opt/homebrew/bin/ccache
CMAKE_CXX_COMPILER_LAUNCHER=/opt/homebrew/bin/ccache
CCACHE_DIR=<temp STIM_HOME>/ccache
CCACHE_BASEDIR=/Users/janicduplessis/Developer/trailhead-worktrees/ccache-a
CCACHE_NOHASHDIR=true
CCACHE_SLOPPINESS=pch_defines,time_macros
CCACHE_MAXSIZE=5G
CCACHE_STATSLOG=<temp STIM_HOME>/workspaces/ccache-a--68830000f168da8d/logs/ccache-stats.log
```

`BUILD SUCCESSFUL in 55s`. `ccache -s`: 380 cacheable calls, 10 hits / 370 misses,
0.2 GB. The stats-log parser read the same numbers: `10 hits / 370 misses (2.6%)`.
One configure was enough to persist the launcher into all seven library modules --
e.g. `node_modules/react-native-reanimated/android/.cxx/Debug/b4a3sy2o/arm64-v8a/CMakeCache.txt`
carries `CMAKE_CXX_COMPILER_LAUNCHER:STRING=/opt/homebrew/bin/ccache`.

**Consumer** (`ccache-b`, a different absolute path, its own `.cxx`, same warm
cache; `--profile` added to this run only, to read per-task times). 35s wall.
`ccache -s` went 380 -> 760 cacheable calls and 10 -> 186 hits, i.e. 176 hits and
204 misses for this build -- which is exactly what the parser reported and what
`--json` carried:

```
{"status":"reported","hits":176,"misses":204,"hitRatePercent":46.3}
```

Per-task, the six modules that hit collapse to a second or so; the three
`target_precompile_headers` modules are the misses:

```
:react-native-gesture-handler:buildCMakeDebug[arm64-v8a]         0.442s
:react-native-screens:buildCMakeDebug[arm64-v8a]                 0.467s
:react-native-nitro-modules:buildCMakeDebug[arm64-v8a]           0.674s
:react-native-mmkv:buildCMakeDebug[arm64-v8a]                    0.721s
:shopify_react-native-skia:buildCMakeDebug[arm64-v8a]            1.190s
:app:buildCMakeDebug[arm64-v8a]                                  1.348s
:react-native-worklets:buildCMakeDebug[arm64-v8a][worklets]      5.256s
:expo-modules-core:buildCMakeDebug[arm64-v8a]                   10.637s
:react-native-reanimated:buildCMakeDebug[arm64-v8a][reanimated] 17.690s
```

That 176/204 split matches the 176-of-380 the issue predicted, and the misses in
this run are the three `target_precompile_headers` modules (each worktree got its
own `npm ci`, so every PCH input had a new mtime).

**End to end with the built CLI** in `ccache-b` (temporary `STIM_HOME`, owned
emulator created, then shut down and deleted):

```
$ stim start && stim android --json
  build       compiling debug with Gradle
  cache       ccache on (<temp STIM_HOME>/ccache)
  cache       gradle build cache on (--build-cache, shared under the Gradle user home)
  build       ok (17.6s)
  launch      com.appandflow.trailhead (375ms)
...,"ccache":{"status":"reported","hits":0,"misses":2,"hitRatePercent":0},...

$ stim android                 # second run, artifact cache hit
  cache       cache hit
  compilation cache not run; artifact cache supplied the app

$ stim gc
        350M  ccache (registered)
              ccache keeps itself under CCACHE_MAXSIZE, so it is emptied whole or not at all
```

`stim logs --errors` was clean and `stim stop` shut the emulator down. 350 MB for
one arm64 Debug worktree pair matches the size the issue measured, PCH duplicates
included. Both trailhead worktrees were removed afterwards.

`doctor` on a real project, with and without `/opt/homebrew/bin` on PATH:

```
$ PATH=/usr/bin:/bin:/usr/sbin:/sbin stim doctor --platform android
costs time  ccache is not on PATH, so Android C++ recompiles in every worktree
  -> brew install ccache, then delete android/app/.cxx and
     node_modules/**/android/.cxx once so CMake reconfigures with the launcher. ...

$ stim doctor --platform android          # ccache on PATH, and in ccache-a after the build
(no ccache finding)
```

### Suites

`pnpm run format:check`, `lint`, `build`, `typecheck`, `knip` clean;
`NODE_OPTIONS=--use-openssl-ca pnpm test` 3642 tests across 98 files;
`pnpm run test:e2e` 24/24. New coverage in `engine-ccache.test.ts` (exact variable
set, absolute-path locator, project-launcher gate, and the stats-log parser
against a fixture captured from real ccache 4.12.3 output), plus the environment
reaching the Gradle child in `engine-gradle.test.ts` -- including that without
ccache the argv and environment are byte-identical to before -- and the facts,
doctor and guide contracts.

Fixes #398


