### PR TITLE
fix: scope native e2e cleanup to each run

### DIFF
--- a/test/e2e/native-cleanup.e2e.js
+++ b/test/e2e/native-cleanup.e2e.js
@@ -3,9 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
-import { createCleanupTracker, verifyCleanup, workspaceLogsDir } from './native/harness.mjs';
+import { createCleanupTracker, createHarness, verifyCleanup, workspaceLogsDir } from './native/harness.mjs';
 
-function fixture(t, platform = 'ios') {
+function fixture(t, platform = 'ios', processExitTimeoutMs = 0) {
   const home = mkdtempSync(join(tmpdir(), 'stim-native-cleanup-'));
   const previousHome = process.env.STIM_HOME;
   process.env.STIM_HOME = home;
@@ -16,16 +16,33 @@ function fixture(t, platform = 'ios') {
   });
   const cwd = join(home, 'worktree');
   const stateFile = join(workspaceLogsDir(cwd), '..', 'state.json');
-  const output = { devices: [], avds: [], processes: '', status: '', porcelain: '', worktrees: '', gc: '' };
+  const output = {
+    devices: [],
+    avds: [],
+    processes: '',
+    status: '',
+    porcelain: '',
+    worktrees: '',
+    gc: '',
+    failure: null,
+    processReads: 0,
+  };
   const h = {
+    env: { STIM_HOME: home },
     banner() {},
     log() {},
-    sh(file, argv) {
+    sh(file, argv, options) {
+      if (file === output.failure) {
+        assert.equal(options.allowFail, true);
+        return { code: 1, stdout: '', stderr: 'fixture inspection failed' };
+      }
       let stdout;
       if (file === 'xcrun') stdout = JSON.stringify({ devices: { runtime: output.devices } });
       else if (file === 'emulator') stdout = output.avds.join('\n');
-      else if (file === 'ps') stdout = output.processes;
-      else if (file === 'git' && argv.includes('status')) stdout = output.porcelain;
+      else if (file === 'ps') {
+        output.processReads++;
+        stdout = output.processes;
+      } else if (file === 'git' && argv.includes('status')) stdout = output.porcelain;
       else if (file === 'git' && argv.includes('worktree')) stdout = output.worktrees;
       else assert.fail(`unexpected command: ${file} ${argv.join(' ')}`);
       return { code: 0, stdout, stderr: '' };
@@ -34,10 +51,11 @@ function fixture(t, platform = 'ios') {
       return { code: 0, stdout: argv[0] === 'status' ? output.status : output.gc, stderr: '' };
     },
   };
-  const cleanup = createCleanupTracker({ h, platform });
+  const cleanup = createCleanupTracker({ h, platform, processExitTimeoutMs });
   return {
     cwd,
     stateFile,
+    configFile: join(home, 'config.json'),
     output,
     cleanup,
     writeState(state) {
@@ -45,38 +63,78 @@ function fixture(t, platform = 'ios') {
       writeFileSync(stateFile, JSON.stringify(state));
     },
     verify() {
-      verifyCleanup({ h, cleanup, appDir: join(home, 'app'), created: [cwd] });
+      return verifyCleanup({ h, cleanup, appDir: join(home, 'app'), created: [cwd] });
     },
   };
 }
 
 for (const platform of ['ios', 'android']) {
-  test(`native cleanup ignores unrelated ${platform} devices and supervisors`, (t) => {
+  test(`native cleanup ignores unrelated ${platform} devices and supervisors`, async (t) => {
     const f = fixture(t, platform);
     f.cleanup.recordBuild({ udid: 'RUN-UDID', avdName: 'stim-this-run' });
     f.output.devices = [{ udid: 'OTHER-UDID', name: 'stim-this-run', state: 'Booted' }];
     f.output.avds = ['stim-this-run-unrelated', 'personal-avd'];
     f.output.processes = ' 123 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /another/worktree';
-    f.verify();
+    await f.verify();
   });
 
-  test(`native cleanup still detects this run's leaked ${platform} device after state removal`, (t) => {
+  test(`native cleanup still detects this run's leaked ${platform} device after state removal`, async (t) => {
     const f = fixture(t, platform);
     f.cleanup.recordBuild({ udid: 'RUN-UDID', avdName: 'stim-this-run' });
     f.writeState({});
     rmSync(f.stateFile);
     f.output.devices = [{ udid: 'RUN-UDID', name: 'stim-parked', state: 'Shutdown' }];
     f.output.avds = ['stim-this-run'];
-    assert.throws(() => f.verify(), /a device from this run was left behind/);
+    await assert.rejects(() => f.verify(), /a device from this run was left behind/);
   });
 
-  test(`native cleanup requires ${platform} build identity`, (t) => {
+  test(`native cleanup requires ${platform} build identity`, async (t) => {
     const f = fixture(t, platform);
     assert.throws(() => f.cleanup.recordBuild({}), /build did not identify its device/);
   });
+
+  test(`native cleanup retains a failed build's registered ${platform} device`, async (t) => {
+    const f = fixture(t, platform);
+    writeFileSync(
+      f.configFile,
+      JSON.stringify({
+        projects: {
+          [f.cwd]: { platforms: { [platform]: { owned: true, deviceUdid: 'RUN', avdName: 'stim-run' } } },
+          '/another/worktree': {
+            platforms: { [platform]: { owned: true, deviceUdid: 'OTHER', avdName: 'stim-other' } },
+          },
+        },
+      }),
+    );
+    f.cleanup.recordWorkspace(f.cwd);
+    rmSync(f.configFile);
+    f.cleanup.recordWorkspace(f.cwd);
+    f.output.devices = [{ udid: 'RUN', name: 'stim-parked' }];
+    f.output.avds = ['stim-run'];
+    await assert.rejects(() => f.verify(), /a device from this run was left behind/);
+    f.output.devices = [{ udid: 'OTHER', name: 'stim-other' }];
+    f.output.avds = ['stim-other'];
+    await f.verify();
+  });
+
+  test(`native cleanup does not claim an unowned registered ${platform} device`, async (t) => {
+    const f = fixture(t, platform);
+    writeFileSync(
+      f.configFile,
+      JSON.stringify({
+        projects: {
+          [f.cwd]: { platforms: { [platform]: { owned: false, deviceUdid: 'OTHER', avdName: 'personal-avd' } } },
+        },
+      }),
+    );
+    f.cleanup.recordWorkspace(f.cwd);
+    f.output.devices = [{ udid: 'OTHER', name: 'personal simulator' }];
+    f.output.avds = ['personal-avd'];
+    await f.verify();
+  });
 }
 
-test('pool counts tracked UDIDs across rename, eviction and adoption', (t) => {
+test('pool counts tracked UDIDs across rename, eviction and adoption', async (t) => {
   const f = fixture(t);
   f.cleanup.recordBuild({ udid: 'FIRST' });
   f.cleanup.recordBuild({ udid: 'SECOND' });
@@ -91,13 +149,13 @@ test('pool counts tracked UDIDs across rename, eviction and adoption', (t) => {
   f.output.devices[0].name = 'stim-pool-3';
   assert.deepEqual(f.cleanup.remainingDevices(), ['SECOND']);
   f.output.devices.shift();
-  f.verify();
+  await f.verify();
 });
 
-test('native cleanup ignores unrelated supervisors when this run has no live processes', (t) => {
+test('native cleanup ignores unrelated supervisors when this run has no live processes', async (t) => {
   const f = fixture(t);
   f.output.processes = ' 987 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /unrelated';
-  f.verify();
+  await f.verify();
 });
 
 for (const [kind, state] of [
@@ -105,65 +163,118 @@ for (const [kind, state] of [
   ['Metro child', { supervisor: { serverPid: 123, startedAt: '2026-09-05T01:00:00Z' } }],
   ['collector', { collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } }],
 ]) {
-  test(`native cleanup detects a leaked ${kind} after its state record disappears`, (t) => {
+  test(`native cleanup detects a leaked ${kind} after its state record disappears`, async (t) => {
     const f = fixture(t);
     f.writeState(state);
     f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node stim-cli ${kind} --root ${f.cwd}`;
-    f.cleanup.recordProcesses(f.cwd);
+    f.cleanup.recordWorkspace(f.cwd);
     rmSync(f.stateFile);
-    f.cleanup.recordProcesses(f.cwd);
-    assert.throws(() => f.verify(), /a workspace process is still running/);
+    f.cleanup.recordWorkspace(f.cwd);
+    await assert.rejects(() => f.verify(), /a workspace process is still running/);
     f.output.processes = ' 987 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /unrelated';
-    f.verify();
+    await f.verify();
   });
 
-  test(`native cleanup does not recapture a reused ${kind} PID from stale state`, (t) => {
+  test(`native cleanup does not recapture a reused ${kind} PID from stale state`, async (t) => {
     const f = fixture(t);
     f.writeState(state);
     f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node stim-cli ${kind} --root ${f.cwd}`;
-    f.cleanup.recordProcesses(f.cwd);
+    f.cleanup.recordWorkspace(f.cwd);
     f.output.processes = ' 123 Sat Sep 5 02:00:00 2026 node stim-cli supervisor --root /unrelated';
-    f.cleanup.recordProcesses(f.cwd);
-    f.verify();
+    f.cleanup.recordWorkspace(f.cwd);
+    await f.verify();
   });
 }
 
-test('native cleanup does not hide unreadable workspace state', (t) => {
+test('native cleanup does not hide unreadable workspace state', async (t) => {
   const f = fixture(t);
   f.writeState({});
   writeFileSync(f.stateFile, '{');
-  assert.throws(() => f.cleanup.recordProcesses(f.cwd), SyntaxError);
+  assert.throws(() => f.cleanup.recordWorkspace(f.cwd), SyntaxError);
 });
 
-test('native cleanup retains replaced collectors and ignores a reused PID', (t) => {
+test('native cleanup retains replaced collectors and ignores a reused PID', async (t) => {
   const f = fixture(t);
   const first = ` 123 Sat Sep 5 01:00:00 2026 node collector --root ${f.cwd}`;
   const second = ` 456 Sat Sep 5 01:01:00 2026 node collector --root ${f.cwd}`;
   f.writeState({ collectors: { android: { pid: 123 } } });
   f.output.processes = first;
-  f.cleanup.recordProcesses(f.cwd);
+  f.cleanup.recordWorkspace(f.cwd);
   f.writeState({ collectors: { android: { pid: 456 } } });
   f.output.processes = `${first}\n${second}`;
-  f.cleanup.recordProcesses(f.cwd);
+  f.cleanup.recordWorkspace(f.cwd);
   f.output.processes = first;
-  assert.throws(() => f.verify(), /a workspace process is still running/);
+  await assert.rejects(() => f.verify(), /a workspace process is still running/);
   f.output.processes = first.replace('01:00:00', '02:00:00');
-  f.verify();
+  await f.verify();
 });
 
-test('native cleanup tracks a new registration even when it recycles a captured PID', (t) => {
+test('native cleanup tracks a new registration even when it recycles a captured PID', async (t) => {
   const f = fixture(t);
   f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } });
   f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node collector --root ${f.cwd}`;
-  f.cleanup.recordProcesses(f.cwd);
+  f.cleanup.recordWorkspace(f.cwd);
   f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T02:00:00Z' } } });
   f.output.processes = ` 123 Sat Sep 5 02:00:00 2026 node collector --root ${f.cwd}`;
-  f.cleanup.recordProcesses(f.cwd);
+  f.cleanup.recordWorkspace(f.cwd);
   rmSync(f.stateFile);
-  assert.throws(() => f.verify(), /a workspace process is still running/);
+  await assert.rejects(() => f.verify(), /a workspace process is still running/);
 });
 
-test('native cleanup preserves registry, checkout, worktree and GC checks', (t) => {
+test('native cleanup does not adopt a reused PID missing from its first snapshot', async (t) => {
+  const f = fixture(t);
+  f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } });
+  f.cleanup.recordWorkspace(f.cwd);
+  f.output.processes = ' 123 Sat Sep 5 02:00:00 2026 node stim-cli supervisor --root /unrelated';
+  f.cleanup.recordWorkspace(f.cwd);
+  await f.verify();
+});
+
+test('native cleanup waits for a signalled collector to exit', async (t) => {
+  const f = fixture(t, 'ios', 200);
+  f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } });
+  f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node collector --root ${f.cwd}`;
+  f.cleanup.recordWorkspace(f.cwd);
+  const timer = setTimeout(() => {
+    f.output.processes = '';
+  }, 10);
+  t.after(() => clearTimeout(timer));
+  await f.verify();
+  assert.ok(f.output.processReads >= 3);
+});
+
+test('native cleanup still fails a process that survives the settle window', async (t) => {
+  const f = fixture(t, 'ios', 20);
+  f.writeState({ supervisor: { serverPid: 123, startedAt: '2026-09-05T01:00:00Z' } });
+  f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node expo --root ${f.cwd}`;
+  f.cleanup.recordWorkspace(f.cwd);
+  await assert.rejects(() => f.verify(), /a workspace process is still running/);
+  assert.ok(f.output.processReads >= 3);
+});
+
+for (const [platform, tool] of [
+  ['ios', 'xcrun'],
+  ['android', 'emulator'],
+  ['ios', 'ps'],
+]) {
+  test(`native cleanup throws when ${tool} inspection fails`, async (t) => {
+    const f = fixture(t, platform);
+    f.output.failure = tool;
+    await assert.rejects(() => f.verify(), new RegExp(`could not inspect ${tool}: fixture inspection failed`));
+  });
+}
+
+test('missing executables remain inspection failures with allowFail enabled', async () => {
+  const h = createHarness({ env: { ...process.env, PATH: '' }, cliPath: '/unused', label: 'missing-inspection' });
+  const result = h.sh('stim-native-cleanup-unavailable-tool', [], { allowFail: true });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /ENOENT/);
+  const cleanup = createCleanupTracker({ h, platform: 'android', processExitTimeoutMs: 0 });
+  assert.throws(() => cleanup.remainingDevices(), /could not inspect emulator:.*ENOENT/);
+  await assert.rejects(() => cleanup.verifyProcesses(), /could not inspect ps:.*ENOENT/);
+});
+
+test('native cleanup preserves registry, checkout, worktree and GC checks', async (t) => {
   const f = fixture(t);
   for (const [field, text, message] of [
     ['status', f.cwd, /status still lists a removed workspace/],
@@ -172,8 +283,8 @@ test('native cleanup preserves registry, checkout, worktree and GC checks', (t) 
     ['gc', f.cwd, /gc reports one of our workspaces as orphaned/],
   ]) {
     f.output[field] = text;
-    assert.throws(() => f.verify(), message);
+    await assert.rejects(() => f.verify(), message);
     f.output[field] = '';
   }
-  f.verify();
+  await f.verify();
 });

--- a/test/e2e/native-cleanup.e2e.js
+++ b/test/e2e/native-cleanup.e2e.js
@@ -101,9 +101,9 @@ test('native cleanup ignores unrelated supervisors when this run has no live pro
 });
 
 for (const [kind, state] of [
-  ['supervisor', { supervisor: { pid: 123 } }],
-  ['Metro child', { supervisor: { serverPid: 123 } }],
-  ['collector', { collectors: { ios: { pid: 123 } } }],
+  ['supervisor', { supervisor: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } }],
+  ['Metro child', { supervisor: { serverPid: 123, startedAt: '2026-09-05T01:00:00Z' } }],
+  ['collector', { collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } }],
 ]) {
   test(`native cleanup detects a leaked ${kind} after its state record disappears`, (t) => {
     const f = fixture(t);
@@ -114,6 +114,16 @@ for (const [kind, state] of [
     f.cleanup.recordProcesses(f.cwd);
     assert.throws(() => f.verify(), /a workspace process is still running/);
     f.output.processes = ' 987 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /unrelated';
+    f.verify();
+  });
+
+  test(`native cleanup does not recapture a reused ${kind} PID from stale state`, (t) => {
+    const f = fixture(t);
+    f.writeState(state);
+    f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node stim-cli ${kind} --root ${f.cwd}`;
+    f.cleanup.recordProcesses(f.cwd);
+    f.output.processes = ' 123 Sat Sep 5 02:00:00 2026 node stim-cli supervisor --root /unrelated';
+    f.cleanup.recordProcesses(f.cwd);
     f.verify();
   });
 }
@@ -139,6 +149,18 @@ test('native cleanup retains replaced collectors and ignores a reused PID', (t) 
   assert.throws(() => f.verify(), /a workspace process is still running/);
   f.output.processes = first.replace('01:00:00', '02:00:00');
   f.verify();
+});
+
+test('native cleanup tracks a new registration even when it recycles a captured PID', (t) => {
+  const f = fixture(t);
+  f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T01:00:00Z' } } });
+  f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node collector --root ${f.cwd}`;
+  f.cleanup.recordProcesses(f.cwd);
+  f.writeState({ collectors: { ios: { pid: 123, startedAt: '2026-09-05T02:00:00Z' } } });
+  f.output.processes = ` 123 Sat Sep 5 02:00:00 2026 node collector --root ${f.cwd}`;
+  f.cleanup.recordProcesses(f.cwd);
+  rmSync(f.stateFile);
+  assert.throws(() => f.verify(), /a workspace process is still running/);
 });
 
 test('native cleanup preserves registry, checkout, worktree and GC checks', (t) => {

--- a/test/e2e/native-cleanup.e2e.js
+++ b/test/e2e/native-cleanup.e2e.js
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { createCleanupTracker, verifyCleanup, workspaceLogsDir } from './native/harness.mjs';
+
+function fixture(t, platform = 'ios') {
+  const home = mkdtempSync(join(tmpdir(), 'stim-native-cleanup-'));
+  const previousHome = process.env.STIM_HOME;
+  process.env.STIM_HOME = home;
+  t.after(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (previousHome === undefined) delete process.env.STIM_HOME;
+    else process.env.STIM_HOME = previousHome;
+  });
+  const cwd = join(home, 'worktree');
+  const stateFile = join(workspaceLogsDir(cwd), '..', 'state.json');
+  const output = { devices: [], avds: [], processes: '', status: '', porcelain: '', worktrees: '', gc: '' };
+  const h = {
+    banner() {},
+    log() {},
+    sh(file, argv) {
+      let stdout;
+      if (file === 'xcrun') stdout = JSON.stringify({ devices: { runtime: output.devices } });
+      else if (file === 'emulator') stdout = output.avds.join('\n');
+      else if (file === 'ps') stdout = output.processes;
+      else if (file === 'git' && argv.includes('status')) stdout = output.porcelain;
+      else if (file === 'git' && argv.includes('worktree')) stdout = output.worktrees;
+      else assert.fail(`unexpected command: ${file} ${argv.join(' ')}`);
+      return { code: 0, stdout, stderr: '' };
+    },
+    cli(argv) {
+      return { code: 0, stdout: argv[0] === 'status' ? output.status : output.gc, stderr: '' };
+    },
+  };
+  const cleanup = createCleanupTracker({ h, platform });
+  return {
+    cwd,
+    stateFile,
+    output,
+    cleanup,
+    writeState(state) {
+      mkdirSync(dirname(stateFile), { recursive: true });
+      writeFileSync(stateFile, JSON.stringify(state));
+    },
+    verify() {
+      verifyCleanup({ h, cleanup, appDir: join(home, 'app'), created: [cwd] });
+    },
+  };
+}
+
+for (const platform of ['ios', 'android']) {
+  test(`native cleanup ignores unrelated ${platform} devices and supervisors`, (t) => {
+    const f = fixture(t, platform);
+    f.cleanup.recordBuild({ udid: 'RUN-UDID', avdName: 'stim-this-run' });
+    f.output.devices = [{ udid: 'OTHER-UDID', name: 'stim-this-run', state: 'Booted' }];
+    f.output.avds = ['stim-this-run-unrelated', 'personal-avd'];
+    f.output.processes = ' 123 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /another/worktree';
+    f.verify();
+  });
+
+  test(`native cleanup still detects this run's leaked ${platform} device after state removal`, (t) => {
+    const f = fixture(t, platform);
+    f.cleanup.recordBuild({ udid: 'RUN-UDID', avdName: 'stim-this-run' });
+    f.writeState({});
+    rmSync(f.stateFile);
+    f.output.devices = [{ udid: 'RUN-UDID', name: 'stim-parked', state: 'Shutdown' }];
+    f.output.avds = ['stim-this-run'];
+    assert.throws(() => f.verify(), /a device from this run was left behind/);
+  });
+
+  test(`native cleanup requires ${platform} build identity`, (t) => {
+    const f = fixture(t, platform);
+    assert.throws(() => f.cleanup.recordBuild({}), /build did not identify its device/);
+  });
+}
+
+test('pool counts tracked UDIDs across rename, eviction and adoption', (t) => {
+  const f = fixture(t);
+  f.cleanup.recordBuild({ udid: 'FIRST' });
+  f.cleanup.recordBuild({ udid: 'SECOND' });
+  f.output.devices = [
+    { udid: 'FIRST', name: 'stim-parked' },
+    { udid: 'SECOND', name: 'stim-pool-2' },
+    { udid: 'UNRELATED', name: 'stim-other' },
+  ];
+  assert.deepEqual(f.cleanup.remainingDevices(), ['FIRST', 'SECOND']);
+  f.output.devices.shift();
+  f.cleanup.recordBuild({ udid: 'SECOND' });
+  f.output.devices[0].name = 'stim-pool-3';
+  assert.deepEqual(f.cleanup.remainingDevices(), ['SECOND']);
+  f.output.devices.shift();
+  f.verify();
+});
+
+test('native cleanup ignores unrelated supervisors when this run has no live processes', (t) => {
+  const f = fixture(t);
+  f.output.processes = ' 987 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /unrelated';
+  f.verify();
+});
+
+for (const [kind, state] of [
+  ['supervisor', { supervisor: { pid: 123 } }],
+  ['Metro child', { supervisor: { serverPid: 123 } }],
+  ['collector', { collectors: { ios: { pid: 123 } } }],
+]) {
+  test(`native cleanup detects a leaked ${kind} after its state record disappears`, (t) => {
+    const f = fixture(t);
+    f.writeState(state);
+    f.output.processes = ` 123 Sat Sep 5 01:00:00 2026 node stim-cli ${kind} --root ${f.cwd}`;
+    f.cleanup.recordProcesses(f.cwd);
+    rmSync(f.stateFile);
+    f.cleanup.recordProcesses(f.cwd);
+    assert.throws(() => f.verify(), /a workspace process is still running/);
+    f.output.processes = ' 987 Sat Sep 5 01:00:00 2026 node stim-cli supervisor --root /unrelated';
+    f.verify();
+  });
+}
+
+test('native cleanup does not hide unreadable workspace state', (t) => {
+  const f = fixture(t);
+  f.writeState({});
+  writeFileSync(f.stateFile, '{');
+  assert.throws(() => f.cleanup.recordProcesses(f.cwd), SyntaxError);
+});
+
+test('native cleanup retains replaced collectors and ignores a reused PID', (t) => {
+  const f = fixture(t);
+  const first = ` 123 Sat Sep 5 01:00:00 2026 node collector --root ${f.cwd}`;
+  const second = ` 456 Sat Sep 5 01:01:00 2026 node collector --root ${f.cwd}`;
+  f.writeState({ collectors: { android: { pid: 123 } } });
+  f.output.processes = first;
+  f.cleanup.recordProcesses(f.cwd);
+  f.writeState({ collectors: { android: { pid: 456 } } });
+  f.output.processes = `${first}\n${second}`;
+  f.cleanup.recordProcesses(f.cwd);
+  f.output.processes = first;
+  assert.throws(() => f.verify(), /a workspace process is still running/);
+  f.output.processes = first.replace('01:00:00', '02:00:00');
+  f.verify();
+});
+
+test('native cleanup preserves registry, checkout, worktree and GC checks', (t) => {
+  const f = fixture(t);
+  for (const [field, text, message] of [
+    ['status', f.cwd, /status still lists a removed workspace/],
+    ['porcelain', ' M tracked-file', /main checkout is dirty/],
+    ['worktrees', `worktree ${f.cwd}\n`, /a worktree registration survived/],
+    ['gc', f.cwd, /gc reports one of our workspaces as orphaned/],
+  ]) {
+    f.output[field] = text;
+    assert.throws(() => f.verify(), message);
+    f.output[field] = '';
+  }
+  f.verify();
+});

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -183,21 +183,76 @@ export function ensureGitignore({ appDir, framework }) {
   }
 }
 
-export function verifyCleanup({ h, platform, appDir, created }) {
+export function createCleanupTracker({ h, platform }) {
+  const devices = new Set();
+  const processes = new Set();
+
+  function recordBuild(facts) {
+    const id = platform === 'ios' ? facts.udid : facts.avdName;
+    assert(typeof id === 'string' && id.length > 0, `the ${platform} build did not identify its device`);
+    devices.add(id);
+  }
+
+  function recordProcesses(cwd) {
+    let state;
+    try {
+      state = JSON.parse(readFileSync(join(workspaceLogsDir(cwd), '..', 'state.json'), 'utf-8'));
+    } catch (error) {
+      if (error.code === 'ENOENT') return;
+      throw error;
+    }
+    const pids = new Set([
+      state.supervisor?.pid,
+      state.supervisor?.serverPid,
+      ...Object.values(state.collectors ?? {}).map((record) => record.pid),
+    ]);
+    for (const [pid, identity] of processSnapshot(h)) {
+      if (pids.has(pid)) processes.add(identity);
+    }
+  }
+
+  function remainingDevices() {
+    const ids =
+      platform === 'ios'
+        ? Object.values(JSON.parse(h.sh('xcrun', ['simctl', 'list', 'devices', '--json']).stdout).devices)
+            .flat()
+            .map((device) => device.udid)
+        : h
+            .sh('emulator', ['-list-avds'])
+            .stdout.split('\n')
+            .map((name) => name.trim());
+    return ids.filter((id) => devices.has(id));
+  }
+
+  function verifyProcesses() {
+    const live = new Set(processSnapshot(h).values());
+    const leaked = [...processes].filter((identity) => live.has(identity));
+    assert(leaked.length === 0, `a workspace process is still running:\n${leaked.join('\n')}`);
+  }
+
+  return { recordBuild, recordProcesses, remainingDevices, verifyProcesses };
+}
+
+function processSnapshot(h) {
+  const out = h.sh('ps', ['-ax', '-o', 'pid=,lstart=,command=']).stdout;
+  return new Map(
+    out
+      .split('\n')
+      .map((line) => /^\s*(\d+)\s+(.+)$/.exec(line))
+      .filter(Boolean)
+      .map((match) => [Number(match[1]), match[0].trim()]),
+  );
+}
+
+export function verifyCleanup({ h, cleanup, appDir, created }) {
   h.banner('cleanup checks');
 
-  if (platform === 'ios') {
-    const out = h.sh('xcrun', ['simctl', 'list', 'devices']).stdout;
-    assert(!/stim-/.test(out), 'an stim-* simulator was left behind');
-  } else {
-    const out = h.sh('emulator', ['-list-avds'], { allowFail: true }).stdout;
-    assert(!/stim-/.test(out), 'an stim-* AVD was left behind');
-  }
-  h.log('(1) no stim-* devices remain');
+  const devices = cleanup.remainingDevices();
+  assert(devices.length === 0, `a device from this run was left behind: ${devices.join(', ')}`);
+  h.log('(1) no devices from this run remain');
 
-  const ps = h.sh('ps', ['ax'], { allowFail: true }).stdout;
-  assert(!/stim-cli.*supervisor|supervisor\/run\.js/.test(ps), 'a supervisor process is still running');
-  h.log('(2) no supervisor/collector processes');
+  cleanup.verifyProcesses();
+  h.log('(2) no workspace supervisor/Metro/collector processes remain');
 
   const status = h.cli(['status'], { allowFail: true }).stdout;
   assert(!created.some((p) => status.includes(p)), 'status still lists a removed workspace');

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 export function createHarness({ env, cliPath, label }) {
   const log = (msg) => process.stderr.write(`[${label}] ${msg}\n`);
@@ -20,10 +21,10 @@ export function createHarness({ env, cliPath, label }) {
       maxBuffer: 64 * 1024 * 1024,
     });
     const stdout = r.stdout || '';
-    const stderr = r.stderr || '';
+    const stderr = r.stderr || r.error?.message || '';
     if (stderr) process.stderr.write(stderr);
     if (r.error && !opts.allowFail) die(`${file} ${argv.join(' ')} could not run: ${r.error.message}`);
-    const code = r.status ?? (r.signal ? 1 : 0);
+    const code = r.status ?? (r.signal || r.error ? 1 : 0);
     if (code !== 0 && !opts.allowFail)
       die(`${file} ${argv.slice(0, 3).join(' ')} exited ${code}:\n${lastLines(stderr, 40)}`);
     return { code, stdout, stderr };
@@ -183,7 +184,7 @@ export function ensureGitignore({ appDir, framework }) {
   }
 }
 
-export function createCleanupTracker({ h, platform }) {
+export function createCleanupTracker({ h, platform, processExitTimeoutMs = 5000 }) {
   const devices = new Set();
   const processes = new Map();
 
@@ -193,7 +194,16 @@ export function createCleanupTracker({ h, platform }) {
     devices.add(id);
   }
 
-  function recordProcesses(cwd) {
+  function recordWorkspace(cwd) {
+    let device;
+    try {
+      const config = JSON.parse(readFileSync(join(h.env.STIM_HOME, 'config.json'), 'utf-8'));
+      device = config.projects?.[resolve(cwd)]?.platforms?.[platform];
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    if (device?.owned === true) recordBuild({ udid: device.deviceUdid, avdName: device.avdName });
+
     let state;
     try {
       state = JSON.parse(readFileSync(join(workspaceLogsDir(cwd), '..', 'state.json'), 'utf-8'));
@@ -208,35 +218,46 @@ export function createCleanupTracker({ h, platform }) {
     ].filter(Boolean);
     const live = processSnapshot(h);
     for (const record of records) {
+      if (!Number.isInteger(record.pid) || record.pid <= 0) continue;
       const key = JSON.stringify([cwd, record.pid, record.startedAt]);
-      if (!processes.has(key) && live.has(record.pid)) processes.set(key, live.get(record.pid));
+      if (!processes.has(key)) processes.set(key, live.get(record.pid));
     }
   }
 
   function remainingDevices() {
     const ids =
       platform === 'ios'
-        ? Object.values(JSON.parse(h.sh('xcrun', ['simctl', 'list', 'devices', '--json']).stdout).devices)
+        ? Object.values(JSON.parse(inspect(h, 'xcrun', ['simctl', 'list', 'devices', '--json'])).devices)
             .flat()
             .map((device) => device.udid)
-        : h
-            .sh('emulator', ['-list-avds'])
-            .stdout.split('\n')
+        : inspect(h, 'emulator', ['-list-avds'])
+            .split('\n')
             .map((name) => name.trim());
     return ids.filter((id) => devices.has(id));
   }
 
-  function verifyProcesses() {
-    const live = new Set(processSnapshot(h).values());
-    const leaked = [...processes.values()].filter((identity) => live.has(identity));
-    assert(leaked.length === 0, `a workspace process is still running:\n${leaked.join('\n')}`);
+  async function verifyProcesses() {
+    const deadline = Date.now() + processExitTimeoutMs;
+    while (true) {
+      const live = new Set(processSnapshot(h).values());
+      const leaked = [...processes.values()].filter((identity) => live.has(identity));
+      if (leaked.length === 0) return;
+      assert(Date.now() < deadline, `a workspace process is still running:\n${leaked.join('\n')}`);
+      await sleep(Math.min(100, deadline - Date.now()));
+    }
   }
 
-  return { recordBuild, recordProcesses, remainingDevices, verifyProcesses };
+  return { recordBuild, recordWorkspace, remainingDevices, verifyProcesses };
+}
+
+function inspect(h, file, argv) {
+  const result = h.sh(file, argv, { allowFail: true, timeout: 5000 });
+  assert(result.code === 0, `could not inspect ${file}: ${result.stderr}`);
+  return result.stdout;
 }
 
 function processSnapshot(h) {
-  const out = h.sh('ps', ['-ax', '-o', 'pid=,lstart=,command=']).stdout;
+  const out = inspect(h, 'ps', ['-ax', '-o', 'pid=,lstart=,command=']);
   return new Map(
     out
       .split('\n')
@@ -246,14 +267,14 @@ function processSnapshot(h) {
   );
 }
 
-export function verifyCleanup({ h, cleanup, appDir, created }) {
+export async function verifyCleanup({ h, cleanup, appDir, created }) {
   h.banner('cleanup checks');
 
   const devices = cleanup.remainingDevices();
   assert(devices.length === 0, `a device from this run was left behind: ${devices.join(', ')}`);
   h.log('(1) no devices from this run remain');
 
-  cleanup.verifyProcesses();
+  await cleanup.verifyProcesses();
   h.log('(2) no workspace supervisor/Metro/collector processes remain');
 
   const status = h.cli(['status'], { allowFail: true }).stdout;

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -185,7 +185,7 @@ export function ensureGitignore({ appDir, framework }) {
 
 export function createCleanupTracker({ h, platform }) {
   const devices = new Set();
-  const processes = new Set();
+  const processes = new Map();
 
   function recordBuild(facts) {
     const id = platform === 'ios' ? facts.udid : facts.avdName;
@@ -201,13 +201,15 @@ export function createCleanupTracker({ h, platform }) {
       if (error.code === 'ENOENT') return;
       throw error;
     }
-    const pids = new Set([
-      state.supervisor?.pid,
-      state.supervisor?.serverPid,
-      ...Object.values(state.collectors ?? {}).map((record) => record.pid),
-    ]);
-    for (const [pid, identity] of processSnapshot(h)) {
-      if (pids.has(pid)) processes.add(identity);
+    const records = [
+      state.supervisor,
+      { pid: state.supervisor?.serverPid, startedAt: state.supervisor?.startedAt },
+      ...Object.values(state.collectors ?? {}),
+    ].filter(Boolean);
+    const live = processSnapshot(h);
+    for (const record of records) {
+      const key = JSON.stringify([cwd, record.pid, record.startedAt]);
+      if (!processes.has(key) && live.has(record.pid)) processes.set(key, live.get(record.pid));
     }
   }
 
@@ -226,7 +228,7 @@ export function createCleanupTracker({ h, platform }) {
 
   function verifyProcesses() {
     const live = new Set(processSnapshot(h).values());
-    const leaked = [...processes].filter((identity) => live.has(identity));
+    const leaked = [...processes.values()].filter((identity) => live.has(identity));
     assert(leaked.length === 0, `a workspace process is still running:\n${leaked.join('\n')}`);
   }
 

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -18,6 +18,7 @@ import {
   assert,
   buildLog,
   cleanupTmp,
+  createCleanupTracker,
   createFixture,
   createHarness,
   describeGrowth,
@@ -148,6 +149,7 @@ function ownerIsAlive(home) {
 const RACE_CACHE_ROOT = args.dryRun ? '<dry-run>' : join(WORK_DIR, 'race-build-cache');
 
 const h = createHarness({ env: ENV, cliPath: CLI, label: `cache-e2e ${VARIANT}` });
+const cleanup = createCleanupTracker({ h, platform: PLATFORM });
 const { cli, cliJson, sh, log, banner, die } = h;
 
 const created = [];
@@ -418,6 +420,8 @@ async function main() {
 
       log('forcing gradle to execute in wt2 with --no-build-cache so its task cache can be observed...');
       const forced = cliJson([PLATFORM, '--json', '--no-build-cache'], { cwd: wt2, timeout: 40 * 60 * 1000 });
+      cleanup.recordBuild(forced);
+      cleanup.recordProcesses(wt2);
       c.ev(`wt2 forced run: cacheSkipped=${JSON.stringify(forced.cacheSkipped)} durationMs=${forced.durationMs}`);
       const lines = readNdjson(buildLog(wt2))
         .map((r) => String(r.msg || ''))
@@ -649,7 +653,7 @@ async function main() {
     dirtyByWorktree.push({ wt, porcelain: entries.join('\n'), diffs });
     worktreeRemove(wt);
   }
-  verifyCleanup({ h, platform: PLATFORM, appDir, created });
+  verifyCleanup({ h, cleanup, appDir, created });
 
   await runCheck('zero-config', (c) => {
     let critical = 0;
@@ -730,6 +734,7 @@ function startAndAssertMode(cwd) {
     die(`stim start failed (exit ${r.code}):\n${lastLines(r.stderr, 40)}`);
   }
   const facts = JSON.parse(r.stdout.trim().split('\n').findLast(Boolean));
+  cleanup.recordProcesses(cwd);
   assert(
     facts.mode === EXPECTED_MODE,
     `start mode for a ${FRAMEWORK} app must be ${EXPECTED_MODE}, got ${JSON.stringify(facts.mode)}`,
@@ -740,6 +745,8 @@ function startAndAssertMode(cwd) {
 function build(cwd, label) {
   log(`building ${PLATFORM} in ${cwd} (${label})...`);
   const facts = cliJson([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
+  cleanup.recordBuild(facts);
+  cleanup.recordProcesses(cwd);
   log(
     `${label}: cacheHit=${JSON.stringify(facts.cacheHit)} key=${facts.cacheKey} launched=${JSON.stringify(facts.launched)} ` +
       `waitedForBuild=${JSON.stringify(facts.waitedForBuild)} durationMs=${facts.durationMs}`,
@@ -757,6 +764,7 @@ function assertArtifact(appPath) {
 
 function stopWorkspace(cwd) {
   if (!existsSync(cwd)) return;
+  cleanup.recordProcesses(cwd);
   cli(['stop'], { cwd, allowFail: true });
 }
 
@@ -882,6 +890,12 @@ function cliAsync(argv, { cwd, env = ENV, timeout = 40 * 60 * 1000 } = {}) {
       } catch {}
       resolveP({ code: code ?? 1, stdout, stderr, facts, cwd });
     });
+  }).then((result) => {
+    if (result.code === 0) {
+      cleanup.recordBuild(result.facts);
+      cleanup.recordProcesses(cwd);
+    }
+    return result;
   });
 }
 

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -421,7 +421,7 @@ async function main() {
       log('forcing gradle to execute in wt2 with --no-build-cache so its task cache can be observed...');
       const forced = cliJson([PLATFORM, '--json', '--no-build-cache'], { cwd: wt2, timeout: 40 * 60 * 1000 });
       cleanup.recordBuild(forced);
-      cleanup.recordProcesses(wt2);
+      cleanup.recordWorkspace(wt2);
       c.ev(`wt2 forced run: cacheSkipped=${JSON.stringify(forced.cacheSkipped)} durationMs=${forced.durationMs}`);
       const lines = readNdjson(buildLog(wt2))
         .map((r) => String(r.msg || ''))
@@ -653,7 +653,7 @@ async function main() {
     dirtyByWorktree.push({ wt, porcelain: entries.join('\n'), diffs });
     worktreeRemove(wt);
   }
-  verifyCleanup({ h, cleanup, appDir, created });
+  await verifyCleanup({ h, cleanup, appDir, created });
 
   await runCheck('zero-config', (c) => {
     let critical = 0;
@@ -734,7 +734,7 @@ function startAndAssertMode(cwd) {
     die(`stim start failed (exit ${r.code}):\n${lastLines(r.stderr, 40)}`);
   }
   const facts = JSON.parse(r.stdout.trim().split('\n').findLast(Boolean));
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   assert(
     facts.mode === EXPECTED_MODE,
     `start mode for a ${FRAMEWORK} app must be ${EXPECTED_MODE}, got ${JSON.stringify(facts.mode)}`,
@@ -746,7 +746,7 @@ function build(cwd, label) {
   log(`building ${PLATFORM} in ${cwd} (${label})...`);
   const facts = cliJson([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
   cleanup.recordBuild(facts);
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   log(
     `${label}: cacheHit=${JSON.stringify(facts.cacheHit)} key=${facts.cacheKey} launched=${JSON.stringify(facts.launched)} ` +
       `waitedForBuild=${JSON.stringify(facts.waitedForBuild)} durationMs=${facts.durationMs}`,
@@ -764,7 +764,7 @@ function assertArtifact(appPath) {
 
 function stopWorkspace(cwd) {
   if (!existsSync(cwd)) return;
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   cli(['stop'], { cwd, allowFail: true });
 }
 
@@ -891,10 +891,8 @@ function cliAsync(argv, { cwd, env = ENV, timeout = 40 * 60 * 1000 } = {}) {
       resolveP({ code: code ?? 1, stdout, stderr, facts, cwd });
     });
   }).then((result) => {
-    if (result.code === 0) {
-      cleanup.recordBuild(result.facts);
-      cleanup.recordProcesses(cwd);
-    }
+    cleanup.recordWorkspace(cwd);
+    if (result.code === 0) cleanup.recordBuild(result.facts);
     return result;
   });
 }

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -9,6 +9,7 @@ import {
   assert,
   buildLog,
   cleanupTmp,
+  createCleanupTracker,
   createFixture,
   createHarness,
   dumpDiagnostics,
@@ -45,6 +46,7 @@ process.env.STIM_HOME = HOME_DIR;
 const WARM_CACHE = process.env.STIM_E2E_WARM_CACHE === '1';
 
 const h = createHarness({ env: ENV, cliPath: CLI, label: `native-e2e ${VARIANT}` });
+const cleanup = createCleanupTracker({ h, platform: PLATFORM });
 const { cli, cliJson, sh, log, banner, die } = h;
 
 const created = [];
@@ -89,11 +91,13 @@ async function main() {
   handleLaunch(build2, 'wt2');
   log('CACHE PROOF: second worktree installed from cache without compiling.');
 
+  cleanup.recordProcesses(wt2);
   cli(['stop'], { cwd: wt2 });
+  cleanup.recordProcesses(wt1);
   cli(['stop'], { cwd: wt1 });
   worktreeRemove(wt2);
   worktreeRemove(wt1);
-  verifyCleanup({ h, platform: PLATFORM, appDir, created });
+  verifyCleanup({ h, cleanup, appDir, created });
 }
 
 function worktreeCreate(name, appDir) {
@@ -116,6 +120,7 @@ function startAndAssertMode(cwd) {
   }
   const line = r.stdout.trim().split('\n').findLast(Boolean);
   const facts = JSON.parse(line);
+  cleanup.recordProcesses(cwd);
   assert(
     facts.mode === EXPECTED_MODE,
     `start mode for a ${FRAMEWORK} app must be ${EXPECTED_MODE}, got ${JSON.stringify(facts.mode)} ` +
@@ -127,6 +132,8 @@ function startAndAssertMode(cwd) {
 function buildAndAssert(cwd, { expectCacheHit }) {
   log(`building ${PLATFORM} in ${cwd} (expect cache ${expectCacheHit ? 'HIT' : 'MISS'})...`);
   const facts = cliJson([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
+  cleanup.recordBuild(facts);
+  cleanup.recordProcesses(cwd);
   log(
     `build facts: cacheHit=${JSON.stringify(facts.cacheHit)} launched=${JSON.stringify(facts.launched)} ` +
       `waitedForBuild=${JSON.stringify(facts.waitedForBuild)} durationMs=${facts.durationMs}`,

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -91,13 +91,13 @@ async function main() {
   handleLaunch(build2, 'wt2');
   log('CACHE PROOF: second worktree installed from cache without compiling.');
 
-  cleanup.recordProcesses(wt2);
+  cleanup.recordWorkspace(wt2);
   cli(['stop'], { cwd: wt2 });
-  cleanup.recordProcesses(wt1);
+  cleanup.recordWorkspace(wt1);
   cli(['stop'], { cwd: wt1 });
   worktreeRemove(wt2);
   worktreeRemove(wt1);
-  verifyCleanup({ h, cleanup, appDir, created });
+  await verifyCleanup({ h, cleanup, appDir, created });
 }
 
 function worktreeCreate(name, appDir) {
@@ -120,7 +120,7 @@ function startAndAssertMode(cwd) {
   }
   const line = r.stdout.trim().split('\n').findLast(Boolean);
   const facts = JSON.parse(line);
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   assert(
     facts.mode === EXPECTED_MODE,
     `start mode for a ${FRAMEWORK} app must be ${EXPECTED_MODE}, got ${JSON.stringify(facts.mode)} ` +
@@ -133,7 +133,7 @@ function buildAndAssert(cwd, { expectCacheHit }) {
   log(`building ${PLATFORM} in ${cwd} (expect cache ${expectCacheHit ? 'HIT' : 'MISS'})...`);
   const facts = cliJson([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
   cleanup.recordBuild(facts);
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   log(
     `build facts: cacheHit=${JSON.stringify(facts.cacheHit)} launched=${JSON.stringify(facts.launched)} ` +
       `waitedForBuild=${JSON.stringify(facts.waitedForBuild)} durationMs=${facts.durationMs}`,

--- a/test/e2e/native/run-pool-e2e.mjs
+++ b/test/e2e/native/run-pool-e2e.mjs
@@ -7,6 +7,7 @@ import {
   FIXTURE_COMMANDS,
   assert,
   cleanupTmp,
+  createCleanupTracker,
   createFixture,
   createHarness,
   dumpDiagnostics,
@@ -29,6 +30,7 @@ const ENV = { ...process.env, STIM_HOME: HOME_DIR, CI: '1', STIM_POOL_IOS_PARKED
 process.env.STIM_HOME = HOME_DIR;
 
 const h = createHarness({ env: ENV, cliPath: CLI, label: `pool-e2e ${FRAMEWORK}` });
+const cleanup = createCleanupTracker({ h, platform: PLATFORM });
 const { cli, sh, log, banner, die } = h;
 
 const created = [];
@@ -50,12 +52,14 @@ async function main() {
   assert(second.udid !== first.udid, 'two workspaces shared one simulator');
 
   banner('remove: the first parks');
+  cleanup.recordProcesses(wt1);
   cli(['stop'], { cwd: wt1 });
   const removed1 = worktreeRemove(wt1);
   assert(/ {2}device {6}parked stim-parked /.test(removed1), `worktree remove did not park:\n${removed1}`);
   assertPoolSize(1);
 
   banner('remove: the second parks and evicts the first');
+  cleanup.recordProcesses(wt2);
   cli(['stop'], { cwd: wt2 });
   const removed2 = worktreeRemove(wt2);
   assert(/ {2}device {6}parked stim-parked /.test(removed2), `the second remove did not park:\n${removed2}`);
@@ -74,6 +78,7 @@ async function main() {
   assertPoolSize(0);
 
   banner('remove: the third parks');
+  cleanup.recordProcesses(wt3);
   cli(['stop'], { cwd: wt3 });
   const removed3 = worktreeRemove(wt3);
   assert(/ {2}device {6}parked stim-parked /.test(removed3), `the third remove did not park:\n${removed3}`);
@@ -89,7 +94,7 @@ async function main() {
   );
   assertPoolSize(0);
 
-  verifyCleanup({ h, platform: PLATFORM, appDir, created });
+  verifyCleanup({ h, cleanup, appDir, created });
 }
 
 function worktreeCreate(name, appDir) {
@@ -103,8 +108,11 @@ function worktreeCreate(name, appDir) {
 
 function runIos(cwd) {
   cli(['start', '--json', '--wait', '240'], { cwd });
+  cleanup.recordProcesses(cwd);
   const r = cli([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
   const facts = JSON.parse(r.stdout.trim().split('\n').findLast(Boolean));
+  cleanup.recordBuild(facts);
+  cleanup.recordProcesses(cwd);
   const deviceLine = r.stderr.split('\n').find((line) => / {2}device {6}.*(booted|adopted) /.test(line)) ?? '';
   log(`device line: ${deviceLine.trim()}`);
   return { udid: facts.udid, adopted: / adopted /.test(deviceLine), deviceLine };
@@ -128,9 +136,12 @@ function assertPoolSize(expected) {
 }
 
 function assertSimCount(expected) {
-  const out = sh('xcrun', ['simctl', 'list', 'devices']).stdout;
-  const actual = out.split('\n').filter((line) => line.includes('stim-')).length;
-  assert(actual === expected, `${actual} stim-* simulators exist, expected ${expected}:\n${out}`);
+  const remaining = cleanup.remainingDevices();
+  const actual = remaining.length;
+  assert(
+    actual === expected,
+    `${actual} simulators from this run exist, expected ${expected}:\n${remaining.join('\n')}`,
+  );
 }
 
 function cleanupAfterFailure() {

--- a/test/e2e/native/run-pool-e2e.mjs
+++ b/test/e2e/native/run-pool-e2e.mjs
@@ -52,14 +52,14 @@ async function main() {
   assert(second.udid !== first.udid, 'two workspaces shared one simulator');
 
   banner('remove: the first parks');
-  cleanup.recordProcesses(wt1);
+  cleanup.recordWorkspace(wt1);
   cli(['stop'], { cwd: wt1 });
   const removed1 = worktreeRemove(wt1);
   assert(/ {2}device {6}parked stim-parked /.test(removed1), `worktree remove did not park:\n${removed1}`);
   assertPoolSize(1);
 
   banner('remove: the second parks and evicts the first');
-  cleanup.recordProcesses(wt2);
+  cleanup.recordWorkspace(wt2);
   cli(['stop'], { cwd: wt2 });
   const removed2 = worktreeRemove(wt2);
   assert(/ {2}device {6}parked stim-parked /.test(removed2), `the second remove did not park:\n${removed2}`);
@@ -78,7 +78,7 @@ async function main() {
   assertPoolSize(0);
 
   banner('remove: the third parks');
-  cleanup.recordProcesses(wt3);
+  cleanup.recordWorkspace(wt3);
   cli(['stop'], { cwd: wt3 });
   const removed3 = worktreeRemove(wt3);
   assert(/ {2}device {6}parked stim-parked /.test(removed3), `the third remove did not park:\n${removed3}`);
@@ -94,7 +94,7 @@ async function main() {
   );
   assertPoolSize(0);
 
-  verifyCleanup({ h, cleanup, appDir, created });
+  await verifyCleanup({ h, cleanup, appDir, created });
 }
 
 function worktreeCreate(name, appDir) {
@@ -108,11 +108,11 @@ function worktreeCreate(name, appDir) {
 
 function runIos(cwd) {
   cli(['start', '--json', '--wait', '240'], { cwd });
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   const r = cli([PLATFORM, '--json'], { cwd, timeout: 40 * 60 * 1000 });
   const facts = JSON.parse(r.stdout.trim().split('\n').findLast(Boolean));
   cleanup.recordBuild(facts);
-  cleanup.recordProcesses(cwd);
+  cleanup.recordWorkspace(cwd);
   const deviceLine = r.stderr.split('\n').find((line) => / {2}device {6}.*(booted|adopted) /.test(line)) ?? '';
   log(`device line: ${deviceLine.trim()}`);
   return { udid: facts.udid, adopted: / adopted /.test(deviceLine), deviceLine };


### PR DESCRIPTION
## Description

Native loop, cache and pool suites reject successful cleanup when another workspace still owns a Stim device or supervisor. Their machine-wide assertions make release QA fail on a shared developer machine.

## Solution

Remember device identities from build results and each workspace's owned registry entries, including failed builds. Keep the first observation of each registered process and allow a bounded exit window after teardown. Inspection failures throw so the cache suite can still emit its failure summary. Pool counts use the same recorded UDIDs through parking and adoption. Unrelated resources can remain; the registry, checkout, worktree and GC checks still apply.

## Test plan

- Twenty-nine fast harness regressions cover unrelated survivors, this run's leaked devices/processes after repeated cleanup and state removal, renamed/adopted pool devices, reused PIDs, delayed exits, failed-build devices, and missing inspection tools. Restoring either old global guard makes its regression fail.
- Real read-only `simctl`, `emulator` and `ps` queries accepted the argument lists and detected the temporary test process. No existing device was changed.

Fixes #411.


