### PR TITLE
fix: accept ABI-scoped Android benchmark caches

### DIFF
--- a/scripts/agent-benchmark/cache-key.mjs
+++ b/scripts/agent-benchmark/cache-key.mjs
@@ -1,0 +1,11 @@
+export function selectBenchmarkCacheKey(platform, fingerprint, entries) {
+  const base = `${fingerprint}-debug-sim`;
+  const matches =
+    platform === 'android'
+      ? entries.filter((entry) => entry.startsWith(`${base}-`))
+      : entries.filter((entry) => entry === base);
+  if (matches.length !== 1) {
+    throw new Error(`expected one ${platform} benchmark cache key for ${base}, got ${JSON.stringify(matches)}`);
+  }
+  return matches[0];
+}

--- a/scripts/agent-benchmark/cache-key.test.mjs
+++ b/scripts/agent-benchmark/cache-key.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { selectBenchmarkCacheKey } from './cache-key.mjs';
+
+describe('benchmark cache key selection', () => {
+  it('selects the exact iOS simulator key', () => {
+    expect(selectBenchmarkCacheKey('ios', 'abc', ['abc-debug-sim', 'abc-debug-sim-arm64-v8a'])).toBe('abc-debug-sim');
+  });
+
+  it('selects the ABI-scoped Android simulator key', () => {
+    expect(selectBenchmarkCacheKey('android', 'abc', ['abc-debug-sim-arm64-v8a'])).toBe('abc-debug-sim-arm64-v8a');
+  });
+
+  it('rejects missing or ambiguous Android keys', () => {
+    expect(() => selectBenchmarkCacheKey('android', 'abc', [])).toThrow(/got \[\]/);
+    expect(() =>
+      selectBenchmarkCacheKey('android', 'abc', ['abc-debug-sim-arm64-v8a', 'abc-debug-sim-x86_64']),
+    ).toThrow(/arm64-v8a.*x86_64/);
+  });
+});

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -26,6 +26,7 @@ import {
   launchCrashToken,
 } from '../launch-crash-benchmark.mjs';
 import { selectBenchmarkCacheKey } from './cache-key.mjs';
