### PR TITLE
fix: reject unproven benchmark environments

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -30,6 +30,10 @@ commit, runner version, model, reasoning effort, service tier, `agent-device`
 version and executable hash, Node.js, host machine, and platform toolchain
 before preparing the block. iOS also pins CocoaPods, Xcode, iPhone model, and
 runtime. Android pins the SDK tools, emulator, adb, and system-image package.
+The coordinator gives timed shells an isolated login profile, resolves `stim`
+through that same shell before dispatch, and records its version plus executable
+and CLI hashes. A mismatch refuses dispatch; checking only the coordinator's
+own PATH is insufficient.
 
 Preparation runs outside the timer. On iOS it creates one Stim-owned simulator,
 warms the fixed fixture, removes its seed worktree, and verifies that cleanup
@@ -44,6 +48,13 @@ state, required disk space, no benchmark-owned process from an earlier run,
 and no unexpected listener on Metro ports 8081 through 8090. Wait for a
 one-minute load average at or below 3.0 for two consecutive 15-second samples.
 Runs are sequential.
+
+Each machine has targets for every platform, change kind, and arm. The
+screen-ready target is a visible performance signal, not a validity gate,
+because agent reasoning time is part of what the benchmark measures. A Stim
+platform-command target is a validity gate for abnormal host/build work, and a
+larger run timeout terminates a runaway attempt. This separates slow model
+behavior from a missing or ineffective cache.
 
 Give the campaign its own `AGENT_DEVICE_STATE_DIR`, separate from the
 operator's normal sessions, and set `AGENT_DEVICE_SESSION` to the exact run id.
@@ -107,6 +118,9 @@ pinned system image. The control must not inspect that home or use Stim; it
 creates a new benchmark-named device with the same platform configuration.
 Android control uses the same `avdmanager` default profile, 8 GiB data
 partition, system image, and default Quick Boot policy as Stim.
+Installing dependencies inside the timed interval, a failed `guide agent` or
+`worktree warm`, and an Android native build without Stim's `--build-cache`
+evidence invalidate the attempt.
 
 ## Settings readiness proof
 
@@ -168,6 +182,9 @@ of the successful, validated `agent-device screenshot` command. Report
 `dispatchToAppAliveSeconds` separately. Also retain command count, raw token
 fields, worktree and simulator evidence, cache and adoption/build output, and
 invalid-attempt reasons.
+The run record also stores its selected machine target, whether screen-ready
+met that target, the longest Stim platform-command duration, timeout status,
+and the timed shell's Stim provenance.
 
 The coordinator timestamps every runner event and reconstructs every command's
 start, end, duration, exit status, and output. The website's interactive

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -18,6 +18,7 @@ benchmark-root/
   bin/stim
   golden/
   pins.env
+  targets.json
   runtime/node_modules/stim-cli/
   results/
   state/
@@ -26,7 +27,32 @@ benchmark-root/
 `bin/stim` is an executable shim for the pinned `stim-cli` in `runtime`.
 `pins.env` contains the exact fixture, CLI, agent-device, OS, Xcode, Node, and
 CocoaPods values checked by `preflight`; use the keys read by `versionChecks`
-in `driver.mjs`. Keep authentication and raw evidence out of Git.
+in `driver.mjs`. `targets.json` defines this machine's timing expectations for
+each platform, change, and arm:
+
+```json
+{
+  "schemaVersion": 1,
+  "machine": "Mac mini, Apple M4, 16 GB",
+  "targets": {
+    "android.native.stim": {
+      "screenReadySeconds": 300,
+      "platformCommandSeconds": 180,
+      "runTimeoutSeconds": 600
+    },
+    "android.native.control": {
+      "screenReadySeconds": 600,
+      "runTimeoutSeconds": 900
+    }
+  }
+}
+```
+
+Every dispatched cell needs an entry. `screenReadySeconds` is reported as a
+performance target but does not invalidate a slow model. A Stim platform
+command over `platformCommandSeconds` is an invalid machine/build result.
+`runTimeoutSeconds` terminates and invalidates a runaway agent. Keep
+authentication and raw evidence out of Git.
 
 Set the machine-local paths explicitly:
 
@@ -41,6 +67,10 @@ export STIM_BENCH_SKILLS_ROOT=/path/to/skills
 
 `STIM_BENCH_CODEX_BIN`, `STIM_BENCH_CLAUDE_BIN`, and
 `STIM_BENCH_AGENT_DEVICE_BIN` can pin non-default executable paths.
+
+Preflight runs the pinned Stim shim through the same isolated login-shell
+startup used by timed commands. Dispatch refuses a Stim version, executable,
+or CLI digest mismatch and refuses a control shell that can resolve Stim.
 
 ## Run a cell
 
