### PR TITLE
docs: verify UI changes before agent cleanup

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1288,6 +1288,10 @@ test('the agent guide carries the normal workflow and safety rules', () => {
   expect(agent).toContain('stim reload');
   expect(normalWorkflow).not.toContain('stim reload');
   expect(normalWorkflow).not.toContain('agent-device metro reload');
+  expect(normalWorkflow.match(/stim logs --errors/g)).toHaveLength(2);
+  expect(normalWorkflow.lastIndexOf('stim logs --errors')).toBeLessThan(normalWorkflow.lastIndexOf('stim stop'));
+  expect(agent).toContain('stim guide lifecycle verification');
+  expect(renderSection('lifecycle', 'verification')).toBeTruthy();
   expect(agent).toMatch(/app error but also says the native process is alive,[\s\S]*app did not crash/);
   expect(agent).toMatch(/FATAL because the app process exited,[\s\S]*Metro cannot restart it/);
   expect(agent).toMatch(/Ordinary stim stop and an authorized clean\s+stim worktree remove do not need/);
@@ -1320,7 +1324,7 @@ test('the logs and lifecycle guides distinguish query success from a clean captu
   expect(logs).toContain('a workspace with no log directory also returns an empty result');
   const lifecycle = renderTopic('lifecycle');
   assert(lifecycle);
-  expect(lifecycle).toContain('Check captured errors: require exit 0 AND no matching errors');
+  expect(lifecycle).toContain('require exit 0 AND no matching errors');
   expect(lifecycle).toContain('Exit 0 alone means the query succeeded, even when it printed errors');
 });
 

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -33,7 +33,15 @@ upstream gap.
 
   stim start
   stim ios                             # or: stim android
+
+  # Reproduce the affected behavior and capture the baseline errors.
   stim logs --errors
+
+  # Edit JavaScript or TypeScript; Fast Refresh applies the change.
+  # For UI work, wait for the expected UI and repeat the affected interaction
+  # on the reported device. Keep using the existing automation session, if any.
+  stim logs --errors
+  # Retain proof before cleanup: a screenshot, recording, or relevant runtime output.
 
   stim stop
   stim worktree remove
@@ -151,6 +159,7 @@ LOAD ADVANCED GUIDANCE WHEN NEEDED
   stim guide errors unverified    # launch unverified, and the Local Network reason
   stim guide errors fallbacks     # swap, cache, and install notes on a release cache hit
   stim guide lifecycle            # the ordered flow, consent rules, and capacity
+  stim guide lifecycle verification # reproduce, edit, verify the UI, and retain proof
   stim guide lifecycle builds     # cache hits, misses, fingerprints, .fingerprintignore
   stim guide lifecycle options    # every flag, Android variants, --device-type, --system-image
   stim guide lifecycle devices    # ios --device and android --device on a physical phone

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -29,12 +29,18 @@ const lifecycle: GuideTopic = {
     install     from cache (3s)
     launch      com.example.app (1s)
 
-  # 4. Check captured errors: require exit 0 AND no matching errors.
+  # 4. Reproduce the affected behavior and inspect the baseline errors.
+  #    For a clean check, require exit 0 AND no matching errors.
   #    Human mode prints "No matching log records" on stderr for zero matches.
   #    Exit 0 alone means the query succeeded, even when it printed errors.
   stim logs --errors
 
   # 5. Edit the JS. Fast Refresh applies it; no Stim command is involved.
+  #    For UI work, wait for the expected UI and repeat the affected interaction
+  #    on the reported device, using the existing automation session if any.
+  stim logs --errors
+  #    Retain proof: a screenshot, recording, or relevant runtime output.
+  #    See: stim guide lifecycle verification
 
   # 6. Pausing: supervisor halted, collectors reaped, owned device SHUT DOWN
   #    (never deleted), port freed. Coming back costs a boot, not a create.
@@ -95,6 +101,39 @@ TWO REPORTS, TWO QUESTIONS
   the machine, with a hit rate and an estimate of the time saved (see
   \`guide facts stats\`).`,
   sections: {
+    verification: {
+      summary: 'reproduce the affected behavior, verify the change on the reported device, and retain proof',
+      body: () => `VERIFY THE CHANGE
+
+For a UI change or bug fix, decide what observable result would prove the task
+is complete. A successful build, a live process, or an empty log query does
+not prove that result.
+
+1. On the device reported by ios or android, reproduce the affected behavior
+   before editing and capture the baseline with stim logs --errors. If the
+   issue does not reproduce, record what you tried instead of claiming it did.
+2. Make the change. JavaScript and TypeScript normally use Fast Refresh;
+   native input changes need another ios or android run. Follow the printed
+   recovery remedy if an error screen remains or the native process exited.
+3. Use the full reported device ID with your UI automation tool. Continue in
+   the existing session for that device when one exists. Wait for the expected
+   content or control before inspecting the screen; launch evidence alone
+   does not prove that the first screen has rendered. Bound the wait and report
+   verification as incomplete if the expected state never appears.
+4. Repeat the affected interaction and check its expected outcome, then run
+   stim logs --errors. Read the records, not just the exit code. Earlier client
+   errors can remain after Fast Refresh; compare their timestamps with the
+   reproduction and check whether they recur. Do not relaunch just to clear
+   the log window. An empty query does not prove log capture succeeded.
+5. Retain a screenshot for a visible result or a short recording for an
+   interaction. Report what you exercised, what you observed, any unresolved
+   errors, and the proof location before stopping the app or removing the
+   worktree. If device access or another prerequisite prevents verification,
+   name the missing check.
+
+For a change without a UI effect, use the relevant runtime output or test
+result as proof instead of requiring an unrelated screenshot.`,
+    },
     progress: {
       summary: 'phase lines, the label set, heartbeats and their ~ estimate, what create, start, stop and remove print',
       body: () => `PROGRESS ON A LONG RUN


### PR DESCRIPTION
## Description

The standard agent loop ends at a launch and error query, which does not establish that a UI fix works.

Fixes #417.

## Solution

Adds reproduction and post-edit UI verification before cleanup, with a focused lifecycle guide for retaining proof and reporting incomplete checks. Fast Refresh remains the normal JavaScript path; changes without a UI effect use relevant runtime or test evidence.

## Test plan

- Render `stim guide agent` and `stim guide lifecycle verification` from the built CLI; check that baseline capture, post-edit verification, and retained proof precede cleanup.
- Guide contracts cover the two error queries, their ordering before cleanup, and the verification section routing.