+import { matchesGoldenPreparation } from './golden-state.mjs';
 import {
   androidApplicationLabelFromBadging,
   matchesExpectedAndroidEmulator,
@@ -641,12 +642,30 @@ function prepareAndroid() {
   if (existsSync(seedHome)) throw new Error('partial Android seed golden exists; inspect it before retrying');
   mkdirSync(platformGolden, { recursive: true });
   const preparingHome = existsSync(finalHome) ? finalHome : seedHome;
+  const preparation = {
+    fixtureCommit: git('rev-parse', 'HEAD'),
+    stimVersion: pins.STIM_VERSION,
+    stimIntegrity: pins.STIM_INTEGRITY,
+    stimCliSha256: sha256(stimCli),
+    agentDeviceVersion: pins.AGENT_DEVICE_VERSION,
+    agentDeviceSha256: pins.AGENT_DEVICE_SHA256,
+  };
+  const preparationPath = join(preparingHome, 'benchmark-preparation.json');
   if (!existsSync(finalHome)) {
     mkdirSync(seedHome, { recursive: true });
     writeFileSync(
       join(seedHome, 'config.json'),
       `${JSON.stringify({ version: 2, projects: {}, repos: {} }, null, 2)}\n`,
     );
+    writeFileSync(preparationPath, `${JSON.stringify(preparation, null, 2)}\n`);
+  } else {
+    let retainedPreparation = null;
+    try {
+      retainedPreparation = JSON.parse(readFileSync(preparationPath, 'utf8'));
+    } catch {}
+    if (!matchesGoldenPreparation(retainedPreparation, preparation)) {
+      throw new Error(`retained Android golden provenance does not match current pins: ${finalHome}`);
+    }
   }
   const seedEnv = { ...cleanRubyEnvironment(process.env), STIM_HOME: preparingHome };
   let preparedDevice = null;

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -25,6 +25,7 @@ import {
   launchCrashRepair,
   launchCrashToken,
 } from '../launch-crash-benchmark.mjs';
+import { selectBenchmarkCacheKey } from './cache-key.mjs';
 import {
   androidApplicationLabelFromBadging,
   matchesExpectedAndroidEmulator,
@@ -202,8 +203,9 @@ function verifyGoldenCache(platform, platformGolden = goldenFor(platform)) {
     cwd: main,
     timeout: 2 * 60 * 1000,
   });
-  const cacheKey = `${fingerprint}-debug-sim`;
-  const cacheDir = join(platformGolden, 'stim-home', 'build-cache', platform, cacheKey);
+  const cacheRoot = join(platformGolden, 'stim-home', 'build-cache', platform);
+  const cacheKey = selectBenchmarkCacheKey(platform, fingerprint, existsSync(cacheRoot) ? readdirSync(cacheRoot) : []);
+  const cacheDir = join(cacheRoot, cacheKey);
   const extension = platform === 'ios' ? '.app' : '.apk';
   const artifact = existsSync(cacheDir) ? readdirSync(cacheDir).find((name) => name.endsWith(extension)) : null;
   if (!artifact) {
@@ -638,9 +640,15 @@ function prepareAndroid() {
   const controlTmp = join(platformGolden, 'control-tmp');
   if (existsSync(seedHome)) throw new Error('partial Android seed golden exists; inspect it before retrying');
   mkdirSync(platformGolden, { recursive: true });
-  mkdirSync(seedHome, { recursive: true });
-  writeFileSync(join(seedHome, 'config.json'), `${JSON.stringify({ version: 2, projects: {}, repos: {} }, null, 2)}\n`);
-  const seedEnv = { ...cleanRubyEnvironment(process.env), STIM_HOME: seedHome };
+  const preparingHome = existsSync(finalHome) ? finalHome : seedHome;
+  if (!existsSync(finalHome)) {
+    mkdirSync(seedHome, { recursive: true });
+    writeFileSync(
+      join(seedHome, 'config.json'),
+      `${JSON.stringify({ version: 2, projects: {}, repos: {} }, null, 2)}\n`,
+    );
+  }
+  const seedEnv = { ...cleanRubyEnvironment(process.env), STIM_HOME: preparingHome };
   let preparedDevice = null;
   const worktree = join(worktreeParent, 'bench-golden-android-seed');
   run('git', ['worktree', 'add', '--detach', worktree, 'HEAD'], {
@@ -686,9 +694,9 @@ function prepareAndroid() {
       stdio: 'inherit',
     });
   } catch (error) {
-    throw new Error(`Android golden preparation failed; retained ${seedHome}`, { cause: error });
+    throw new Error(`Android golden preparation failed; retained ${preparingHome}`, { cause: error });
   }
-  renameSync(seedHome, finalHome);
+  if (preparingHome === seedHome) renameSync(seedHome, finalHome);
   mkdirSync(controlTmp, { recursive: true });
   const exportPath = join(platformGolden, 'control-export');
   run('npx', ['expo', 'export', '--platform', 'android', '--dev', '--output-dir', exportPath], {

--- a/scripts/agent-benchmark/golden-state.mjs
+++ b/scripts/agent-benchmark/golden-state.mjs
@@ -1,0 +1,7 @@
+export function matchesGoldenPreparation(actual, expected) {
+  return (
+    actual !== null &&
+    typeof actual === 'object' &&
+    Object.entries(expected).every(([key, value]) => actual[key] === value)
+  );
+}

--- a/scripts/agent-benchmark/golden-state.test.mjs
+++ b/scripts/agent-benchmark/golden-state.test.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { matchesGoldenPreparation } from './golden-state.mjs';
+
+const expected = {
+  fixtureCommit: 'fixture',
+  stimVersion: '1.0.0-rc.15',
+  stimIntegrity: 'sha512-current',
+  stimCliSha256: 'cli-current',
+  agentDeviceVersion: '0.20.10',
+  agentDeviceSha256: 'agent-device-current',
+};
+
+describe('golden preparation provenance', () => {
+  it('accepts an exact preparation identity', () => {
+    expect(matchesGoldenPreparation(expected, expected)).toBe(true);
+  });
+
+  it('rejects missing or mismatched preparation identity', () => {
+    expect(matchesGoldenPreparation(null, expected)).toBe(false);
+    expect(matchesGoldenPreparation({ ...expected, stimVersion: '1.0.0-rc.14' }, expected)).toBe(false);
+    expect(matchesGoldenPreparation({ ...expected, stimIntegrity: 'sha512-old' }, expected)).toBe(false);
+    expect(matchesGoldenPreparation({ ...expected, stimCliSha256: 'cli-old' }, expected)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

The Android benchmark golden completed its RC.15 build and launch but the driver rejected the artifact because it still expected the old ABI-less cache key. That late failure also left a valid final golden which Android preparation could not reuse on retry, blocking every timed Android cell.

## Solution

Resolve exactly one ABI-scoped Android simulator cache entry while preserving exact cache-key matching on iOS and failing closed when the Android result is missing or ambiguous. Android golden preparation now mirrors iOS recovery by reusing a retained final home after a late verification failure, but only when its recorded fixture, Stim package, and agent-device identity match the current pins.

## Test plan

- Focused benchmark tests: 5 passed, covering iOS exact matching, Android success/missing/ambiguous keys, and retained-golden pin mismatches.
- `pnpm test`: 3,560 tests passed; `pnpm run test:e2e`: 65 tests passed.
- Prepared a provenance-recorded RC.15 golden from scratch on Android 36 arm64, then removed its `READY.json` and retried. Stim reported an artifact cache hit, launched and verified the app, tore down the owned emulator, and the driver recreated `READY.json` with the `-arm64-v8a` cache key.

Fixes #430