@@ -67,8 +97,10 @@ node scripts/agent-benchmark/driver.mjs dispatch gpt-5.6-sol stim javascript sol
 the agent the fixture checkout as its starting directory, and requires the
 agent to create the measured run worktree itself. `collect` rejects source
 inspection before launch/error capture, a missing exact repair, a missing
-mismatched device, or missing Settings-screen proof. The recovery mechanism is
-measured, not prescribed.
+mismatched device, missing Settings-screen proof, failed Stim guide or warm
+setup, dependency installation inside the timer, missing Gradle cache injection,
+or exceeded machine phase target. The recovery mechanism is measured, not
+prescribed.
 
 Run the self-tests before a campaign:
 
@@ -77,4 +109,5 @@ node scripts/agent-benchmark/driver.mjs selftest-device-targeting
 node scripts/agent-benchmark/driver.mjs selftest-agent-device-isolation
 node scripts/agent-benchmark/driver.mjs selftest-launch-crash
 node scripts/agent-benchmark/driver.mjs selftest-android
+node scripts/agent-benchmark/driver.mjs selftest-runner-timeout
 ```

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -33,6 +33,13 @@ import {
   matchesExpectedIosSimulator,
 } from './watch-app-selection.mjs';
 import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
+import {
+  benchmarkSetupInvalidReasons,
+  benchmarkTarget,
+  benchmarkTiming,
+  parseBenchmarkTargets,
+  stimShellProvenanceInvalidReasons,
+} from './run-guards.mjs';
 
 const launchCrashVariant = 'launch-crash';
 const scriptRoot = dirname(fileURLToPath(import.meta.url));
@@ -64,6 +71,57 @@ const pins = Object.fromEntries(
       return [line.slice(0, at), line.slice(at + 1)];
     }),
 );
+
+function benchmarkTargets() {
+  const path = join(root, 'targets.json');
+  if (!existsSync(path)) throw new Error(`benchmark targets missing: ${path}`);
+  return parseBenchmarkTargets(readFileSync(path, 'utf8'));
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function isolatedShellEnvironment(environment, directory) {
+  const shellHome = join(directory, 'shell-home');
+  mkdirSync(shellHome, { recursive: true });
+  const startup = `export PATH=${shellQuote(environment.PATH)}\n`;
+  writeFileSync(join(shellHome, '.zshenv'), startup);
+  writeFileSync(join(shellHome, '.zprofile'), startup);
+  return { ...environment, ZDOTDIR: shellHome };
+}
+
+function expectedStimShellProvenance() {
+  return {
+    resolvedPath: join(stimBin, 'stim'),
+    version: pins.STIM_VERSION,
+    executableSha256: sha256(join(stimBin, 'stim')),
+    cliSha256: sha256(stimCli),
+  };
+}
+
+function stimShellProvenance(environment) {
+  return {
+    resolvedPath: run('/bin/zsh', ['-lc', 'command -v stim'], { cwd: main, env: environment }),
+    version: run('/bin/zsh', ['-lc', 'stim --version'], { cwd: main, env: environment }),
+    executableSha256: sha256(join(stimBin, 'stim')),
+    cliSha256: sha256(stimCli),
+  };
+}
+
+function verifyRunnerShell(arm, environment) {
+  if (arm === 'control') {
+    const resolved = run('/bin/zsh', ['-lc', 'command -v stim || true'], { cwd: main, env: environment });
+    if (resolved) throw new Error(`control login shell resolved Stim: ${resolved}`);
+    return null;
+  }
+  const expected = expectedStimShellProvenance();
+  const actual = stimShellProvenance(environment);
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`timed shell Stim provenance mismatch: ${JSON.stringify({ expected, actual })}`);
+  }
+  return actual;
+}
 
 function checkedPlatform(value = 'ios') {
   if (!['ios', 'android'].includes(value)) throw new Error(`unsupported benchmark platform: ${value}`);
@@ -460,9 +518,21 @@ function preflight(requestedPlatform = 'ios') {
   ensureDirs();
   prepareAllowedBin();
   const actual = versionChecks();
+  const targets = benchmarkTargets();
   if (!readFileSync(join(stimBin, 'stim'), 'utf8').includes(stimCli)) {
     throw new Error('Stim shim does not target the pinned CLI checkout');
   }
+  const shellProbeHome = join(state, 'shell-probe');
+  const shellProbeEnvironment = isolatedShellEnvironment(
+    {
+      ...cleanRubyEnvironment(process.env),
+      STIM_HOME: join(shellProbeHome, 'stim-home'),
+      BENCH_STIM_HOME: join(shellProbeHome, 'stim-home'),
+      PATH: `${stimBin}:${allowedBin}:/usr/bin:/bin:/usr/sbin:/sbin`,
+    },
+    shellProbeHome,
+  );
+  const shellProvenance = verifyRunnerShell('stim', shellProbeEnvironment);
   const booted = platform === 'android' ? androidEmulatorTransports() : bootedSimulators().map((device) => device.udid);
   if (booted.length) {
     throw new Error(`booted ${platform} devices require operator cleanup: ${JSON.stringify(booted)}`);
@@ -499,8 +569,13 @@ function preflight(requestedPlatform = 'ios') {
     load,
     thermal,
     platform,
+    timingTargets: {
+      machine: targets.machine,
+      keys: Object.keys(targets.targets).toSorted(),
+    },
     goldenCache,
     parkedSimulator,
+    shellProvenance,
     stimExecutableSha256: sha256(join(stimBin, 'stim')),
     stimCliSha256: sha256(stimCli),
   };
@@ -1016,13 +1091,31 @@ async function runnerSmoke(arm) {
   process.stdout.write(`${JSON.stringify({ arm, result, usage }, null, 2)}\n`);
 }
 
-function spawnStamped(command, args, output, options, input, timeoutMs = null) {
-  const child = spawn(command, args, options);
+function killProcessTree(child, processGroupId, signal) {
+  try {
+    if (process.platform !== 'win32' && processGroupId) process.kill(-processGroupId, signal);
+    else if (child.exitCode == null && child.signalCode == null) child.kill(signal);
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
+function terminateProcessTree(child, processGroupId, graceMs) {
+  killProcessTree(child, processGroupId, 'SIGTERM');
+  const timer = setTimeout(() => killProcessTree(child, processGroupId, 'SIGKILL'), graceMs);
+  timer.unref();
+  return timer;
+}
+
+function spawnStamped(command, args, output, options, input, timeoutMs = null, killGraceMs = 5000) {
+  const child = spawn(command, args, { ...options, detached: process.platform !== 'win32' });
+  const processGroupId = process.platform === 'win32' ? null : child.pid;
   let timedOut = false;
+  let forceKill = null;
   const timeout = timeoutMs
     ? setTimeout(() => {
         timedOut = true;
-        child.kill('SIGTERM');
+        forceKill = terminateProcessTree(child, processGroupId, killGraceMs);
       }, timeoutMs)
     : null;
   const stampOut = spawn('node', [join(scriptRoot, 'stamp.mjs'), 'stdout'], {
@@ -1043,6 +1136,10 @@ function spawnStamped(command, args, output, options, input, timeoutMs = null) {
   return new Promise((resolvePromise) => {
     child.on('close', (code, signal) => {
       if (timeout) clearTimeout(timeout);
+      if (forceKill) {
+        clearTimeout(forceKill);
+        killProcessTree(child, processGroupId, 'SIGKILL');
+      }
       stampOut.stdin.end();
       stampErr.stdin.end();
       return Promise.all([stampOutClosed, stampErrClosed]).then(() => {
@@ -1077,6 +1174,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     throw new Error('the launch-crash benchmark currently supports iOS only');
   }
   const preflightReport = preflight(platform);
+  const timingTarget = benchmarkTarget(benchmarkTargets(), { platform, variant, arm });
   preflightReport.loadGate = await waitForLoadGate();
   if (!preflightReport.loadGate.passed) {
     throw new Error('one-minute load average did not pass two consecutive samples within 10 minutes');
@@ -1130,13 +1228,14 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     cwd: root,
     timeout: 5 * 60 * 1000,
   });
-  const env = {
+  const baseEnv = {
     ...cleanRubyEnvironment(process.env),
     CODEX_HOME: codexHome,
     STIM_HOME: join(runDir, 'stim-home'),
     TMPDIR: runTmp,
     PATH: `${arm === 'stim' ? `${stimBin}:` : ''}${allowedBin}:/usr/bin:/bin:/usr/sbin:/sbin`,
   };
+  const env = isolatedShellEnvironment(baseEnv, runDir);
   if (arm === 'stim' && platform === 'ios') env.STIM_POOL_IOS_PARKED_MAX = '1';
   env.BENCH_STIM_HOME = env.STIM_HOME;
   mkdirSync(env.STIM_HOME, { recursive: true });
@@ -1149,6 +1248,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   const crash = variant === launchCrashVariant ? prepareLaunchCrashFixture(arm, runId, env) : null;
   const prompt = promptFor(arm, variant, runId, runDir, crash, platform);
   writeFileSync(join(runDir, 'prompt.txt'), `${prompt}\n`);
+  const shellProvenance = verifyRunnerShell(arm, env);
   const profile = verifyRunnerProfile(codexHome, env, arm, runDir);
   const claudeGuidance = runnerKind === 'claude' ? writeClaudeGuidance(codexHome, arm, runDir) : null;
   const agentDevice = prepareAgentDeviceRun(runId, platform, expectedParkedSimulator?.udid ?? null);
@@ -1166,7 +1266,10 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     worktreeParent,
     deviceTargetingRequired: true,
     dispatchAt,
+    timingTarget,
     preflight: preflightReport,
+    expectedStimShellProvenance: arm === 'stim' ? expectedStimShellProvenance() : null,
+    stimShellProvenance: shellProvenance,
     profile: { ...profile, claudeGuidance },
     expectedBuildCache,
     expectedParkedSimulator,
@@ -1195,7 +1298,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
       expectedControlSimulator.systemImage ?? '',
       `Trailhead ${runId}`,
     ],
-    { cwd: main, env, stdio: ['ignore', 'pipe', 'pipe'] },
+    { cwd: main, env, stdio: ['ignore', 'pipe', 'pipe'], detached: process.platform !== 'win32' },
   );
   const watcherClosed = new Promise((resolvePromise) => {
     watcher.on('close', (code, signal) => resolvePromise({ code, signal }));
@@ -1247,10 +1350,15 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     join(runDir, 'events.jsonl'),
     { cwd: runnerCwd, env, stdio: ['pipe', 'pipe', 'pipe'] },
     prompt,
-    25 * 60 * 1000,
+    timingTarget.runTimeoutSeconds * 1000,
   );
   const runnerResult = await runner;
+  const watcherForceKill = runnerResult.timedOut ? terminateProcessTree(watcher, watcher.pid, 5000) : null;
   const watcherResult = await watcherClosed;
+  if (watcherForceKill) {
+    clearTimeout(watcherForceKill);
+    killProcessTree(watcher, watcher.pid, 'SIGKILL');
+  }
   meta.runnerResult = runnerResult;
   meta.watcherResult = watcherResult;
   meta.finishedAt = new Date().toISOString();
@@ -1965,6 +2073,12 @@ function collect(runDir) {
   const eventsPath = join(runDir, 'events.jsonl');
   const commandAudit = commandEvidence(meta, eventsPath, runDir);
   const screen = screenEvidence(meta, appAlive, commandAudit.commands, runDir);
+  const timing = benchmarkTiming(
+    meta.timingTarget,
+    commandAudit.commands,
+    screen.dispatchToScreenReadySeconds,
+    meta.runnerResult?.timedOut,
+  );
   const recording = recordingEvidence(meta, commandAudit.commands, runDir, screen);
   const worktreeRecord = worktreeEvidence(runDir, meta, eventsPath);
   const worktree = worktreeRecord?.path ?? null;
@@ -1999,7 +2113,6 @@ function collect(runDir) {
   const invalidReasons = [
     ...(appAlive.error ? [appAlive.error] : []),
     ...(meta.runnerResult?.code === 0 ? [] : [`runner-exit-${meta.runnerResult?.code}`]),
-    ...(meta.runnerResult?.timedOut ? ['benchmark-timeout-25m'] : []),
     ...(runnerMetrics?.isError ? [`runner-${runnerMetrics.terminalReason ?? 'error'}`] : []),
     ...(runnerMetrics?.subagentsSpawned ? ['runner-used-subagents'] : []),
     ...(proof.valid ? [] : [proof.reason ?? 'proof-failed']),
@@ -2015,6 +2128,9 @@ function collect(runDir) {
       : []),
     ...deviceMismatchReasons(meta, appAlive.simulator),
     ...commandAudit.invalidReasons,
+    ...benchmarkSetupInvalidReasons(meta, commandAudit.commands),
+    ...stimShellProvenanceInvalidReasons(meta),
+    ...timing.invalidReasons,
     ...(git('status', '--short') === '' ? [] : ['main-checkout-dirty']),
   ];
   const nextRunRecord = {
@@ -2033,6 +2149,8 @@ function collect(runDir) {
     dispatchToAppAliveSeconds: appAlive.dispatchToAppAliveSeconds ?? null,
     dispatchToProofSeconds: appAlive.dispatchToProofSeconds ?? null,
     dispatchToScreenReadySeconds: screen.dispatchToScreenReadySeconds ?? null,
+    timing,
+    stimShellProvenance: meta.stimShellProvenance ?? null,
     dispatchToDiagnosisSeconds: diagnosis?.dispatchToDiagnosisSeconds ?? null,
     diagnosisCommandCount: diagnosis?.commandCount ?? null,
     diagnosisUsage,
@@ -2566,6 +2684,48 @@ function selftestAndroid() {
   process.stdout.write('Android self-test passed\n');
 }
 
+async function selftestRunnerTimeout() {
+  const runDir = join(state, `runner-timeout-selftest-${process.pid}`);
+  rmSync(runDir, { recursive: true, force: true });
+  mkdirSync(runDir, { recursive: true });
+  const startedAt = Date.now();
+  const eventsPath = join(runDir, 'events.jsonl');
+  const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)";
+  const parentScript = `const { spawn } = require('node:child_process'); const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' }); process.stdout.write(String(child.pid) + '\\n'); setInterval(() => {}, 1000)`;
+  const result = await spawnStamped(
+    process.execPath,
+    ['-e', parentScript],
+    eventsPath,
+    { cwd: root, env: process.env, stdio: ['pipe', 'pipe', 'pipe'] },
+    '',
+    250,
+    50,
+  );
+  const elapsedMs = Date.now() - startedAt;
+  const childPid = Number(
+    readFileSync(eventsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+      .find((line) => line.stream === 'stdout')?.line,
+  );
+  let childAlive = Number.isInteger(childPid);
+  for (let attempt = 0; childAlive && attempt < 50; attempt += 1) {
+    try {
+      process.kill(childPid, 0);
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error;
+      childAlive = false;
+    }
+  }
+  rmSync(runDir, { recursive: true, force: true });
+  if (!result.timedOut || childAlive || elapsedMs > 2000) {
+    throw new Error(`runner timeout was not enforced: ${JSON.stringify({ result, elapsedMs, childPid })}`);
+  }
+  process.stdout.write('runner timeout self-test passed\n');
+}
+
 const [command, ...args] = process.argv.slice(2);
 ensureDirs();
 if (command === 'preflight') {
@@ -2593,8 +2753,10 @@ if (command === 'preflight') {
   selftestLaunchCrash();
 } else if (command === 'selftest-android') {
   selftestAndroid();
+} else if (command === 'selftest-runner-timeout') {
+  await selftestRunnerTimeout();
 } else {
   throw new Error(
-    'usage: bench.mjs preflight [ios|android] | prepare [ios|android] | smoke <stim|control> | runner-smoke <stim|control> | dispatch <model> <stim|control> <javascript|native|launch-crash> [stage] [ios|android] | collect <run-dir> | cleanup <run-dir> | report <stage> | selftest-device-targeting | selftest-agent-device-isolation | selftest-launch-crash | selftest-android',
+    'usage: bench.mjs preflight [ios|android] | prepare [ios|android] | smoke <stim|control> | runner-smoke <stim|control> | dispatch <model> <stim|control> <javascript|native|launch-crash> [stage] [ios|android] | collect <run-dir> | cleanup <run-dir> | report <stage> | selftest-device-targeting | selftest-agent-device-isolation | selftest-launch-crash | selftest-android | selftest-runner-timeout',
   );
 }

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -1,0 +1,195 @@
+const platforms = new Set(['ios', 'android']);
+const variants = new Set(['javascript', 'native', 'launch-crash']);
+const arms = new Set(['stim', 'control']);
+
+function positiveSeconds(value, field, key) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`benchmark target ${key}.${field} must be a positive number`);
+  }
+  return value;
+}
+
+function targetKey({ platform, variant, arm }) {
+  return `${platform}.${variant}.${arm}`;
+}
+
+export function parseBenchmarkTargets(contents) {
+  const config = typeof contents === 'string' ? JSON.parse(contents) : contents;
+  if (config?.schemaVersion !== 1) throw new Error('benchmark targets schemaVersion must be 1');
+  if (typeof config.machine !== 'string' || !config.machine.trim()) {
+    throw new Error('benchmark targets machine must be a non-empty string');
+  }
+  if (!config.targets || typeof config.targets !== 'object' || Array.isArray(config.targets)) {
+    throw new Error('benchmark targets must be an object');
+  }
+  for (const [key, target] of Object.entries(config.targets)) {
+    const [platform, variant, arm, extra] = key.split('.');
+    if (extra || !platforms.has(platform) || !variants.has(variant) || !arms.has(arm)) {
+      throw new Error(`unsupported benchmark target key: ${key}`);
+    }
+    positiveSeconds(target?.screenReadySeconds, 'screenReadySeconds', key);
+    positiveSeconds(target?.runTimeoutSeconds, 'runTimeoutSeconds', key);
+    if (target.runTimeoutSeconds < target.screenReadySeconds) {
+      throw new Error(`benchmark target ${key}.runTimeoutSeconds must be at least screenReadySeconds`);
+    }
+    if (target.platformCommandSeconds != null) {
+      positiveSeconds(target.platformCommandSeconds, 'platformCommandSeconds', key);
+      if (target.runTimeoutSeconds < target.platformCommandSeconds) {
+        throw new Error(`benchmark target ${key}.runTimeoutSeconds must be at least platformCommandSeconds`);
+      }
+    }
+  }
+  return config;
+}
+
+export function benchmarkTarget(config, selection) {
+  const key = targetKey(selection);
+  const value = config.targets[key];
+  if (!value) throw new Error(`benchmark target missing for ${key}`);
+  return { key, machine: config.machine, ...value };
+}
+
+function topLevelShellCommand(command) {
+  const trimmed = String(command ?? '').trim();
+  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc (["'])([\s\S]*)\1$/);
+  return (match?.[2] ?? trimmed).trim();
+}
+
+export function shellCommandSegments(command) {
+  const source = topLevelShellCommand(command);
+  const segments = [];
+  let start = 0;
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+    const next = source[index + 1];
+    const separator = char === '\n' || char === ';' || char === '|' || char === '&';
+    if (!separator) continue;
+    const segment = source.slice(start, index).trim();
+    if (segment) segments.push(segment);
+    if ((char === '|' || char === '&') && next === char) index += 1;
+    start = index + 1;
+  }
+  const tail = source.slice(start).trim();
+  if (tail) segments.push(tail);
+  return segments;
+}
+
+function commandSegmentsStartingWith(command, expected) {
+  return shellCommandSegments(command).filter((segment) => segment === expected || segment.startsWith(`${expected} `));
+}
+
+function successfulCommand(commands, expected) {
+  return commands.some((command) => {
+    if (command.exitCode !== 0) return false;
+    const segments = shellCommandSegments(command.command);
+    const final = segments.at(-1);
+    return final === expected || final?.startsWith(`${expected} `);
+  });
+}
+
+function dependencyInstallCommand(command) {
+  return shellCommandSegments(command).some((segment) =>
+    /^(?:npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn(?:\s+install)?|bun\s+install)(?:\s|$)/.test(segment),
+  );
+}
+
+export function benchmarkSetupInvalidReasons(meta, commands) {
+  const reasons = [];
+  if (commands.some((command) => dependencyInstallCommand(command.command))) {
+    reasons.push('dependencies-installed-inside-timer');
+  }
+  if (meta.arm !== 'stim') return reasons;
+  if (!successfulCommand(commands, 'stim guide agent')) {
+    reasons.push('stim-guide-agent-missing-or-failed');
+  }
+  if (!successfulCommand(commands, 'stim worktree warm')) {
+    reasons.push('stim-worktree-warm-missing-or-failed');
+  }
+  const platformCommand = `stim ${meta.platform ?? 'ios'}`;
+  const platformRuns = commands.filter(
+    (command) => commandSegmentsStartingWith(command.command, platformCommand).length > 0,
+  );
+  const builtRun = platformRuns.find(
+    (command) => command.exitCode === 0 && /fingerprint\s+[0-9a-f]{6}\.\.\s+miss\b/.test(command.output),
+  );
+  if (
+    builtRun &&
+    meta.platform === 'android' &&
+    !/cache\s+gradle build cache on\s+\(--build-cache/.test(builtRun.output)
+  ) {
+    reasons.push('stim-gradle-build-cache-missing');
+  }
+  return reasons;
+}
+
+export function benchmarkTiming(target, commands, screenReadySeconds, timedOut) {
+  if (!target) {
+    return {
+      target: null,
+      screenReadySeconds: Number.isFinite(screenReadySeconds) ? screenReadySeconds : null,
+      screenReadyTargetMet: null,
+      platformCommandSeconds: null,
+      platformCommandTargetMet: null,
+      timedOut: Boolean(timedOut),
+      invalidReasons: ['benchmark-target-missing'],
+    };
+  }
+  const platformPrefix = `stim ${target.key.split('.').at(0)}`;
+  const platformCommands = commands.filter(
+    (command) => commandSegmentsStartingWith(command.command, platformPrefix).length > 0,
+  );
+  const platformCommandSeconds = platformCommands.reduce(
+    (maximum, command) => Math.max(maximum, command.elapsedSeconds ?? 0),
+    0,
+  );
+  const screenReadyTargetMet = Number.isFinite(screenReadySeconds) && screenReadySeconds <= target.screenReadySeconds;
+  const invalidReasons = [];
+  if (timedOut) invalidReasons.push('benchmark-run-timeout');
+  if (target.platformCommandSeconds != null && platformCommandSeconds > target.platformCommandSeconds) {
+    invalidReasons.push('platform-command-target-exceeded');
+  }
+  return {
+    target,
+    screenReadySeconds: Number.isFinite(screenReadySeconds) ? screenReadySeconds : null,
+    screenReadyTargetMet,
+    platformCommandSeconds: platformCommandSeconds || null,
+    platformCommandTargetMet:
+      target.platformCommandSeconds == null
+        ? null
+        : platformCommandSeconds > 0 && platformCommandSeconds <= target.platformCommandSeconds,
+    timedOut: Boolean(timedOut),
+    invalidReasons,
+  };
+}
+
+export function stimShellProvenanceInvalidReasons(meta) {
+  if (meta.arm !== 'stim') return [];
+  const probe = meta.stimShellProvenance;
+  if (!probe) return ['stim-shell-provenance-missing'];
+  const expected = meta.expectedStimShellProvenance;
+  if (!expected) return ['stim-shell-provenance-expectation-missing'];
+  return probe.resolvedPath === expected.resolvedPath &&
+    probe.version === expected.version &&
+    probe.executableSha256 === expected.executableSha256 &&
+    probe.cliSha256 === expected.cliSha256
+    ? []
+    : ['stim-shell-provenance-mismatch'];
+}

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  benchmarkSetupInvalidReasons,
+  benchmarkTarget,
+  benchmarkTiming,
+  parseBenchmarkTargets,
+  shellCommandSegments,
+  stimShellProvenanceInvalidReasons,
+} from './run-guards.mjs';
+
+const targetConfig = parseBenchmarkTargets({
+  schemaVersion: 1,
+  machine: 'Test Mac',
+  targets: {
+    'android.native.stim': {
+      screenReadySeconds: 300,
+      platformCommandSeconds: 180,
+      runTimeoutSeconds: 600,
+    },
+  },
+});
+
+describe('benchmark run guards', () => {
+  it('selects and validates a machine target', () => {
+    expect(benchmarkTarget(targetConfig, { platform: 'android', variant: 'native', arm: 'stim' })).toEqual({
+      key: 'android.native.stim',
+      machine: 'Test Mac',
+      screenReadySeconds: 300,
+      platformCommandSeconds: 180,
+      runTimeoutSeconds: 600,
+    });
+    expect(() => benchmarkTarget(targetConfig, { platform: 'ios', variant: 'native', arm: 'stim' })).toThrow(
+      /target missing/,
+    );
+    expect(() =>
+      parseBenchmarkTargets({
+        schemaVersion: 1,
+        machine: 'Test Mac',
+        targets: { 'android.native.stim': { screenReadySeconds: 300, runTimeoutSeconds: 200 } },
+      }),
+    ).toThrow(/at least screenReadySeconds/);
+    expect(() =>
+      parseBenchmarkTargets({
+        schemaVersion: 1,
+        machine: 'Test Mac',
+        targets: {
+          'android.native.stim': {
+            screenReadySeconds: 100,
+            platformCommandSeconds: 300,
+            runTimeoutSeconds: 200,
+          },
+        },
+      }),
+    ).toThrow(/at least platformCommandSeconds/);
+  });
+
+  it('finds commands in shell chains without splitting quoted operators', () => {
+    expect(shellCommandSegments(`/bin/zsh -lc 'cd "$WT" && echo "a && b"; stim guide agent'`)).toEqual([
+      'cd "$WT"',
+      'echo "a && b"',
+      'stim guide agent',
+    ]);
+  });
+
+  it('rejects setup recovery inside the timer', () => {
+    const commands = [
+      { command: "/bin/zsh -lc 'stim guide agent'", exitCode: 1 },
+      { command: "/bin/zsh -lc 'stim worktree warm'", exitCode: 1 },
+      { command: "/bin/zsh -lc 'npm install'", exitCode: 0 },
+      {
+        command: "/bin/zsh -lc 'stim android --system-image image'",
+        exitCode: 0,
+        output: 'fingerprint abcdef.. miss\nbuild ok',
+      },
+    ];
+    expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'android' }, commands)).toEqual([
+      'dependencies-installed-inside-timer',
+      'stim-guide-agent-missing-or-failed',
+      'stim-worktree-warm-missing-or-failed',
+      'stim-gradle-build-cache-missing',
+    ]);
+  });
+
+  it('accepts a warm native build with the shared Gradle cache enabled', () => {
+    const commands = [
+      { command: "/bin/zsh -lc 'stim guide agent'", exitCode: 0 },
+      { command: "/bin/zsh -lc 'stim worktree warm'", exitCode: 0 },
+      {
+        command: "/bin/zsh -lc 'stim android --system-image image'",
+        exitCode: 0,
+        output: 'fingerprint abcdef.. miss\ncache gradle build cache on (--build-cache, shared)',
+      },
+    ];
+    expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'android' }, commands)).toEqual([]);
+  });
+
+  it('audits Claude-style chained commands', () => {
+    const commands = [
+      { command: `/bin/zsh -lc 'cd "$WT" && stim guide agent'`, exitCode: 0 },
+      { command: `/bin/zsh -lc 'cd "$WT" && stim worktree warm'`, exitCode: 0 },
+      { command: `/bin/zsh -lc 'cd "$WT" && npm install'`, exitCode: 0 },
+      {
+        command: `/bin/zsh -lc 'cd "$WT" && stim android --system-image image'`,
+        exitCode: 0,
+        elapsedSeconds: 346,
+        output: 'fingerprint abcdef.. miss\nbuild ok',
+      },
+    ];
+    expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'android' }, commands)).toEqual([
+      'dependencies-installed-inside-timer',
+      'stim-gradle-build-cache-missing',
+    ]);
+    const target = benchmarkTarget(targetConfig, { platform: 'android', variant: 'native', arm: 'stim' });
+    expect(benchmarkTiming(target, commands, 400, false)).toMatchObject({
+      platformCommandSeconds: 346,
+      platformCommandTargetMet: false,
+      invalidReasons: ['platform-command-target-exceeded'],
+    });
+  });
+
+  it('does not let a later successful command mask failed setup', () => {
+    const commands = [
+      { command: `/bin/zsh -lc 'stim guide agent; true'`, exitCode: 0 },
+      { command: `/bin/zsh -lc 'stim worktree warm\ntrue'`, exitCode: 0 },
+    ];
+    expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'ios' }, commands)).toEqual([
+      'stim-guide-agent-missing-or-failed',
+      'stim-worktree-warm-missing-or-failed',
+    ]);
+  });
+
+  it('reports target status without treating model latency as invalid', () => {
+    const target = benchmarkTarget(targetConfig, { platform: 'android', variant: 'native', arm: 'stim' });
+    const commands = [
+      {
+        command: "/bin/zsh -lc 'stim android --system-image image'",
+        elapsedSeconds: 346,
+      },
+    ];
+    expect(benchmarkTiming(target, commands, 502, false)).toMatchObject({
+      screenReadyTargetMet: false,
+      platformCommandTargetMet: false,
+      invalidReasons: ['platform-command-target-exceeded'],
+    });
+  });
+
+  it('requires exact timed-shell Stim provenance', () => {
+    const expected = {
+      resolvedPath: '/bench/bin/stim',
+      version: '1.0.0-rc.15',
+      executableSha256: 'shim',
+      cliSha256: 'cli',
+    };
+    expect(
+      stimShellProvenanceInvalidReasons({
+        arm: 'stim',
+        expectedStimShellProvenance: expected,
+        stimShellProvenance: expected,
+      }),
+    ).toEqual([]);
+    expect(
+      stimShellProvenanceInvalidReasons({
+        arm: 'stim',
+        expectedStimShellProvenance: expected,
+        stimShellProvenance: { ...expected, version: '1.0.0-rc.14' },
+      }),
+    ).toEqual(['stim-shell-provenance-mismatch']);
+  });
+});


