### PR TITLE
docs: prepare built-source fixtures for warm cache QA

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -172,13 +172,15 @@ node test/e2e/native/run-cache-e2e.mjs --framework bare --platform android
 # skip the single-flight race (saves one cold compile; that check reports SKIP)
 node test/e2e/native/run-cache-e2e.mjs --framework expo --platform ios --skip-race
 
-# against an existing checkout with matching ios/Podfile.lock and ios/Pods/Manifest.lock
+# warm-cache parity: use a previously built disposable main checkout with matching Pods
 node test/e2e/native/run-cache-e2e.mjs --framework expo --platform ios \
-  --app-dir ~/src/my-app --summary /tmp/cache-summary.json
+  --app-dir /tmp/my-app-fixture --summary /tmp/cache-summary.json
 
 # print the plan, no side effects
 node test/e2e/native/run-cache-e2e.mjs --framework bare --platform ios --dry-run
 ```
+
+See the [source-fixture preparation requirements](./field-test-protocol.md#use-a-fixture-that-looks-like-a-real-repo).
 
 On CI it is `workflow_dispatch` only: **Actions -> Native E2E -> Run workflow ->
 suite: `caches`** (or `all` for both). The default stays `loop`, so the nightly

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -67,8 +67,8 @@ For warm-cache parity, use a disposable main checkout that has completed a
 normal native build for the tested platform and configuration, and record that
 build and its clean tracked baseline before warming linked worktrees.
 Dependency installation and native setup alone can leave first-build generated
-inputs unsettled. Keep the cache suite's dedicated cache roots empty during
-source preparation.
+inputs unsettled. Prepare under a separate `STIM_HOME`; do not reuse it as the
+suite's `--home`, whose dedicated caches must start empty.
 
 ## Safety rules (non-negotiable)
 

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -63,6 +63,13 @@ or commit in a user's main checkout. Otherwise the fixture manufactures a
 transition that few users see, and the result reads as a product bug. Test the
 cold/warm split deliberately only when it is the behavior under test.
 
+For warm-cache parity, use a disposable main checkout that has completed a
+normal native build for the tested platform and configuration, and record that
+build and its clean tracked baseline before warming linked worktrees.
+Dependency installation and native setup alone can leave first-build generated
+inputs unsettled. Keep the cache suite's dedicated cache roots empty during
+source preparation.
+
 ## Safety rules (non-negotiable)
 
 - NEVER modify the target repo's main checkout. Worktrees only.


### PR DESCRIPTION
## Description

Warm-cache QA can mistake first-build generated-input changes for a cache regression when its source fixture has only had dependencies and native setup prepared.

## Solution

Document a completed normal build of the disposable source checkout before warming linked worktrees, while keeping the suite's dedicated cache roots empty. The existing first-build scenarios and no-build `--fixture-only` behavior remain unchanged.

## Test plan

Reviewed the wording against the native harness's preparation and cache-isolation behavior. No runtime or harness behavior changes.

Fixes #428
