### PR TITLE
fix: disable Android PCH for compiler cache reuse

### DIFF
--- a/packages/stim-cli/shim/android-no-pch.gradle
+++ b/packages/stim-cli/shim/android-no-pch.gradle
@@ -1,0 +1,17 @@
+gradle.beforeProject { project ->
+    ["com.android.application", "com.android.library"].each { plugin ->
+        project.pluginManager.withPlugin(plugin) {
+            project.extensions.getByName("androidComponents").finalizeDsl { android ->
+                def configs = [android.defaultConfig] + android.buildTypes.toList() + android.productFlavors.toList()
+                def configured = configs.any { config ->
+                    config.externalNativeBuild.cmake.arguments.any { arg ->
+                        arg =~ /^(?:-D\s*)?CMAKE_DISABLE_PRECOMPILE_HEADERS(?::[^=]+)?=/
+                    }
+                }
+                if (!configured) {
+                    android.defaultConfig.externalNativeBuild.cmake.arguments.add("-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON")
+                }
+            }
+        }
+    }
+}

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -718,7 +718,7 @@ describe('buildAndroid', () => {
     expect(beats.length).toBe(settled);
   });
 
-  test('the ccache environment reaches the Gradle child, and its stats log is read back', async () => {
+  test('ccache opts into the packaged PCH policy, forwards its environment, and reads fresh statistics', async () => {
     makeAndroidProject();
     const statsLog = join(root, 'logs', 'ccache-stats.log');
     mkdirSync(join(root, 'logs'), { recursive: true });
@@ -733,7 +733,11 @@ describe('buildAndroid', () => {
           statsLog,
           env: { CMAKE_CXX_COMPILER_LAUNCHER: '/opt/homebrew/bin/ccache', CCACHE_DIR: join(root, 'ccache') },
         },
-        spawnFn: (_cmd, _args, opts) => {
+        spawnFn: (_cmd, args, opts) => {
+          expect(args.slice(0, 3)).toEqual(['assembleDebug', '--build-cache', '--init-script']);
+          expect(args).toHaveLength(4);
+          expect(args[3]).toBe(join(import.meta.dirname, '../../shim/android-no-pch.gradle'));
+          expect(existsSync(args[3]!)).toBe(true);
           envs.push(opts.env as NodeJS.ProcessEnv);
           expect(existsSync(statsLog)).toBe(false);
           return fakeChild({
@@ -754,7 +758,7 @@ describe('buildAndroid', () => {
     expect(spawnEnv.CCACHE_DIR).toBe(join(root, 'ccache'));
     expect(spawnEnv.TERM).toBe('dumb');
     expect(result.ccache).toEqual({ status: 'reported', hits: 1, misses: 1, hitRatePercent: 50 });
-    expect(notes.filter((line) => line.includes('ccache'))).toEqual([]);
+    expect(notes.some((line) => line.includes('PCH off by default'))).toBe(true);
   });
 
   test('without ccache the Gradle argv and environment are unchanged and no statistics are claimed', async () => {

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { phaseLine } from '../command-output.ts';
 import { getExecutor } from '../exec.ts';
@@ -477,6 +478,16 @@ export async function buildAndroid(
   const spawn: SpawnFn = spawnFn || ((cmd, args, opts) => getExecutor().spawn(cmd, args, opts));
   const task = assembleTaskFor(variant);
   const args = gradleArgs(task, { buildCache, abi });
+  if (ccache) {
+    const script = ['../shim/android-no-pch.gradle', '../../shim/android-no-pch.gradle']
+      .map((path) => fileURLToPath(new URL(path, import.meta.url)))
+      .find((path) => existsSync(path));
+    if (!script) throw new Error('Stim installation is missing shim/android-no-pch.gradle. Reinstall stim-cli.');
+    args.push('--init-script', script);
+    onNote(
+      chalk.dim(phaseLine('cache', 'CMake PCH off by default for ccache reuse (explicit project settings preserved)')),
+    );
+  }
   if (buildCache) {
     onNote(chalk.dim(phaseLine('cache', 'gradle build cache on (--build-cache, shared under the Gradle user home)')));
   }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -65,6 +65,9 @@ RULES DURING THE LOOP
 - If fingerprinting fails after native inputs change during the run, Stim
   installs the build without caching it. A null fingerprint or cacheKey is
   unavailable cache information, not an install failure.
+- When Stim supplies Android ccache, it defaults CMake PCH off for reuse
+  across worktrees; explicit project PCH settings are preserved. This favors
+  warm builds over cold C++ compilation. See guide lifecycle builds.
 - Android Debug builds target the owned emulator system-image ABI or the
   physical device's primary ABI. Unknown targets and Release builds stay
   universal.

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -65,9 +65,6 @@ RULES DURING THE LOOP
 - If fingerprinting fails after native inputs change during the run, Stim
   installs the build without caching it. A null fingerprint or cacheKey is
   unavailable cache information, not an install failure.
-- When Stim supplies Android ccache, it defaults CMake PCH off for reuse
-  across worktrees; explicit project PCH settings are preserved. This favors
-  warm builds over cold C++ compilation. See guide lifecycle builds.
 - Android Debug builds target the owned emulator system-image ABI or the
   physical device's primary ABI. Unknown targets and Release builds stay
   universal.

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -389,14 +389,16 @@ The trade-off is the same class as the iOS CAS one: an object reused from
 worktree A carries A's directory as its DWARF comp_dir, so a debugger stepping
 into reused C++ resolves sources against that path.
 
-Precompiled headers are where the misses are, and the cause is mtime, not
-paths. worklets and expo-modules-core precompile a header without
--fno-pch-timestamp, so ccache re-checks the mtime of the PCH inputs
-(\`Precompiled header includes ..., which has a new mtime\`), rebuilds the
-header, and every translation unit that includes it misses too -- 5 to 11
-seconds per module, paid again after anything that rewrites those mtimes,
-a fresh npm ci included. No stale .pch is ever served. reanimated passes
--Xclang -fno-pch-timestamp and hits across worktrees like everything else.
+When Stim supplies ccache, its Gradle init script defaults Android app and
+library CMake builds to CMAKE_DISABLE_PRECOMPILE_HEADERS=ON. PCH inputs can
+retain a previous worktree's paths even with upstream timestamp fixes, causing
+the header and its consuming objects to miss. Compiling ordinary headers
+instead favors reuse across worktrees at the cost of a slower cold C++ build.
+This does not edit dependency sources or change iOS builds. Without Stim's
+ccache setup, PCH behavior is unchanged. A module with an explicit
+CMAKE_DISABLE_PRECOMPILE_HEADERS argument in its default config, build types,
+or product flavors keeps that choice; CMake target-level PCH overrides also
+take precedence. Direct Gradle builds do not receive Stim's init script.
 
 The launcher persists in the project. AGP writes it into each
 .cxx/**/CMakeCache.txt on the first configure, so a plain \`./gradlew\` in that


### PR DESCRIPTION
## Description

Android PCHs retain worktree-specific paths even with the timestamp fixes in the SDK 58 fixture, preventing C++ cache reuse. Fixes #444.

## Solution

When Stim supplies ccache, default Android app and library CMake builds to `CMAKE_DISABLE_PRECOMPILE_HEADERS=ON`. This favors cross-worktree cache reuse over faster cold C++ compilation, without dependency-source edits or a compiler wrapper. Explicit module/variant PCH arguments and CMake target overrides retain precedence. Uncached builds and iOS are unchanged.

This corrects the timestamp-only guidance from [b9743cd](https://github.com/appandflow/stim/commit/b9743cd32a76dbd979dd1b54417a66757d30830e); relocation PR #446 remains a closed proof of concept in favor of this simpler approach.

## Test plan

- Two full ARM64 Debug APK builds from separate SDK 58 / RN 0.87 checkouts: **386 hits / 0 misses**, 47 seconds on the second build, with the first checkout unavailable. Tested with AGP 9.2.1, NDK 27.1, and ccache 4.13.6. Diagnostic build-only evidence, not an agent benchmark or an app-launch test.
- Verified no PCH compile/use commands across all nine native modules. Real AGP configuration preserved explicit default-config, build-type, and flavor arguments, including typed and separate `-D` forms.
- Verified the packed CLI includes the Gradle hook and the existing no-ccache build path stays unchanged.
