### PR TITLE
docs: explain when Stim adds little value

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -57,6 +57,16 @@
   gap: 1.5rem;
 }
 
+.stimFit {
+  max-width: 800px;
+  padding: 0 1rem 4rem;
+  line-height: 1.7;
+}
+
+.stimFit li {
+  margin-bottom: 1rem;
+}
+
 .stimFeatureCard {
   overflow: hidden;
   padding: 1.5rem;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -99,6 +99,40 @@ export default function Home(): ReactNode {
             ))}
           </div>
         </section>
+        <section className="container stimFit" aria-labelledby="when-you-dont-need-stim">
+          <Heading as="h2" id="when-you-dont-need-stim">
+            When you probably don't need Stim
+          </Heading>
+          <p>
+            Stim helps with repeated setup, builds, and device management across worktrees. If those aren't slowing you
+            down, it may add little.
+          </p>
+          <ul>
+            <li>
+              <strong>One long-lived checkout, one running app.</strong> Your existing tooling already keeps builds
+              warm. If you aren't juggling worktrees or agents, there's less to isolate and less duplicated work to
+              avoid.
+            </li>
+            <li>
+              <strong>An installed Expo development build and mostly JavaScript changes.</strong> You can keep using the
+              same native app while Metro serves your changes. If native dependencies and configuration rarely change,
+              there may be little build time to save.
+            </li>
+            <li>
+              <strong>Agents that don't run the app.</strong> If your agents only edit code and run unit tests, they
+              don't need isolated simulators or a native build workflow.
+            </li>
+            <li>
+              <strong>Your existing setup already handles this.</strong> If your scripts or development platform provide
+              isolated environments and reliable build reuse, Stim may duplicate what you have.
+            </li>
+            <li>
+              <strong>You want cloud builds or app distribution.</strong> Stim builds locally; it doesn't replace hosted
+              build infrastructure, signing workflows, or store submission.
+            </li>
+          </ul>
+          <p>You don't need to replace a workflow that already works.</p>
+        </section>
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Description

The homepage describes benefits without helping visitors recognize workflows where Stim adds little value.

## Solution

Add the approved “When you probably don't need Stim” copy below the feature cards as a plain, readable section. Existing homepage content stays unchanged.

## Test plan

Open the homepage and read the new section at desktop and mobile widths. Check all five cases, text wrapping, and spacing above the footer. Verified at 1440px and 390px with no horizontal overflow or browser errors.

Repository formatting, lint, builds, typechecks, and all 3,580 unit tests passed. The test suite used an isolated TMPDIR to avoid unrelated shared-temp leftovers. The website production build and typecheck also passed.

![Desktop section](https://github.com/user-attachments/assets/ddb262b4-c83d-4a2f-ac7f-20c5f77cb5b7)

<details>
<summary>Mobile page</summary>

<img src="https://github.com/user-attachments/assets/ee8b5fd0-03f0-49d4-88e3-4a2b5bdec1d1" width="390" alt="Mobile homepage with the new section above the footer" />

</details>

Fixes #453
