### PR TITLE
feat: warm existing linked worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The normal flow is:
 worktree create -> start -> ios|android -> logs --errors -> stop -> worktree remove
 ```
 
-The command surface is `doctor`, `worktree create|remove`, `start`, `stop`,
+The command surface is `doctor`, `worktree create|warm|remove`, `start`, `stop`,
 `ios`, `android`, `reload`, `device lock|unlock`, `logs`, `status`, `stats`, `gc`, and
 `guide`. Do not add commands or flags without an explicit product decision.
 Projects can wrap Stim when they need custom behavior.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ not after every JavaScript edit.
 Stim needs no project initialization. Runtime state stays under `~/.stim` by
 default.
 
+If a harness already created a linked worktree, run `stim worktree warm`
+inside it to copy missing ignored state from the main checkout, including
+eligible `.env` and local configuration files. Existing entries are preserved;
+existing directories such as `node_modules` are skipped whole. See the
+[worktree guide](https://appandflow.github.io/stim/docs/worktrees) for exclusions
+and copy-failure remedies.
+
 ## Documentation
 
 Read the [Stim documentation](https://appandflow.github.io/stim/) for the

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -59,6 +59,13 @@ an error screen remains after a fix, or when you explicitly need an app
 restart. It is not part of the normal workflow and does not build, install,
 boot, or launch an app. The platform is optional when only one app is live.
 
+If a harness already created a linked worktree, run `stim worktree warm`
+inside it to copy missing ignored state from the main checkout, including
+eligible `.env` and local configuration files. Existing entries are preserved;
+existing directories such as `node_modules` are skipped whole. See the
+[worktree guide](https://appandflow.github.io/stim/docs/worktrees) for exclusions
+and copy-failure remedies.
+
 ## Reference
 
 The [documentation website](https://appandflow.github.io/stim/) explains the

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1766,3 +1766,27 @@ test('the repository guide names stats in the command surface', () => {
 
   expect(agents).toMatch(/The command surface is[\s\S]*`status`, `stats`, `gc`/);
 });
+
+test('warm guidance covers current linked worktrees, main-source exclusions, and whole-entry preservation', () => {
+  const agent = renderTopic('agent');
+  const options = renderSection('lifecycle', 'options');
+  const settings = renderTopic('settings');
+  const errors = renderSection('errors', 'carry');
+  assert(agent);
+  assert(options);
+  assert(settings);
+  assert(errors);
+  expect(agent).toMatch(/harness already created this linked worktree[\s\S]*stim worktree warm/);
+  expect(agent).toMatch(/\.env and local\s+configuration/);
+  expect(options).toMatch(/worktree warm.*takes no arguments or flags/);
+  expect(options).toMatch(/main\s+checkout/);
+  expect(options).toMatch(/existing\s+directory such as node_modules is skipped WHOLE/i);
+  expect(options).toMatch(/dangling symlinks/);
+  expect(options).toMatch(/does not copy tracked changes/);
+  expect(options).toMatch(/stdout stays empty/);
+  expect(options).toMatch(/copy failure exits 1/);
+  expect(settings).toMatch(/source\s+checkout \(main for warm\)/);
+  expect(settings).toMatch(/nonempty .worktreeexclude\s+in that source replaces this setting/);
+  expect(errors).toMatch(/incomplete:.*ignored entries copied/);
+  expect(errors).toMatch(/partially|already published/);
+});

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -474,3 +474,36 @@ test('staging ignored files never exposes their contents to Git status or git ad
   expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('source secret');
 });
+
+test('warm preserves a deleted tracked file when main has ignored descendants at that path', () => {
+  write(root, 'local/README', 'main readme');
+  git(root, 'add', '-f', 'local/README');
+  git(root, 'commit', '-qm', 'track main local readme');
+  write(root, 'local/data.cache', 'main cache');
+  write(target, 'local', 'linked tracked file');
+  git(target, 'add', '-f', 'local');
+  git(target, 'commit', '-qm', 'track local file');
+  rmSync(join(target, 'local'));
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.skipped).toEqual([{ file: 'local/data.cache', reason: 'tracked' }]);
+  expect(result.failed).toEqual([]);
+  expect(existsSync(join(target, 'local'))).toBe(false);
+  expect(git(target, 'diff', '--name-status')).toBe('D\tlocal');
+});
+
+test('warm permits ignored siblings under a directory containing tracked files', () => {
+  write(root, 'local/README', 'main readme');
+  git(root, 'add', '-f', 'local/README');
+  git(root, 'commit', '-qm', 'track main local readme');
+  write(root, 'local/data.cache', 'main cache');
+  write(target, 'local/README', 'linked readme');
+  git(target, 'add', '-f', 'local/README');
+  git(target, 'commit', '-qm', 'track linked local readme');
+  const result = warm();
+  expect(result.copied).toEqual(['local/data.cache']);
+  expect(result.skipped).toEqual([]);
+  expect(result.failed).toEqual([]);
+  expect(readFileSync(join(target, 'local/data.cache'), 'utf-8')).toBe('main cache');
+  expect(readFileSync(join(target, 'local/README'), 'utf-8')).toBe('linked readme');
+});

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -406,6 +406,26 @@ test('missing-only copy preserves executable file modes', () => {
   expect(lstatSync(join(target, 'node_modules/pkg/bin')).mode & 0o777).toBe(0o755);
 });
 
+test('warm copies read-only directories, preserves their modes, and removes staging', async () => {
+  write(root, 'node_modules/pkg/index.js', 'read-only package');
+  write(root, 'node_modules/pkg/.DerivedData/large', 'excluded');
+  chmodSync(join(root, 'node_modules/pkg'), 0o555);
+  try {
+    const result = await runWarm(target);
+    expect(result.code).toBe(0);
+    expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('read-only package');
+    expect(lstatSync(join(target, 'node_modules/pkg')).mode & 0o777).toBe(0o555);
+    expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
+    expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+  } finally {
+    chmodSync(join(root, 'node_modules/pkg'), 0o755);
+    for (const entry of readdirSync(target)) {
+      const pkg = join(target, entry, entry.startsWith('.stim-warm-') ? 'entry/pkg' : 'pkg');
+      if (existsSync(pkg)) chmodSync(pkg, 0o755);
+    }
+  }
+});
+
 test('missing-only copy does not restore a deleted tracked file from ignored main state', () => {
   write(target, '.env', 'tracked linked env');
   git(target, 'add', '-f', '.env');

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -1,0 +1,419 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
+import { cloneIgnoredEntries, warmWorktreePaths } from '../worktree.ts';
+import { Command } from 'commander';
+import { registerWarm } from '../commands/worktree.ts';
+
+const publication = vi.hoisted(() => ({
+  beforeCopy: null as ((path: string) => void) | null,
+  beforeMkdir: null as ((path: string) => void) | null,
+}));
+vi.mock('fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('fs')>();
+  return {
+    ...fs,
+    mkdirSync: (path: string, options?: import('fs').MakeDirectoryOptions) => {
+      publication.beforeMkdir?.(path);
+      return fs.mkdirSync(path, options);
+    },
+    copyFileSync: (from: string, to: string, mode?: number) => {
+      publication.beforeCopy?.(to);
+      return fs.copyFileSync(from, to, mode);
+    },
+  };
+});
+
+let base: string;
+let root: string;
+let target: string;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf-8' }).trim();
+}
+
+function write(dir: string, rel: string, value: string): void {
+  mkdirSync(dirname(join(dir, rel)), { recursive: true });
+  writeFileSync(join(dir, rel), value);
+}
+
+beforeEach(() => {
+  base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-test-warm-')));
+  root = join(base, 'main');
+  target = join(base, 'linked');
+  process.env.STIM_HOME = join(base, 'home');
+  mkdirSync(root);
+  git(root, 'init', '-q', '-b', 'main');
+  git(root, 'config', 'user.name', 'test');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'commit.gpgsign', 'false');
+  write(root, '.gitignore', 'node_modules/\nios/Pods/\nios/build/\n.env*\nlocal/\n.worktrees/\n.DerivedData/\n');
+  write(root, 'package.json', '{"name":"warm-fixture"}\n');
+  write(root, 'ios/Podfile.lock', 'branch pods\n');
+  git(root, 'add', '.');
+  git(root, 'commit', '-qm', 'fixture');
+  git(root, 'worktree', 'add', '-qb', 'linked', target);
+});
+
+afterEach(() => {
+  resetExecutor();
+  publication.beforeCopy = null;
+  publication.beforeMkdir = null;
+  process.exitCode = 0;
+  delete process.env.STIM_HOME;
+  rmSync(base, { recursive: true, force: true });
+});
+
+function warm() {
+  return cloneIgnoredEntries({ root, target, patterns: [], preserveExisting: true });
+}
+
+test('missing-only copy preserves existing directories, files, and dangling symlinks wholesale', () => {
+  write(root, 'node_modules/new/index.js', 'source package');
+  write(root, '.env', 'source env');
+  write(root, '.env.local', 'source local');
+  write(target, 'node_modules/own/index.js', 'destination package');
+  write(target, '.env', 'destination env');
+  symlinkSync('absent-env', join(target, '.env.local'));
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.failed).toEqual([]);
+  expect(result.skipped).toHaveLength(3);
+  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('destination env');
+  expect(readlinkSync(join(target, '.env.local'))).toBe('absent-env');
+  expect(readdirSync(join(target, 'node_modules'))).toEqual(['own']);
+});
+
+test('missing-only copy refuses destination symlink ancestors', () => {
+  write(root, 'ios/Pods/Manifest.lock', 'source pods');
+  rmSync(join(target, 'ios'), { recursive: true });
+  const outside = join(base, 'outside');
+  mkdirSync(outside);
+  symlinkSync(outside, join(target, 'ios'));
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.skipped).toEqual([{ file: 'ios/Pods', reason: 'symlink ancestor: ios' }]);
+  expect(readdirSync(outside)).toEqual([]);
+});
+
+test('missing-only copy skips registered nested worktrees and their ignored parents on either side', () => {
+  const sourceNested = join(root, '.worktrees', 'source');
+  const targetNested = join(target, 'local', 'linked');
+  git(root, 'worktree', 'add', '-qb', 'source-nested', sourceNested);
+  git(root, 'worktree', 'add', '-qb', 'target-nested', targetNested);
+  write(root, '.worktrees/other.txt', 'source sibling');
+  write(root, 'local/source.txt', 'must not enter target parent');
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(existsSync(join(target, '.worktrees'))).toBe(false);
+  expect(existsSync(join(target, 'local/source.txt'))).toBe(false);
+  expect(git(targetNested, 'branch', '--show-current')).toBe('target-nested');
+});
+
+test('missing-only copy discards partial clone output before byte-copy fallback', () => {
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  const real = getExecutor();
+  setExecutor({
+    ...real,
+    runFile(file, args, opts) {
+      if (file === 'cp' && args[0] === '-Rc') {
+        write(args[2], 'partial', 'failed clone');
+        throw new Error('clone not supported');
+      }
+      return real.runFile(file, args, opts);
+    },
+  });
+  const result = warm();
+  expect(result.failed).toEqual([]);
+  expect(result.cloned).toBe(false);
+  expect(result.copied).toEqual(['node_modules']);
+  expect(readdirSync(join(target, 'node_modules'))).toEqual(['pkg']);
+  expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
+  expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+});
+
+test.each(['file', 'empty directory', 'dangling symlink'])(
+  'missing-only copy preserves a concurrently created %s',
+  (kind) => {
+    write(root, 'node_modules/pkg/index.js', 'source package');
+    const real = getExecutor();
+    setExecutor({
+      ...real,
+      runFile(file, args, opts) {
+        const result = real.runFile(file, args, opts);
+        if (file === 'cp') {
+          if (kind === 'file') writeFileSync(join(target, 'node_modules'), 'concurrent file');
+          else if (kind === 'empty directory') mkdirSync(join(target, 'node_modules'));
+          else symlinkSync('missing-packages', join(target, 'node_modules'));
+        }
+        return result;
+      },
+    });
+    const result = warm();
+    expect(result.copied).toEqual([]);
+    expect(result.skipped).toEqual([{ file: 'node_modules', reason: 'exists' }]);
+    const actual =
+      kind === 'file'
+        ? readFileSync(join(target, 'node_modules'), 'utf-8')
+        : kind === 'empty directory'
+          ? readdirSync(join(target, 'node_modules'))
+          : readlinkSync(join(target, 'node_modules'));
+    const expected = kind === 'file' ? 'concurrent file' : kind === 'empty directory' ? [] : 'missing-packages';
+    expect(actual).toEqual(expected);
+  },
+);
+
+test('failed missing-only copies leave no partial destination and retain their error', () => {
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  const real = getExecutor();
+  setExecutor({
+    ...real,
+    runFile(file, args, opts) {
+      if (file === 'cp') {
+        write(args[2], 'partial', 'incomplete');
+        throw new Error('copy failed');
+      }
+      return real.runFile(file, args, opts);
+    },
+  });
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.failed).toEqual([{ file: 'node_modules', error: 'copy failed' }]);
+  expect(existsSync(join(target, 'node_modules'))).toBe(false);
+  expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+});
+
+test('missing-only copy preserves relative symlinks without linking files back to the source', () => {
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  symlinkSync('pkg', join(root, 'node_modules/alias'));
+  const result = warm();
+  expect(result.failed).toEqual([]);
+  expect(readlinkSync(join(target, 'node_modules/alias'))).toBe('pkg');
+  expect(lstatSync(join(target, 'node_modules/pkg/index.js')).ino).not.toBe(
+    lstatSync(join(root, 'node_modules/pkg/index.js')).ino,
+  );
+  write(target, 'node_modules/pkg/index.js', 'edited destination');
+  expect(readFileSync(join(root, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
+});
+
+async function runWarm(cwd: string) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((value) => stdout.push(String(value)));
+  const error = vi.spyOn(console, 'error').mockImplementation((value) => stderr.push(String(value)));
+  const previous = process.cwd();
+  try {
+    process.chdir(cwd);
+    const command = new Command();
+    registerWarm(command);
+    await command.parseAsync(['warm'], { from: 'user' });
+    return { stdout, stderr: stderr.join('\n'), code: process.exitCode || 0 };
+  } finally {
+    process.chdir(previous);
+    log.mockRestore();
+    error.mockRestore();
+  }
+}
+
+test('publication collisions report incomplete and preserve concurrent content and earlier published files', () => {
+  write(root, 'node_modules/a.js', 'source a');
+  write(root, 'node_modules/b.js', 'source b');
+  publication.beforeCopy = (path) => {
+    if (path === join(target, 'node_modules/b.js')) writeFileSync(path, 'concurrent b');
+  };
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.failed).toHaveLength(1);
+  expect(result.failed[0]?.error).toMatch(/EEXIST/);
+  expect(readFileSync(join(target, 'node_modules/a.js'), 'utf-8')).toBe('source a');
+  expect(readFileSync(join(target, 'node_modules/b.js'), 'utf-8')).toBe('concurrent b');
+});
+
+test('warm identifies canonical main and linked roots from a symlinked subdirectory', () => {
+  const alias = join(base, 'alias');
+  symlinkSync(target, alias);
+  expect(warmWorktreePaths(join(alias, 'ios'))).toEqual({ root, target, common: join(root, '.git') });
+});
+
+test('warm rejects the main checkout and non-repositories without changing them', async () => {
+  write(root, '.env', 'source env');
+  const main = await runWarm(root);
+  expect(main.code).toBe(1);
+  expect(main.stdout).toEqual([]);
+  expect(main.stderr).toMatch(/linked worktree, not the main checkout/);
+  process.exitCode = 0;
+  const outside = await runWarm(base);
+  expect(outside.code).toBe(1);
+  expect(outside.stderr).toMatch(/Not a git repository/);
+});
+
+test('warm refuses an unregistered target, missing main checkout, or mismatched Git common directory', () => {
+  const real = getExecutor();
+  for (const kind of ['unregistered', 'missing main', 'different common']) {
+    setExecutor({
+      ...real,
+      runFileQuiet(file, args, opts) {
+        if (kind === 'unregistered' && args.includes('worktree') && args.includes('list')) {
+          return `worktree ${root}\nbranch refs/heads/main\n`;
+        }
+        if (kind === 'missing main' && args.includes('--git-dir') && args[1] === root) return null;
+        if (
+          kind === 'different common' &&
+          args.at(-1) === '--git-common-dir' &&
+          !args.includes('--git-dir') &&
+          args[1] === root
+        ) {
+          return base;
+        }
+        return real.runFileQuiet(file, args, opts);
+      },
+    });
+    expect(() => warmWorktreePaths(target)).toThrow(/Could not/);
+  }
+});
+
+test('warm copies main ignored state but preserves the linked branch and tracked edits', async () => {
+  write(root, 'node_modules/pkg/index.js', 'main dependency');
+  write(root, '.env', 'main env');
+  write(root, 'package.json', '{"name":"dirty-main"}\n');
+  write(target, 'package.json', '{"name":"dirty-linked"}\n');
+  write(target, '.env.local', 'linked local env');
+  const result = await runWarm(join(target, 'ios'));
+  expect(result.code).toBe(0);
+  expect(result.stdout).toEqual([]);
+  expect(result.stderr).toMatch(/complete: 2 ignored entries copied/);
+  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
+  expect(readFileSync(join(target, '.env.local'), 'utf-8')).toBe('linked local env');
+  expect(readFileSync(join(target, 'package.json'), 'utf-8')).toBe('{"name":"dirty-linked"}\n');
+  expect(git(target, 'branch', '--show-current')).toBe('linked');
+  expect(existsSync(join(base, 'home/config.json'))).toBe(false);
+  expect((await runWarm(target)).stderr).toMatch(/complete: 0 ignored entries copied, 2 kept, 0 failed/);
+});
+
+test('warm reads main exclusion settings and lets its nonempty pattern file replace them', async () => {
+  write(root, '.env', 'source env');
+  write(root, '.env.local', 'source local');
+  write(root, '.stim.json', '{"worktree":{"exclude":[".env"],"baseRef":"not-a-ref"}}');
+  write(target, '.stim.json', '{"worktree":{"exclude":[".env.local"]}}');
+  const settings = await runWarm(target);
+  expect(settings.code).toBe(0);
+  expect(existsSync(join(target, '.env'))).toBe(false);
+  expect(readFileSync(join(target, '.env.local'), 'utf-8')).toBe('source local');
+  rmSync(join(target, '.env.local'));
+  write(root, '.worktreeexclude', '.env.local\n');
+  const patterns = await runWarm(target);
+  expect(patterns.code).toBe(0);
+  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('source env');
+  expect(existsSync(join(target, '.env.local'))).toBe(false);
+});
+
+test('warm reports copy failures with nonzero status and no ready claim', async () => {
+  write(root, '.env', 'source env');
+  const real = getExecutor();
+  setExecutor({
+    ...real,
+    runFile(file, args, opts) {
+      if (file === 'cp') throw new Error('disk full');
+      return real.runFile(file, args, opts);
+    },
+  });
+  const result = await runWarm(target);
+  expect(result.code).toBe(1);
+  expect(result.stdout).toEqual([]);
+  expect(result.stderr).toMatch(/could not copy .env: disk full/);
+  expect(result.stderr).toMatch(/incomplete: 0 ignored entries copied, 0 kept, 1 failed/);
+  expect(result.stderr).not.toMatch(/ready|warmed/);
+});
+
+test('warm refuses unreadable source or destination inventories instead of reporting an empty success', async () => {
+  const real = getExecutor();
+  for (const kind of ['ignored', 'tracked']) {
+    process.exitCode = 0;
+    setExecutor({
+      ...real,
+      runFile(file, args, opts) {
+        if (kind === 'ignored' && args.includes('--ignored')) throw new Error('ignored inventory failed');
+        return real.runFile(file, args, opts);
+      },
+      runFileQuiet(file, args, opts) {
+        if (kind === 'tracked' && args.includes('ls-files') && !args.includes('--ignored')) return null;
+        return real.runFileQuiet(file, args, opts);
+      },
+    });
+    const result = await runWarm(target);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/Could not warm/);
+    expect(result.stderr).not.toMatch(/complete:/);
+  }
+});
+
+test('warm reports carried dependency and Pods lockfile mismatches against the linked branch', async () => {
+  write(root, 'package-lock.json', 'main lock');
+  write(target, 'package-lock.json', 'linked lock');
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  write(root, 'ios/Pods/Manifest.lock', 'main pods');
+  const result = await runWarm(target);
+  expect(result.code).toBe(0);
+  expect(result.stderr).toMatch(/carried dependencies may be stale.*package-lock.json/);
+  expect(result.stderr).toMatch(/carried ios\/Pods does not match/);
+  expect(readFileSync(join(target, 'ios/Podfile.lock'), 'utf-8')).toBe('branch pods\n');
+});
+
+test('warm copies literal ignored filenames and skips excluded derived data', () => {
+  write(root, '.env with "quotes"', 'literal env');
+  write(root, 'node_modules/pkg/.DerivedData/large', 'skip');
+  write(root, 'node_modules/pkg/index.js', 'package');
+  const result = warm();
+  expect(result.failed).toEqual([]);
+  expect(readFileSync(join(target, '.env with "quotes"'), 'utf-8')).toBe('literal env');
+  expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
+});
+
+test('exclusive directory publication preserves an empty directory created after the final precheck', () => {
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  publication.beforeMkdir = (path) => {
+    if (path === join(target, 'node_modules')) {
+      publication.beforeMkdir = null;
+      mkdirSync(path);
+    }
+  };
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.failed[0]?.error).toMatch(/EEXIST/);
+  expect(readdirSync(join(target, 'node_modules'))).toEqual([]);
+});
+
+test('missing-only copy preserves executable file modes', () => {
+  write(root, 'node_modules/pkg/bin', '#!/bin/sh\nexit 0\n');
+  chmodSync(join(root, 'node_modules/pkg/bin'), 0o755);
+  const result = warm();
+  expect(result.failed).toEqual([]);
+  expect(lstatSync(join(target, 'node_modules/pkg/bin')).mode & 0o777).toBe(0o755);
+});
+
+test('missing-only copy does not restore a deleted tracked file from ignored main state', () => {
+  write(target, '.env', 'tracked linked env');
+  git(target, 'add', '-f', '.env');
+  git(target, 'commit', '-qm', 'track linked env');
+  rmSync(join(target, '.env'));
+  write(root, '.env', 'ignored main env');
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.skipped).toEqual([{ file: '.env', reason: 'tracked' }]);
+  expect(existsSync(join(target, '.env'))).toBe(false);
+});

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -23,11 +23,17 @@ import { registerWarm } from '../commands/worktree.ts';
 const publication = vi.hoisted(() => ({
   beforeCopy: null as ((path: string) => void) | null,
   beforeMkdir: null as ((path: string) => void) | null,
+  stagingPaths: [] as string[],
 }));
 vi.mock('fs', async (importOriginal) => {
   const fs = await importOriginal<typeof import('fs')>();
   return {
     ...fs,
+    mkdtempSync: (prefix: string) => {
+      const path = fs.mkdtempSync(prefix);
+      if (prefix.endsWith('.stim-warm-')) publication.stagingPaths.push(path);
+      return path;
+    },
     mkdirSync: (path: string, options?: import('fs').MakeDirectoryOptions) => {
       publication.beforeMkdir?.(path);
       return fs.mkdirSync(path, options);
@@ -53,6 +59,7 @@ function write(dir: string, rel: string, value: string): void {
 }
 
 beforeEach(() => {
+  publication.stagingPaths = [];
   base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-test-warm-')));
   root = join(base, 'main');
   target = join(base, 'linked');
@@ -77,6 +84,7 @@ afterEach(() => {
   process.exitCode = 0;
   delete process.env.STIM_HOME;
   rmSync(base, { recursive: true, force: true });
+  for (const path of publication.stagingPaths) rmSync(path, { recursive: true, force: true });
 });
 
 function warm() {
@@ -144,7 +152,7 @@ test('missing-only copy discards partial clone output before byte-copy fallback'
   expect(result.copied).toEqual(['node_modules']);
   expect(readdirSync(join(target, 'node_modules'))).toEqual(['pkg']);
   expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
-  expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
 
 test.each(['file', 'empty directory', 'dangling symlink'])(
@@ -195,7 +203,7 @@ test('failed missing-only copies leave no partial destination and retain their e
   expect(result.copied).toEqual([]);
   expect(result.failed).toEqual([{ file: 'node_modules', error: 'copy failed' }]);
   expect(existsSync(join(target, 'node_modules'))).toBe(false);
-  expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
 
 test('missing-only copy preserves relative symlinks without linking files back to the source', () => {
@@ -416,11 +424,14 @@ test('warm copies read-only directories, preserves their modes, and removes stag
     expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('read-only package');
     expect(lstatSync(join(target, 'node_modules/pkg')).mode & 0o777).toBe(0o555);
     expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
-    expect(readdirSync(target).some((name) => name.startsWith('.stim-warm-'))).toBe(false);
+    expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   } finally {
     chmodSync(join(root, 'node_modules/pkg'), 0o755);
-    for (const entry of readdirSync(target)) {
-      const pkg = join(target, entry, entry.startsWith('.stim-warm-') ? 'entry/pkg' : 'pkg');
+    for (const entry of [
+      join(target, 'node_modules'),
+      ...publication.stagingPaths.map((path) => join(path, 'entry')),
+    ]) {
+      const pkg = join(entry, 'pkg');
       if (existsSync(pkg)) chmodSync(pkg, 0o755);
     }
   }
@@ -436,4 +447,30 @@ test('missing-only copy does not restore a deleted tracked file from ignored mai
   expect(result.copied).toEqual([]);
   expect(result.skipped).toEqual([{ file: '.env', reason: 'tracked' }]);
   expect(existsSync(join(target, '.env'))).toBe(false);
+});
+
+test('staging ignored files never exposes their contents to Git status or git add', async () => {
+  write(root, '.env', 'source secret');
+  const observations: { status: string; add: string; staged: string }[] = [];
+  const real = getExecutor();
+  setExecutor({
+    ...real,
+    runFile(file, args, opts) {
+      const result = real.runFile(file, args, opts);
+      if (file === 'cp') {
+        observations.push({
+          status: git(target, 'status', '--porcelain', '--untracked-files=all'),
+          add: git(target, 'add', '--dry-run', '--all'),
+          staged: readFileSync(args[2], 'utf-8'),
+        });
+      }
+      return result;
+    },
+  });
+  const result = await runWarm(target);
+  expect(result.code).toBe(0);
+  expect(observations).toEqual([{ status: '', add: '', staged: 'source secret' }]);
+  expect(publication.stagingPaths.map((path) => realpathSync(dirname(path)))).toEqual([realpathSync(tmpdir())]);
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('source secret');
 });

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -43,6 +43,7 @@ import {
   restoreFile,
   unpushedCommits,
   worktreePath,
+  warmWorktreePaths,
 } from '../worktree.ts';
 import type { WorktreeEntry } from '../worktree.ts';
 
@@ -362,35 +363,7 @@ export function registerCreate(worktree: Command): void {
         } else if (changes?.conflicted) {
           console.error(chalk.yellow(phaseLine('carry', carryConflictWarning(changes.files))));
         }
-        const staleDeps = depsOutOfSync(root, target, res.copied);
-        if (staleDeps.length) {
-          const manifests = staleDeps.map((d) => (d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`)).join(', ');
-          const remedies = [
-            ...new Set(staleDeps.map((dependency) => dependencyInstallCommand(target, dependency.dir))),
-          ];
-          console.error(
-            chalk.yellow(
-              phaseLine(
-                'carry',
-                `carried dependencies may be stale: they do not match ${manifests}. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
-              ),
-            ),
-          );
-        }
-        for (const p of podsOutOfSync(target, res.copied)) {
-          const where = p.dir === '.' ? 'Podfile.lock' : `${p.dir}/Podfile.lock`;
-          const pod = podInstallCommand(p.dir === '.' ? target : resolve(target, p.dir, '..'));
-          console.error(
-            chalk.yellow(
-              phaseLine(
-                'carry',
-                p.reason === 'missing'
-                  ? `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
-                  : `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match the ${where} on disk here. Pods are gitignored and cloned; Podfile.lock is tracked, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
-              ),
-            ),
-          );
-        }
+        reportCarriedStateHealth(root, target, res.copied);
       } else {
         const excluded = readWorktreeExclude(root);
         const skip = excluded && excluded.length ? excluded : settings?.worktree?.exclude || [];
@@ -430,6 +403,81 @@ export function registerCreate(worktree: Command): void {
       console.error(chalk.dim(phaseLine('ready', target)));
 
       console.log(target);
+    });
+}
+
+function reportCarriedStateHealth(root: string, target: string, copied: string[]): void {
+  const staleDeps = depsOutOfSync(root, target, copied);
+  if (staleDeps.length) {
+    const manifests = staleDeps.map((d) => (d.dir === '.' ? d.lockfile : `${d.dir}/${d.lockfile}`)).join(', ');
+    const remedies = [...new Set(staleDeps.map((dependency) => dependencyInstallCommand(target, dependency.dir)))];
+    console.error(
+      chalk.yellow(
+        phaseLine(
+          'carry',
+          `carried dependencies may be stale: they do not match ${manifests}. Run ${remedies.map((command) => `\`${command}\``).join(' and ')} before building.`,
+        ),
+      ),
+    );
+  }
+  for (const p of podsOutOfSync(target, copied)) {
+    const where = p.dir === '.' ? 'Podfile.lock' : `${p.dir}/Podfile.lock`;
+    const pod = podInstallCommand(p.dir === '.' ? target : resolve(target, p.dir, '..'));
+    console.error(
+      chalk.yellow(
+        phaseLine(
+          'carry',
+          p.reason === 'missing'
+            ? `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} but there is no ${where}. Run \`${pod}\` before building.`
+            : `carried ${p.dir === '.' ? 'Pods' : `${p.dir}/Pods`} does not match the ${where} on disk here. Pods are gitignored and cloned; Podfile.lock is tracked, so the two can disagree. Run \`${pod}\` before building, or xcodebuild fails with "sandbox is not in sync" only after every pod has compiled.`,
+        ),
+      ),
+    );
+  }
+}
+
+export function registerWarm(worktree: Command): void {
+  worktree
+    .command('warm')
+    .description('Copy missing ignored paths from the main checkout into the current linked worktree.')
+    .action(() => {
+      try {
+        const { root, target, common } = warmWorktreePaths(process.cwd());
+        const settings = resolveSettings({ gitCommonDir: common, repoRoot: root }) as WorktreeSettings;
+        const shapeErrors = settingShapeErrors(settings);
+        if (shapeErrors.length) {
+          for (const message of shapeErrors) console.error(chalk.red(message));
+          console.error(chalk.dim(SETTING_SHAPE_REMEDY));
+          process.exitCode = 1;
+          return;
+        }
+        for (const key of unknownSettingKeys(settings)) {
+          console.error(chalk.yellow(`Warning: setting "${key}" is not read by Stim and will be ignored.`));
+        }
+        const excluded = readWorktreeExclude(root);
+        const patterns = excluded?.length ? excluded : settings.worktree?.exclude || [];
+        const result = cloneIgnoredEntries({ root, target, patterns, preserveExisting: true });
+        for (const entry of result.skipped) {
+          console.error(chalk.dim(phaseLine('carry', `kept ${entry.file} (${entry.reason})`)));
+        }
+        for (const entry of result.failed) {
+          console.error(chalk.yellow(phaseLine('carry', `could not copy ${entry.file}: ${entry.error}`)));
+        }
+        if (result.copied.length) {
+          console.error(chalk.dim(phaseLine('carry', `copied ${carriedFileList(result.copied)} from ${root}`)));
+          reportCarriedStateHealth(root, target, result.copied);
+        }
+        console.error(
+          phaseLine(
+            'carry',
+            `${result.failed.length ? 'incomplete' : 'complete'}: ${result.copied.length} ignored entries copied, ${result.skipped.length} kept, ${result.failed.length} failed`,
+          ),
+        );
+        if (result.failed.length) process.exitCode = 1;
+      } catch (error) {
+        console.error(chalk.red(`Could not warm this worktree: ${(error as Error).message}`));
+        process.exitCode = 1;
+      }
     });
 }
 
