### PR TITLE
fix: preserve APFS clones when warming worktrees

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -11,6 +12,7 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -21,7 +23,8 @@ import { Command } from 'commander';
 import { registerWarm } from '../commands/worktree.ts';
 
 const publication = vi.hoisted(() => ({
-  beforeCopy: null as ((path: string) => void) | null,
+  beforePublish: null as ((path: string) => void) | null,
+  beforeLink: null as ((from: string, to: string) => void) | null,
   beforeMkdir: null as ((path: string) => void) | null,
   stagingPaths: [] as string[],
 }));
@@ -39,8 +42,13 @@ vi.mock('fs', async (importOriginal) => {
       return fs.mkdirSync(path, options);
     },
     copyFileSync: (from: string, to: string, mode?: number) => {
-      publication.beforeCopy?.(to);
+      publication.beforePublish?.(to);
       return fs.copyFileSync(from, to, mode);
+    },
+    linkSync: (from: string, to: string) => {
+      publication.beforePublish?.(to);
+      publication.beforeLink?.(from, to);
+      return fs.linkSync(from, to);
     },
   };
 });
@@ -79,7 +87,8 @@ beforeEach(() => {
 
 afterEach(() => {
   resetExecutor();
-  publication.beforeCopy = null;
+  publication.beforePublish = null;
+  publication.beforeLink = null;
   publication.beforeMkdir = null;
   process.exitCode = 0;
   delete process.env.STIM_HOME;
@@ -208,15 +217,73 @@ test('failed missing-only copies leave no partial destination and retain their e
 
 test('missing-only copy preserves relative symlinks without linking files back to the source', () => {
   write(root, 'node_modules/pkg/index.js', 'source package');
+  const source = join(root, 'node_modules/pkg/index.js');
+  const destination = join(target, 'node_modules/pkg/index.js');
+  linkSync(source, join(root, 'node_modules/pkg/sibling.js'));
   symlinkSync('pkg', join(root, 'node_modules/alias'));
   const result = warm();
   expect(result.failed).toEqual([]);
   expect(readlinkSync(join(target, 'node_modules/alias'))).toBe('pkg');
-  expect(lstatSync(join(target, 'node_modules/pkg/index.js')).ino).not.toBe(
-    lstatSync(join(root, 'node_modules/pkg/index.js')).ino,
-  );
+  const published = lstatSync(destination);
+  expect(published.ino).not.toBe(lstatSync(source).ino);
+  expect(published.nlink).toBe(1);
+  expect(lstatSync(join(target, 'node_modules/pkg/sibling.js')).ino).not.toBe(published.ino);
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+  write(target, 'node_modules/pkg/index.js', 'edited destination');
+  expect(readFileSync(source, 'utf-8')).toBe('source package');
+  expect(readFileSync(join(target, 'node_modules/pkg/sibling.js'), 'utf-8')).toBe('source package');
+  writeFileSync(source, 'edited source');
+  expect(readFileSync(destination, 'utf-8')).toBe('edited destination');
+});
+
+test.skipIf(process.platform !== 'darwin')(
+  'publication reuses the private staged inode and preserves timestamps',
+  () => {
+    write(root, '.env', 'source config');
+    const source = join(root, '.env');
+    utimesSync(source, new Date('2020-01-01'), new Date('2021-01-01'));
+    let staged: ReturnType<typeof lstatSync> | undefined;
+    publication.beforeLink = (from) => {
+      expect(from).toBe(join(publication.stagingPaths[0]!, 'entry'));
+      staged = lstatSync(from);
+      expect(staged.ino).not.toBe(lstatSync(source).ino);
+    };
+    const result = warm();
+    expect(result.failed).toEqual([]);
+    const published = lstatSync(join(target, '.env'));
+    expect(staged).toBeDefined();
+    expect(published.ino).toBe(staged?.ino);
+    expect(published.atimeMs).toBe(staged?.atimeMs);
+    expect(published.mtimeMs).toBe(staged?.mtimeMs);
+    expect(published.nlink).toBe(1);
+    expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+  },
+);
+
+test.skipIf(process.platform !== 'darwin')('cross-volume publication copies independently and reports fallback', () => {
+  write(root, 'node_modules/pkg/index.js', 'source package');
+  publication.beforeLink = () => {
+    throw Object.assign(new Error('cross-volume link'), { code: 'EXDEV' });
+  };
+  const result = warm();
+  expect(result.failed).toEqual([]);
+  expect(result.copied).toEqual(['node_modules']);
+  expect(result.cloned).toBe(false);
   write(target, 'node_modules/pkg/index.js', 'edited destination');
   expect(readFileSync(join(root, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+});
+
+test.skipIf(process.platform !== 'darwin')('publication refuses link errors other than cross-volume failures', () => {
+  write(root, '.env', 'source config');
+  publication.beforeLink = () => {
+    throw Object.assign(new Error('link permission refused'), { code: 'EPERM' });
+  };
+  const result = warm();
+  expect(result.copied).toEqual([]);
+  expect(result.failed).toEqual([{ file: '.env', error: 'link permission refused' }]);
+  expect(existsSync(join(target, '.env'))).toBe(false);
+  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
 
 async function runWarm(cwd: string) {
@@ -238,18 +305,26 @@ async function runWarm(cwd: string) {
   }
 }
 
-test('publication collisions report incomplete and preserve concurrent content and earlier published files', () => {
+test.each(['file', 'dangling symlink'])('publication preserves a late %s and earlier published files', (kind) => {
   write(root, 'node_modules/a.js', 'source a');
   write(root, 'node_modules/b.js', 'source b');
-  publication.beforeCopy = (path) => {
-    if (path === join(target, 'node_modules/b.js')) writeFileSync(path, 'concurrent b');
+  publication.beforePublish = (path) => {
+    if (path === join(target, 'node_modules/b.js')) {
+      if (kind === 'file') writeFileSync(path, 'concurrent b');
+      else symlinkSync('missing-b', path);
+    }
   };
   const result = warm();
   expect(result.copied).toEqual([]);
   expect(result.failed).toHaveLength(1);
   expect(result.failed[0]?.error).toMatch(/EEXIST/);
   expect(readFileSync(join(target, 'node_modules/a.js'), 'utf-8')).toBe('source a');
-  expect(readFileSync(join(target, 'node_modules/b.js'), 'utf-8')).toBe('concurrent b');
+  const actual =
+    kind === 'file'
+      ? readFileSync(join(target, 'node_modules/b.js'), 'utf-8')
+      : readlinkSync(join(target, 'node_modules/b.js'));
+  expect(actual).toBe(kind === 'file' ? 'concurrent b' : 'missing-b');
+  expect(existsSync(join(target, 'node_modules/missing-b'))).toBe(false);
 });
 
 test('warm identifies canonical main and linked roots from a symlinked subdirectory', () => {

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -86,6 +86,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetExecutor();
   publication.beforePublish = null;
   publication.beforeLink = null;
@@ -243,15 +244,17 @@ test.skipIf(process.platform !== 'darwin')(
     const source = join(root, '.env');
     utimesSync(source, new Date('2020-01-01'), new Date('2021-01-01'));
     let staged: ReturnType<typeof lstatSync> | undefined;
+    let stagedPath: string | undefined;
     publication.beforeLink = (from) => {
-      expect(from).toBe(join(publication.stagingPaths[0]!, 'entry'));
+      stagedPath = from;
       staged = lstatSync(from);
-      expect(staged.ino).not.toBe(lstatSync(source).ino);
     };
     const result = warm();
     expect(result.failed).toEqual([]);
     const published = lstatSync(join(target, '.env'));
     expect(staged).toBeDefined();
+    expect(stagedPath).toBe(join(publication.stagingPaths[0]!, 'entry'));
+    expect(staged?.ino).not.toBe(lstatSync(source).ino);
     expect(published.ino).toBe(staged?.ino);
     expect(published.atimeMs).toBe(staged?.atimeMs);
     expect(published.mtimeMs).toBe(staged?.mtimeMs);
@@ -260,12 +263,16 @@ test.skipIf(process.platform !== 'darwin')(
   },
 );
 
-test.skipIf(process.platform !== 'darwin')('cross-volume publication copies independently and reports fallback', () => {
+test.each(['EXDEV', 'ENOTSUP', 'EPERM'])('publication copies independently when linking fails with %s', (code) => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
   write(root, 'node_modules/pkg/index.js', 'source package');
+  let links = 0;
   publication.beforeLink = () => {
-    throw Object.assign(new Error('cross-volume link'), { code: 'EXDEV' });
+    links++;
+    throw Object.assign(new Error('link unavailable'), { code });
   };
   const result = warm();
+  expect(links).toBe(1);
   expect(result.failed).toEqual([]);
   expect(result.copied).toEqual(['node_modules']);
   expect(result.cloned).toBe(false);
@@ -274,14 +281,15 @@ test.skipIf(process.platform !== 'darwin')('cross-volume publication copies inde
   expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
 
-test.skipIf(process.platform !== 'darwin')('publication refuses link errors other than cross-volume failures', () => {
+test('publication refuses EEXIST without attempting to copy', () => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
   write(root, '.env', 'source config');
   publication.beforeLink = () => {
-    throw Object.assign(new Error('link permission refused'), { code: 'EPERM' });
+    throw Object.assign(new Error('link destination exists'), { code: 'EEXIST' });
   };
   const result = warm();
   expect(result.copied).toEqual([]);
-  expect(result.failed).toEqual([{ file: '.env', error: 'link permission refused' }]);
+  expect(result.failed).toEqual([{ file: '.env', error: 'link destination exists' }]);
   expect(existsSync(join(target, '.env'))).toBe(false);
   expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
@@ -305,11 +313,23 @@ async function runWarm(cwd: string) {
   }
 }
 
-test.each(['file', 'dangling symlink'])('publication preserves a late %s and earlier published files', (kind) => {
+test.each([
+  ['file', false],
+  ['dangling symlink', false],
+  ['file', true],
+  ['dangling symlink', true],
+])('publication preserves a late %s and earlier files (copy fallback: %s)', (kind, fallback) => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
   write(root, 'node_modules/a.js', 'source a');
   write(root, 'node_modules/b.js', 'source b');
+  if (fallback) {
+    publication.beforeLink = () => {
+      throw Object.assign(new Error('link unavailable'), { code: 'ENOTSUP' });
+    };
+  }
   publication.beforePublish = (path) => {
     if (path === join(target, 'node_modules/b.js')) {
+      publication.beforePublish = null;
       if (kind === 'file') writeFileSync(path, 'concurrent b');
       else symlinkSync('missing-b', path);
     }

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -239,7 +239,7 @@ function publishMissingEntry(from: string, to: string): boolean {
       try {
         linkSync(from, to);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error;
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw error;
         cloned = false;
       }
     }

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -4,6 +4,7 @@ import {
   copyFileSync,
   existsSync,
   lstatSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -227,23 +228,38 @@ function missingDestinationReason(target: string, rel: string): string | null {
   return lstatSync(join(target, rel), { throwIfNoEntry: false }) ? 'exists' : null;
 }
 
-function publishMissingEntry(from: string, to: string): void {
+function publishMissingEntry(from: string, to: string): boolean {
+  let cloned = true;
   const stat = lstatSync(from);
   if (stat.isSymbolicLink()) {
     symlinkSync(readlinkSync(from), to);
   } else if (stat.isFile()) {
-    copyFileSync(from, to, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE);
+    if (process.platform === 'darwin') {
+      // libuv has no macOS clonefile backend: https://github.com/libuv/libuv/pull/3987.
+      try {
+        linkSync(from, to);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error;
+        cloned = false;
+      }
+    }
+    if (process.platform !== 'darwin' || !cloned) {
+      copyFileSync(from, to, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE);
+    }
     utimesSync(to, stat.atime, stat.mtime);
   } else if (stat.isDirectory()) {
     mkdirSync(to, { mode: stat.mode | 0o700 });
     for (const name of readdirSync(from)) {
-      if (!CARRY_SKIP_BASENAMES.has(name)) publishMissingEntry(join(from, name), join(to, name));
+      if (!CARRY_SKIP_BASENAMES.has(name) && !publishMissingEntry(join(from, name), join(to, name))) {
+        cloned = false;
+      }
     }
     utimesSync(to, stat.atime, stat.mtime);
     chmodSync(to, stat.mode);
   } else {
     throw new Error(`Unsupported ignored entry: ${from}`);
   }
+  return cloned;
 }
 
 function removeStagedEntry(path: string): void {
@@ -302,7 +318,7 @@ export function cloneIgnoredEntries({
         continue;
       }
       mkdirSync(dirname(to), { recursive: true });
-      publishMissingEntry(destination, to);
+      if (!publishMissingEntry(destination, to)) cloned = false;
       copied.push(rel);
     } catch (e) {
       failed.push({ file: rel, error: String((e as Error)?.message || e) });


### PR DESCRIPTION
## Description

On macOS, warming several large worktrees can consume a full copy of their ignored files even on APFS. Node's optional clone flag falls back to copying because [libuv has no macOS clonefile backend](https://github.com/libuv/libuv/pull/3987), discarding the benefit of Stim's cloned staging files.

## Solution

Publish each regular file from private staging through an exclusive hard link, then remove its staged name. The completed files remain independent of the main checkout. Existing destinations refuse immediately; other link failures fall back to exclusive copying. Other platforms keep their existing publication path.

## Test plan

- Run `pnpm exec vitest run packages/stim-cli/src/__tests__/worktree-warm.test.ts packages/stim-cli/src/__tests__/worktree.test.ts`. Real Git/filesystem regressions cover independent source hard links, staged inode reuse, timestamps, cleanup, and late file or dangling-link collisions; injected EXDEV, ENOTSUP, and EPERM cover fallback policy. The policy tests exercise the macOS branch on every CI platform.
- On macOS 26.5 with Node 22.22.2, ran the changed warm function in a disposable real-Git fixture containing a 128 KiB file. Native `getattrlist` reported `EF_SHARES_ALL_BLOCKS` on both the staged and published files. The published inode matched staging, had one remaining link after cleanup, and editing it left the source unchanged.

Fixes #425.
