### PR TITLE
fix: repair stale CMake state with doctor

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -41,6 +41,13 @@ one native platform is in scope; shared project checks still run. Doctor also
 prints the running CLI version and the `stim` installation resolved from PATH,
 and flags a resolved installation that is older than another available one.
 
+For stale Android CMake launcher findings, stop native builds and run
+`stim doctor --fix --platform android` in the affected checkout. It clears
+affected ignored, untracked generated `.cxx` configurations in the app and
+installed native modules, then reports remaining findings. The next build
+recreates that output; source files, custom launcher settings, and shared
+ccache entries are preserved.
+
 Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.

--- a/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { getExecutor } from '../exec.ts';
+import { acquireBuildLock, releaseBuildLock } from '../engine/build-lock.ts';
+import { readCxxLauncherStates, repairCxxLauncherState } from '../doctor-cxx.ts';
+import { checkCxxCompilerLauncher } from '../doctor.ts';
+
+let root: string;
+let home: string;
+let previousPath: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'stim-cxx-project-'));
+  home = mkdtempSync(join(tmpdir(), 'stim-cxx-home-'));
+  process.env.STIM_HOME = home;
+  previousPath = process.env.PATH;
+  writeFileSync(join(home, 'ccache'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  process.env.PATH = `${home}:${previousPath}`;
+  getExecutor().runFile('git', ['init', '-q', root]);
+  writeFileSync(join(root, '.gitignore'), '.cxx/\nnode_modules/\n');
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+  if (previousPath === undefined) delete process.env.PATH;
+  else process.env.PATH = previousPath;
+});
+
+function cache(module: string, launcher: string | null, abi = 'arm64-v8a'): string {
+  const path = join(root, module, '.cxx', 'Debug', 'abc123', abi);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(
+    join(path, 'CMakeCache.txt'),
+    `CMAKE_BUILD_TYPE:STRING=Debug\nCMAKE_CXX_COMPILER_LAUNCHER:STRING=${launcher ?? ''}\n`,
+  );
+  return path;
+}
+
+test('a healthy ABI cannot hide a stale app or scoped native-module configuration', () => {
+  const stale = cache('android/app', null);
+  const healthy = cache('android/app', join(home, 'ccache'), 'x86_64');
+  const module = cache('node_modules/@example/native/android', '/missing/bin/ccache');
+  const states = readCxxLauncherStates(root);
+  expect(states).toHaveLength(3);
+  expect(checkCxxCompilerLauncher({ states, ccacheOnPath: true })).not.toBeNull();
+  const result = repairCxxLauncherState(root);
+  expect(result.refused).toEqual([]);
+  expect(result.removed).toHaveLength(2);
+  expect(existsSync(stale)).toBe(false);
+  expect(existsSync(module)).toBe(false);
+  expect(existsSync(healthy)).toBe(true);
+  expect(checkCxxCompilerLauncher({ states: readCxxLauncherStates(root), ccacheOnPath: true })).toBeNull();
+  expect(repairCxxLauncherState(root)).toEqual({ removed: [], refused: [] });
+});
+
+test('repair refuses tracked or non-ignored output and leaves neighboring source intact', () => {
+  const tracked = cache('android/app', null);
+  getExecutor().runFile('git', ['add', '-f', join(tracked, 'CMakeCache.txt')], { cwd: root });
+  writeFileSync(join(root, '.gitignore'), '');
+  const source = join(root, 'android/app/CMakeLists.txt');
+  writeFileSync(source, 'project(Example)\n');
+  const result = repairCxxLauncherState(root);
+  expect(result.removed).toEqual([]);
+  expect(result.refused[0]?.reason).toMatch(/tracked/);
+  expect(existsSync(tracked)).toBe(true);
+  expect(existsSync(source)).toBe(true);
+  getExecutor().runFile('git', ['rm', '--cached', '-f', join(tracked, 'CMakeCache.txt')], { cwd: root });
+  expect(repairCxxLauncherState(root).refused).toHaveLength(1);
+  expect(existsSync(tracked)).toBe(true);
+});
+
+test('repair preserves explicit project launchers and healthy custom launchers', () => {
+  const stale = cache('android/app', null);
+  const custom = cache('node_modules/native/android', 'sccache');
+  writeFileSync(join(root, 'android/app/build.gradle.kts'), 'arguments.add("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")');
+  expect(repairCxxLauncherState(root).refused[0]?.reason).toMatch(/own compiler launcher/);
+  expect(existsSync(stale)).toBe(true);
+  expect(existsSync(custom)).toBe(true);
+});
+
+test('repair refuses an external linked dependency and an active Stim Android build', () => {
+  const external = join(home, 'native/android/.cxx/Debug/abc123/arm64-v8a');
+  mkdirSync(external, { recursive: true });
+  writeFileSync(join(external, 'CMakeCache.txt'), 'CMAKE_BUILD_TYPE:STRING=Debug\n');
+  mkdirSync(join(root, 'node_modules'), { recursive: true });
+  symlinkSync(join(home, 'native'), join(root, 'node_modules/native'), 'dir');
+  expect(repairCxxLauncherState(root).refused[0]?.reason).toMatch(/outside/);
+  expect(existsSync(external)).toBe(true);
+  const app = cache('android/app', null);
+  const lock = acquireBuildLock({ platform: 'android', key: 'test', root });
+  try {
+    expect(repairCxxLauncherState(root).refused.some(({ reason }) => /build is active/.test(reason))).toBe(true);
+    expect(existsSync(app)).toBe(true);
+  } finally {
+    releaseBuildLock(lock);
+  }
+});
+
+test('repair refuses a redirected .cxx directory even when its target is within the checkout', () => {
+  const app = cache('android/generated', null);
+  mkdirSync(join(root, 'android/app'), { recursive: true });
+  symlinkSync(dirname(dirname(dirname(app))), join(root, 'android/app/.cxx'), 'dir');
+  expect(repairCxxLauncherState(root).refused[0]?.reason).toMatch(/symbolic link/);
+  expect(existsSync(app)).toBe(true);
+});
+
+test('doctor --json --fix reports the post-repair state as one JSON payload', () => {
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture', dependencies: { 'react-native': '0.81.0' } }),
+  );
+  const stale = cache('android/app', null);
+  const cli = join(import.meta.dirname, '../../dist/cli.mjs');
+  const plain = JSON.parse(
+    getExecutor().runFile(process.execPath, [cli, 'doctor', '--json', '--platform', 'android'], { cwd: root }),
+  );
+  expect(plain.findings.some((finding: { code?: string }) => finding.code === 'android-cmake-launcher')).toBe(true);
+  expect(existsSync(stale)).toBe(true);
+  const fixed = JSON.parse(
+    getExecutor().runFile(process.execPath, [cli, 'doctor', '--json', '--fix', '--platform', 'android'], { cwd: root }),
+  );
+  expect(fixed.findings.some((finding: { code?: string }) => finding.code === 'android-cmake-launcher')).toBe(false);
+  expect(existsSync(stale)).toBe(false);
+});