@@ -1052,7 +1100,8 @@ export function registerRemove(worktree: Command): void {
 }
 
 export default function worktreeCommand(program: Command): void {
-  const worktree = program.command('worktree').description('Create and remove isolated worktrees');
+  const worktree = program.command('worktree').description('Create, warm, and remove isolated worktrees');
   registerCreate(worktree);
+  registerWarm(worktree);
   registerRemove(worktree);
 }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -11,7 +11,12 @@ NORMAL WORKFLOW
 
 Work in the current checkout by default. When the task needs another branch or
 an isolated environment, create a worktree and carry its dependencies and
-native outputs.
+native outputs. If a harness already created this linked worktree, run
+stim worktree warm here instead of creating another one. It copies missing
+ignored paths from the main checkout, including eligible .env and local
+configuration files. It preserves the branch, tracked files, and every existing
+destination entry; existing directories are skipped whole, not filled in.
+Read guide lifecycle options for exclusions and incomplete-copy remedies.
 
 Before native worktree work, run doctor for the platform in scope. It checks
 the main checkout from a linked worktree. Fix relevant findings and inspect the

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -816,8 +816,17 @@ not on any remote"  (worktree remove)
   Every keep names \`git branch -D\`.`,
     },
     carry: {
-      summary: 'every carry line worktree create prints, and what each means',
-      body: () => `"carry       carried <dir>/Pods does not match the <dir>/Podfile.lock on
+      summary: 'worktree create and warm copy results, lockfile mismatches, and remedies',
+      body: () => `"carry       incomplete: ... ignored entries copied, ... kept, ... failed"
+(worktree warm)
+  At least one entry could not be copied. The command exits 1 and names each
+  failure. Existing entries stay untouched; any files already published remain.
+  Inspect failed paths before retrying, because existing directories are skipped
+  whole. "complete" means the eligible copy finished, not that dependencies
+  are installed or match this branch. Lockfile mismatch remedies below also
+  apply to warm. It writes progress and results to stderr, with empty stdout.
+
+"carry       carried <dir>/Pods does not match the <dir>/Podfile.lock on
 disk here"  (worktree create)
   \`ios/Pods\` is gitignored, so --carry-ignored clones it; \`ios/Podfile.lock\`
   is tracked. The check compares the cloned

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -14,6 +14,10 @@ const lifecycle: GuideTopic = {
   # checkout remains one flat + separated directory directly under worktreeDir.
   # Default device labels include a stable hash so flat names cannot collide.
 
+  # Already in a linked worktree created by a harness? Instead of step 1:
+  #   stim worktree warm
+  # It copies missing ignored paths from the main checkout.
+
   # 2. The dev server, under a detached supervisor. Blocks until it is
   #    verifiably THIS project's, then hands your shell back.
   stim start
@@ -519,12 +523,36 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   doctor          --json --fix --platform <ios|android>
                                   (--platform keeps shared checks and filters native findings)
   gc              --delete --older-than <days> --cache <name|all>
-  worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; remove [path] --force
+  worktree create <name> --carry-ignored --base <ref> --dir <path> --label <label>; warm; remove [path] --force
 
   That is the whole surface today, and it is deliberately small. It can grow
   when a flag is genuinely the best answer -- but project-specific knowledge
   (release builds, variants, device targets) belongs in a script the repo owns,
   not in a flag here.
+
+  \`stim worktree warm\` takes no arguments or flags. Run it anywhere inside
+  the current linked worktree to copy missing ignored entries from its main
+  checkout, regardless of either branch's HEAD or worktree.baseRef. Both roots
+  must be registered worktrees of the same Git repository; the main checkout
+  must be available. Running it in the main checkout refuses.
+
+  The ignored scope matches create --carry-ignored from that source: installed
+  dependencies, Pods, native output, and any other eligible ignored paths,
+  including .env and local configuration. The source's nonempty
+  .worktreeexclude replaces its resolved worktree.exclude setting. Nested
+  registered worktrees and .DerivedData are excluded. Warm also skips paths
+  overlapping a nested destination worktree or below a symlink ancestor.
+
+  Existing entries, including dangling symlinks, stay untouched. An existing
+  directory such as node_modules is skipped WHOLE; missing children are not
+  filled in. Warm does not copy tracked changes, switch branches, install
+  dependencies, or build. stdout stays empty; stderr reports copied, kept,
+  and failed entry counts. A copy failure exits 1 and reports incomplete;
+  files published before a failure remain. Inspect the named failed entry
+  before retrying: a partially published directory will be kept on the retry.
+  A completed copy is not proof that dependencies match this branch. Follow
+  any lockfile remedies before building, and install missing dependencies
+  with the project's package manager when the source has none to copy.
 
   \`android --variant <name>\` selects the gradle variant to assemble and
   install on a project with product flavors -- \`--variant productionDebug\`

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -185,9 +185,11 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         finds an existing worktree-<name> still attaches to it
                         and says which ref was not applied.
   worktree.include      carry-over patterns, same role as .worktreeinclude
-  worktree.exclude      additional --carry-ignored skip list, same role as
-                        .worktreeexclude. Registered nested Git worktrees are
-                        always skipped.
+  worktree.exclude      ignored-path skip list for create --carry-ignored
+                        and worktree warm. Both read settings from the source
+                        checkout (main for warm). A nonempty .worktreeexclude
+                        in that source replaces this setting. Registered
+                        nested Git worktrees are always skipped.
   cache.provider        one optional SECOND-TIER cache provider: a module
                         path relative to the settings file that names it, or a
                         package name. It implements the @stim-cli/cache

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   constants,
   copyFileSync,
   existsSync,
@@ -333,12 +334,26 @@ function publishMissingEntry(from: string, to: string): void {
     copyFileSync(from, to, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE);
     utimesSync(to, stat.atime, stat.mtime);
   } else if (stat.isDirectory()) {
-    mkdirSync(to, { mode: stat.mode });
-    for (const name of readdirSync(from)) publishMissingEntry(join(from, name), join(to, name));
+    mkdirSync(to, { mode: stat.mode | 0o700 });
+    for (const name of readdirSync(from)) {
+      if (!CARRY_SKIP_BASENAMES.has(name)) publishMissingEntry(join(from, name), join(to, name));
+    }
     utimesSync(to, stat.atime, stat.mtime);
+    chmodSync(to, stat.mode);
   } else {
     throw new Error(`Unsupported ignored entry: ${from}`);
   }
+}
+
+function removeStagedEntry(path: string): void {
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (stat?.isDirectory()) {
+    chmodSync(path, stat.mode | 0o700);
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      if (entry.isDirectory()) removeStagedEntry(join(path, entry.name));
+    }
+  }
+  rmSync(path, { recursive: true, force: true });
 }
 
 export function cloneIgnoredEntries({
@@ -382,11 +397,11 @@ export function cloneIgnoredEntries({
       try {
         getExecutor().runFile('cp', ['-Rc', from, destination]);
       } catch {
-        if (staging) rmSync(destination, { recursive: true, force: true });
+        if (staging) removeStagedEntry(destination);
         getExecutor().runFile('cp', ['-R', from, destination]);
         cloned = false;
       }
-      if (isDir) pruneCarriedArtifacts(destination);
+      if (isDir && !staging) pruneCarriedArtifacts(destination);
       if (staging) {
         const changed = missingDestinationReason(target, rel);
         if (changed) {
@@ -400,7 +415,7 @@ export function cloneIgnoredEntries({
     } catch (e) {
       failed.push({ file: rel, error: String((e as Error)?.message || e) });
     } finally {
-      if (staging) rmSync(staging, { recursive: true, force: true });
+      if (staging) removeStagedEntry(staging);
     }
   }
   return { copied, skipped, failed, cloned };

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -215,12 +215,21 @@ interface TrackedGuard {
 function trackedGuard(dir: string): TrackedGuard {
   const paths = listTrackedPaths(dir);
   if (paths === null) return { known: false, covers: () => false };
-  const set = new Set<string>();
+  const entries = new Set(paths);
+  const covered = new Set(paths);
   for (const p of paths) {
-    set.add(p);
-    for (let i = p.indexOf('/'); i !== -1; i = p.indexOf('/', i + 1)) set.add(p.slice(0, i));
+    for (let i = p.indexOf('/'); i !== -1; i = p.indexOf('/', i + 1)) covered.add(p.slice(0, i));
   }
-  return { known: true, covers: (rel) => set.has(rel) };
+  return {
+    known: true,
+    covers: (rel) => {
+      if (covered.has(rel)) return true;
+      for (let i = rel.indexOf('/'); i !== -1; i = rel.indexOf('/', i + 1)) {
+        if (entries.has(rel.slice(0, i))) return true;
+      }
+      return false;
+    },
+  };
 }
 
 function refuseReason(guard: TrackedGuard, rel: string, destPath: string): 'tracked' | 'unverified' | null {

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -1,12 +1,18 @@
 import {
+  constants,
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
+  readlinkSync,
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
+  utimesSync,
   writeFileSync,
 } from 'fs';
 import { tmpdir } from 'os';
@@ -61,6 +67,34 @@ export function isMainWorkingTree(path: string): boolean {
 export function repoRoot(cwd: string): string | null {
   const out = getExecutor().runFileQuiet('git', ['-C', cwd, 'rev-parse', '--show-toplevel']);
   return out ? out.trim() : null;
+}
+
+export function warmWorktreePaths(cwd: string): { root: string; target: string; common: string } {
+  const currentRoot = repoRoot(cwd);
+  if (!currentRoot) throw new Error('Not a git repository.');
+  const target = realpathSync(currentRoot);
+  if (isMainWorkingTree(target)) {
+    throw new Error('Run stim worktree warm from a linked worktree, not the main checkout.');
+  }
+  const entries = listWorktrees(target);
+  const current = entries.find((entry) => canonicalPath(entry.path) === target);
+  const main = entries.find((entry) => isMainWorkingTree(entry.path));
+  if (!current || !main) throw new Error('Could not identify the linked worktree and its main checkout.');
+  const root = realpathSync(main.path);
+  const sourceRoot = repoRoot(root);
+  const sourceCommon = gitCommonDir(root);
+  const targetCommon = gitCommonDir(target);
+  if (
+    root === target ||
+    !sourceRoot ||
+    realpathSync(sourceRoot) !== root ||
+    !sourceCommon ||
+    !targetCommon ||
+    realpathSync(sourceCommon) !== realpathSync(targetCommon)
+  ) {
+    throw new Error('Could not verify that the main checkout belongs to this linked worktree.');
+  }
+  return { root, target, common: realpathSync(targetCommon) };
 }
 
 export function defaultWorktreeDir(root: string): string {
@@ -245,8 +279,8 @@ export function carryOverFiles({
   return { copied, skipped, failed };
 }
 
-export function listGitignoredEntries(root: string): string[] {
-  const out = getExecutor().runFileQuiet('git', [
+export function listGitignoredEntries(root: string, strict = false): string[] {
+  const args = [
     '-C',
     root,
     'ls-files',
@@ -255,17 +289,23 @@ export function listGitignoredEntries(root: string): string[] {
     '--exclude-standard',
     '--directory',
     '--no-empty-directory',
-  ]);
+    ...(strict ? ['-z'] : []),
+  ];
+  const out = strict ? getExecutor().runFile('git', args) : getExecutor().runFileQuiet('git', args);
   if (!out) return [];
   return out
-    .split('\n')
+    .split(strict ? '\0' : '\n')
     .filter(Boolean)
     .map((e) => (e.endsWith('/') ? e.slice(0, -1) : e));
 }
 
-export function listCarryableIgnoredEntries(root: string, patterns: string[] | null | undefined): string[] {
+export function listCarryableIgnoredEntries(
+  root: string,
+  patterns: string[] | null | undefined,
+  strict = false,
+): string[] {
   const nested = nestedWorktreePaths(root);
-  return listGitignoredEntries(root).filter(
+  return listGitignoredEntries(root, strict).filter(
     (rel) => !isCarrySkipped(rel) && !overlapsNestedWorktree(rel, nested) && !matchesInclude(rel, patterns),
   );
 }
@@ -274,44 +314,93 @@ interface CloneResult extends CarryResult {
   cloned: boolean;
 }
 
+function missingDestinationReason(target: string, rel: string): string | null {
+  const parts = rel.split('/');
+  for (let i = 1; i < parts.length; i++) {
+    const parent = parts.slice(0, i).join('/');
+    const stat = lstatSync(join(target, parent), { throwIfNoEntry: false });
+    if (stat?.isSymbolicLink()) return `symlink ancestor: ${parent}`;
+    if (stat && !stat.isDirectory()) return `non-directory ancestor: ${parent}`;
+  }
+  return lstatSync(join(target, rel), { throwIfNoEntry: false }) ? 'exists' : null;
+}
+
+function publishMissingEntry(from: string, to: string): void {
+  const stat = lstatSync(from);
+  if (stat.isSymbolicLink()) {
+    symlinkSync(readlinkSync(from), to);
+  } else if (stat.isFile()) {
+    copyFileSync(from, to, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE);
+    utimesSync(to, stat.atime, stat.mtime);
+  } else if (stat.isDirectory()) {
+    mkdirSync(to, { mode: stat.mode });
+    for (const name of readdirSync(from)) publishMissingEntry(join(from, name), join(to, name));
+    utimesSync(to, stat.atime, stat.mtime);
+  } else {
+    throw new Error(`Unsupported ignored entry: ${from}`);
+  }
+}
+
 export function cloneIgnoredEntries({
   root,
   target,
   patterns,
+  preserveExisting = false,
 }: {
   root: string;
   target: string;
   patterns: string[] | null | undefined;
+  preserveExisting?: boolean;
 }): CloneResult {
   const copied: string[] = [];
   const skipped: SkippedEntry[] = [];
   const failed: FailedEntry[] = [];
   let cloned = true;
   const guard = trackedGuard(target);
-  for (const rel of listCarryableIgnoredEntries(root, patterns)) {
+  if (preserveExisting && !guard.known) throw new Error("Could not list the destination's tracked files.");
+  const nested = preserveExisting ? nestedWorktreePaths(target) : [];
+  for (const rel of listCarryableIgnoredEntries(root, patterns, preserveExisting)) {
     const from = join(root, rel);
     const to = join(target, rel);
     let isDir = false;
     try {
       isDir = statSync(from).isDirectory();
     } catch {}
-    const reason = refuseReason(guard, rel, to);
-    if (reason) {
-      skipped.push({ file: rel, reason });
-      continue;
-    }
+    let staging: string | undefined;
     try {
-      mkdirSync(dirname(to), { recursive: true });
+      const reason =
+        refuseReason(guard, rel, to) ||
+        (preserveExisting &&
+          (overlapsNestedWorktree(rel, nested) ? 'nested worktree' : missingDestinationReason(target, rel)));
+      if (reason) {
+        skipped.push({ file: rel, reason });
+        continue;
+      }
+      if (preserveExisting) staging = mkdtempSync(join(target, '.stim-warm-'));
+      const destination = staging ? join(staging, 'entry') : to;
+      mkdirSync(dirname(destination), { recursive: true });
       try {
-        getExecutor().runFile('cp', ['-Rc', from, to]);
+        getExecutor().runFile('cp', ['-Rc', from, destination]);
       } catch {
-        getExecutor().runFile('cp', ['-R', from, to]);
+        if (staging) rmSync(destination, { recursive: true, force: true });
+        getExecutor().runFile('cp', ['-R', from, destination]);
         cloned = false;
       }
-      if (isDir) pruneCarriedArtifacts(to);
+      if (isDir) pruneCarriedArtifacts(destination);
+      if (staging) {
+        const changed = missingDestinationReason(target, rel);
+        if (changed) {
+          skipped.push({ file: rel, reason: changed });
+          continue;
+        }
+        mkdirSync(dirname(to), { recursive: true });
+        publishMissingEntry(destination, to);
+      }
       copied.push(rel);
     } catch (e) {
       failed.push({ file: rel, error: String((e as Error)?.message || e) });
+    } finally {
+      if (staging) rmSync(staging, { recursive: true, force: true });
     }
   }
   return { copied, skipped, failed, cloned };

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -391,7 +391,7 @@ export function cloneIgnoredEntries({
         skipped.push({ file: rel, reason });
         continue;
       }
-      if (preserveExisting) staging = mkdtempSync(join(target, '.stim-warm-'));
+      if (preserveExisting) staging = mkdtempSync(join(tmpdir(), '.stim-warm-'));
       const destination = staging ? join(staging, 'entry') : to;
       mkdirSync(dirname(destination), { recursive: true });
       try {

--- a/test/e2e/worktree-warm.e2e.js
+++ b/test/e2e/worktree-warm.e2e.js
@@ -112,3 +112,39 @@ function write(rel, contents) {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, contents);
 }
+
+test('an externally created worktree can warm from main without changing its branch or existing entries', () => {
+  const linked = join(ctx.tmp, 'external-linked');
+  git(['worktree', 'add', '-b', 'external-linked', linked]);
+  write('.gitignore', readFileSync(join(ctx.repo, '.gitignore'), 'utf-8') + '.env\n');
+  write('.env', 'main local config');
+  write('.worktreeexclude', 'ios/build\n');
+  write('package.json', '{"name":"dirty-main"}\n');
+  mkdirSync(join(linked, 'node_modules', 'own'), { recursive: true });
+  writeFileSync(join(linked, 'node_modules', 'own', 'index.js'), 'own dependency');
+  const head = execFileSync('git', ['-C', linked, 'rev-parse', 'HEAD'], { encoding: 'utf-8' });
+  const run = () =>
+    spawnSync(process.execPath, [CLI, 'worktree', 'warm'], {
+      cwd: join(linked, 'ios'),
+      env: { ...process.env, STIM_HOME: ctx.home },
+      encoding: 'utf-8',
+    });
+  const warmed = run();
+  assert.equal(warmed.status, 0, warmed.stderr);
+  assert.equal(warmed.stdout, '');
+  assert.match(warmed.stderr, /kept node_modules \(exists\)/);
+  assert.match(warmed.stderr, /complete: .*0 failed/);
+  assert.equal(readFileSync(join(linked, '.env'), 'utf-8'), 'main local config');
+  assert.equal(readFileSync(join(linked, 'node_modules', 'own', 'index.js'), 'utf-8'), 'own dependency');
+  assert.equal(existsSync(join(linked, 'node_modules', 'pkg')), false);
+  assert.equal(existsSync(join(linked, 'ios', 'build')), false);
+  assert.equal(readFileSync(join(linked, 'package.json'), 'utf-8'), '{"name":"warm-fixture","private":true}\n');
+  assert.equal(execFileSync('git', ['-C', linked, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }), head);
+  assert.equal(
+    execFileSync('git', ['-C', linked, 'branch', '--show-current'], { encoding: 'utf-8' }).trim(),
+    'external-linked',
+  );
+  const repeated = run();
+  assert.equal(repeated.status, 0, repeated.stderr);
+  assert.match(repeated.stderr, /complete: 0 ignored entries copied/);
+});

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -48,7 +48,9 @@ stim ios                  # or: stim android
 stim stop`}
 />
 
