### PR TITLE
fix: audit benchmark device sessions per command

### DIFF
--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -35,6 +35,7 @@ import {
 } from './watch-app-selection.mjs';
 import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
 import {
+  agentDeviceIsolationInvalidReasons,
   benchmarkSetupInvalidReasons,
   benchmarkTarget,
   benchmarkTiming,
@@ -1623,14 +1624,7 @@ function commandEvidence(meta, eventsPath, runDir) {
   ) {
     invalidReasons.push('android-native-control-used-release-build');
   }
-  if (topLevelCommands.some((command) => /(?:^|\s)agent-device\s+daemon\s+stop(?:\s|$)/.test(command))) {
-    invalidReasons.push('agent-device-daemon-recovery-inside-timer');
-  }
-  const expectedAgentDevicePrefix = agentDeviceCommand(meta, '');
-  const agentDeviceCommands = topLevelCommands.filter((command) => /(?:^|\s)agent-device(?:\s|$)/.test(command));
-  if (agentDeviceCommands.some((command) => !command.startsWith(expectedAgentDevicePrefix))) {
-    invalidReasons.push('agent-device-run-session-not-applied');
-  }
+  invalidReasons.push(...agentDeviceIsolationInvalidReasons(commands, agentDeviceCommand(meta, '')));
   return { commands, activities, completedEvents, invalidReasons };
 }
 

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -103,6 +103,19 @@ export function shellCommandSegments(command) {
   return segments;
 }
 
+export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix) {
+  const segments = commands.flatMap((command) => shellCommandSegments(command.command));
+  const reasons = [];
+  if (segments.some((command) => /(?:^|\s)agent-device\s+daemon\s+stop(?:\s|$)/.test(command))) {
+    reasons.push('agent-device-daemon-recovery-inside-timer');
+  }
+  const deviceCommands = segments.filter((command) => /(?:^|\s)agent-device(?:\s|$)/.test(command));
+  if (deviceCommands.some((command) => !command.startsWith(expectedPrefix))) {
+    reasons.push('agent-device-run-session-not-applied');
+  }
+  return reasons;
+}
+
 function commandSegmentsStartingWith(command, expected) {
   return shellCommandSegments(command).filter((segment) => segment === expected || segment.startsWith(`${expected} `));
 }

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  agentDeviceIsolationInvalidReasons,
   benchmarkSetupInvalidReasons,
   benchmarkTarget,
   benchmarkTiming,
@@ -25,6 +26,41 @@ const targetConfig = parseBenchmarkTargets({
 });
 
 const build = (output) => [{ id: 'build', command: 'stim android', exitCode: 0, output }];
+
+describe('agent-device session isolation', () => {
+  const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=bench-run agent-device ';
+
+  it('accepts delayed scoped navigation without splitting quoted separators', () => {
+    for (const command of [
+      `sleep 5; ${prefix}snapshot`,
+      `/bin/zsh -lc 'sleep 5 && ${prefix}snapshot'`,
+      `${prefix}fill @e5 "text; more text"`,
+      `${prefix}snapshot\n${prefix}click @e1`,
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command }], prefix)).toEqual([]);
+    }
+  });
+
+  it('rejects an unscoped or mismatched invocation anywhere in a chain', () => {
+    for (const command of [
+      'agent-device snapshot',
+      `sleep 5; agent-device snapshot`,
+      `${prefix}snapshot; agent-device click @e1`,
+      `${prefix}snapshot && ${prefix.replace('SESSION=bench-run', 'SESSION=default')}snapshot`,
+      `agent-device snapshot\n${prefix}snapshot`,
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command }], prefix)).toEqual([
+        'agent-device-run-session-not-applied',
+      ]);
+    }
+  });
+
+  it('rejects delayed daemon recovery even with the correct session', () => {
+    expect(agentDeviceIsolationInvalidReasons([{ command: `sleep 5; ${prefix}daemon stop --clean` }], prefix)).toEqual([
+      'agent-device-daemon-recovery-inside-timer',
+    ]);
+  });
+});
 
 describe('compiler cache health', () => {
   const meta = { arm: 'stim', platform: 'android', variant: 'native', timingTarget: { ccacheMinHitRatePercent: 50 } };


### PR DESCRIPTION
## Description

The benchmark rejects `sleep 5; env AGENT_DEVICE_STATE_DIR=... AGENT_DEVICE_SESSION=... agent-device snapshot` even when the session is correct, because it checks the whole shell command's prefix. Conversely, a scoped first invocation can hide a later default-session invocation.

## Solution

Check each segment with the existing quote-aware shell parser. Every agent-device invocation still needs the exact run-scoped environment, daemon recovery remains invalid, and final screenshot/recording proof commands must still stand alone. This changes only the benchmark collector, not the published CLI or timed prompts.

## Test plan

Regression coverage accepts delayed scoped navigation and quoted separators, and rejects bare/mismatched invocations anywhere in a chain plus delayed daemon recovery. The existing standalone-proof self-test passes. Re-collecting the retained affected run clears the false positive with identical evidence hashes and timing; its original audit is preserved.

Fixes #456.
