### PR TITLE
fix: decode quoted benchmark shell commands

### DIFF
--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -45,6 +45,7 @@ import {
   benchmarkCcache,
   ccacheMeasurements,
   runnerToolOutput,
+  topLevelShellCommand,
 } from './run-guards.mjs';
 
 const launchCrashVariant = 'launch-crash';
@@ -1626,12 +1627,6 @@ function commandEvidence(meta, eventsPath, runDir) {
   }
   invalidReasons.push(...agentDeviceIsolationInvalidReasons(commands, agentDeviceCommand(meta, '')));
   return { commands, activities, completedEvents, invalidReasons };
-}
-
-function topLevelShellCommand(command) {
-  const trimmed = String(command ?? '').trim();
-  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc (["'])([\s\S]*)\1$/);
-  return (match?.[2] ?? trimmed).trim();
 }
 
 function agentDeviceOpenCommand(meta, appAlive) {

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -60,10 +60,12 @@ export function benchmarkTarget(config, selection) {
   return { key, machine: config.machine, ...value };
 }
 
-function topLevelShellCommand(command) {
+export function topLevelShellCommand(command) {
   const trimmed = String(command ?? '').trim();
   const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc (["'])([\s\S]*)\1$/);
-  return (match?.[2] ?? trimmed).trim();
+  if (!match) return trimmed;
+  const source = match[1] === '"' ? match[2].replace(/\\(["\\$`])/g, '$1').replace(/\\\n/g, '') : match[2];
+  return source.trim();
 }
 
 export function shellCommandSegments(command) {

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -64,7 +64,8 @@ export function topLevelShellCommand(command) {
   const trimmed = String(command ?? '').trim();
   const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc (["'])([\s\S]*)\1$/);
   if (!match) return trimmed;
-  const source = match[1] === '"' ? match[2].replace(/\\(["\\$`])/g, '$1').replace(/\\\n/g, '') : match[2];
+  const source =
+    match[1] === '"' ? match[2].replace(/\\(["\\$`\n])/g, (_, char) => (char === '\n' ? '' : char)) : match[2];
   return source.trim();
 }
 

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -228,6 +228,9 @@ describe('benchmark run guards', () => {
     expect(topLevelShellCommand(`/bin/zsh -lc ${JSON.stringify(literal)}`)).toBe(literal);
     expect(topLevelShellCommand('/bin/zsh -lc "echo \\$VALUE"')).toBe('echo $VALUE');
     expect(topLevelShellCommand('/bin/zsh -lc "echo \\q"')).toBe('echo \\q');
+    const quotedNewline = "printf '%s' 'before" + '\\'.repeat(2) + "\nafter'";
+    expect(topLevelShellCommand(`/bin/zsh -lc "${quotedNewline}"`)).toBe("printf '%s' 'before\\\nafter'");
+    expect(topLevelShellCommand('/bin/zsh -lc "echo before\\\nafter"')).toBe('echo beforeafter');
   });
 
   it('rejects setup recovery inside the timer', () => {

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -6,6 +6,7 @@ import {
   benchmarkTiming,
   parseBenchmarkTargets,
   shellCommandSegments,
+  topLevelShellCommand,
   stimShellProvenanceInvalidReasons,
   benchmarkCcache,
   assertAndroidDoctorClean,
@@ -211,6 +212,22 @@ describe('benchmark run guards', () => {
       'echo "a && b"',
       'stim guide agent',
     ]);
+    const search = 'rg -n "run:android|agent-device|emulator" .';
+    const body = `${search} | sed -n '1,180p'`;
+    const wrapped = `/bin/zsh -lc ${JSON.stringify(body)}`;
+    expect(shellCommandSegments(wrapped)).toEqual([search, "sed -n '1,180p'"]);
+    expect(agentDeviceIsolationInvalidReasons([{ command: wrapped }], 'env expected agent-device ')).toEqual([]);
+  });
+
+  it('decodes one shell quoting layer while preserving proof command boundaries and literal backslashes', () => {
+    const proof =
+      'env AGENT_DEVICE_STATE_DIR=/tmp/bench AGENT_DEVICE_SESSION=run agent-device wait text "Offline maps"';
+    expect(topLevelShellCommand(`/bin/zsh -lc ${JSON.stringify(proof)}`)).toBe(proof);
+    expect(topLevelShellCommand(`/bin/zsh -lc ${JSON.stringify(`${proof}; agent-device close`)}`)).not.toBe(proof);
+    const literal = "rg '\\d+\\s' file";
+    expect(topLevelShellCommand(`/bin/zsh -lc ${JSON.stringify(literal)}`)).toBe(literal);
+    expect(topLevelShellCommand('/bin/zsh -lc "echo \\$VALUE"')).toBe('echo $VALUE');
+    expect(topLevelShellCommand('/bin/zsh -lc "echo \\q"')).toBe('echo \\q');
   });
 
   it('rejects setup recovery inside the timer', () => {


### PR DESCRIPTION
## Description

The benchmark can reject a valid run when an agent searches for `run:android|agent-device|emulator`. Codex's displayed shell command escapes the inner quotes; stripping only the outer quotes makes the parser split that search pattern into fake commands.

## Solution

Decode one outer double-quoted shell argument before auditing, using the same normalizer for command segments and proof matching. Literal backslashes retain shell quoting semantics. Standalone proof boundaries and session requirements remain unchanged. This is collector-only: no CLI, prompt, or timing changes.

## Test plan

Regression coverage uses the encoded quoted-search reproduction, quoted proof text, chained proof rejection, and literal backslashes. The standalone-proof self-test passes. Re-collection of the affected retained run clears the false positive with identical evidence hashes and timing; its original audit remains preserved. Existing real setup violations still fail the corrected audit.

Fixes #458.