-Later worktrees can reuse that cache entry. `stim worktree create
+Later worktrees can reuse that cache entry. In an existing linked worktree,
+`stim worktree warm` copies missing ignored state from main without replacing
+existing entries. See [worktree isolation](./worktrees.md) for its full scope. `stim worktree create
 --carry-ignored` can also copy installed dependencies, Pods, and native output
 from the source checkout.
 

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -314,6 +314,28 @@ under the worktree root: `feature/settings` becomes `feature+settings`.
 - `--label` sets the short Stim name used by the environment and device.
 - `--carry-ignored` copies safe ignored files and compatible uncommitted changes.
 
+## `worktree warm`
+
+```text
+stim worktree warm
+```
+
+Copies missing ignored entries from the repository's main checkout into the
+current linked worktree. It takes no arguments or flags and accepts a current
+subdirectory. The main checkout must be available in the same Git repository;
+running warm in the main checkout refuses.
+
+The branch, tracked files, and existing destination entries stay untouched.
+Existing directories, including `node_modules`, are skipped whole. Eligible
+ignored `.env` and local configuration files are included. The main checkout's
+nonempty `.worktreeexclude` replaces its resolved `worktree.exclude` setting.
+See [worktree isolation](./worktrees.md) for the shared exclusions.
+
+stdout stays empty. stderr reports copied, kept, and failed entries. Failures
+exit 1; inspect failed paths before retrying, since partially published
+entries remain and existing directories are skipped. Warm does not install
+dependencies or build.
+
 ## `worktree remove`
 
 ```text

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -54,13 +54,18 @@ reports it as a finding instead of refusing.
 | `worktreeDir`                 | Parent directory for created worktrees; `worktree create --dir` overrides it for one run |
 | `worktree.baseRef`            | Default worktree base: `head`, `fresh`, or a git ref                                     |
 | `worktree.include`            | Explicit ignored paths to carry                                                          |
