### PR TITLE
fix: keep temporary copies on their volume

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor-storage.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-storage.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkStorageLayout } from '../doctor-storage.ts';
+import { apkOutputsDir } from '../engine/gradle.ts';
+import { workspaceDerivedData } from '../paths.ts';
+
+let base: string;
+let project: string;
+let cache: string;
+beforeEach(() => {
+  base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-storage-test-')));
+  project = join(base, 'project');
+  cache = join(base, 'cache');
+  mkdirSync(project);
+  vi.stubEnv('STIM_HOME', join(base, 'home'));
+  vi.stubEnv('STIM_BUILD_CACHE', cache);
+  vi.stubEnv('STIM_TMPDIR', undefined);
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(base, { recursive: true, force: true });
+});
+
+test('doctor distinguishes Android project output from iOS workspace output', () => {
+  const output = apkOutputsDir(project);
+  const findings = checkStorageLayout(project, {
+    platform: 'android',
+    device: (path) => (path === output ? 2 : 1),
+    stagingRoot: (path) => path,
+  });
+  expect(findings.map((finding) => finding.title)).toEqual(['Android build-cache storage crosses filesystems']);
+  expect(findings[0]?.detail).toContain(output);
+  expect(findings[0]?.detail).toContain(cache);
+  expect(findings[0]?.fix).toContain('STIM_BUILD_CACHE');
+  expect(checkStorageLayout(project, { platform: 'ios', device: () => 1, stagingRoot: (path) => path })).toEqual([]);
+});
+
+test('doctor detects iOS output/cache and configured staging mismatches separately', () => {
+  const output = join(workspaceDerivedData(project), 'Build', 'Products');
+  const findings = checkStorageLayout(project, {
+    platform: 'ios',
+    device: (path) => (path === cache ? 2 : 1),
+    stagingRoot: () => base,
+  });
+  expect(findings.map((finding) => finding.title)).toEqual([
+    'Cached app/APK staging crosses filesystems',
+    'iOS build-cache storage crosses filesystems',
+  ]);
+  expect(findings[1]?.detail).toContain(output);
+});
+
+test('an explicit override on another volume warns for warm and artifact preparation', () => {
+  const staging = join(base, 'override');
+  const findings = checkStorageLayout(project, {
+    platform: 'ios',
+    device: (path) => (path === staging ? 2 : 1),
+    stagingRoot: () => staging,
+  });
+  expect(findings.map((finding) => finding.title)).toEqual([
+    'Worktree staging crosses filesystems',
+    'Cached app/APK staging crosses filesystems',
+    'iOS device app staging crosses filesystems',
+  ]);
+  expect(findings.every((finding) => finding.level === 'cost' && finding.fix?.includes('STIM_TMPDIR'))).toBe(true);
+});
+
+test('an invalid machine override produces a finding instead of a healthy report', () => {
+  mkdirSync(process.env.STIM_HOME!);
+  writeFileSync(join(process.env.STIM_HOME!, 'config.json'), JSON.stringify({ tempDir: 'relative' }));
+  const findings = checkStorageLayout(project);
+  expect(findings.map((finding) => finding.title)).toEqual(['Could not resolve temporary storage']);
+  expect(findings[0]?.detail).toMatch(/absolute directory/);
+});

