### PR TITLE
docs: align error headings with emitted messages

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -257,6 +257,8 @@ test('the errors topic quotes the shared config-lock timeout message', () => {
   expect(src).toContain('`Timed out waiting for the lock at ${lockPath}. `');
   const config = readFileSync(new URL('../config.ts', import.meta.url), 'utf-8');
   expect(config).toContain('withDirLock(lockPath(), fn');
+  const wrapper = readFileSync(new URL('../dir-lock.ts', import.meta.url), 'utf-8');
+  expect(wrapper).toContain("export { withDirLock } from '@stim-cli/core'");
 });
 
 test('the errors topic quotes the carry lines exactly as worktree create writes them', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -241,6 +241,24 @@ test('the errors topic quotes the stop refusals in the column stop actually prin
   expect(src).toContain("phaseLine('stop', `refusing to signal supervisor pid ${target.pid}");
 });
 
+test('the errors topic quotes the teardown failure reason that reclaim reports', () => {
+  const body = renderSection('errors', 'teardown');
+  assert(body);
+  expect(body).toContain('"teardown failed: <reason>"');
+  const src = readFileSync(new URL('../reclaim.ts', import.meta.url), 'utf-8');
+  expect(src).toContain('reason: `teardown failed: ${r.reason}`');
+});
+
+test('the errors topic quotes the shared config-lock timeout message', () => {
+  const body = renderSection('errors', 'STIM_LOCK_TIMEOUT');
+  assert(body);
+  expect(body).toContain('"Timed out waiting for the lock at <path>."');
+  const src = readFileSync(new URL('../../../core/index.ts', import.meta.url), 'utf-8');
+  expect(src).toContain('`Timed out waiting for the lock at ${lockPath}. `');
+  const config = readFileSync(new URL('../config.ts', import.meta.url), 'utf-8');
+  expect(config).toContain('withDirLock(lockPath(), fn');
+});
+
 test('the errors topic quotes the carry lines exactly as worktree create writes them', () => {
   const body = renderSection('errors', 'carry');
   assert(body);

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -731,10 +731,10 @@ captured"  (in metro.ndjson, bare RN)
   EAS project locks. A lock whose owner died is taken over automatically (pid
   liveness is checked every poll), so this means another Stim command really
   is working on this workspace: wait for it and retry. If nothing is running,
-  the message names the lock directory and removing it is safe. This is not
-  the config lock, which reports the message below.
+  the message names the lock directory and removing it is safe. The same code
+  also covers the config-lock timeout below.
 
-"Timed out waiting for the Stim config lock at <path>"
+"Timed out waiting for the lock at <path>."
   Every config write is serialised so parallel commands cannot lose each
   other's records. A lock older than 10s is taken over automatically, so this
   means a command really is holding it. If none is running, remove that
@@ -762,10 +762,10 @@ captured"  (in metro.ndjson, bare RN)
   reserved. Re-run \`stop\`, or signal it yourself: kill -9 -<n> (note the
   minus -- it is a process group).
 
-"Could not tear down the <platform> device: ..."
-  The delete failed, so the ASSIGNMENT was kept and the command exited 1. That
-  is deliberate: dropping the record would leave a device on the machine that
-  nothing references and nothing will ever reap. Fix the cause and re-run.`,
+"teardown failed: <reason>"
+  Stim could not release the owned device and keeps its record for a retry.
+  \`worktree remove\` refuses to remove the worktree while the device is still
+  tracked. Fix the reported cause and re-run.`,
     },
     remove: {
       summary: 'worktree remove refused a dirty tree: what it restores itself and what --force discards',

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -724,21 +724,21 @@ captured"  (in metro.ndjson, bare RN)
   STIM_WORKTREE_REMOVAL_IN_PROGRESS instead.`,
     },
     STIM_LOCK_TIMEOUT: {
-      summary: 'a lock held by a live command past the wait; the config-lock timeout',
+      summary: 'a lock held past the wait; workspace-process and short directory locks',
       body: () => `STIM_LOCK_TIMEOUT
   The same locks, held by an ordinary command that is still running, for
   longer than the wait -- 60s by default, 4 minutes for the remote-session and
   EAS project locks. A lock whose owner died is taken over automatically (pid
   liveness is checked every poll), so this means another Stim command really
   is working on this workspace: wait for it and retry. If nothing is running,
-  the message names the lock directory and removing it is safe. The same code
-  also covers the config-lock timeout below.
+  the message names the lock directory and removing it is safe. The same error
+  code also covers the short directory-lock timeout below.
 
 "Timed out waiting for the lock at <path>."
-  Every config write is serialised so parallel commands cannot lose each
-  other's records. A lock older than 10s is taken over automatically, so this
-  means a command really is holding it. If none is running, remove that
-  directory.`,
+  Short directory locks serialize writes to config, workspace state, device
+  leases, ownership records, metadata, and cache manifests. The path identifies
+  the lock. A lock older than 10s is taken over automatically. Wait for the
+  command holding it; if none is running, remove the named directory.`,
     },
     teardown: {
       summary: 'stop refusing to kill a port or signal a supervisor, and a failed device teardown',
@@ -764,8 +764,8 @@ captured"  (in metro.ndjson, bare RN)
 
 "teardown failed: <reason>"
   Stim could not release the owned device and keeps its record for a retry.
-  \`worktree remove\` refuses to remove the worktree while the device is still
-  tracked. Fix the reported cause and re-run.`,
+  \`worktree remove\` exits 1 without removing the worktree while the device is
+  still tracked. Fix the reported cause and re-run.`,
     },
     remove: {
       summary: 'worktree remove refused a dirty tree: what it restores itself and what --force discards',


### PR DESCRIPTION
## Description

Two headings in the errors guide quote messages that Stim never prints, making them impossible to match to a reported failure.

## Solution

Use the actual config-lock timeout and teardown failure messages. Clarify which shared locks report `STIM_LOCK_TIMEOUT` and that failed device cleanup keeps the record for a retry.

Depends on #408.

## Test plan

Both new guide contracts fail on the old headings and pass with this change. They check the rendered headings against the source strings in the shared lock implementation and device reclamation code; all 111 guide contracts pass.

Fixes #407