-| `worktree.exclude`            | Ignored paths skipped by `--carry-ignored`                                               |
+| `worktree.exclude`            | Ignored paths skipped by `create --carry-ignored` and `worktree warm`                    |
 | `cache.provider`              | Optional second-tier cache provider module                                               |
 | `cache.options`               | Options passed to that provider                                                          |
 | `caches`                      | Additional cache paths reported by `gc`                                                  |
 
 A relative `worktreeDir` resolves against the settings root, the repository
 root, so a committed `.stim.json` can place worktrees inside the repository.
+Both ignored-copy operations read exclusions from their source checkout: main
+for `worktree warm`, the current checkout for `create --carry-ignored`. A
+nonempty `.worktreeexclude` in that source replaces its resolved
+`worktree.exclude` setting; an empty or absent file uses the setting.
+
 A relative `worktree create --dir` resolves against the current directory.
 
 `worktree.baseRef` is a default, not an assertion: only the `--base` flag

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -50,7 +50,7 @@ that overlap registered nested worktrees or have symlink ancestors.
 
 Both operations copy safe gitignored paths, such as `node_modules`, `ios/Pods`, and
 native build output, `.env`, and local configuration files. APFS clone copies remain space-efficient on one volume.
-Stim reports when it must make a normal byte copy.
+If cloning is unavailable, Stim makes a normal byte copy.
 
 Stim excludes:
 

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -36,15 +36,29 @@ only the branch created by that attempt so a retry can use the requested base.
 code={`stim worktree create feature-x --carry-ignored`}
 />
 