--- a/packages/stim-cli/src/__tests__/engine-apk-swap.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-apk-swap.test.ts
@@ -442,6 +442,7 @@ describe('swapApkBundle', () => {
     const result = await run();
     expect(result.failed).toBe(true);
     expect(result.step).toBe('assets');
+    expect(existsSync(tmp)).toBe(false);
   });
 
   test('a failed bundle command is a return value naming the step, and nothing downstream runs', async () => {

--- a/packages/stim-cli/src/__tests__/engine-apk-swap.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-apk-swap.test.ts
@@ -400,6 +400,7 @@ describe('swapApkBundle', () => {
     expect(result.ok).toBeUndefined();
     expect(result.failed).toBeUndefined();
     expect(result.assetMismatch).toBe(true);
+    expect(existsSync(tmp)).toBe(false);
     expect(result.assetDiff?.added).toEqual(['drawable-mdpi/brand_new.png']);
     expect(result.reason).toMatch(/added drawable-mdpi\/brand_new\.png/);
     expect(calls.some((c) => c.file === 'zip')).toBe(false);
@@ -411,6 +412,7 @@ describe('swapApkBundle', () => {
     const { run } = harness({ fresh: manifest({ 'drawable-mdpi/logo.png': LOGO }) });
     const result = await run();
     expect(result.assetMismatch).toBe(true);
+    expect(existsSync(tmp)).toBe(false);
     expect(result.assetDiff?.removed).toEqual(['raw/sound.mp3']);
   });
 
@@ -420,6 +422,7 @@ describe('swapApkBundle', () => {
     });
     const result = await run();
     expect(result.assetMismatch).toBe(true);
+    expect(existsSync(tmp)).toBe(false);
     expect(result.assetDiff?.added).toEqual([]);
     expect(result.assetDiff?.removed).toEqual([]);
     expect(result.assetDiff?.changed).toEqual(['drawable-mdpi/logo.png']);
@@ -431,6 +434,7 @@ describe('swapApkBundle', () => {
     const { calls, run } = harness({ stored: null });
     const result = await run();
     expect(result.assetMismatch).toBe(true);
+    expect(existsSync(tmp)).toBe(false);
     expect(result.assetDiff).toBeUndefined();
     expect(result.reason).toMatch(/predates asset tracking/);
     expect(calls.some((c) => c.file === 'zip')).toBe(false);

--- a/packages/stim-cli/src/__tests__/engine-ios-lan.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-lan.test.ts
@@ -16,10 +16,12 @@ let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'stim-ios-lan-'));
+  process.env.STIM_HOME = join(dir, 'home');
 });
 
 afterEach(() => {
   resetExecutor();
+  delete process.env.STIM_HOME;
   rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/stim-cli/src/__tests__/engine-js-swap.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-js-swap.test.ts
@@ -259,6 +259,7 @@ describe('swapJsBundle', () => {
     expect(result.failed).toBe(true);
     expect(result.step).toBe('bundle');
     expect(result.lastLines).toEqual(['Writing bundle output...']);
+    expect(existsSync(tmp)).toBe(false);
     expect(calls.some((c) => c.file === 'codesign')).toBe(false);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-js-swap.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-js-swap.test.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -13,6 +13,7 @@ import {
   readHermesEnabled,
   swapJsBundle,
 } from '../engine/js-swap.ts';
+import { getExecutor } from '../exec.ts';
 import { makeChildProcess, makeExecutor, makeWriter } from './_factories.ts';
 
 describe('hermescPath', () => {
@@ -261,6 +262,27 @@ describe('swapJsBundle', () => {
     expect(result.lastLines).toEqual(['Writing bundle output...']);
     expect(existsSync(tmp)).toBe(false);
     expect(calls.some((c) => c.file === 'codesign')).toBe(false);
+  });
+
+  test('failed swaps remove copied read-only app directories and preserve the full-build fallback', async () => {
+    const source = mkdtempSync(join(tmpdir(), 'stim-readonly-app-'));
+    const app = join(source, 'Fixture.app');
+    const resources = join(app, 'Resources');
+    mkdirSync(resources, { recursive: true });
+    writeFileSync(join(resources, 'asset.txt'), 'cached asset');
+    chmodSync(resources, 0o555);
+    try {
+      const { run } = harness({ bundleExit: 1 });
+      const result = await run({ cachedAppPath: app, exec: getExecutor() });
+      expect(result.failed).toBe(true);
+      expect(result.step).toBe('bundle');
+      expect(existsSync(tmp)).toBe(false);
+      expect(statSync(resources).mode & 0o777).toBe(0o555);
+      expect(readFileSync(join(resources, 'asset.txt'), 'utf-8')).toBe('cached asset');
+    } finally {
+      chmodSync(resources, 0o755);
+      rmSync(source, { recursive: true, force: true });
+    }
   });
 
   test('a bundle that exits 0 without writing the file is still a bundle failure', async () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -356,3 +356,12 @@ test('warm guidance protects existing entries and tracked changes', () => {
   expect(options).toMatch(/dangling symlinks/);
   expect(options).toMatch(/does not copy tracked changes/);
 });
+
+test('temporary storage guidance names the override and Git visibility boundary', () => {
+  const settings = renderTopic('settings');
+  expect(settings).toContain('STIM_TMPDIR');
+  expect(settings).toContain('tempDir');
+  expect(settings).toMatch(/outside Git working trees/);
+  expect(renderTopic('agent')).toContain('STIM_TMPDIR');
+  expect(renderSection('lifecycle', 'options')).toContain('STIM_TMPDIR');
+});

--- a/packages/stim-cli/src/__tests__/temporary.test.ts
+++ b/packages/stim-cli/src/__tests__/temporary.test.ts
@@ -1,0 +1,102 @@
+import { lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { filesystemDevice, makeTemporaryDirectory, temporaryRoot } from '../temporary.ts';
+
+const volume = vi.hoisted(() => ({ path: '' }));
+vi.mock('node:fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...fs,
+    statSync: (...args: Parameters<typeof fs.statSync>) => {
+      const stat = fs.statSync(...args);
+      if (
+        stat &&
+        typeof stat.dev === 'number' &&
+        volume.path &&
+        !relative(volume.path, String(args[0])).startsWith('..')
+      )
+        stat.dev += 1;
+      return stat;
+    },
+  };
+});
+
+let base: string;
+let near: string;
+beforeEach(() => {
+  base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-temporary-test-')));
+  const internal = join(base, 'internal');
+  volume.path = join(base, 'volume');
+  near = join(volume.path, 'main', 'nested', 'linked');
+  mkdirSync(internal);
+  mkdirSync(near, { recursive: true });
+  writeFileSync(join(volume.path, 'main', '.git'), 'gitdir: elsewhere');
+  writeFileSync(join(near, '.git'), 'gitdir: elsewhere');
+  vi.stubEnv('TMPDIR', internal);
+  vi.stubEnv('STIM_HOME', join(base, 'home'));
+  vi.stubEnv('STIM_TMPDIR', undefined);
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  volume.path = '';
+  rmSync(base, { recursive: true, force: true });
+});
+
+test('default staging stays on the target volume outside nested Git working trees', () => {
+  const staging = makeTemporaryDirectory(near, '.stim-warm-');
+  expect(temporaryRoot(near)).toBe(volume.path);
+  expect(filesystemDevice(staging)).toBe(filesystemDevice(near));
+  expect(filesystemDevice(staging)).not.toBe(filesystemDevice(tmpdir()));
+  expect(lstatSync(staging).mode & 0o777).toBe(0o700);
+});
+
+test('a safe system temporary directory on the same volume remains usable', () => {
+  vi.stubEnv('TMPDIR', volume.path);
+  expect(temporaryRoot(near)).toBe(volume.path);
+});
+
+test('no safe directory on the target volume refuses instead of spilling to system temp', () => {
+  writeFileSync(join(volume.path, '.git'), 'gitdir: elsewhere');
+  expect(() => makeTemporaryDirectory(near, '.stim-warm-')).toThrow(/No writable temporary directory/);
+});
+
+test('machine tempDir can be created, and STIM_TMPDIR overrides it', () => {
+  mkdirSync(process.env.STIM_HOME!);
+  const configured = join(volume.path, 'custom', 'temp');
+  writeFileSync(join(process.env.STIM_HOME!, 'config.json'), JSON.stringify({ tempDir: configured }));
+  expect(temporaryRoot(near)).toBe(configured);
+  const staging = makeTemporaryDirectory(near, 'stim-app-');
+  expect(lstatSync(staging).isDirectory()).toBe(true);
+  vi.stubEnv('STIM_TMPDIR', tmpdir());
+  expect(temporaryRoot(near)).toBe(tmpdir());
+});
+
+test.each(['', 'relative'])('invalid override %j refuses rather than being ignored', (override) => {
+  vi.stubEnv('STIM_TMPDIR', override);
+  expect(() => temporaryRoot(near)).toThrow(/absolute directory/);
+});
+
+test('overrides and symlinks into a working tree cannot expose staged secrets', () => {
+  const alias = join(base, 'alias');
+  symlinkSync(near, alias);
+  vi.stubEnv('STIM_TMPDIR', join(alias, 'new-temp'));
+  expect(() => temporaryRoot(near)).toThrow(/outside Git working trees/);
+  expect(filesystemDevice(join(alias, 'missing', 'file'))).toBe(filesystemDevice(near));
+});
+
+test('a dangling symlink cannot be mistaken for its parent filesystem', () => {
+  const alias = join(base, 'unmounted');
+  symlinkSync(join(base, 'absent-volume'), alias);
+  expect(() => filesystemDevice(join(alias, 'file'))).toThrow(/ENOENT/);
+});
+
+test('app staging cannot modify or recursively copy the source bundle', () => {
+  const app = join(volume.path, 'Fixture.app');
+  mkdirSync(app);
+  const staging = makeTemporaryDirectory(app, 'stim-app-');
+  expect(temporaryRoot(app)).toBe(volume.path);
+  expect(relative(app, staging).startsWith('..')).toBe(true);
+  vi.stubEnv('STIM_TMPDIR', join(app, 'temp'));
+  expect(() => temporaryRoot(app)).toThrow(/must not be inside/);
+});

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import { cloneIgnoredEntries, warmWorktreePaths } from '../worktree.ts';
+import { temporaryRoot } from '../temporary.ts';
 import { Command } from 'commander';
 import { registerWarm } from '../commands/worktree.ts';
 
@@ -576,7 +577,7 @@ test('staging ignored files never exposes their contents to Git status or git ad
   const result = await runWarm(target);
   expect(result.code).toBe(0);
   expect(observations).toEqual([{ status: '', add: '', staged: 'source secret' }]);
-  expect(publication.stagingPaths.map((path) => realpathSync(dirname(path)))).toEqual([realpathSync(tmpdir())]);
+  expect(publication.stagingPaths.map((path) => realpathSync(dirname(path)))).toEqual([temporaryRoot(target)]);
   expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('source secret');
 });

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -113,6 +113,7 @@ export const OUTPUT_LABELS: readonly string[] = [
   'state',
   'stats',
   'stop',
+  'storage',
   'swap',
   'verify',
   'workspace',

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -58,6 +58,7 @@ export function doctorSuccessLines(platform?: DoctorPlatform): string[] {
 
   lines.push('', 'Shared');
   lines.push(phaseLine('services', 'EAS session'));
+  lines.push(phaseLine('storage', 'temporary staging and build-cache volume placement'));
   lines.push(phaseLine('fingerprint', 'parity when dependencies are absent'));
   lines.push('', 'Handled automatically');
   const suppliedCaches =

--- a/packages/stim-cli/src/doctor-storage.ts
+++ b/packages/stim-cli/src/doctor-storage.ts
@@ -1,0 +1,62 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DoctorPlatform, Finding } from './doctor.ts';
+import { apkOutputsDir } from './engine/gradle.ts';
+import { sharedBuildCache, workspaceDerivedData } from './paths.ts';
+import { filesystemDevice, temporaryRoot } from './temporary.ts';
+import { listWorktrees, repoRoot } from './worktree.ts';
+
+export function checkStorageLayout(
+  projectRoot: string,
+  {
+    platform,
+    device = filesystemDevice,
+    stagingRoot = temporaryRoot,
+  }: {
+    platform?: DoctorPlatform;
+    device?: typeof filesystemDevice;
+    stagingRoot?: typeof temporaryRoot;
+  } = {},
+): Finding[] {
+  const findings: Finding[] = [];
+  const temporaryFix =
+    'Unset STIM_TMPDIR / machine tempDir to select same-volume staging automatically, ' +
+    'or point the override at a writable directory on the relevant volume outside Git working trees.';
+  const check = (operation: string, paths: string[], fix: string) => {
+    if (new Set(paths.map(device)).size < 2) return;
+    findings.push({
+      level: 'cost',
+      title: `${operation} crosses filesystems`,
+      detail:
+        `${paths.join(' -> ')}. These copies cannot share file blocks across volumes and can consume the full ` +
+        'artifact size in space and I/O. cp -c can silently perform a full copy without an error.',
+      fix,
+    });
+  };
+  try {
+    const target = repoRoot(projectRoot) ?? projectRoot;
+    const source = listWorktrees(target)[0]?.path ?? target;
+    check('Worktree staging', [source, stagingRoot(target), target], temporaryFix);
+    const cache = sharedBuildCache();
+    check('Cached app/APK staging', [cache, stagingRoot(join(cache, 'artifact.app'))], temporaryFix);
+    const cacheFix =
+      'Place STIM_BUILD_CACHE / machine caches.buildCache on the build-output volume, ' +
+      'or accept the full-copy cost of keeping the cache on a separate volume.';
+    if (platform === 'ios' || (platform !== 'android' && existsSync(join(projectRoot, 'ios')))) {
+      const output = join(workspaceDerivedData(projectRoot), 'Build', 'Products');
+      check('iOS build-cache storage', [output, cache], cacheFix);
+      check('iOS device app staging', [output, stagingRoot(join(output, 'artifact.app'))], temporaryFix);
+    }
+    if (platform === 'android' || (platform !== 'ios' && existsSync(join(projectRoot, 'android')))) {
+      check('Android build-cache storage', [apkOutputsDir(projectRoot), cache], cacheFix);
+    }
+  } catch (error) {
+    findings.push({
+      level: 'cost',
+      title: 'Could not resolve temporary storage',
+      detail: String((error as Error).message),
+      fix: temporaryFix,
+    });
+  }
+  return findings;
+}

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
-import { tmpdir } from 'os';
+import { existsSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
+import { makeTemporaryDirectory } from './temporary.ts';
+import { checkStorageLayout } from './doctor-storage.ts';
 import { appProjectProblem, detectIsExpo } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
 import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
@@ -803,6 +804,7 @@ export function runDoctor(
   return [
     checkAppProject(projectRoot),
     ...checkMainCheckout(projectRoot, { platform }),
+    ...checkStorageLayout(projectRoot, { platform }),
     checkDevClient(pkg, isExpo),
     checkMetroCache(metroConfig),
     platform === 'android' ? null : checkCompilationCache(podfile, xcodeMajor),
@@ -929,7 +931,12 @@ export async function detectFingerprintParity(
     selectedPlatform ??
     (existsSync(join(projectRoot, 'ios')) ? 'ios' : existsSync(join(projectRoot, 'android')) ? 'android' : undefined);
 
-  const base = mkdtempSync(join(tmpdir(), 'stim-parity-'));
+  let base: string;
+  try {
+    base = makeTemporaryDirectory(projectRoot, 'stim-parity-');
+  } catch {
+    return null;
+  }
   const worktree = join(base, 'head');
   const added = exec.runFileQuiet('git', ['-C', projectRoot, 'worktree', 'add', '--detach', worktree, 'HEAD'], {
     timeoutMs: 60000,

--- a/packages/stim-cli/src/engine/apk-swap.ts
+++ b/packages/stim-cli/src/engine/apk-swap.ts
@@ -1,6 +1,6 @@
+import { makeTemporaryDirectory } from '../temporary.ts';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
@@ -196,7 +196,7 @@ export async function swapApkBundle({
   logWriter = null,
   exec = null,
   spawnFn = null,
-  mkdtemp = () => mkdtempSync(join(tmpdir(), 'stim-apk-swap-')),
+  mkdtemp = () => makeTemporaryDirectory(cachedApkPath, 'stim-apk-swap-'),
   exists = existsSync,
   hermesEnabled = null,
   buildTools = null,
@@ -228,6 +228,7 @@ export async function swapApkBundle({
   const e = exec || getExecutor();
   const startedAt = now();
   const elapsed = () => now() - startedAt;
+  let tmp: string | undefined;
   const fail = (step: string, reason: string, lastLines: string[] = []): ApkSwapResult => {
     logWriter?.write?.({
       src: 'build',
@@ -235,10 +236,10 @@ export async function swapApkBundle({
       msg: `APK swap failed at ${step}: ${reason}`,
       event: 'apk_swap',
     });
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
     return { failed: true, step, reason, lastLines, durationMs: elapsed() };
   };
 
-  let tmp: string;
   let work: string;
   let final: string;
   try {

--- a/packages/stim-cli/src/engine/apk-swap.ts
+++ b/packages/stim-cli/src/engine/apk-swap.ts
@@ -1,6 +1,6 @@
-import { makeTemporaryDirectory } from '../temporary.ts';
+import { makeTemporaryDirectory, removeTemporaryEntry } from '../temporary.ts';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
@@ -236,7 +236,7 @@ export async function swapApkBundle({
       msg: `APK swap failed at ${step}: ${reason}`,
       event: 'apk_swap',
     });
-    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    if (tmp) removeTemporaryEntry(tmp);
     return { failed: true, step, reason, lastLines, durationMs: elapsed() };
   };
 
@@ -348,6 +348,7 @@ export async function swapApkBundle({
 
   const refuse = (reason: string, assetDiff?: AssetManifestDiff): ApkSwapResult => {
     logWriter?.write?.({ src: 'build', level: 'warn', msg: `APK swap refused: ${reason}`, event: 'apk_swap' });
+    removeTemporaryEntry(tmp);
     const result: ApkSwapResult = { assetMismatch: true, reason, durationMs: elapsed() };
     if (assetDiff) result.assetDiff = assetDiff;
     return result;

--- a/packages/stim-cli/src/engine/ios-lan.ts
+++ b/packages/stim-cli/src/engine/ios-lan.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { makeTemporaryDirectory } from '../temporary.ts';
+import { rmSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
@@ -100,7 +100,7 @@ export function copyAppAside(
   appPath: string,
   {
     exec = null,
-    mkdtemp = () => mkdtempSync(join(tmpdir(), 'stim-ios-device-')),
+    mkdtemp = () => makeTemporaryDirectory(appPath, 'stim-ios-device-'),
   }: { exec?: Executor | null; mkdtemp?: () => string } = {},
 ): { tmpDir: string; appPath: string } {
   const e = exec || getExecutor();
@@ -109,7 +109,12 @@ export function copyAppAside(
   try {
     e.runFile('cp', ['-c', '-R', appPath, copy]);
   } catch {
-    e.runFile('cp', ['-R', appPath, copy]);
+    try {
+      e.runFile('cp', ['-R', appPath, copy]);
+    } catch (error) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      throw error;
+    }
   }
   return { tmpDir, appPath: copy };
 }

--- a/packages/stim-cli/src/engine/ios-lan.ts
+++ b/packages/stim-cli/src/engine/ios-lan.ts
@@ -1,5 +1,5 @@
-import { makeTemporaryDirectory } from '../temporary.ts';
-import { rmSync, writeFileSync } from 'node:fs';
+import { makeTemporaryDirectory, removeTemporaryEntry } from '../temporary.ts';
+import { writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
@@ -112,7 +112,7 @@ export function copyAppAside(
     try {
       e.runFile('cp', ['-R', appPath, copy]);
     } catch (error) {
-      rmSync(tmpDir, { recursive: true, force: true });
+      removeTemporaryEntry(tmpDir);
       throw error;
     }
   }

--- a/packages/stim-cli/src/engine/js-swap.ts
+++ b/packages/stim-cli/src/engine/js-swap.ts
@@ -1,6 +1,6 @@
+import { makeTemporaryDirectory } from '../temporary.ts';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
@@ -132,7 +132,7 @@ export async function swapJsBundle({
   logWriter = null,
   exec = null,
   spawnFn = null,
-  mkdtemp = () => mkdtempSync(join(tmpdir(), 'stim-js-swap-')),
+  mkdtemp = () => makeTemporaryDirectory(cachedAppPath, 'stim-js-swap-'),
   exists = existsSync,
   hermesEnabled = null,
   now = Date.now,
@@ -155,12 +155,13 @@ export async function swapJsBundle({
   const e = exec || getExecutor();
   const startedAt = now();
   const elapsed = () => now() - startedAt;
+  let tmp: string | undefined;
   const fail = (step: string, reason: string, lastLines: string[] = []): JsSwapResult => {
     logWriter?.write?.({ src: 'build', level: 'error', msg: `JS swap failed at ${step}: ${reason}`, event: 'js_swap' });
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
     return { failed: true, step, reason, lastLines, durationMs: elapsed() };
   };
 
-  let tmp: string;
   let appCopy: string;
   try {
     tmp = mkdtemp();

--- a/packages/stim-cli/src/engine/js-swap.ts
+++ b/packages/stim-cli/src/engine/js-swap.ts
@@ -1,6 +1,6 @@
-import { makeTemporaryDirectory } from '../temporary.ts';
+import { makeTemporaryDirectory, removeTemporaryEntry } from '../temporary.ts';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
@@ -158,7 +158,7 @@ export async function swapJsBundle({
   let tmp: string | undefined;
   const fail = (step: string, reason: string, lastLines: string[] = []): JsSwapResult => {
     logWriter?.write?.({ src: 'build', level: 'error', msg: `JS swap failed at ${step}: ${reason}`, event: 'js_swap' });
-    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    if (tmp) removeTemporaryEntry(tmp);
     return { failed: true, step, reason, lastLines, durationMs: elapsed() };
   };
 

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -20,7 +20,10 @@ Read guide lifecycle options for exclusions and incomplete-copy remedies.
 
 Before native worktree work, run doctor for the platform in scope. It checks
 the main checkout from a linked worktree. Fix relevant findings and inspect the
-upstream gap.
+upstream gap. Doctor also reports cross-volume staging and build-cache copies.
+Large temporary copies use a writable location on the relevant volume outside
+Git working trees. STIM_TMPDIR or machine tempDir overrides that location;
+read guide settings for placement and guide lifecycle options for warm behavior.
 
   stim doctor --platform ios          # or: --platform android
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -157,7 +157,7 @@ result as proof instead of requiring an unrelated screenshot.`,
     logs        meaning     metro       pods        port        prebuild
     project     ready       remedy      removed     result      services
     setting     settings    setup       state       stats       stop
-    swap        verify      workspace
+    storage     swap        verify      workspace
 
   \`app\` and \`compilation cache\` join them in the stdout block a successful
   run ends with, and nowhere else. A line states a fact; the reason a fact
@@ -582,6 +582,13 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   .worktreeexclude replaces its resolved worktree.exclude setting. Nested
   registered worktrees and .DerivedData are excluded. Warm also skips paths
   overlapping a nested destination worktree or below a symlink ancestor.
+
+  Large copies stage privately outside Git working trees on the destination
+  volume. STIM_TMPDIR or machine tempDir overrides that placement; doctor warns
+  when the source, staging, and destination cross volumes and require full
+  copies. Read guide settings for temporary storage configuration. If no safe
+  writable staging location exists, warm refuses instead of using another
+  volume automatically.
 
   Existing entries, including dangling symlinks, stay untouched. An existing
   ignored directory such as node_modules is skipped WHOLE; missing children are not

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -301,6 +301,36 @@ from inside that process that the store is in the config Metro loaded. Only the
 second one means transforms are being shared. A bare project writes
 \`cache_store_added\` directly, because there Stim adds the store itself.
 
+TEMPORARY STORAGE
+Large temporary copies for worktree warm, iOS app preparation, release JS/APK
+swaps, and the doctor fingerprint checkout select a writable directory on the
+relevant filesystem. Warm uses the destination worktree volume; app/APK
+preparation uses the artifact volume. A system temporary directory on that
+volume is preferred, then a writable ancestor of the relevant path. Staging
+is private and outside Git working trees, so ignored secrets cannot enter
+Git status or git add. If no safe location exists, the operation refuses.
+
+Set STIM_TMPDIR or top-level tempDir in $STIM_HOME/config.json (default
+~/.stim/config.json) to override placement. STIM_TMPDIR takes precedence.
+The value must be an absolute directory outside Git working trees; missing
+directories are created privately. An override is used even on another volume.
+Doctor reports cross-volume copy costs and invalid temporary settings; it
+creates no directories for this placement check. Unset the override to restore
+automatic selection. An example machine setting:
+
+  { "tempDir": "/Volumes/SSD/stim-tmp" }
+
+Small tool-response and entitlement files still use the system temporary
+directory. Build-cache storage stages beside its destination independently of
+tempDir. Keeping build output and its cache on different volumes still requires
+a full copy. iOS build output lives under STIM_HOME/workspaces; Android APKs
+live under the project's android/app/build/outputs/apk. Doctor compares these
+locations with the cache, using resolved symlinks and filesystem device IDs.
+It checks the current layout; arbitrary provider-returned paths and future
+mount changes cannot be predicted. Same-volume placement permits cloning when
+the filesystem supports it; it does not prove cloning occurred. On macOS,
+cp -c can silently fall back to copying and exit successfully.
+
 CACHE LOCATIONS ARE MACHINE-LEVEL TOO
 The shared build cache and Metro transform cache default to living under
 ~/.stim. To relocate them (say, to an external disk), set a top-level

--- a/packages/stim-cli/src/temporary.ts
+++ b/packages/stim-cli/src/temporary.ts
@@ -1,4 +1,15 @@
-import { accessSync, constants, lstatSync, mkdirSync, mkdtempSync, realpathSync, statSync } from 'node:fs';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { getConfigDir, loadConfig } from './config.ts';
@@ -78,4 +89,15 @@ export function makeTemporaryDirectory(near: string, prefix: string): string {
   const root = temporaryRoot(near);
   mkdirSync(root, { recursive: true, mode: 0o700 });
   return mkdtempSync(join(root, prefix));
+}
+
+export function removeTemporaryEntry(path: string): void {
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (stat?.isDirectory()) {
+    chmodSync(path, stat.mode | 0o700);
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      if (entry.isDirectory()) removeTemporaryEntry(join(path, entry.name));
+    }
+  }
+  rmSync(path, { recursive: true, force: true });
 }

--- a/packages/stim-cli/src/temporary.ts
+++ b/packages/stim-cli/src/temporary.ts
@@ -1,0 +1,81 @@
+import { accessSync, constants, lstatSync, mkdirSync, mkdtempSync, realpathSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { getConfigDir, loadConfig } from './config.ts';
+
+function existingPath(path: string): { existing: string; resolved: string } {
+  const missing: string[] = [];
+  let current = resolve(path);
+  while (!lstatSync(current, { throwIfNoEntry: false })) {
+    missing.unshift(basename(current));
+    current = dirname(current);
+  }
+  const existing = realpathSync(current);
+  return { existing, resolved: join(existing, ...missing) };
+}
+
+export function filesystemDevice(path: string): number {
+  return statSync(existingPath(path).existing).dev;
+}
+
+function outsideWorkingTree(path: string): boolean {
+  let current = path;
+  while (true) {
+    if (lstatSync(join(current, '.git'), { throwIfNoEntry: false })) return false;
+    const parent = dirname(current);
+    if (parent === current) return true;
+    current = parent;
+  }
+}
+
+export function temporaryRoot(near: string): string {
+  const reference = existingPath(near);
+  const insideReference = (path: string) => {
+    const rel = relative(reference.resolved, path);
+    return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+  };
+  const override = process.env.STIM_TMPDIR ?? loadConfig()?.tempDir;
+  if (override !== undefined) {
+    if (typeof override !== 'string' || !isAbsolute(override)) {
+      throw new Error('STIM_TMPDIR / tempDir must be an absolute directory path.');
+    }
+    const { existing, resolved } = existingPath(override);
+    if (!statSync(existing).isDirectory() || !outsideWorkingTree(existing)) {
+      throw new Error(`Temporary directory ${override} must be outside Git working trees.`);
+    }
+    if (insideReference(resolved)) {
+      throw new Error(`Temporary directory ${override} must not be inside ${near}.`);
+    }
+    accessSync(existing, constants.W_OK);
+    return resolved;
+  }
+
+  const { existing } = reference;
+  const device = statSync(existing).dev;
+  const candidates = [tmpdir()];
+  let current = existing === reference.resolved || !statSync(existing).isDirectory() ? dirname(existing) : existing;
+  while (statSync(current).dev === device) {
+    candidates.push(current);
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  for (const candidate of candidates) {
+    try {
+      const path = realpathSync(candidate);
+      if (statSync(path).dev !== device || insideReference(path) || !outsideWorkingTree(path)) continue;
+      accessSync(path, constants.W_OK);
+      return path;
+    } catch {}
+  }
+  throw new Error(
+    `No writable temporary directory on the filesystem containing ${near}. ` +
+      `Set STIM_TMPDIR or tempDir in ${join(getConfigDir(), 'config.json')} to a directory outside Git working trees.`,
+  );
+}
+
+export function makeTemporaryDirectory(near: string, prefix: string): string {
+  const root = temporaryRoot(near);
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  return mkdtempSync(join(root, prefix));
+}

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -71,6 +71,7 @@ export interface StimConfig {
   version?: number;
   projects: Record<string, ProjectRecord>;
   repos: Record<string, RepoRecord>;
+  tempDir?: unknown;
   concurrency?: { maxBuilds?: unknown; maxDevices?: unknown };
   pool?: { iosParkedMax?: unknown; androidParkedMax?: unknown };
   parked?: { ios?: unknown; android?: unknown };

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -6,7 +6,6 @@ import {
   lstatSync,
   linkSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   readlinkSync,
@@ -15,9 +14,9 @@ import {
   symlinkSync,
   utimesSync,
 } from 'fs';
-import { tmpdir } from 'os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
+import { makeTemporaryDirectory } from './temporary.ts';
 
 const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
 
@@ -303,7 +302,7 @@ export function cloneIgnoredEntries({
         skipped.push({ file: rel, reason });
         continue;
       }
-      staging = mkdtempSync(join(tmpdir(), '.stim-warm-'));
+      staging = makeTemporaryDirectory(target, '.stim-warm-');
       const destination = join(staging, 'entry');
       try {
         getExecutor().runFile('cp', ['-Rc', from, destination]);

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -10,13 +10,12 @@ import {
   readdirSync,
   readlinkSync,
   realpathSync,
-  rmSync,
   symlinkSync,
   utimesSync,
 } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
-import { makeTemporaryDirectory } from './temporary.ts';
+import { makeTemporaryDirectory, removeTemporaryEntry } from './temporary.ts';
 
 const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
 
@@ -261,17 +260,6 @@ function publishMissingEntry(from: string, to: string): boolean {
   return cloned;
 }
 
-function removeStagedEntry(path: string): void {
-  const stat = lstatSync(path, { throwIfNoEntry: false });
-  if (stat?.isDirectory()) {
-    chmodSync(path, stat.mode | 0o700);
-    for (const entry of readdirSync(path, { withFileTypes: true })) {
-      if (entry.isDirectory()) removeStagedEntry(join(path, entry.name));
-    }
-  }
-  rmSync(path, { recursive: true, force: true });
-}
-
 export function cloneIgnoredEntries({
   root,
   target,
@@ -307,7 +295,7 @@ export function cloneIgnoredEntries({
       try {
         getExecutor().runFile('cp', ['-Rc', from, destination]);
       } catch {
-        removeStagedEntry(destination);
+        removeTemporaryEntry(destination);
         getExecutor().runFile('cp', ['-R', from, destination]);
         cloned = false;
       }
@@ -322,7 +310,7 @@ export function cloneIgnoredEntries({
     } catch (e) {
       failed.push({ file: rel, error: String((e as Error)?.message || e) });
     } finally {
-      if (staging) removeStagedEntry(staging);
+      if (staging) removeTemporaryEntry(staging);
     }
   }
   return { copied, skipped, failed, cloned };

--- a/test/e2e/storage-volumes.e2e.js
+++ b/test/e2e/storage-volumes.e2e.js
@@ -1,0 +1,102 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { getExecutor, resetExecutor, setExecutor } from '../../packages/stim-cli/src/exec.ts';
+import { cloneIgnoredEntries } from '../../packages/stim-cli/src/worktree.ts';
+import { checkStorageLayout } from '../../packages/stim-cli/src/doctor-storage.ts';
+
+test(
+  'warm stages on the destination APFS volume even when cloning falls back',
+  { skip: process.platform !== 'darwin' },
+  () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-volumes-e2e-')));
+    const image = join(base, 'test.sparseimage');
+    const volume = join(base, 'volume');
+    const source = join(volume, 'main');
+    const previous = Object.fromEntries(
+      ['STIM_HOME', 'STIM_TMPDIR', 'STIM_BUILD_CACHE', 'TMPDIR'].map((key) => [key, process.env[key]]),
+    );
+    const real = getExecutor();
+    const run = (file, args) => real.runFile(file, args, { timeoutMs: 30000 });
+    const git = (args) => run('git', ['-C', source, ...args]);
+    let mounted = false;
+    try {
+      run('hdiutil', [
+        'create',
+        '-size',
+        '128m',
+        '-fs',
+        'APFS',
+        '-volname',
+        'StimVolumeTest',
+        '-type',
+        'SPARSE',
+        image,
+      ]);
+      run('hdiutil', ['attach', '-nobrowse', '-mountpoint', volume, image]);
+      mounted = true;
+      assert.notEqual(statSync(volume).dev, statSync(base).dev);
+      process.env.STIM_HOME = join(base, 'home');
+      process.env.STIM_BUILD_CACHE = join(volume, 'cache');
+      process.env.TMPDIR = base;
+      delete process.env.STIM_TMPDIR;
+      mkdirSync(source);
+      git(['init', '-q', '-b', 'main']);
+      writeFileSync(join(source, '.gitignore'), 'node_modules/\n');
+      writeFileSync(join(source, 'package.json'), '{"name":"volume-test"}\n');
+      git(['add', '.']);
+      git([
+        '-c',
+        'user.name=test',
+        '-c',
+        'user.email=test@example.com',
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+      mkdirSync(join(source, 'node_modules', 'pkg'), { recursive: true });
+      writeFileSync(join(source, 'node_modules', 'pkg', 'index.js'), 'source package');
+      for (const fallback of [false, true]) {
+        const target = join(volume, `linked-${fallback}`);
+        git(['worktree', 'add', '-qb', `linked-${fallback}`, target]);
+        const staged = [];
+        setExecutor({
+          ...real,
+          runFile(file, args, opts) {
+            if (file !== 'cp') return real.runFile(file, args, opts);
+            const staging = dirname(args.at(-1));
+            assert.equal(statSync(staging).dev, statSync(target).dev);
+            staged.push(staging);
+            if (fallback && args[0] === '-Rc') throw new Error('force clone fallback');
+            return real.runFile(file, args, opts);
+          },
+        });
+        const result = cloneIgnoredEntries({ root: source, target, patterns: [] });
+        assert.deepEqual(result.failed, []);
+        assert.deepEqual(result.copied, ['node_modules']);
+        assert.equal(result.cloned, !fallback);
+        assert.equal(readFileSync(join(target, 'node_modules', 'pkg', 'index.js'), 'utf8'), 'source package');
+        for (const path of staged) assert.throws(() => statSync(path), { code: 'ENOENT' });
+      }
+      resetExecutor();
+      assert.deepEqual(checkStorageLayout(source, { platform: 'android' }), []);
+      process.env.STIM_TMPDIR = base;
+      assert.deepEqual(
+        checkStorageLayout(source, { platform: 'android' }).map((finding) => finding.title),
+        ['Worktree staging crosses filesystems', 'Cached app/APK staging crosses filesystems'],
+      );
+    } finally {
+      resetExecutor();
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      if (mounted) run('hdiutil', ['detach', volume]);
+      rmSync(base, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Description

Large worktree and app copies on another volume can silently materialize in system temp and exhaust the internal disk. Staging stays outside Git working trees to preserve [secret-file protection](https://github.com/appandflow/stim/commit/64121692796dacd0b24e90fe2115346f49d42a46).

## Solution

Select private, writable staging on the operation's volume for warming, app preparation, release swaps, and fingerprint checks. `STIM_TMPDIR` or machine `tempDir` can override placement. Doctor reports when that override or the build-cache layout requires full cross-volume copies. Failed swaps remove their staging directories.

## Test plan

- Added a macOS end-to-end test using a disposable APFS image: warm stays on the destination volume with both normal cloning and forced copy fallback; an override on the internal volume produces doctor findings.
- Verified copy stages across two APFS volumes: automatic staging shares blocks; a cross-volume override makes full copies. Mobile builds were not tested.
- All 3,575 unit tests and 66 end-to-end tests pass.

Fixes #431.
