### PR TITLE
feat: report Stim versions in doctor

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -37,7 +37,9 @@ when it prints errors; an empty result does not prove launch or log capture
 succeeded.
 
 Use `stim doctor --platform ios` or `stim doctor --platform android` when only
-one native platform is in scope; shared project checks still run.
+one native platform is in scope; shared project checks still run. Doctor also
+prints the running CLI version and the `stim` installation resolved from PATH,
+and flags a resolved installation that is older than another available one.
 
 Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use

--- a/packages/stim-cli/bin/cli.ts
+++ b/packages/stim-cli/bin/cli.ts
@@ -20,7 +20,7 @@ const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
 const program = new Command();
 program.name('stim').description('Isolated React Native dev environments per project/worktree').version(pkg.version);
 
-doctorCommand(program);
+doctorCommand(program, pkg.version);
 worktreeCommand(program);
 startCommand(program);
 stopCommand(program);

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -1,8 +1,17 @@
 import { execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { Command } from 'commander';
 import {
   checkBuildCacheProvider,
@@ -24,11 +33,19 @@ import {
   parseXcodeMajor,
   checkConcurrency,
 } from '../doctor.ts';
-import doctorCommand, { doctorSuccessLines, parseDoctorPlatform } from '../commands/doctor.ts';
+import doctorCommand, { doctorSuccessLines, parseDoctorPlatform, shadowedStimFinding } from '../commands/doctor.ts';
 import type { Finding } from '../doctor.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import type { EasAuthResult } from '../engine/remote-cache.ts';
 import assert from 'node:assert';
+import {
+  analyzeStimVersions,
+  compareStimVersions,
+  inspectStimVersions,
+  parseStimVersionOutput,
+} from '../stim-installations.ts';
+
+const testStimVersions = analyzeStimVersions('1.2.3', '/tools/stim-cli', []);
 
 test('checkMainCheckout reports missing dependencies, Pods, and native output', () => {
   const project = mkdtempSync(join(tmpdir(), 'stim-doctor-source-cold-'));
@@ -78,6 +95,72 @@ test('parseDoctorPlatform accepts the two native platforms and rejects other val
   expect(parseDoctorPlatform('ios')).toBe('ios');
   expect(parseDoctorPlatform('android')).toBe('android');
   expect(() => parseDoctorPlatform('web')).toThrow(/ios, android/);
+});
+
+test('Stim version comparison follows semver prerelease precedence', () => {
+  expect(compareStimVersions('1.0.0-rc.14', '1.0.0-rc.15')).toBeLessThan(0);
+  expect(compareStimVersions('1.0.0-rc.15', '1.0.0')).toBeLessThan(0);
+  expect(compareStimVersions('2.0.0', '1.99.99')).toBeGreaterThan(0);
+  expect(compareStimVersions('1.0.0-1', '1.0.0-alpha')).toBeLessThan(0);
+  expect(compareStimVersions('1.0.0-A', '1.0.0-a')).toBeLessThan(0);
+  expect(compareStimVersions('1.0.0-01', '1.0.0-1')).toBe(null);
+  expect(parseStimVersionOutput('v1.2.3\n')).toBe('1.2.3');
+  expect(parseStimVersionOutput('stim 1.2.3')).toBe(null);
+});
+
+test('Stim installation inspection finds a shadowed older executable and deduplicates real paths', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-doctor-versions-'));
+  const oldBin = join(root, 'old');
+  const newBin = join(root, 'new');
+  const aliasBin = join(root, 'alias');
+  mkdirSync(oldBin);
+  mkdirSync(newBin);
+  mkdirSync(aliasBin);
+  writeFileSync(join(oldBin, 'stim'), '#!/bin/sh\nprintf "1.0.0-rc.14\\n"\n');
+  writeFileSync(join(newBin, 'stim'), '#!/bin/sh\nprintf "1.0.0-rc.15\\n"\n');
+  chmodSync(join(oldBin, 'stim'), 0o755);
+  chmodSync(join(newBin, 'stim'), 0o755);
+  symlinkSync(join(newBin, 'stim'), join(aliasBin, 'stim'));
+  try {
+    const report = await inspectStimVersions('1.0.0-rc.15', {
+      pathValue: [oldBin, newBin, aliasBin].join(delimiter),
+      runningPath: join(newBin, 'stim'),
+    });
+    expect(report.resolved).toMatchObject({ path: join(oldBin, 'stim'), version: '1.0.0-rc.14' });
+    expect(report.installations).toHaveLength(2);
+    expect(report.versions).toEqual(['1.0.0-rc.15', '1.0.0-rc.14']);
+    expect(report.highestVersion).toBe('1.0.0-rc.15');
+    expect(report.resolvedIsOlder).toBe(true);
+    expect(shadowedStimFinding(report)).toMatchObject({
+      level: 'cost',
+      title: 'The Stim resolved from PATH is older than another installation',
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Stim installation probes share one timeout window', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-doctor-version-timeout-'));
+  const first = join(root, 'first');
+  const second = join(root, 'second');
+  mkdirSync(first);
+  mkdirSync(second);
+  for (const directory of [first, second]) {
+    writeFileSync(join(directory, 'stim'), "#!/bin/sh\ntrap '' TERM\nsleep 1\n");
+    chmodSync(join(directory, 'stim'), 0o755);
+  }
+  try {
+    const startedAt = Date.now();
+    const report = await inspectStimVersions('1.0.0-rc.15', {
+      pathValue: [first, second].join(delimiter),
+      probeTimeoutMs: 50,
+    });
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(report.installations.map((entry) => entry.version)).toEqual([null, null]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('checkMainCheckout recognizes non-npm dependency installs', () => {
@@ -1285,7 +1368,7 @@ test('doctor --json prints exactly one line of JSON on stdout', async () => {
   const originalLog = console.log;
   writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
   const program = new Command();
-  doctorCommand(program);
+  doctorCommand(program, '1.2.3', () => testStimVersions);
   console.log = (msg) => logs.push(String(msg));
   process.chdir(project);
   try {
@@ -1305,14 +1388,18 @@ test('doctor --json prints exactly one line of JSON on stdout', async () => {
   expect(Array.isArray(payload.findings)).toBe(true);
   expect(typeof payload.project).toBe('string');
   expect(payload.platform).toBe(null);
+  expect(payload.stim.runningVersion).toBe('1.2.3');
+  expect(payload.stim.resolved).toBe(null);
 });
 
 test('doctor success output groups iOS checks and optional capabilities', () => {
-  const output = doctorSuccessLines('ios').join('\n');
+  const output = doctorSuccessLines('ios', testStimVersions).join('\n');
 
   expect(output).toContain('Doctor (iOS)');
   expect(output).toContain('result      PASS');
   expect(output).toContain('findings    0');
+  expect(output).toContain('version     1.2.3');
+  expect(output).toContain('resolved    not found on PATH');
   expect(output).toContain('Project');
   expect(output).toContain('iOS');
   expect(output).toContain('setup       CocoaPods, warm state, dev client');
@@ -1324,7 +1411,7 @@ test('doctor success output groups iOS checks and optional capabilities', () => 
 });
 
 test('doctor success output scopes native checks to Android', () => {
-  const output = doctorSuccessLines('android').join('\n');
+  const output = doctorSuccessLines('android', testStimVersions).join('\n');
 
   expect(output).toContain('Doctor (Android)');
   expect(output).toContain('Android');
@@ -1346,7 +1433,7 @@ test('doctor --platform includes the selection in JSON and suppresses the other 
   mkdirSync(join(project, 'ios'));
   mkdirSync(join(project, 'android'));
   const program = new Command();
-  doctorCommand(program);
+  doctorCommand(program, '1.2.3', () => testStimVersions);
   console.log = (msg) => logs.push(String(msg));
   process.chdir(project);
   try {
@@ -1398,7 +1485,7 @@ test('doctor --platform android does not invoke Xcode tooling', async () => {
     },
   });
   const program = new Command();
-  doctorCommand(program);
+  doctorCommand(program, '1.2.3', () => testStimVersions);
   console.log = (msg) => logs.push(String(msg));
   process.chdir(project);
   try {

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -90,6 +90,7 @@ export const OUTPUT_LABELS: readonly string[] = [
   'fingerprint',
   'gems',
   'install',
+  'installs',
   'ip.txt',
   'lan',
   'launch',
@@ -105,6 +106,7 @@ export const OUTPUT_LABELS: readonly string[] = [
   'ready',
   'remedy',
   'removed',
+  'resolved',
   'result',
   'services',
   'setting',
@@ -115,6 +117,7 @@ export const OUTPUT_LABELS: readonly string[] = [
   'stop',
   'swap',
   'verify',
+  'version',
   'workspace',
 ];
 

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -14,6 +14,7 @@ import {
 import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.ts';
 import type { DoctorPlatform, Finding } from '../doctor.ts';
 import { phaseLine } from '../command-output.ts';
+import { compareStimVersions, inspectStimVersions, type StimVersionReport } from '../stim-installations.ts';
 
 interface DoctorOptions {
   json?: boolean;
@@ -32,11 +33,26 @@ function doctorTarget(platform?: DoctorPlatform): string {
   return 'all platforms';
 }
 
-export function doctorSuccessLines(platform?: DoctorPlatform): string[] {
+function stimVersionLines(report: StimVersionReport): string[] {
+  const resolved = report.resolved
+    ? `${report.resolved.version ?? 'unknown version'} at ${report.resolved.path}`
+    : 'not found on PATH';
+  const paths = `${report.installations.length} distinct PATH install${report.installations.length === 1 ? '' : 's'}`;
+  const pathVersions = [...new Set(report.installations.map((entry) => entry.version).filter(Boolean))];
+  const versions = pathVersions.length > 1 ? ` (${pathVersions.join(', ')})` : '';
+  return [
+    phaseLine('version', report.runningVersion),
+    phaseLine('resolved', resolved),
+    phaseLine('installs', paths + versions),
+  ];
+}
+
+export function doctorSuccessLines(platform: DoctorPlatform | undefined, stim: StimVersionReport): string[] {
   const lines = [
     `Doctor (${doctorTarget(platform)})`,
     phaseLine('result', 'PASS'),
     phaseLine('findings', '0'),
+    ...stimVersionLines(stim),
     '',
     'Project',
     phaseLine('project', 'main checkout, dependencies, local upstream'),
@@ -69,6 +85,25 @@ export function doctorSuccessLines(platform?: DoctorPlatform): string[] {
   lines.push(phaseLine('caches', suppliedCaches));
   lines.push(phaseLine('meaning', 'missing project cache settings are healthy'));
   return lines;
+}
+
+export function shadowedStimFinding(report: StimVersionReport): Finding | null {
+  if (!report.resolvedIsOlder || !report.resolved?.version || !report.highestVersion) return null;
+  const newer = [
+    ...((compareStimVersions(report.runningVersion, report.resolved.version) ?? 0) > 0
+      ? [{ path: report.runningPath, version: report.runningVersion }]
+      : []),
+    ...report.installations.filter(
+      (entry) => entry.version && (compareStimVersions(entry.version, report.resolved?.version ?? '') ?? 0) > 0,
+    ),
+  ].find((entry) => entry.version === report.highestVersion);
+  const newerLocation = newer?.path ? ` at ${newer.path}` : '';
+  return {
+    level: 'cost',
+    title: 'The Stim resolved from PATH is older than another installation',
+    detail: `${report.resolved.path} reports ${report.resolved.version}, while ${report.highestVersion} is also installed${newerLocation}. A shell command named stim uses the first executable on PATH, so newer commands and fixes can appear to be missing.`,
+    fix: `Update or remove ${report.resolved.path}, or put the ${report.highestVersion} installation earlier on PATH. Then run \`stim doctor\` again.`,
+  };
 }
 
 /**
@@ -116,7 +151,11 @@ export function applySandboxFix(root: string, env: NodeJS.ProcessEnv = process.e
   );
 }
 
-export default function doctorCommand(program: Command): void {
+export default function doctorCommand(
+  program: Command,
+  version: string,
+  inspectVersions: (version: string) => StimVersionReport | Promise<StimVersionReport> = inspectStimVersions,
+): void {
   program
     .command('doctor')
     .description(
@@ -142,6 +181,8 @@ export default function doctorCommand(program: Command): void {
 
       if (opts.fix) applySandboxFix(root);
 
+      const stim = await inspectVersions(version);
+
       const findings: Finding[] = runDoctor(root, {
         xcodeMajor: opts.platform === 'android' ? null : detectXcodeMajor(),
         platform: opts.platform,
@@ -155,13 +196,16 @@ export default function doctorCommand(program: Command): void {
         if (sandbox) findings.push(sandbox);
       }
 
+      const shadowed = shadowedStimFinding(stim);
+      if (shadowed) findings.push(shadowed);
+
       if (opts.json) {
-        console.log(JSON.stringify({ project: root, platform: opts.platform ?? null, findings }));
+        console.log(JSON.stringify({ project: root, platform: opts.platform ?? null, stim, findings }));
         return;
       }
 
       if (findings.length === 0) {
-        const lines = doctorSuccessLines(opts.platform);
+        const lines = doctorSuccessLines(opts.platform, stim);
         for (const [index, line] of lines.entries()) {
           if (index === 1) console.log(chalk.green(line));
           else if (line && !line.startsWith('  ')) console.log(chalk.bold(line));
@@ -172,6 +216,7 @@ export default function doctorCommand(program: Command): void {
 
       const ordered = findings.toSorted((a, b) => (a.level === b.level ? 0 : a.level === 'cost' ? -1 : 1));
       console.log(chalk.bold(`Doctor (${doctorTarget(opts.platform)})`));
+      for (const line of stimVersionLines(stim)) console.log(chalk.dim(line));
       for (const f of ordered) {
         const tag = f.level === 'cost' ? chalk.yellow('costs time') : chalk.dim('note');
         console.log(`\n${tag}  ${chalk.bold(f.title)}`);

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -20,7 +20,9 @@ Read guide lifecycle options for exclusions and incomplete-copy remedies.
 
 Before native worktree work, run doctor for the platform in scope. It checks
 the main checkout from a linked worktree. Fix relevant findings and inspect the
-upstream gap.
+upstream gap. It also prints the running CLI version and the stim installation
+resolved from PATH. If that resolved installation is older than another one,
+fix PATH or the installation before continuing so commands and guidance match.
 
   stim doctor --platform ios          # or: --platform android
 

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -224,6 +224,20 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
   strategy        "deep-link" for Expo/dev-client, "android-broadcast" for
                   bare Android, or "metro-websocket" for an identifiable bare iOS peer
 
+  stim doctor --json
+
+  project         the resolved app root
+  platform        "ios" | "android" | null
+  stim            { runningVersion, runningPath, resolved, installations,
+                    versions, highestVersion, resolvedIsOlder }
+                  resolved is the first executable named stim on PATH;
+                  installations contains every distinct real executable on
+                  PATH and the version each reports. resolvedIsOlder is true
+                  only when that first executable is below the highest version
+                  available from this invocation or PATH
+  findings        the diagnostic findings; a lower resolved Stim is a
+                  costs-time finding with a PATH or installation remedy
+
 ON FAILURE
   \`start\`, \`ios\` and \`android\` all print the error contract instead,
   still one line on stdout, and exit 1:

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -153,11 +153,13 @@ result as proof instead of requiring an unrelated screenshot.`,
 
     branch      build       cache       caches      carry       device
     devices     error       failed      findings    fingerprint gems
-    install     ip.txt      lan         launch      lease       log
+    install     installs    ip.txt      lan         launch      lease
+    log
     logs        meaning     metro       pods        port        prebuild
-    project     ready       remedy      removed     result      services
+    project     ready       remedy      removed     resolved    result
+    services
     setting     settings    setup       state       stats       stop
-    swap        verify      workspace
+    swap        verify      version     workspace
 
   \`app\` and \`compilation cache\` join them in the stdout block a successful
   run ends with, and nowhere else. A line states a fact; the reason a fact

--- a/packages/stim-cli/src/stim-installations.ts
+++ b/packages/stim-cli/src/stim-installations.ts
@@ -1,0 +1,185 @@
+import { accessSync, constants, realpathSync, statSync } from 'node:fs';
+import { delimiter, join, resolve } from 'node:path';
+import { getExecutor } from './exec.ts';
+
+const VERSION_OUTPUT_LIMIT = 4096;
+
+export interface StimInstallation {
+  path: string;
+  realPath: string;
+  version: string | null;
+}
+
+export interface StimVersionReport {
+  runningVersion: string;
+  runningPath: string | null;
+  resolved: StimInstallation | null;
+  installations: StimInstallation[];
+  versions: string[];
+  highestVersion: string | null;
+  resolvedIsOlder: boolean;
+}
+
+interface ParsedVersion {
+  core: number[];
+  prerelease: Array<number | string> | null;
+}
+
+function parsedVersion(version: string): ParsedVersion | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(version);
+  if (!match) return null;
+  const core = [match[1] as string, match[2] as string, match[3] as string];
+  if (core.some((part) => part.length > 1 && part.startsWith('0'))) return null;
+  const prereleaseParts = match[4]?.split('.');
+  if (prereleaseParts?.some((part) => !part || (/^\d+$/.test(part) && part.length > 1 && part.startsWith('0')))) {
+    return null;
+  }
+  const prerelease = prereleaseParts?.map((part) => (/^\d+$/.test(part) ? Number(part) : part));
+  return {
+    core: core.map(Number),
+    prerelease: prerelease ?? null,
+  };
+}
+
+export function compareStimVersions(left: string, right: string): number | null {
+  const a = parsedVersion(left);
+  const b = parsedVersion(right);
+  if (!a || !b) return null;
+  for (let index = 0; index < a.core.length; index += 1) {
+    const difference = (a.core[index] ?? 0) - (b.core[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  if (!a.prerelease && !b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  for (let index = 0; index < Math.max(a.prerelease.length, b.prerelease.length); index += 1) {
+    const x = a.prerelease[index];
+    const y = b.prerelease[index];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    if (x === y) continue;
+    if (typeof x === 'number' && typeof y === 'number') return x - y;
+    if (typeof x === 'number') return -1;
+    if (typeof y === 'number') return 1;
+    return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+export function parseStimVersionOutput(output: string | null): string | null {
+  const version = output?.split('\n')[0]?.trim() ?? '';
+  return parsedVersion(version) ? version.replace(/^v/, '') : null;
+}
+
+function executableNames(platform: NodeJS.Platform): string[] {
+  return platform === 'win32' ? ['stim.cmd', 'stim.exe', 'stim'] : ['stim'];
+}
+
+function stimExecutablePaths(
+  pathValue: string,
+  { platform = process.platform, cwd = process.cwd() }: { platform?: NodeJS.Platform; cwd?: string } = {},
+): Array<{ path: string; realPath: string }> {
+  const found: Array<{ path: string; realPath: string }> = [];
+  const seen = new Set<string>();
+  for (const entry of pathValue.split(delimiter)) {
+    const directory = resolve(cwd, entry || '.');
+    for (const name of executableNames(platform)) {
+      const path = join(directory, name);
+      try {
+        accessSync(path, platform === 'win32' ? constants.F_OK : constants.X_OK);
+        if (!statSync(path).isFile()) continue;
+        const realPath = realpathSync(path);
+        if (seen.has(realPath)) continue;
+        seen.add(realPath);
+        found.push({ path, realPath });
+      } catch {}
+    }
+  }
+  return found;
+}
+
+function canonicalPath(path: string | undefined): string | null {
+  if (!path) return null;
+  try {
+    return realpathSync(resolve(path));
+  } catch {
+    return resolve(path);
+  }
+}
+
+export function analyzeStimVersions(
+  runningVersion: string,
+  runningPath: string | null,
+  installations: StimInstallation[],
+): StimVersionReport {
+  const candidates: Array<string | null> = [runningVersion, ...installations.map((entry) => entry.version)];
+  const versions = [...new Set(candidates)]
+    .filter((version): version is string => version !== null && compareStimVersions(version, version) !== null)
+    .toSorted((left, right) => -(compareStimVersions(left, right) ?? 0));
+  const highestVersion = versions[0] ?? null;
+  const resolved = installations[0] ?? null;
+  return {
+    runningVersion,
+    runningPath,
+    resolved,
+    installations,
+    versions,
+    highestVersion,
+    resolvedIsOlder: Boolean(
+      resolved?.version && highestVersion && (compareStimVersions(resolved.version, highestVersion) ?? 0) < 0,
+    ),
+  };
+}
+
+function probeStimVersion(path: string, timeoutMs: number): Promise<string | null> {
+  return new Promise((resolveProbe) => {
+    let settled = false;
+    let output = '';
+    const finish = (version: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe(version);
+    };
+    let child;
+    try {
+      child = getExecutor().spawn(path, ['--version'], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        detached: process.platform !== 'win32',
+      });
+    } catch {
+      resolveProbe(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        if (process.platform !== 'win32' && child.pid) process.kill(-child.pid, 'SIGKILL');
+        else child.kill('SIGKILL');
+      } catch {}
+      finish(null);
+    }, timeoutMs);
+    child.stdout?.on('data', (chunk) => {
+      if (output.length < VERSION_OUTPUT_LIMIT) output += String(chunk).slice(0, VERSION_OUTPUT_LIMIT - output.length);
+    });
+    child.on('error', () => finish(null));
+    child.on('close', (code) => finish(code === 0 ? parseStimVersionOutput(output) : null));
+  });
+}
+
+export async function inspectStimVersions(
+  runningVersion: string,
+  {
+    pathValue = process.env.PATH ?? '',
+    runningPath = process.argv[1],
+    probeTimeoutMs = 5000,
+  }: { pathValue?: string; runningPath?: string; probeTimeoutMs?: number } = {},
+): Promise<StimVersionReport> {
+  const paths = stimExecutablePaths(pathValue);
+  const versions = await Promise.all(paths.map((entry) => probeStimVersion(entry.path, probeTimeoutMs)));
+  const installations = paths.map((entry, index) => ({
+    path: entry.path,
+    realPath: entry.realPath,
+    version: versions[index] ?? null,
+  }));
+  return analyzeStimVersions(runningVersion, canonicalPath(runningPath), installations);
+}


### PR DESCRIPTION
## Description

`stim doctor` did not show which CLI version was running or which `stim` the shell would resolve. With multiple global or package-manager installations, an older executable could appear first on PATH, making newer commands and fixes seem missing while doctor reported no relevant problem.

The output change is additive. Doctor probes only executables already on PATH; an unresponsive candidate may add up to five seconds to the report but cannot make doctor fail.

## Solution

Doctor now reports:

- the running package version
- the first `stim` resolved from PATH
- every distinct PATH installation and its version
- whether the resolved executable is older than the newest available version

This also works when the current invocation, such as `npx stim-cli doctor`, is newer than every `stim` on PATH. JSON output includes the same structured data and canonical executable paths.

PATH candidates are canonicalized to deduplicate symlinks and queried through the shared process wrapper. Semver comparison handles prerelease versions correctly. When PATH resolves an older version, doctor warns with a concrete update, removal, or PATH-order remedy.

The README and version-matched guide document the new output contract.

## Test plan

- Built the CLI and ran `doctor --platform android` with rc.14 first on PATH and rc.15 later; doctor identified both, selected rc.15 as newest, and warned about rc.14.
- Added coverage for prerelease ordering, executable probing, symlink deduplication, JSON and plain output, and the stale-resolution finding.
- Ran all 3,562 unit tests.
- Ran format, lint, build, and typecheck checks.

Fixes #436