-The option copies safe gitignored paths, such as `node_modules`, `ios/Pods`, and
-native build output. APFS clone copies remain space-efficient on one volume.
+If a harness or `git worktree add` already created the linked worktree, run
+this inside it instead:
+
+<StimTabs code={`stim worktree warm`} />
+
+Warm uses the repository's main checkout as its source, regardless of either
+branch's `HEAD`. The main checkout must still be available. It preserves the
+current branch, tracked files, and every existing destination entry, including
+dangling symlinks. An existing directory such as `node_modules` is skipped
+whole; warm does not fill missing children. It also skips destination paths
+that overlap registered nested worktrees or have symlink ancestors.
+
+Both operations copy safe gitignored paths, such as `node_modules`, `ios/Pods`, and
+native build output, `.env`, and local configuration files. APFS clone copies remain space-efficient on one volume.
 Stim reports when it must make a normal byte copy.
 
 Stim excludes:
 
 - Nested registered git worktrees.
 - Any `.DerivedData` directory.
-- Paths matched by `.worktreeexclude` or `worktree.exclude`.
+- Paths matched by the source checkout's nonempty `.worktreeexclude`, or its
+  resolved `worktree.exclude` setting when that file is absent or empty. Warm
+  reads both from main; create reads both from its current source checkout.
 
 Use `.worktreeinclude` or `worktree.include` to copy a small explicit set during
 a normal create. This is useful for `.env` files. Stim only copies paths that
