### PR TITLE
fix: describe reload success as a request

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -53,11 +53,14 @@ Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.
 
-`stim reload [ios|android]` reloads JavaScript in the live app on this
+`stim reload [ios|android]` requests a JavaScript reload in the live app on this
 workspace's owned local device. Use it after a failed first bundle load, when
 an error screen remains after a fix, or when you explicitly need an app
 restart. It is not part of the normal workflow and does not build, install,
 boot, or launch an app. The platform is optional when only one app is live.
+Success confirms that the request was sent; Stim does not observe completion.
+Verify the expected UI on the reported device and inspect `stim logs --errors`
+before claiming recovery.
 
 ## Reference
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -1477,6 +1477,7 @@ test('the guide defines reload as a JavaScript-only live-app recovery', () => {
   expect(lifecycle).toMatch(/iOS Local Network first-load[\s\S]*no Metro peer exists yet/);
   expect(renderSection('lifecycle', 'options')).toMatch(/^  reload\s+\[ios\|android\] --json$/m);
   expect(renderSection('facts', 'payloads')).toContain('stim reload [ios|android] --json');
+  expect(renderSection('facts', 'payloads')).toMatch(/reload request was sent[\s\S]*does not observe completion/);
   expect(renderSection('facts', 'payloads')).toMatch(/platform[\s\S]*deviceId[\s\S]*metroPort[\s\S]*strategy/);
   expect(errors).toContain('STIM_RELOAD_AMBIGUOUS');
   expect(errors).toContain('STIM_RELOAD_RELEASE');

--- a/packages/stim-cli/src/__tests__/reload-command.test.ts
+++ b/packages/stim-cli/src/__tests__/reload-command.test.ts
@@ -208,10 +208,31 @@ test('reload --json prints exactly one parseable facts line', async () => {
   }
 
   expect(lines).toHaveLength(1);
-  expect(JSON.parse(lines[0]!)).toMatchObject({
+  expect(JSON.parse(lines[0]!)).toEqual({
     platform: 'android',
     deviceId: 'emulator-5554',
+    deviceName: 'stim-android',
+    appId: 'com.example.android',
     metroPort: 8082,
     strategy: 'android-broadcast',
   });
+});
+
+test('reload plain output reports a request and retains the target facts', async () => {
+  const program = new Command();
+  registerReload(program, reloadDeps());
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await program.parseAsync(['node', 'stim', 'reload', 'android']);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(lines).toHaveLength(1);
+  expect(lines[0]).toMatch(/^Reload requested for com\.example\.android /);
+  expect(lines[0]).toContain('emulator-5554');
+  expect(lines[0]).toContain('8082');
+  expect(lines[0]).toContain('stim logs --errors');
 });

--- a/packages/stim-cli/src/commands/reload.ts
+++ b/packages/stim-cli/src/commands/reload.ts
@@ -350,7 +350,7 @@ export function registerReload(program: Command, deps: Partial<ReloadDeps> = {})
   program
     .command('reload [platform]')
     .description(
-      "Reload JavaScript in this workspace's live app without building, installing, or cold-launching it. Specify ios or android when both are live.",
+      "Request a JavaScript reload in this workspace's live app without observing completion. Specify ios or android when both are live.",
     )
     .option('--json', 'Emit the reload facts as one JSON line')
     .action(async (value: string | undefined, opts: ReloadOptions) => {
@@ -395,7 +395,7 @@ export function registerReload(program: Command, deps: Partial<ReloadDeps> = {})
       } else {
         const facts = result.facts;
         console.log(
-          `Reloaded ${facts.appId} on ${facts.deviceName} (${facts.deviceId}) via ${facts.strategy}; ${facts.platform} Metro port ${facts.metroPort}.`,
+          `Reload requested for ${facts.appId} on ${facts.deviceName} (${facts.deviceId}) via ${facts.strategy}; ${facts.platform} Metro port ${facts.metroPort}. Completion is not observed; verify the expected UI and run stim logs --errors.`,
         );
       }
     });

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -60,6 +60,9 @@ RULES DURING THE LOOP
   physical device that reached Metro, use agent-device metro reload with the
   reported port. The detected iOS Local Network first-load remedy uses UI
   automation instead because that app never established a Metro connection.
+- A successful stim reload confirms that the request was sent, not that new
+  JavaScript loaded or the screen recovered. Verify the expected UI on the
+  reported device and inspect stim logs --errors before claiming recovery.
 - If launch reports an app error but also says the native process is alive,
   the app did not crash. Fix JavaScript or TypeScript and use Fast Refresh. If
   the error screen remains, follow the printed reload remedy instead of

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -211,8 +211,13 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
 
   stim reload [ios|android] --json
 
+  Exit 0 and this payload confirm that the reload request was sent. They do
+  not prove that new JavaScript loaded or that the screen recovered. The
+  command does not observe completion. Verify the expected UI on deviceId
+  and inspect stim logs --errors before claiming recovery.
+
   platform        "ios" | "android"
-  deviceId        the exact owned simulator UDID or emulator serial reloaded
+  deviceId        the exact owned simulator UDID or emulator serial targeted
   deviceName      the owned simulator or AVD name
   appId           the live bundle id or Android package
   metroPort       the workspace's verified Metro port

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -68,6 +68,11 @@ Metro cannot identify one iOS peer, the command tells the agent to press Reload
 through its existing automation session on the exact simulator. Stim does not
 take over that stateful session.
 
+A successful reload confirms that the request was sent. It does not wait for
+new JavaScript or observe the resulting UI. Verify the expected screen or
+interaction on the reported device and inspect \`stim logs --errors\` before
+claiming recovery; exit 0 alone does not prove it.
+
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
   gc --delete --cache all empties the shared build caches every project uses

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -176,7 +176,7 @@ A variant that ends in `Release` embeds its JavaScript bundle and skips Metro.
 stim reload [ios|android] [--json]
 ```
 
-Reloads JavaScript in the live app on this workspace's owned local simulator
+Requests a JavaScript reload in the live app on this workspace's owned local simulator
 or emulator. It never builds, installs, boots, or cold-launches. Omit the
 platform when exactly one owned app is live; name it when both iOS and Android
 are live.
@@ -191,6 +191,9 @@ over that stateful session.
 The command refuses release builds, stopped or unowned devices, a missing or
 foreign Metro server, and ambiguous selection. `--json` prints one object with
 `platform`, `deviceId`, `deviceName`, `appId`, `metroPort`, and `strategy`.
+Success, including exit 0 with `--json`, confirms that the request was sent.
+The command does not observe completion. Verify the expected UI on the reported
+device and inspect `stim logs --errors` before claiming recovery.
 
 ## `logs`
 


### PR DESCRIPTION
## Description

`stim reload` prints `Reloaded` after sending an action, without observing whether new JavaScript loaded or the screen recovered.

Fixes #418.

## Solution

Reports `Reload requested` with the existing target facts and tells the caller to verify the UI and inspect errors. Help and current documentation explain the same limit, including for JSON callers. Reload mechanisms, exit statuses, and JSON fields stay unchanged.

## Test plan

- Command tests exercise plain and JSON success output: plain output identifies the request and target; JSON retains the exact six fields.
- Inspect built `stim reload --help` and `stim guide facts payloads` output for the dispatch-only contract.
