### PR TITLE
fix: validate benchmark caches with the pinned fingerprint library

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -87,6 +87,8 @@ export STIM_BENCH_SKILLS_ROOT=/path/to/skills
 Preflight runs the pinned Stim shim through the same isolated login-shell
 startup used by timed commands. Dispatch refuses a Stim version, executable,
 or CLI digest mismatch and refuses a control shell that can resolve Stim.
+Golden cache validation hashes the fixture with the pinned CLI's fingerprint
+dependency, not the fixture's potentially different version.
 
 ## Run a cell
 

--- a/scripts/agent-benchmark/cache-key.mjs
+++ b/scripts/agent-benchmark/cache-key.mjs
@@ -1,3 +1,30 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+export function benchmarkFingerprint(projectRoot, stimPackage, platform) {
+  const script = [
+    'import { createRequire } from "node:module";',
+    'const fingerprint = createRequire(process.argv[1])("@expo/fingerprint");',
+    'const result = await fingerprint.createFingerprintAsync(process.cwd(), {',
+    '  platforms: [process.argv[2]],',
+    '  silent: true,',
+    '  ignorePaths: ["**/android/local.properties", "**/android/.idea/**"],',
+    '});',
+    'process.stdout.write(result.hash);',
+  ].join('\n');
+  return execFileSync(
+    process.execPath,
+    ['--input-type=module', '-e', script, join(stimPackage, 'package.json'), platform],
+    {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 2 * 60 * 1000,
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  ).trim();
+}
+
 export function selectBenchmarkCacheKey(platform, fingerprint, entries) {
   const base = `${fingerprint}-debug-sim`;
   const matches =

--- a/scripts/agent-benchmark/cache-key.test.mjs
+++ b/scripts/agent-benchmark/cache-key.test.mjs
@@ -1,5 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { selectBenchmarkCacheKey } from './cache-key.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
+
+it('hashes native inputs with the pinned CLI dependency despite a conflicting fixture fingerprint package', () => {
+  const root = mkdtempSync(join(tmpdir(), 'benchmark fingerprint '));
+  const stimPackage = fileURLToPath(new URL('../../packages/stim-cli/', import.meta.url));
+  const previousStimHome = process.env.STIM_HOME;
+  process.env.STIM_HOME = join(root, 'stim-home');
+  try {
+    mkdirSync(join(root, 'android'));
+    mkdirSync(join(root, 'ios'));
+    mkdirSync(join(root, 'node_modules/@expo/fingerprint'), { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fingerprint-fixture', version: '1.0.0' }));
+    writeFileSync(
+      join(root, 'node_modules/@expo/fingerprint/package.json'),
+      JSON.stringify({ name: '@expo/fingerprint', main: 'index.js' }),
+    );
+    writeFileSync(
+      join(root, 'node_modules/@expo/fingerprint/index.js'),
+      'throw new Error("Fixture fingerprint must not be loaded");',
+    );
+    writeFileSync(join(root, 'android/build.gradle'), 'version = "one"');
+    writeFileSync(join(root, 'ios/native.m'), 'one');
+    const initial = benchmarkFingerprint(root, stimPackage, 'android');
+    expect(initial).toMatch(/^[a-f0-9]{40}$/);
+    writeFileSync(join(root, 'android/local.properties'), 'sdk.dir=/machine-specific-sdk');
+    writeFileSync(join(root, 'ios/native.m'), 'two');
+    expect(benchmarkFingerprint(root, stimPackage, 'android')).toBe(initial);
+    writeFileSync(join(root, 'android/build.gradle'), 'version = "two"');
+    expect(benchmarkFingerprint(root, stimPackage, 'android')).not.toBe(initial);
+  } finally {
+    if (previousStimHome === undefined) delete process.env.STIM_HOME;
+    else process.env.STIM_HOME = previousStimHome;
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 60_000);
 
 describe('benchmark cache key selection', () => {
   it('selects the exact iOS simulator key', () => {

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -26,7 +26,7 @@ import {
   launchCrashRepair,
   launchCrashToken,
 } from '../launch-crash-benchmark.mjs';
-import { selectBenchmarkCacheKey } from './cache-key.mjs';
+import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
 import { matchesGoldenPreparation } from './golden-state.mjs';
 import {
   androidApplicationLabelFromBadging,
@@ -254,19 +254,7 @@ function sha256(path) {
 }
 
 function verifyGoldenCache(platform, platformGolden = goldenFor(platform)) {
-  const script = [
-    'const fingerprint = await import("@expo/fingerprint");',
-    'const result = await fingerprint.createFingerprintAsync(process.cwd(), {',
-    `  platforms: [${JSON.stringify(platform)}],`,
-    '  silent: true,',
-    '  ignorePaths: ["**/android/local.properties", "**/android/.idea/**"],',
-    '});',
-    'process.stdout.write(result.hash);',
-  ].join('\n');
-  const fingerprint = run('node', ['--input-type=module', '-e', script], {
-    cwd: main,
-    timeout: 2 * 60 * 1000,
-  });
+  const fingerprint = benchmarkFingerprint(main, stimPackage, platform);
   const cacheRoot = join(platformGolden, 'stim-home', 'build-cache', platform);
   const cacheKey = selectBenchmarkCacheKey(platform, fingerprint, existsSync(cacheRoot) ? readdirSync(cacheRoot) : []);
   const cacheDir = join(cacheRoot, cacheKey);


### PR DESCRIPTION
## Description

The SDK 58 benchmark refused a successfully built golden because it calculated the expected cache key with the app's fingerprint dependency. rc.17 uses a different version; the two versions enumerate different inputs and produce different hashes for the same app.

## Solution

Resolve the fingerprint implementation from the pinned Stim package while hashing the fixture directory. Keep the platform and generated-path exclusions unchanged. This changes only benchmark validation, not published Stim behavior or stored cache keys.

## Test plan

The regression supplies a conflicting fixture fingerprint package and exercises the real pinned implementation: machine-local Android configuration and iOS edits preserve the Android key, while an Android native edit invalidates it. On the SDK 58 fixture, the pinned implementation reproduces the stored `47b4b4` cache key instead of the fixture dependency's `7999f7` key.

Fixes #451.
