### PR TITLE
docs: keep excluded benchmark commentary private

### DIFF
--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -226,22 +226,6 @@ export default function Benchmarks(): ReactNode {
                   reuse against a fixed threshold established before dispatch.
                 </dd>
               </div>
-              <div>
-                <dt>Current Android coverage</dt>
-                <dd>
-                  Nine of 16 attempts passed publication review. Seven were excluded for setup, completion, or
-                  coordinator-path isolation violations. Missing cells stay disabled; they are not zero-time results or
-                  evidence of a performance win.
-                </dd>
-              </div>
-              <div>
-                <dt>Current crash coverage</dt>
-                <dd>
-                  Sol completed the iOS Stim repair with recorded Settings proof. Control reached the 20-minute limit
-                  before completing the recording protocol and is excluded. This is one valid attempt, not a paired
-                  speedup comparison.
-                </dd>
-              </div>
             </dl>
           </section>
 


### PR DESCRIPTION
## Description

Keep excluded benchmark attempts out of public commentary, as requested. The summary currently describes their counts and failure reasons.

## Solution

Remove the Android and crash coverage paragraphs. Valid results, disabled missing cells, general methodology, and private investigation records stay unchanged.

## Test plan

Open `/benchmarks`: the methodology no longer lists failed-attempt counts or reasons, while the result graphs and links remain. Website typecheck and production build pass.

Fixes #464