--- a/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
@@ -108,6 +108,17 @@ test('repair refuses a redirected .cxx directory even when its target is within 
   expect(existsSync(app)).toBe(true);
 });
 
+test('repair follows pnpm package links within the checkout for Git safety checks', () => {
+  const module = 'node_modules/.pnpm/native@1/node_modules/native';
+  const stale = cache(`${module}/android`, null);
+  symlinkSync(join(root, module), join(root, 'node_modules/native'), 'dir');
+  expect(repairCxxLauncherState(root)).toEqual({
+    removed: ['node_modules/native/android/.cxx/Debug/abc123/arm64-v8a'],
+    refused: [],
+  });
+  expect(existsSync(stale)).toBe(false);
+});
+
 test('doctor --json --fix reports the post-repair state as one JSON payload', () => {
   writeFileSync(
     join(root, 'package.json'),

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -15,6 +15,7 @@ import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.
 import type { DoctorPlatform, Finding } from '../doctor.ts';
 import { phaseLine } from '../command-output.ts';
 import { compareStimVersions, inspectStimVersions, type StimVersionReport } from '../stim-installations.ts';
+import { repairCxxLauncherState } from '../doctor-cxx.ts';
 
 interface DoctorOptions {
   json?: boolean;
@@ -169,7 +170,7 @@ export default function doctorCommand(
     )
     .option(
       '--fix',
-      'apply the findings Stim can repair itself and report the rest, which stay read-only. Every repair writes a per-user file, never a committed one, and refuses a file it cannot read back rather than replace it. Today one finding qualifies: the sandbox allowance.',
+      'repair the sandbox allowance and stale Android .cxx configurations in this checkout. Stop native builds first. Generated CMake output must be ignored and untracked; custom launcher settings and source files are preserved.',
     )
     .action(async (opts: DoctorOptions) => {
       const root = findProjectRoot(process.cwd());
@@ -179,7 +180,21 @@ export default function doctorCommand(
         return;
       }
 
-      if (opts.fix) applySandboxFix(root);
+      if (opts.fix) {
+        if (opts.platform !== 'android') applySandboxFix(root);
+        if (opts.platform !== 'ios') {
+          try {
+            const repair = repairCxxLauncherState(root);
+            for (const path of repair.removed)
+              console.error(phaseLine('cache', `removed ${path}; next build reconfigures`));
+            for (const { path, reason } of repair.refused) console.error(phaseLine('cache', `kept ${path}: ${reason}`));
+            if (repair.refused.length > 0) process.exitCode = 1;
+          } catch (error) {
+            console.error(phaseLine('cache', `CMake cleanup failed: ${(error as Error).message}`));
+            process.exitCode = 1;
+          }
+        }
+      }
 
       const stim = await inspectVersions(version);
 

--- a/packages/stim-cli/src/doctor-cxx.ts
+++ b/packages/stim-cli/src/doctor-cxx.ts
@@ -99,12 +99,13 @@ export function repairCxxLauncherState(root: string): CxxRepairResult {
       if (!contained(canonicalRoot, canonicalTarget))
         throw new Error('generated directory resolves outside this checkout');
       if (realpathSync(cxx) !== join(realpathSync(dirname(cxx)), '.cxx')) throw new Error('.cxx is a symbolic link');
-      const tracked = getExecutor().runFile('git', ['ls-files', '-z', '--', `:(literal)${label}`], {
-        cwd: root,
+      const gitPath = relative(canonicalRoot, canonicalTarget);
+      const tracked = getExecutor().runFile('git', ['ls-files', '-z', '--', `:(literal)${gitPath}`], {
+        cwd: canonicalRoot,
         timeoutMs: 5000,
       });
       if (tracked) throw new Error('directory contains tracked files');
-      getExecutor().runFile('git', ['check-ignore', '-q', '--', label], { cwd: root, timeoutMs: 5000 });
+      getExecutor().runFile('git', ['check-ignore', '-q', '--', gitPath], { cwd: canonicalRoot, timeoutMs: 5000 });
       const active = listBuildLocks().some((lock) => {
         if (lock.platform !== 'android' || !lock.alive || !lock.projectRoot) return false;
         return realpathSync(lock.projectRoot) === canonicalRoot;

--- a/packages/stim-cli/src/doctor-cxx.ts
+++ b/packages/stim-cli/src/doctor-cxx.ts
@@ -1,0 +1,121 @@
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, rmSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { getExecutor } from './exec.ts';
+import { listBuildLocks } from './engine/build-lock.ts';
+import { projectCmakeLauncher } from './engine/ccache.ts';
+
+export interface CxxLauncherState {
+  path: string;
+  launcher: string | null;
+}
+
+export function parseCmakeCacheLauncher(source: unknown): string | null {
+  if (typeof source !== 'string') return null;
+  const match = /^CMAKE_CXX_COMPILER_LAUNCHER(?::[A-Z]+)?=(.*)$/m.exec(source);
+  return match?.[1]?.trim() || null;
+}
+
+function children(path: string): string[] {
+  try {
+    return readdirSync(path).toSorted();
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) return [];
+    throw error;
+  }
+}
+
+function moduleRoots(root: string): string[] {
+  const modules = [join(root, 'android', 'app')];
+  const dependencies = join(root, 'node_modules');
+  for (const name of children(dependencies)) {
+    if (name.startsWith('.')) continue;
+    const entry = join(dependencies, name);
+    const packages = name.startsWith('@') ? children(entry).map((child) => join(entry, child)) : [entry];
+    modules.push(...packages.map((pkg) => join(pkg, 'android')));
+  }
+  return modules;
+}
+
+function cacheFiles(base: string, depth = 0): string[] {
+  const files: string[] = [];
+  for (const name of children(base)) {
+    const path = join(base, name);
+    const entry = lstatSync(path);
+    if (entry.isSymbolicLink()) continue;
+    if (name === 'CMakeCache.txt' && entry.isFile()) files.push(path);
+    else if (depth < 3 && entry.isDirectory() && name !== 'CMakeFiles') files.push(...cacheFiles(path, depth + 1));
+  }
+  return files;
+}
+
+export function readCxxLauncherStates(root: string): CxxLauncherState[] {
+  return moduleRoots(root).flatMap((module) =>
+    cacheFiles(join(module, '.cxx')).map((path) => ({
+      path: relative(root, path),
+      launcher: parseCmakeCacheLauncher(readFileSync(path, 'utf8')),
+    })),
+  );
+}
+
+function declaredLauncher(module: string): boolean {
+  return ['build.gradle', 'build.gradle.kts', 'CMakeLists.txt'].some((name) => {
+    const path = join(module, name);
+    return existsSync(path) && Boolean(projectCmakeLauncher(readFileSync(path, 'utf8')));
+  });
+}
+
+function contained(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+export interface CxxRepairResult {
+  removed: string[];
+  refused: { path: string; reason: string }[];
+}
+
+export function repairCxxLauncherState(root: string): CxxRepairResult {
+  const canonicalRoot = realpathSync(root);
+  const result: CxxRepairResult = { removed: [], refused: [] };
+  const ccache = getExecutor().runQuiet('command -v ccache', { timeoutMs: 5000 });
+  if (!ccache) return result;
+  const appOverrides = declaredLauncher(join(root, 'android', 'app'));
+  const states = readCxxLauncherStates(root);
+  const targets = states.filter(({ launcher }) => {
+    if (!launcher) return true;
+    const command = launcher.split(';')[0]?.trim();
+    return Boolean(command && isAbsolute(command) && basename(command) === 'ccache' && !existsSync(command));
+  });
+  for (const state of targets) {
+    const target = dirname(join(root, state.path));
+    const label = relative(root, target);
+    try {
+      let cxx = target;
+      while (contained(root, cxx) && basename(cxx) !== '.cxx') cxx = dirname(cxx);
+      if (basename(cxx) !== '.cxx' || target === cxx) throw new Error('unrecognized generated CMake layout');
+      if (appOverrides || declaredLauncher(dirname(cxx)))
+        throw new Error('project configures its own compiler launcher');
+      const canonicalTarget = realpathSync(target);
+      if (!contained(canonicalRoot, canonicalTarget))
+        throw new Error('generated directory resolves outside this checkout');
+      if (realpathSync(cxx) !== join(realpathSync(dirname(cxx)), '.cxx')) throw new Error('.cxx is a symbolic link');
+      const tracked = getExecutor().runFile('git', ['ls-files', '-z', '--', `:(literal)${label}`], {
+        cwd: root,
+        timeoutMs: 5000,
+      });
+      if (tracked) throw new Error('directory contains tracked files');
+      getExecutor().runFile('git', ['check-ignore', '-q', '--', label], { cwd: root, timeoutMs: 5000 });
+      const active = listBuildLocks().some((lock) => {
+        if (lock.platform !== 'android' || !lock.alive || !lock.projectRoot) return false;
+        return realpathSync(lock.projectRoot) === canonicalRoot;
+      });
+      if (active) throw new Error('an Android build is active in this checkout');
+      if (realpathSync(target) !== canonicalTarget) throw new Error('directory changed during inspection');
+      rmSync(target, { recursive: true });
+      result.removed.push(label);
+    } catch (error) {
+      result.refused.push({ path: label, reason: (error as Error).message });
+    }
+  }
+  return result;
+}

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { plural } from './command-output.ts';
@@ -33,12 +33,15 @@ import {
   settingShapeErrors,
 } from './settings.ts';
 import type { RemoteDeviceBackend } from './types.ts';
+import { readCxxLauncherStates, type CxxLauncherState } from './doctor-cxx.ts';
+export { parseCmakeCacheLauncher } from './doctor-cxx.ts';
 
 type AnyJson = Record<string, unknown>;
 
 export { detectXcodeMajor, parseXcodeMajor };
 
 export interface Finding {
+  code?: string;
   level: 'cost' | 'note';
   title: string;
   detail: string;
@@ -360,18 +363,6 @@ export function checkCcacheInstalled(onPath: boolean): Finding | null {
   );
 }
 
-export interface CxxLauncherState {
-  path: string;
-  launcher: string | null;
-}
-
-export function parseCmakeCacheLauncher(source: unknown): string | null {
-  if (typeof source !== 'string') return null;
-  const match = /^CMAKE_CXX_COMPILER_LAUNCHER(?::[A-Z]+)?=(.*)$/m.exec(source);
-  const value = match?.[1]?.trim();
-  return value ? value : null;
-}
-
 // CMake docs, CMAKE_<LANG>_COMPILER_LAUNCHER: the value is a ;-separated
 // command line whose first word is resolved through PATH unless it is
 // absolute, so only an absolute one is a path this machine must hold.
@@ -400,55 +391,18 @@ export function checkCxxCompilerLauncher({
       'cost',
       'A configured CMake cache names a compiler launcher that is not on this machine',
       `${plural(missing.length, 'CMakeCache.txt file')} under this project name ${named}, and CMake runs that path for every C++ compile. Until the cache is reconfigured the build fails there rather than falling back: ${missing[0]?.path}.`,
-      'Delete the configured CMake directories once so the next build reconfigures: `rm -rf android/app/.cxx android/app/build` (and node_modules/*/android/.cxx for library modules).',
+      'With ccache installed, run `stim doctor --fix --platform android` in this checkout to clear affected generated .cxx configurations. Custom launchers require project-specific repair. Stop native builds before repairing.',
     );
   }
   if (!ccacheOnPath) return null;
-  if (states.length === 0) return null;
-  if (states.some((state) => state.launcher !== null)) return null;
+  const stale = states.filter((state) => state.launcher === null);
+  if (stale.length === 0) return null;
   return finding(
     'cost',
     'The configured CMake cache predates the ccache launcher, so C++ compiles still bypass it',
-    `CMake seeds CMAKE_CXX_COMPILER_LAUNCHER from the environment on a FRESH configure only, so a .cxx directory written before Stim set the variable keeps compiling without it and the shared cache stays empty. ${plural(states.length, 'CMakeCache.txt file')} here names no launcher: ${states[0]?.path}.`,
-    'Delete the configured CMake directories once: `rm -rf android/app/.cxx android/app/build` (and node_modules/*/android/.cxx for library modules). The next `stim android` reconfigures with the launcher and every later build keeps it.',
+    `CMake seeds CMAKE_CXX_COMPILER_LAUNCHER from the environment on a fresh configure only. ${plural(stale.length, 'CMakeCache.txt file')} here names no launcher: ${stale[0]?.path}. These configurations can bypass ccache; cache misses reported by ccache itself still represent compilations that used the launcher.`,
+    'Stop native builds, then run `stim doctor --fix --platform android` in this checkout. It clears affected ignored, untracked .cxx configurations; the next `stim android` configures them with ccache. Existing custom launcher settings require project-specific repair.',
   );
-}
-
-const CXX_SCAN_DEPTH = 4;
-
-function readCxxLauncherStates(projectRoot: string): CxxLauncherState[] {
-  const base = join(projectRoot, 'android', 'app', '.cxx');
-  const states: CxxLauncherState[] = [];
-  const walk = (dir: string, depth: number): void => {
-    let names: string[];
-    try {
-      names = readdirSync(dir);
-    } catch {
-      return;
-    }
-    for (const name of names) {
-      const path = join(dir, name);
-      if (name === 'CMakeCache.txt') {
-        let source: string | null = null;
-        try {
-          source = readFileSync(path, 'utf-8');
-        } catch {
-          continue;
-        }
-        states.push({ path: relative(projectRoot, path), launcher: parseCmakeCacheLauncher(source) });
-        continue;
-      }
-      if (depth >= CXX_SCAN_DEPTH) continue;
-      try {
-        if (!statSync(path).isDirectory()) continue;
-      } catch {
-        continue;
-      }
-      walk(path, depth + 1);
-    }
-  };
-  walk(base, 0);
-  return states;
 }
 
 function ccacheIsOnPath(): boolean {
@@ -824,10 +778,19 @@ function androidCcacheFindings(
 ): (Finding | null)[] {
   if (platform !== 'android' && !existsSync(join(projectRoot, 'android'))) return [];
   const onPath = lookupCcache ? lookupCcache() : ccacheIsOnPath();
-  return [
-    checkCcacheInstalled(onPath),
-    checkCxxCompilerLauncher({ states: readCxxLauncherStates(projectRoot), ccacheOnPath: onPath }),
-  ];
+  let cxx: Finding | null;
+  try {
+    cxx = checkCxxCompilerLauncher({ states: readCxxLauncherStates(projectRoot), ccacheOnPath: onPath });
+  } catch (error) {
+    cxx = finding(
+      'cost',
+      'CMake launcher state could not be inspected',
+      String(error),
+      'Restore read access and rerun doctor.',
+    );
+  }
+  if (cxx) cxx.code = 'android-cmake-launcher';
+  return [checkCcacheInstalled(onPath), cxx];
 }
 
 function checkAppProject(projectRoot: string): Finding | null {

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -26,6 +26,14 @@ fix PATH or the installation before continuing so commands and guidance match.
 
   stim doctor --platform ios          # or: --platform android
 
+For stale Android CMake launcher findings, stop native builds and run
+stim doctor --fix --platform android in the affected checkout before warming
+more worktrees. It removes affected ignored, untracked generated .cxx
+configurations, including installed native modules; the next build recreates
+them. It preserves source, custom launcher settings, and the shared ccache.
+
+Continue with cache seeding:
+
   # In the main checkout, seed the shared build caches when more native
   # worktrees are coming. Skip this for one-off or JavaScript-only work.
   stim start

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -401,8 +401,13 @@ a fresh npm ci included. No stale .pch is ever served. reanimated passes
 The launcher persists in the project. AGP writes it into each
 .cxx/**/CMakeCache.txt on the first configure, so a plain \`./gradlew\` in that
 checkout also compiles through ccache -- and a .cxx configured BEFORE the
-variables existed keeps compiling without them until it is deleted once.
-\`stim doctor\` reports both.
+variables existed can keep compiling without them until it is cleared once.
+\`stim doctor\` reports stale configurations in this checkout's app and installed
+native modules. Stop native builds, then run \`stim doctor --fix --platform android\`:
+it removes only affected ignored, untracked generated .cxx configurations and
+reruns the diagnostics. The next build recreates them. It refuses directories
+outside the checkout and configured custom launchers. Shared ccache entries and
+source files are preserved. Run it before copying the checkout into worktrees.
 
 THE BUILD CACHE HAS THREE LEVELS
   1. Stim's own, on this machine: a directory under ~/.stim shared by


### PR DESCRIPTION
## Description

Android CMake configurations created before ccache was enabled can retain an empty launcher. Doctor flags this but currently offers only manual deletion instructions, and healthy app configurations can hide stale ones in native dependencies.

## Solution

`stim doctor --fix --platform android` clears affected generated configurations and reports the remaining findings. Plain doctor scans the app and installed native modules, including mixed healthy/stale state; Android builds gain no extra checks. Shared sandbox repair still applies on Android, and an unrestricted Codex session does not report a false repair failure.

Cleanup requires ignored, untracked output within the checkout and preserves custom launcher settings. Stop all native builds and keep them stopped until repair finishes: the supplemental cache-lock check cannot detect uncached builds, release-swap fallback builds, or direct Gradle. Removed output is recreated on the next build, while shared ccache entries remain intact.

## Test plan

Verified with real Git and CMake: configured and built without a launcher, repaired with doctor, then reconfigured and observed ccache in the actual C++ compile command. Regression coverage checks post-repair JSON under Claude and Codex, shared sandbox allowances, idempotence, healthy configurations, tracked/unignored output, linked dependencies, custom launchers, and detected build locks.

Fixes #440