### PR DESCRIPTION
## Description

The benchmark preflight could verify the pinned CLI while timed agent commands resolved an older global Stim. macOS login-shell initialization reordered PATH, so one Android native attempt failed `stim guide agent` and `stim worktree warm`, installed dependencies inside the timer, and was still collected as valid.

This affects only the benchmark coordinator. Machine targets may reject otherwise usable attempts, but raw evidence is preserved and targets remain machine-local.

## Solution

Timed runs now use the exact CLI verified by preflight. Runner-specific zsh startup restores the constrained PATH after login initialization, and both preflight and each timed Stim environment require the expected shim path, package version, executable hash, and CLI hash. Control shells must not resolve Stim.

Machine-local targets separately record screen-ready expectations, Stim platform-command ceilings, and hard run timeouts. Screen-ready misses stay visible without invalidating a slow model.

Failed guide/warm setup, dependency installation during timing, missing Android Gradle-cache evidence, platform-command overruns, and hard timeouts invalidate the attempt.

## Test plan

- Ran a real Android preflight against the campaign: the login shell resolved the campaign shim, `1.0.0-rc.15`, and the expected executable and CLI hashes.
- Re-collected the problematic attempt and verified it is invalid for dependency installation, failed guide/warm setup, and missing shell provenance/target metadata.
- Ran the four benchmark driver self-tests and the full 3,565-test unit suite.
- Ran format, lint, build, and typecheck checks.

Fixes #433
