### PR TITLE
fix: preserve benchmark audit destinations

### DIFF
--- a/website/src/components/benchmarkData.test.ts
+++ b/website/src/components/benchmarkData.test.ts
@@ -121,6 +121,23 @@ describe('benchmark URL selection', () => {
 });
 
 describe('benchmarkOverview', () => {
+  it('links a platform-filtered overview to the matching run in the full catalog', () => {
+    const android = {
+      stage: 'luna-android',
+      title: 'Luna Android',
+      runs: [{ id: 'javascript-stim', arm: 'stim', variant: 'javascript', valid: true, settingsReadySeconds: 161 }],
+    } as BenchmarkData;
+    const overview = benchmarkOverview([android], 'javascript');
+    const href = overview.rows[0]?.arms[0]?.href;
+    expect(href).toBeTruthy();
+    const url = new URL(href!, 'https://example.test');
+
+    expect(benchmarkSelectionFromSearch(url.search, [...navigationBenchmarks, android])).toEqual({
+      stage: 'luna-android',
+      runId: 'javascript-stim',
+    });
+  });
+
   it('builds paired rows with shared scaling and exact audit links', () => {
     const overview = benchmarkOverview(
       [
@@ -146,7 +163,11 @@ describe('benchmarkOverview', () => {
 
     expect(overview.maxSeconds).toBe(200);
     expect(overview.rows[0]?.arms.map(({ arm, widthPercent, href }) => ({ arm, widthPercent, href }))).toEqual([
-      { arm: 'stim', widthPercent: 25, href: '/benchmarks/details#audit-title' },
+      {
+        arm: 'stim',
+        widthPercent: 25,
+        href: '/benchmarks/details?benchmark=first&run=first-stim#audit-title',
+      },
       {
         arm: 'control',
         widthPercent: 50,

--- a/website/src/components/benchmarkData.ts
+++ b/website/src/components/benchmarkData.ts
@@ -260,7 +260,7 @@ export function benchmarkOverview(benchmarks: BenchmarkData[], variant: Benchmar
         run,
         widthPercent: run ? (run.settingsReadySeconds / maxSeconds) * 100 : 0,
         href: run
-          ? `/benchmarks/details${benchmarkSelectionSearch({ stage: benchmark.stage, runId: run.id }, benchmarks)}#audit-title`
+          ? `/benchmarks/details?${new URLSearchParams({ benchmark: benchmark.stage, run: run.id })}#audit-title`
           : null,
       };
     }),


### PR DESCRIPTION
## Description

Clicking Luna's Android JavaScript result opens the iOS audit: the chart drops the selection parameters for its first row, but the destination's default comes from the full catalog.

## Solution

Overview audit links always name the benchmark and run, so filtering a chart cannot change the destination.

## Test plan

- Reproduced in the browser: the Android 2m 41s result opened the iOS 2m 14s audit.
- Added a regression that resolves a filtered chart's link against the full destination catalog; it fails before the fix and passes after.
- Verified the fixed production build in the browser: the same chart link selects Android and shows the matching 2m 41s audit.

Fixes #413.
