### PR TITLE
fix: flag unhealthy benchmark compiler caches

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -38,6 +38,7 @@ each platform, change, and arm:
     "android.native.stim": {
       "screenReadySeconds": 300,
       "platformCommandSeconds": 180,
+      "ccacheMinHitRatePercent": 50,
       "runTimeoutSeconds": 600
     },
     "android.native.control": {
@@ -53,6 +54,21 @@ performance target but does not invalidate a slow model. A Stim platform
 command over `platformCommandSeconds` is an invalid machine/build result.
 `runTimeoutSeconds` terminates and invalidates a runaway agent. Keep
 authentication and raw evidence out of Git.
+
+Android native Stim cells also require `ccacheMinHitRatePercent`. Establish this
+machine/scenario threshold from a verified warm compiler-cache probe before
+dispatch; the example value is illustrative. Keep it fixed across models.
+Collection records actual hits and misses, accepts proven artifact hits without
+C++ compilation, and flags missing or below-target compiler-cache evidence.
+Completed tool output triggers an immediate `CACHE ALERT` and preserves
+`cache-alerts.json`. A flagged attempt stays available for investigation and is
+excluded from published comparisons; investigate the cause before retrying.
+
+Android golden preparation and every preflight require a structured doctor
+report without cost findings. Repair the fixture with
+`stim doctor --fix --platform android`, seed its shared caches, and verify
+cross-worktree reuse before creating the golden. Preflight only inspects the
+fixture; it never changes cache state during a timed cell.
 
 Set the machine-local paths explicitly:
 

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -17,6 +17,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createInterface } from 'node:readline';
 import {
   changedPathsFromGitOutputs,
   injectRootRenderCrash,
@@ -39,6 +40,10 @@ import {
   benchmarkTiming,
   parseBenchmarkTargets,
   stimShellProvenanceInvalidReasons,
+  assertAndroidDoctorClean,
+  benchmarkCcache,
+  ccacheMeasurements,
+  runnerToolOutput,
 } from './run-guards.mjs';
 
 const launchCrashVariant = 'launch-crash';
@@ -533,6 +538,7 @@ function preflight(requestedPlatform = 'ios') {
     shellProbeHome,
   );
   const shellProvenance = verifyRunnerShell('stim', shellProbeEnvironment);
+  const doctor = platform === 'android' ? androidDoctor(main, shellProbeEnvironment) : null;
   const booted = platform === 'android' ? androidEmulatorTransports() : bootedSimulators().map((device) => device.udid);
   if (booted.length) {
     throw new Error(`booted ${platform} devices require operator cleanup: ${JSON.stringify(booted)}`);
@@ -576,11 +582,24 @@ function preflight(requestedPlatform = 'ios') {
     goldenCache,
     parkedSimulator,
     shellProvenance,
+    doctor,
     stimExecutableSha256: sha256(join(stimBin, 'stim')),
     stimCliSha256: sha256(stimCli),
   };
   writeFileSync(join(state, 'last-preflight.json'), `${JSON.stringify(preflightRecord, null, 2)}\n`);
   return preflightRecord;
+}
+
+function androidDoctor(cwd, env) {
+  return assertAndroidDoctorClean(
+    JSON.parse(
+      run('node', [stimCli, 'doctor', '--platform', 'android', '--json'], {
+        cwd,
+        env,
+        timeout: 2 * 60 * 1000,
+      }),
+    ),
+  );
 }
 
 async function waitForLoadGate() {
@@ -704,6 +723,7 @@ function prepareAndroid() {
   ensureDirs();
   prepareAllowedBin();
   versionChecks();
+  androidDoctor(main, { ...cleanRubyEnvironment(process.env), STIM_HOME: join(state, 'doctor-home') });
   const platformGolden = goldenFor('android');
   const readyPath = join(platformGolden, 'READY.json');
   if (existsSync(readyPath)) {
@@ -1107,7 +1127,7 @@ function terminateProcessTree(child, processGroupId, graceMs) {
   return timer;
 }
 
-function spawnStamped(command, args, output, options, input, timeoutMs = null, killGraceMs = 5000) {
+function spawnStamped(command, args, output, options, input, timeoutMs = null, killGraceMs = 5000, onEvent = null) {
   const child = spawn(command, args, { ...options, detached: process.platform !== 'win32' });
   const processGroupId = process.platform === 'win32' ? null : child.pid;
   let timedOut = false;
@@ -1130,6 +1150,17 @@ function spawnStamped(command, args, output, options, input, timeoutMs = null, k
   stampErr.stdout.on('data', (chunk) => errChunks.push(chunk));
   child.stdout.pipe(stampOut.stdin);
   child.stderr.pipe(stampErr.stdin);
+  if (onEvent) {
+    createInterface({ input: child.stdout, crlfDelay: Infinity }).on('line', (line) => {
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        return;
+      }
+      onEvent(event);
+    });
+  }
   child.stdin.end(input);
   const stampOutClosed = new Promise((done) => stampOut.on('close', done));
   const stampErrClosed = new Promise((done) => stampErr.on('close', done));
@@ -1175,6 +1206,16 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   }
   const preflightReport = preflight(platform);
   const timingTarget = benchmarkTarget(benchmarkTargets(), { platform, variant, arm });
+  if (
+    platform === 'android' &&
+    variant === 'native' &&
+    arm === 'stim' &&
+    timingTarget.ccacheMinHitRatePercent == null
+  ) {
+    throw new Error(
+      'Android native Stim benchmark requires a ccacheMinHitRatePercent target established before dispatch',
+    );
+  }
   preflightReport.loadGate = await waitForLoadGate();
   if (!preflightReport.loadGate.passed) {
     throw new Error('one-minute load average did not pass two consecutive samples within 10 minutes');
@@ -1351,6 +1392,27 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     { cwd: runnerCwd, env, stdio: ['pipe', 'pipe', 'pipe'] },
     prompt,
     timingTarget.runTimeoutSeconds * 1000,
+    5000,
+    (event) => {
+      if (arm !== 'stim' || platform !== 'android' || timingTarget.ccacheMinHitRatePercent == null) return;
+      for (const measurement of ccacheMeasurements(runnerToolOutput(event))) {
+        if (measurement.hitRatePercent != null && measurement.hitRatePercent >= timingTarget.ccacheMinHitRatePercent)
+          continue;
+        const alert = {
+          observedAt: new Date().toISOString(),
+          runId,
+          minimumHitRatePercent: timingTarget.ccacheMinHitRatePercent,
+          ...measurement,
+        };
+        const path = join(runDir, 'cache-alerts.json');
+        const alerts = existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : [];
+        alerts.push(alert);
+        writeFileSync(path, `${JSON.stringify(alerts, null, 2)}\n`);
+        process.stderr.write(
+          `CACHE ALERT ${runId}: ${measurement.hits} hits / ${measurement.misses} misses; expected at least ${timingTarget.ccacheMinHitRatePercent}% hits. Investigate before publishing.\n`,
+        );
+      }
+    },
   );
   const runnerResult = await runner;
   const watcherForceKill = runnerResult.timedOut ? terminateProcessTree(watcher, watcher.pid, 5000) : null;
@@ -2072,6 +2134,7 @@ function collect(runDir) {
     : { error: 'missing-app-alive-record' };
   const eventsPath = join(runDir, 'events.jsonl');
   const commandAudit = commandEvidence(meta, eventsPath, runDir);
+  const ccache = benchmarkCcache(meta, commandAudit.commands);
   const screen = screenEvidence(meta, appAlive, commandAudit.commands, runDir);
   const timing = benchmarkTiming(
     meta.timingTarget,
@@ -2131,6 +2194,7 @@ function collect(runDir) {
     ...benchmarkSetupInvalidReasons(meta, commandAudit.commands),
     ...stimShellProvenanceInvalidReasons(meta),
     ...timing.invalidReasons,
+    ...ccache.invalidReasons,
     ...(git('status', '--short') === '' ? [] : ['main-checkout-dirty']),
   ];
   const nextRunRecord = {
@@ -2150,6 +2214,7 @@ function collect(runDir) {
     dispatchToProofSeconds: appAlive.dispatchToProofSeconds ?? null,
     dispatchToScreenReadySeconds: screen.dispatchToScreenReadySeconds ?? null,
     timing,
+    ccache,
     stimShellProvenance: meta.stimShellProvenance ?? null,
     dispatchToDiagnosisSeconds: diagnosis?.dispatchToDiagnosisSeconds ?? null,
     diagnosisCommandCount: diagnosis?.commandCount ?? null,

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -206,12 +206,38 @@ export function stimShellProvenanceInvalidReasons(meta) {
 }
 
 export function ccacheMeasurements(output) {
+  const structured = structuredCcache(output);
+  if (structured?.status === 'reported') {
+    const { hits, misses } = structured;
+    if (Number.isSafeInteger(hits) && Number.isSafeInteger(misses) && hits >= 0 && misses >= 0) {
+      return [{ hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null }];
+    }
+  }
   return [...String(output ?? '').matchAll(/compilation cache\s+(\d+) hits\s*\/\s*(\d+) misses\s*\([\d.]+%\)/g)].map(
     ([, hits, misses]) => {
       hits = Number(hits);
       misses = Number(misses);
       return { hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null };
     },
+  );
+}
+
+function structuredCcache(output) {
+  const match = String(output ?? '').match(/"ccache"\s*:\s*(\{[^{}]*\})/);
+  try {
+    return match ? JSON.parse(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function artifactCacheHit(entry) {
+  return (
+    entry.exitCode === 0 &&
+    (structuredCcache(entry.output)?.status === 'not-run' ||
+      /cache\s+hit\b|fingerprint\s+[0-9a-f]+\.\.\s+hit\b|compilation cache\s+not run; artifact cache supplied the app/.test(
+        entry.output,
+      ))
   );
 }
 
@@ -226,7 +252,10 @@ export function benchmarkCcache(meta, commands) {
   for (const entry of platformRuns) {
     const measurements = ccacheMeasurements(entry.output);
     result.builds.push(...measurements.map((measurement) => ({ commandId: entry.id ?? null, ...measurement })));
-    if (/build\s+compiling|compilation cache\s+unavailable/.test(entry.output) && measurements.length === 0) {
+    if (
+      measurements.length === 0 &&
+      (!artifactCacheHit(entry) || /build\s+compiling|compilation cache\s+unavailable/.test(entry.output))
+    ) {
       result.invalidReasons.push('ccache-evidence-missing');
     }
   }
@@ -245,14 +274,7 @@ export function benchmarkCcache(meta, commands) {
     result.invalidReasons.push('stale-cmake-launcher-state');
   }
   result.invalidReasons = [...new Set(result.invalidReasons)];
-  const artifactHit = platformRuns.some(
-    (entry) =>
-      entry.exitCode === 0 &&
-      /cache\s+hit\b|fingerprint\s+[0-9a-f]+\.\.\s+hit\b|compilation cache\s+not run; artifact cache supplied the app/.test(
-        entry.output,
-      ),
-  );
-  if (!result.builds.length && !artifactHit) result.invalidReasons.push('ccache-evidence-missing');
+  if (!platformRuns.length) result.invalidReasons.push('ccache-evidence-missing');
   result.invalidReasons = [...new Set(result.invalidReasons)];
   result.status = result.invalidReasons.length ? 'investigate' : result.builds.length ? 'measured' : 'artifact-hit';
   return result;

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -38,6 +38,17 @@ export function parseBenchmarkTargets(contents) {
         throw new Error(`benchmark target ${key}.runTimeoutSeconds must be at least platformCommandSeconds`);
       }
     }
+    if (target.ccacheMinHitRatePercent != null) {
+      if (
+        platform !== 'android' ||
+        arm !== 'stim' ||
+        !Number.isFinite(target.ccacheMinHitRatePercent) ||
+        target.ccacheMinHitRatePercent <= 0 ||
+        target.ccacheMinHitRatePercent > 100
+      ) {
+        throw new Error(`benchmark target ${key}.ccacheMinHitRatePercent must be in (0, 100] for Android Stim`);
+      }
+    }
   }
   return config;
 }
@@ -192,4 +203,82 @@ export function stimShellProvenanceInvalidReasons(meta) {
     probe.cliSha256 === expected.cliSha256
     ? []
     : ['stim-shell-provenance-mismatch'];
+}
+
+export function ccacheMeasurements(output) {
+  return [...String(output ?? '').matchAll(/compilation cache\s+(\d+) hits\s*\/\s*(\d+) misses\s*\([\d.]+%\)/g)].map(
+    ([, hits, misses]) => {
+      hits = Number(hits);
+      misses = Number(misses);
+      return { hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null };
+    },
+  );
+}
+
+export function benchmarkCcache(meta, commands) {
+  const minimum = meta.timingTarget?.ccacheMinHitRatePercent ?? null;
+  const result = { minimumHitRatePercent: minimum, status: 'not-applicable', builds: [], invalidReasons: [] };
+  if (meta.arm !== 'stim' || meta.platform !== 'android') return result;
+  if (meta.variant === 'native' && minimum == null) result.invalidReasons.push('ccache-target-missing');
+  const platformRuns = commands.filter(
+    (entry) => commandSegmentsStartingWith(entry.command, 'stim android').length > 0,
+  );
+  for (const entry of platformRuns) {
+    const measurements = ccacheMeasurements(entry.output);
+    result.builds.push(...measurements.map((measurement) => ({ commandId: entry.id ?? null, ...measurement })));
+    if (/build\s+compiling|compilation cache\s+unavailable/.test(entry.output) && measurements.length === 0) {
+      result.invalidReasons.push('ccache-evidence-missing');
+    }
+  }
+  for (const measurement of result.builds) {
+    if (measurement.hitRatePercent == null) result.invalidReasons.push('ccache-evidence-missing');
+    else if (minimum != null && measurement.hitRatePercent < minimum)
+      result.invalidReasons.push('ccache-hit-rate-below-target');
+  }
+  if (
+    commands.some(
+      (entry) =>
+        commandSegmentsStartingWith(entry.command, 'stim doctor').length > 0 &&
+        /configured CMake cache|CMake launcher state could not be inspected/.test(entry.output),
+    )
+  ) {
+    result.invalidReasons.push('stale-cmake-launcher-state');
+  }
+  result.invalidReasons = [...new Set(result.invalidReasons)];
+  const artifactHit = platformRuns.some(
+    (entry) =>
+      entry.exitCode === 0 &&
+      /cache\s+hit\b|fingerprint\s+[0-9a-f]+\.\.\s+hit\b|compilation cache\s+not run; artifact cache supplied the app/.test(
+        entry.output,
+      ),
+  );
+  if (!result.builds.length && !artifactHit) result.invalidReasons.push('ccache-evidence-missing');
+  result.invalidReasons = [...new Set(result.invalidReasons)];
+  result.status = result.invalidReasons.length ? 'investigate' : result.builds.length ? 'measured' : 'artifact-hit';
+  return result;
+}
+
+export function assertAndroidDoctorClean(report) {
+  if (report?.platform !== 'android' || !Array.isArray(report.findings))
+    throw new Error('invalid Android doctor report');
+  const failures = report.findings.filter((finding) => finding.level === 'cost');
+  if (failures.length)
+    throw new Error(`Android fixture is not ready: ${failures.map((finding) => finding.title).join('; ')}`);
+  return { checkedAt: new Date().toISOString(), platform: report.platform, findings: report.findings };
+}
+
+export function runnerToolOutput(event) {
+  if (event?.type === 'item.completed' && event.item?.type === 'command_execution')
+    return event.item.aggregated_output ?? '';
+  if (event?.type === 'user' && Array.isArray(event.message?.content)) {
+    return event.message.content
+      .filter((part) => part.type === 'tool_result')
+      .map((part) =>
+        typeof part.content === 'string'
+          ? part.content
+          : (part.content ?? []).map((block) => block.text ?? '').join('\n'),
+      )
+      .join('\n');
+  }
+  return '';
 }

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -206,35 +206,40 @@ export function stimShellProvenanceInvalidReasons(meta) {
 }
 
 export function ccacheMeasurements(output) {
-  const structured = structuredCcache(output);
-  if (structured?.status === 'reported') {
-    const { hits, misses } = structured;
-    if (Number.isSafeInteger(hits) && Number.isSafeInteger(misses) && hits >= 0 && misses >= 0) {
-      return [{ hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null }];
-    }
-  }
-  return [...String(output ?? '').matchAll(/compilation cache\s+(\d+) hits\s*\/\s*(\d+) misses\s*\([\d.]+%\)/g)].map(
-    ([, hits, misses]) => {
-      hits = Number(hits);
-      misses = Number(misses);
-      return { hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null };
-    },
-  );
+  const structured = structuredCcaches(output)
+    .filter(
+      ({ status, hits, misses }) =>
+        status === 'reported' && Number.isSafeInteger(hits) && Number.isSafeInteger(misses) && hits >= 0 && misses >= 0,
+    )
+    .map(({ hits, misses }) => ({
+      hits,
+      misses,
+      hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null,
+    }));
+  const human = [
+    ...String(output ?? '').matchAll(/compilation cache\s+(\d+) hits\s*\/\s*(\d+) misses\s*\([\d.]+%\)/g),
+  ].map(([, hits, misses]) => {
+    hits = Number(hits);
+    misses = Number(misses);
+    return { hits, misses, hitRatePercent: hits + misses > 0 ? (100 * hits) / (hits + misses) : null };
+  });
+  return [...structured, ...human];
 }
 
-function structuredCcache(output) {
-  const match = String(output ?? '').match(/"ccache"\s*:\s*(\{[^{}]*\})/);
-  try {
-    return match ? JSON.parse(match[1]) : null;
-  } catch {
-    return null;
-  }
+function structuredCcaches(output) {
+  return [...String(output ?? '').matchAll(/"ccache"\s*:\s*(\{[^{}]*\})/g)].flatMap((match) => {
+    try {
+      return [JSON.parse(match[1])];
+    } catch {
+      return [];
+    }
+  });
 }
 
 function artifactCacheHit(entry) {
   return (
     entry.exitCode === 0 &&
-    (structuredCcache(entry.output)?.status === 'not-run' ||
+    (structuredCcaches(entry.output).some((cache) => cache.status === 'not-run') ||
       /cache\s+hit\b|fingerprint\s+[0-9a-f]+\.\.\s+hit\b|compilation cache\s+not run; artifact cache supplied the app/.test(
         entry.output,
       ))
@@ -252,6 +257,12 @@ export function benchmarkCcache(meta, commands) {
   for (const entry of platformRuns) {
     const measurements = ccacheMeasurements(entry.output);
     result.builds.push(...measurements.map((measurement) => ({ commandId: entry.id ?? null, ...measurement })));
+    if (
+      /compilation cache\s+unavailable/.test(entry.output) ||
+      structuredCcaches(entry.output).some((cache) => cache.status !== 'reported' && cache.status !== 'not-run')
+    ) {
+      result.invalidReasons.push('ccache-evidence-missing');
+    }
     if (
       measurements.length === 0 &&
       (!artifactCacheHit(entry) || /build\s+compiling|compilation cache\s+unavailable/.test(entry.output))

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -6,6 +6,9 @@ import {
   parseBenchmarkTargets,
   shellCommandSegments,
   stimShellProvenanceInvalidReasons,
+  benchmarkCcache,
+  assertAndroidDoctorClean,
+  runnerToolOutput,
 } from './run-guards.mjs';
 
 const targetConfig = parseBenchmarkTargets({
@@ -18,6 +21,74 @@ const targetConfig = parseBenchmarkTargets({
       runTimeoutSeconds: 600,
     },
   },
+});
+
+const build = (output) => [{ id: 'build', command: 'stim android', exitCode: 0, output }];
+
+describe('compiler cache health', () => {
+  const meta = { arm: 'stim', platform: 'android', variant: 'native', timingTarget: { ccacheMinHitRatePercent: 50 } };
+
+  it('flags the observed 9-hit 308-miss run and retains the measured evidence', () => {
+    expect(
+      benchmarkCcache(meta, build('build compiling debug\ncompilation cache 9 hits / 308 misses (2.8%)')),
+    ).toMatchObject({
+      status: 'investigate',
+      builds: [{ hits: 9, misses: 308 }],
+      invalidReasons: ['ccache-hit-rate-below-target'],
+    });
+    expect(benchmarkCcache(meta, build('compilation cache 80 hits / 20 misses (80%)')).status).toBe('measured');
+  });
+
+  it('accepts a proven artifact hit while refusing absent compiler evidence after a build', () => {
+    expect(benchmarkCcache(meta, build('fingerprint abcdef.. hit (1s)')).status).toBe('artifact-hit');
+    expect(benchmarkCcache(meta, build('build compiling debug\ncompilation cache unavailable'))).toMatchObject({
+      status: 'investigate',
+      invalidReasons: ['ccache-evidence-missing'],
+    });
+    expect(benchmarkCcache(meta, build(''))).toMatchObject({ status: 'investigate' });
+    expect(benchmarkCcache({ ...meta, arm: 'control' }, [])).toMatchObject({
+      status: 'not-applicable',
+      invalidReasons: [],
+    });
+  });
+
+  it('does not let a retry hide an earlier poorly cached build or stale doctor finding', () => {
+    const commands = [
+      ...build('build compiling debug\ncompilation cache 9 hits / 308 misses (2.8%)'),
+      ...build('fingerprint abcdef.. hit'),
+      { command: 'stim doctor --platform android', output: 'The configured CMake cache predates the ccache launcher' },
+    ];
+    expect(benchmarkCcache(meta, commands).invalidReasons).toEqual([
+      'ccache-hit-rate-below-target',
+      'stale-cmake-launcher-state',
+    ]);
+    expect(benchmarkCcache({ ...meta, timingTarget: {} }, commands).invalidReasons).toContain('ccache-target-missing');
+  });
+
+  it('rejects dirty or incomplete doctor evidence before timing', () => {
+    expect(() =>
+      assertAndroidDoctorClean({ platform: 'android', findings: [{ level: 'cost', title: 'stale CMake' }] }),
+    ).toThrow(/stale CMake/);
+    expect(() => assertAndroidDoctorClean({ findings: [] })).toThrow(/invalid/);
+    expect(assertAndroidDoctorClean({ platform: 'android', findings: [] })).toMatchObject({
+      platform: 'android',
+      findings: [],
+    });
+  });
+
+  it('only extracts tool output for immediate alerts, including Claude tool results', () => {
+    const output = 'compilation cache 9 hits / 308 misses (2.8%)';
+    expect(
+      runnerToolOutput({ type: 'item.completed', item: { type: 'command_execution', aggregated_output: output } }),
+    ).toBe(output);
+    expect(
+      runnerToolOutput({
+        type: 'user',
+        message: { content: [{ type: 'tool_result', content: [{ type: 'text', text: output }] }] },
+      }),
+    ).toBe(output);
+    expect(runnerToolOutput({ type: 'item.completed', item: { type: 'agent_message', text: output } })).toBe('');
+  });
 });
 
 describe('benchmark run guards', () => {

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -9,6 +9,7 @@ import {
   benchmarkCcache,
   assertAndroidDoctorClean,
   runnerToolOutput,
+  ccacheMeasurements,
 } from './run-guards.mjs';
 
 const targetConfig = parseBenchmarkTargets({
@@ -63,6 +64,35 @@ describe('compiler cache health', () => {
       'stale-cmake-launcher-state',
     ]);
     expect(benchmarkCcache({ ...meta, timingTarget: {} }, commands).invalidReasons).toContain('ccache-target-missing');
+  });
+
+  it('does not let good retry evidence mask an earlier invocation with no evidence', () => {
+    expect(benchmarkCcache(meta, [...build(''), ...build('fingerprint abcdef.. hit')]).invalidReasons).toContain(
+      'ccache-evidence-missing',
+    );
+    expect(
+      benchmarkCcache(meta, [...build(''), ...build('compilation cache 80 hits / 20 misses (80%)')]).invalidReasons,
+    ).toContain('ccache-evidence-missing');
+  });
+
+  it('measures structured Stim output for both collection and immediate alerts', () => {
+    const output = JSON.stringify(
+      { ok: true, facts: { ccache: { status: 'reported', hits: 80, misses: 20, hitRatePercent: 80 } } },
+      null,
+      2,
+    );
+    expect(benchmarkCcache(meta, build(output)).status).toBe('measured');
+    expect(
+      ccacheMeasurements(
+        runnerToolOutput({ type: 'item.completed', item: { type: 'command_execution', aggregated_output: output } }),
+      ),
+    ).toEqual([{ hits: 80, misses: 20, hitRatePercent: 80 }]);
+    expect(
+      benchmarkCcache(
+        meta,
+        build(JSON.stringify({ ok: true, facts: { ccache: { status: 'not-run', hits: null, misses: null } } })),
+      ).status,
+    ).toBe('artifact-hit');
   });
 
   it('rejects dirty or incomplete doctor evidence before timing', () => {

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -95,6 +95,20 @@ describe('compiler cache health', () => {
     ).toBe('artifact-hit');
   });
 
+  it('retains every cache result when agents chain JSON and plain builds', () => {
+    const good = JSON.stringify({ facts: { ccache: { status: 'reported', hits: 80, misses: 20 } } });
+    const bad = JSON.stringify({ facts: { ccache: { status: 'reported', hits: 9, misses: 308 } } });
+    const audit = benchmarkCcache(meta, [
+      { ...build(`${good}\n${bad}`)[0], command: 'stim android --json; stim android --json' },
+    ]);
+    expect(audit.builds).toHaveLength(2);
+    expect(audit.invalidReasons).toContain('ccache-hit-rate-below-target');
+    expect(ccacheMeasurements(`${good}\ncompilation cache 9 hits / 308 misses (2.8%)`)).toHaveLength(2);
+    expect(benchmarkCcache(meta, build(`${good}\ncompilation cache unavailable`)).invalidReasons).toContain(
+      'ccache-evidence-missing',
+    );
+  });
+
   it('rejects dirty or incomplete doctor evidence before timing', () => {
     expect(() =>
       assertAndroidDoctorClean({ platform: 'android', findings: [{ level: 'cost', title: 'stale CMake' }] }),


### PR DESCRIPTION
## Description

The Android benchmark accepted a run with stale CMake configuration and just 9 ccache hits / 308 misses. Existing guards validate task success and timing, but do not flag unexpected compiler-cache behavior.

## Solution

Exclude Android benchmark attempts with dirty doctor findings or missing/below-target compiler-cache evidence from published comparisons. Preserve per-build counts and emit live alerts; proven app artifact hits need no C++ compilation.

Require clean doctor evidence before golden preparation and dispatch. Native Stim cells require a machine-specific hit-rate threshold established from a warm probe before dispatch and fixed across models. Flagged attempts remain available for investigation.

## Test plan

Replayed the 9-hit / 308-miss failure through the audit. Covered artifact hits, missing evidence, retries that could mask a bad build, dirty doctor reports, and Codex/Claude tool-output extraction for live alerts.

Fixes #441