@@ -53,6 +67,13 @@ git already ignores.
 Compatible uncommitted tracked changes are also applied with
 `--carry-ignored`. Untracked files that are not ignored are not copied. Review
 the reported working state before committing.
+
+Warm writes only to stderr: copied, kept, and failed entry counts, plus any
+lockfile remedies. A failure exits 1; files already published remain. Inspect
+the named failure before retrying, because a partially published directory is
+kept on retry. A completed copy does not prove dependencies are installed or
+match the current branch. Install missing dependencies with the project's
+package manager when the source has none to copy.
 
 ## Parallel environments
 


### PR DESCRIPTION
## Description

A linked worktree created by an agent harness or `git worktree add` has no command to copy the main checkout's installed dependencies and native output into place.

## Solution

Add `stim worktree warm` for the current linked worktree. It validates the registered main checkout and shared Git directory, then copies missing ignored entries using the existing exclusions. Eligible `.env` and local configuration files are included; settings and `.worktreeexclude` come from main.

Existing entries are preserved, including whole directories and dangling symlinks. Copies preserve concurrently created entries and skip unsafe destinations. Copy failures return nonzero with an incomplete summary and retain completed copies.

The command does not change the branch or tracked files, install dependencies, or build. Guide topics, README, and the website describe the scope and recovery steps.

## Test plan

- All 26 warm regressions passed. Eight copy regressions failed against the original copier, then passed with the change.
- Real temporary Git worktrees and filesystem copies cover missing-only behavior, symlinks, exclusions, clone fallback, source isolation, branch preservation, read-only modes, and repeated warming. Git status and dry-run add cannot see temporary copies, and deleted tracked ancestors remain absent. Injected publication collisions preserve concurrent contents and report incomplete.

Fixes #344

