### PR TITLE
fix: pin native benchmark compatibility adapters

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,7 @@
   "ignore": [
     "website/**",
     "packages/stim-cli/shim/**",
+    "scripts/agent-benchmark/compat/ps-bridge.mjs",
     "scripts/agent-benchmark/stamp.mjs",
     "scripts/agent-benchmark/watch-app.mjs"
   ]

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -106,6 +106,29 @@ checks before starting the clock and records the policy digest. This is a
 macOS benchmark-data boundary, not a security sandbox for hostile code or
 already-running native services. Unsupported hosts fail closed.
 
+### iOS sandbox compatibility
+
+For the pinned agent-device 0.20.10 / ExpoModulesJSI fixture affected by
+sandboxed process inspection and nested SwiftPM sandboxes, prepare an explicit
+local compatibility copy with `prepareNativeCompatibility` from
+`native-compat.mjs`. Supply a new destination, the installed package, an exact
+reviewed native-helper source commit and SHA-256, and a dedicated fixture copy.
+The adapter refuses unknown base bytes. It does not update a global install.
+It patches the copied package and the selected fixture's ignored JSI build
+script; prepare fresh golden state afterward because native inputs changed.
+
+Set `STIM_BENCH_AGENT_DEVICE_BIN` to the copied `bin/agent-device.mjs`,
+`STIM_BENCH_NATIVE_COMPAT_MANIFEST` to the generated manifest, and pin its digest
+as `NATIVE_COMPAT_SHA256` in the new campaign's `pins.env`. Both arms receive
+the same package and Xcode wrapper. Do not retrofit frozen campaign pins.
+The package tree, native helper source, bridge, and Xcode/JSI changes are
+hash-bound, including executable permissions and internal symlinks. The bridge
+adds a Node process for each process query in both arms. Preflight repeats the
+process-identity and Xcode-resolution smoke inside the run's exact isolation
+profile before starting the clock; collection rejects changed compatibility
+bytes. This does not replace a real untimed build, recording, and cleanup test
+before accepting a new toolchain combination.
+
 ## Run a cell
 
 Prepare the platform golden, then dispatch, collect, and clean one cell:

--- a/scripts/agent-benchmark/compat/ps-bridge.mjs
+++ b/scripts/agent-benchmark/compat/ps-bridge.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const fields = args.at(-1);
+const supported = ['lstart=', 'state=', 'command=', 'pid=,state=,lstart=', 'pid=,ppid=,command='];
+if (!supported.includes(fields)) process.exit(2);
+const all = args.join(' ') === '-ax -o pid=,ppid=,command=';
+const selected = args.length === 4 && args[0] === '-p' && args[2] === '-o' ? args[1].split(',') : [];
+if (!all && (!selected.length || selected.some((pid) => !/^[1-9]\d{0,9}$/.test(pid)))) process.exit(2);
+
+function startTime(seconds) {
+  const date = new Date(Number(seconds) * 1000);
+  const day = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][date.getDay()];
+  const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][date.getMonth()];
+  const time = [date.getHours(), date.getMinutes(), date.getSeconds()].map((n) => String(n).padStart(2, '0')).join(':');
+  return `${day} ${month} ${String(date.getDate()).padStart(2, ' ')} ${time} ${date.getFullYear()}`;
+}
+
+try {
+  const text = execFileSync(fileURLToPath(new URL('./native-process', import.meta.url)), all ? ['--all'] : selected, {
+    encoding: 'utf8',
+    timeout: 1000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  for (const line of text.trim().split('\n').filter(Boolean)) {
+    const value = JSON.parse(line);
+    const bytes = Buffer.from(value.argvHex, 'hex');
+    const decoded = bytes.toString('utf8');
+    const argv = decoded.split('\0');
+    if (!Buffer.from(decoded).equals(bytes) || argv.pop() !== '' || argv.length !== value.argc) process.exit(1);
+    const command = argv.join(' ').trim();
+    const state = value.zombie ? 'Z' : 'S';
+    const start = startTime(value.startSeconds);
+    const output = {
+      'lstart=': start,
+      'state=': state,
+      'command=': command,
+      'pid=,state=,lstart=': `${value.pid} ${state} ${start}`,
+      'pid=,ppid=,command=': `${value.pid} ${value.ppid} ${command}`,
+    };
+    process.stdout.write(`${output[fields]}\n`);
+  }
+} catch {
+  process.exitCode = 1;
+}

--- a/scripts/agent-benchmark/compat/xcodebuild
+++ b/scripts/agent-benchmark/compat/xcodebuild
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+args=()
+has_swift_flags=false
+for arg in "$@"; do
+  case "$arg" in
+    OTHER_SWIFT_FLAGS=*) args+=("$arg -disable-sandbox"); has_swift_flags=true ;;
+    *) args+=("$arg") ;;
+  esac
+done
+if ! "$has_swift_flags"; then
+  args+=('OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox')
+fi
+exec /usr/bin/xcodebuild "${args[@]}" -IDEPackageSupportDisableManifestSandbox=1 -IDEPackageSupportDisablePluginExecutionSandbox=1

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -28,6 +28,7 @@ import {
 } from '../launch-crash-benchmark.mjs';
 import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
 import { matchesGoldenPreparation } from './golden-state.mjs';
+import { collectedNativeCompatibility, probeNativeCompatibility, verifyNativeCompatibility } from './native-compat.mjs';
 import {
   androidApplicationLabelFromBadging,
   matchesExpectedAndroidEmulator,
@@ -66,6 +67,7 @@ const worktreeParent = resolve(process.env.STIM_BENCH_WORKTREE_PARENT ?? join(ro
 const stimPackage = resolve(process.env.STIM_BENCH_STIM_PACKAGE ?? join(root, 'runtime', 'node_modules', 'stim-cli'));
 const stimCli = join(stimPackage, 'dist', 'cli.mjs');
 const agentDeviceBin = process.env.STIM_BENCH_AGENT_DEVICE_BIN ?? 'agent-device';
+const nativeCompatManifest = process.env.STIM_BENCH_NATIVE_COMPAT_MANIFEST;
 const claudeBin = process.env.STIM_BENCH_CLAUDE_BIN ?? 'claude';
 const codexBin = process.env.STIM_BENCH_CODEX_BIN ?? 'codex';
 const agentSkillsRoot = process.env.STIM_BENCH_SKILLS_ROOT;
@@ -332,6 +334,12 @@ function ensureDirs() {
 }
 
 function prepareAllowedBin() {
+  const compatibility = verifyNativeCompatibility(
+    nativeCompatManifest,
+    pins.NATIVE_COMPAT_SHA256,
+    main,
+    executablePath(agentDeviceBin),
+  );
   const names = [
     'adb',
     'agent-device',
@@ -347,15 +355,26 @@ function prepareAllowedBin() {
     'sdkmanager',
     'watchman',
   ];
+  if (compatibility) names.push('xcodebuild');
   for (const name of names) {
     let source;
     try {
-      source = run('/usr/bin/which', [name], { cwd: root });
+      source =
+        name === 'agent-device'
+          ? executablePath(agentDeviceBin)
+          : name === 'xcodebuild' && compatibility
+            ? join(compatibility.directory, 'bin/xcodebuild')
+            : run('/usr/bin/which', [name], { cwd: root });
     } catch {
       continue;
     }
     const target = join(allowedBin, name);
-    if (!existsSync(source) || existsSync(target)) continue;
+    if (!existsSync(source)) continue;
+    if (existsSync(target)) {
+      if (realpathSync(target) !== realpathSync(source))
+        throw new Error(`allowed tool ${name} resolves to a stale target`);
+      continue;
+    }
     symlinkSync(source, target);
   }
   chmodSync(join(stimBin, 'stim'), 0o755);
@@ -514,6 +533,12 @@ function preflight(requestedPlatform = 'ios') {
   ensureDirs();
   prepareAllowedBin();
   const actual = versionChecks();
+  const nativeCompatibility = verifyNativeCompatibility(
+    nativeCompatManifest,
+    pins.NATIVE_COMPAT_SHA256,
+    main,
+    executablePath(agentDeviceBin),
+  );
   const targets = benchmarkTargets();
   if (!readFileSync(join(stimBin, 'stim'), 'utf8').includes(stimCli)) {
     throw new Error('Stim shim does not target the pinned CLI checkout');
@@ -562,6 +587,7 @@ function preflight(requestedPlatform = 'ios') {
   const preflightRecord = {
     checkedAt: new Date().toISOString(),
     actual,
+    nativeCompatibility,
     disk,
     load,
     thermal,
@@ -928,9 +954,9 @@ function platformLaunchInstructions(arm, platform, runId, startMetro) {
       : `Use the Stim skill and only the pinned published command available on PATH as exactly \`stim\` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run \`stim start\`, then run \`stim android --system-image ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)}\`. Leave Metro and the changed app running until the screenshot is saved.`;
   }
   if (platform === 'android') {
-    return `Use only the project's local Expo and Android SDK tooling; do not use Stim. Create a new AVD named exactly ${JSON.stringify(`Trailhead_${runId}`)} from ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)} using avdmanager's default hardware profile, matching Stim; do not use an existing emulator. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim's default 8 GiB data partition. Boot it with the emulator's default Quick Boot policy, matching Stim; the fresh AVD cold-boots because no snapshot exists. Wait for Android boot completion. ${startMetro ? 'Start Metro detached. ' : ''}Build, install, and launch only the default Debug variant; do not use a Release variant. Start that native build/install/launch as a shell background process with its PID and log under /tmp, then poll it using repeated short foreground shell calls such as \`ps -p <pid>\` and \`tail\`; do not use a long blocking shell call or end the turn while waiting. After it finishes successfully, immediately perform the agent-device proof. Leave the emulator${startMetro ? ', Metro,' : ''} and app running. `;
+    return `Use only the project's local Expo and Android SDK tooling; do not use Stim. Create a new AVD named exactly ${JSON.stringify(`Trailhead_${runId}`)} from ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)} using avdmanager's default hardware profile, matching Stim; do not use an existing emulator. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim's default 8 GiB data partition. Boot it with the emulator's default Quick Boot policy, matching Stim; the fresh AVD cold-boots because no snapshot exists. Wait for Android boot completion. ${startMetro ? 'Start Metro detached. ' : ''}Build, install, and launch only the default Debug variant; do not use a Release variant. Start that native build/install/launch as a shell background process with its PID and log under /tmp, then poll it using repeated short foreground shell calls such as \`kill -0 <pid>\` and \`tail\`; do not use a long blocking shell call or end the turn while waiting. After it finishes successfully, immediately perform the agent-device proof. Leave the emulator${startMetro ? ', Metro,' : ''} and app running. `;
   }
-  return `Run the iOS app with the project's local Expo and Apple tooling on a new iPhone 17 simulator running iOS 26.5; do not use an existing simulator. ${startMetro ? 'Start Metro detached. ' : ''}Start the native build/install/launch as a shell background process with its PID and log under /tmp, then poll it using repeated short foreground shell calls such as \`ps -p <pid>\` and \`tail\`; do not use a long blocking shell call or end the turn while waiting. After it finishes successfully, immediately perform the agent-device proof. Leave the changed app running. Do not use Stim.`;
+  return `Run the iOS app with the project's local Expo and Apple tooling on a new iPhone 17 simulator running iOS 26.5; do not use an existing simulator. ${startMetro ? 'Start Metro detached. ' : ''}Start the native build/install/launch as a shell background process with its PID and log under /tmp, then poll it using repeated short foreground shell calls such as \`kill -0 <pid>\` and \`tail\`; do not use a long blocking shell call or end the turn while waiting. After it finishes successfully, immediately perform the agent-device proof. Leave the changed app running. Do not use Stim.`;
 }
 
 function runnerForModel(model) {
@@ -1014,6 +1040,7 @@ function prepareRunIsolation(runId, runDir, env, arm, crash = null, claudeGuidan
       readPaths: [
         ...(!crash ? [main] : []),
         allowedBin,
+        ...(nativeCompatManifest ? [dirname(realpathSync(nativeCompatManifest))] : []),
         ...(arm === 'stim' ? [stimBin, join(root, 'runtime'), stimPackage] : []),
       ],
       writePaths: [env.GRADLE_USER_HOME, env.ANDROID_AVD_HOME].filter(Boolean),
@@ -1317,11 +1344,25 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     });
   }
   const crash = variant === launchCrashVariant ? prepareLaunchCrashFixture(arm, runId, env) : null;
+  if (crash && nativeCompatManifest)
+    verifyNativeCompatibility(
+      nativeCompatManifest,
+      pins.NATIVE_COMPAT_SHA256,
+      crash.fixtureCheckout,
+      executablePath(agentDeviceBin),
+    );
   const prompt = promptFor(arm, variant, runId, runDir, crash, platform);
   writeFileSync(join(runDir, 'prompt.txt'), `${prompt}\n`);
   const shellProvenance = verifyRunnerShell(arm, env);
   const claudeGuidance = runnerKind === 'claude' ? writeClaudeGuidance(codexHome, arm, runDir) : null;
   const isolation = prepareRunIsolation(runId, runDir, env, arm, crash, claudeGuidance);
+  preflightReport.nativeCompatibilityProbe = probeNativeCompatibility(
+    preflightReport.nativeCompatibility,
+    (file, args) => {
+      const invocation = isolatedRunnerInvocation(isolation, file, args);
+      return run(invocation.command, invocation.args, { cwd: main, env, timeout: 30_000 });
+    },
+  );
   const profile = verifyRunnerProfile(codexHome, env, arm, runDir, isolation);
   const agentDevice = prepareAgentDeviceRun(runId, platform, expectedParkedSimulator?.udid ?? null);
   const dispatchAt = new Date().toISOString();
@@ -2164,6 +2205,7 @@ function collect(runDir) {
   const recording = recordingEvidence(meta, commandAudit.commands, runDir, screen);
   const worktreeRecord = worktreeEvidence(runDir, meta, eventsPath);
   const worktree = worktreeRecord?.path ?? null;
+  const nativeCompatibility = collectedNativeCompatibility(meta, worktree, main);
   const proof = proofFor(meta, appAlive, runDir, worktree, commandAudit.completedEvents);
   const rollout =
     meta.runner === 'claude'
@@ -2193,6 +2235,7 @@ function collect(runDir) {
   const diagnosisUsage =
     diagnosis?.valid && meta.runner !== 'claude' ? usageAtOrBefore(rollout, diagnosis.observedAt) : null;
   const invalidReasons = [
+    ...(nativeCompatibility && !nativeCompatibility.valid ? ['native-compatibility-changed-or-unverified'] : []),
     ...(appAlive.error ? [appAlive.error] : []),
     ...(meta.runnerResult?.code === 0 ? [] : [`runner-exit-${meta.runnerResult?.code}`]),
     ...(runnerMetrics?.isError ? [`runner-${runnerMetrics.terminalReason ?? 'error'}`] : []),
@@ -2228,6 +2271,7 @@ function collect(runDir) {
     arm: meta.arm,
     variant: meta.variant,
     valid: invalidReasons.length === 0,
+    nativeCompatibility,
     invalidReasons,
     dispatchToAppAliveSeconds: appAlive.dispatchToAppAliveSeconds ?? null,
     dispatchToProofSeconds: appAlive.dispatchToProofSeconds ?? null,

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -1360,7 +1360,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     preflightReport.nativeCompatibility,
     (file, args) => {
       const invocation = isolatedRunnerInvocation(isolation, file, args);
-      return run(invocation.command, invocation.args, { cwd: main, env, timeout: 30_000 });
+      return run(invocation.command, invocation.args, { cwd: crash?.fixtureCheckout ?? main, env, timeout: 30_000 });
     },
   );
   const profile = verifyRunnerProfile(codexHome, env, arm, runDir, isolation);
@@ -2205,7 +2205,7 @@ function collect(runDir) {
   const recording = recordingEvidence(meta, commandAudit.commands, runDir, screen);
   const worktreeRecord = worktreeEvidence(runDir, meta, eventsPath);
   const worktree = worktreeRecord?.path ?? null;
-  const nativeCompatibility = collectedNativeCompatibility(meta, worktree, main);
+  const nativeCompatibility = collectedNativeCompatibility(meta, worktree);
   const proof = proofFor(meta, appAlive, runDir, worktree, commandAudit.completedEvents);
   const rollout =
     meta.runner === 'claude'

--- a/scripts/agent-benchmark/native-compat.mjs
+++ b/scripts/agent-benchmark/native-compat.mjs
@@ -1,0 +1,217 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const assets = fileURLToPath(new URL('./compat/', import.meta.url));
+const originalHostHash = '773018741804be5685becd296431c3f77f4fad7a22a7e88ce154d51a99d98e13';
+const originalJsiHash = '7f9c3901859a395b628fb7f0c9d59c594ecad61f422de1e41b6583a8667dabe2';
+const jsiRelative = 'node_modules/expo-modules-jsi/apple/scripts/build-xcframework.sh';
+
+export function fileHash(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function packageHash(path) {
+  const hash = createHash('sha256');
+  function visit(directory) {
+    for (const name of readdirSync(directory).toSorted()) {
+      const entry = join(directory, name);
+      const stat = lstatSync(entry);
+      if (stat.isDirectory()) visit(entry);
+      else if (stat.isFile()) hash.update(JSON.stringify([relative(path, entry), stat.mode & 0o777, fileHash(entry)]));
+      else if (stat.isSymbolicLink()) {
+        const link = readlinkSync(entry);
+        const target = relative(realpathSync(path), realpathSync(entry));
+        if (isAbsolute(link) || target === '..' || target.startsWith('../'))
+          throw new Error('compatibility package symlink escapes its package');
+        hash.update(JSON.stringify([relative(path, entry), 'symlink', link]));
+      } else throw new Error(`compatibility package contains an unsupported entry: ${relative(path, entry)}`);
+    }
+  }
+  visit(path);
+  return hash.digest('hex');
+}
+
+function replaceOnce(text, before, after) {
+  if (text.split(before).length !== 2) throw new Error('compatibility patch does not match exactly once');
+  return text.replace(before, after);
+}
+
+export function patchedHostProcess(text) {
+  let output = replaceOnce(
+    text,
+    'const r=1e3,i=process.platform===`win32`?`ps`:`/bin/ps`;',
+    'import{fileURLToPath as compatPath}from"node:url";const r=1e3,i=process.platform===`darwin`?compatPath(new URL("./ps-bridge.mjs",import.meta.url)):process.platform===`win32`?`ps`:`/bin/ps`;',
+  );
+  output = replaceOnce(
+    output,
+    'e(`ps`,[`-p`,i.join(`,`),`-o`,`pid=,state=,lstart=`]',
+    'e(process.platform===`darwin`?compatPath(new URL("./ps-bridge.mjs",import.meta.url)):`ps`,[`-p`,i.join(`,`),`-o`,`pid=,state=,lstart=`]',
+  );
+  return output;
+}
+
+export function patchedJsiBuild(text) {
+  if (text.includes('-disable-sandbox') || text.includes('-IDEPackageSupportDisable'))
+    throw new Error('ExpoModulesJSI compatibility patch is already present');
+  let output = replaceOnce(
+    text,
+    'xcodebuild \\\n',
+    'xcodebuild \\\n  -IDEPackageSupportDisableManifestSandbox=1 \\\n  -IDEPackageSupportDisablePluginExecutionSandbox=1 \\\n',
+  );
+  return replaceOnce(
+    output,
+    'SWIFT_COMPILATION_MODE=wholemodule \\\n',
+    "SWIFT_COMPILATION_MODE=wholemodule \\\n  'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox' \\\n",
+  );
+}
+
+export function prepareNativeCompatibility({
+  destination,
+  agentDevicePackage,
+  nativeSource,
+  expectedNativeSourceSha256,
+  sourceCommit,
+  fixture,
+}) {
+  destination = resolve(destination);
+  if (existsSync(destination)) throw new Error('compatibility destination must be new');
+  const metadata = JSON.parse(readFileSync(join(agentDevicePackage, 'package.json'), 'utf8'));
+  if (metadata.version !== '0.20.10') throw new Error('compatibility patch requires agent-device 0.20.10');
+  const originalHost = join(agentDevicePackage, 'dist/src/host-process.js');
+  if (fileHash(originalHost) !== originalHostHash) throw new Error('agent-device host-process base hash mismatch');
+  if (!/^[a-f0-9]{40}$/.test(sourceCommit)) throw new Error('native helper source commit must be exact');
+  if (fileHash(nativeSource) !== expectedNativeSourceSha256) throw new Error('native helper source hash mismatch');
+  const sourceRepository = execFileSync('git', ['-C', dirname(nativeSource), 'rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  }).trim();
+  const committedSource = execFileSync(
+    'git',
+    ['-C', sourceRepository, 'show', `${sourceCommit}:${relative(sourceRepository, nativeSource)}`],
+    { timeout: 10_000 },
+  );
+  if (createHash('sha256').update(committedSource).digest('hex') !== expectedNativeSourceSha256)
+    throw new Error('native helper does not match its declared source commit');
+  const jsi = join(fixture, jsiRelative);
+  if (fileHash(jsi) !== originalJsiHash) throw new Error('ExpoModulesJSI base hash mismatch');
+  const patchedHost = patchedHostProcess(readFileSync(originalHost, 'utf8'));
+  const patchedJsi = patchedJsiBuild(readFileSync(jsi, 'utf8'));
+  const originalPackageSha256 = packageHash(agentDevicePackage);
+  mkdirSync(destination, { recursive: true });
+  const packagePath = join(destination, 'agent-device');
+  cpSync(agentDevicePackage, packagePath, { recursive: true, verbatimSymlinks: true });
+  const dist = join(packagePath, 'dist/src');
+  copyFileSync(nativeSource, join(dist, 'native-process.c'));
+  copyFileSync(join(assets, 'ps-bridge.mjs'), join(dist, 'ps-bridge.mjs'));
+  chmodSync(join(dist, 'ps-bridge.mjs'), 0o755);
+  execFileSync(
+    '/usr/bin/clang',
+    [
+      '-std=c11',
+      '-O2',
+      '-Wall',
+      '-Wextra',
+      '-Werror',
+      join(dist, 'native-process.c'),
+      '-o',
+      join(dist, 'native-process'),
+    ],
+    { timeout: 30_000 },
+  );
+  writeFileSync(join(dist, 'host-process.js'), patchedHost);
+  mkdirSync(join(destination, 'bin'));
+  copyFileSync(join(assets, 'xcodebuild'), join(destination, 'bin/xcodebuild'));
+  chmodSync(join(destination, 'bin/xcodebuild'), 0o755);
+  writeFileSync(jsi, patchedJsi);
+  const manifest = {
+    schema: 1,
+    preparedAt: new Date().toISOString(),
+    architecture: process.arch,
+    sourceCommit,
+    nativeSourceSha256: expectedNativeSourceSha256,
+    agentDeviceVersion: metadata.version,
+    originalPackageSha256,
+    agentDevicePackageSha256: packageHash(packagePath),
+    originalHostSha256: originalHostHash,
+    originalJsiSha256: originalJsiHash,
+    jsiSha256: fileHash(jsi),
+    xcodebuildSha256: fileHash(join(destination, 'bin/xcodebuild')),
+    bridgeSha256: fileHash(join(dist, 'ps-bridge.mjs')),
+  };
+  const path = join(destination, 'manifest.json');
+  writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { path, sha256: fileHash(path), ...manifest };
+}
+
+export function verifyNativeCompatibility(path, expectedSha256, fixture, agentDeviceBin) {
+  if (!path) {
+    if (expectedSha256) throw new Error('pinned native compatibility manifest is missing');
+    return null;
+  }
+  if (!expectedSha256 || fileHash(path) !== expectedSha256)
+    throw new Error('native compatibility manifest hash mismatch');
+  const directory = dirname(realpathSync(path));
+  const manifest = JSON.parse(readFileSync(path, 'utf8'));
+  if (manifest.schema !== 1 || manifest.architecture !== process.arch)
+    throw new Error('unsupported native compatibility manifest');
+  const packagePath = join(directory, 'agent-device');
+  if (packageHash(packagePath) !== manifest.agentDevicePackageSha256)
+    throw new Error('agent-device compatibility package changed');
+  if (fileHash(join(directory, 'bin/xcodebuild')) !== manifest.xcodebuildSha256)
+    throw new Error('Xcode compatibility wrapper changed');
+  if (fileHash(join(fixture, jsiRelative)) !== manifest.jsiSha256)
+    throw new Error('ExpoModulesJSI compatibility patch missing or changed');
+  if (realpathSync(agentDeviceBin) !== realpathSync(join(packagePath, 'bin/agent-device.mjs')))
+    throw new Error('agent-device is not the compatibility package');
+  return { ...manifest, manifestSha256: expectedSha256, directory };
+}
+
+export function probeNativeCompatibility(compatibility, execute) {
+  if (!compatibility) return null;
+  const host = pathToFileURL(join(compatibility.directory, 'agent-device/dist/src/host-process.js')).href;
+  const script = `import assert from 'node:assert/strict';
+    import {execFileSync} from 'node:child_process';
+    import {realpathSync} from 'node:fs';
+    import {c as start,s as command,i as zombie,a as list} from ${JSON.stringify(host)};
+    assert.throws(() => execFileSync('/bin/ps',['-p',String(process.pid),'-o','command=']));
+    assert(start(process.pid)); assert(command(process.pid)); assert.equal(zombie(process.pid),false);
+    assert((await list({timeoutMs:5000})).some(x => x.pid === process.pid));
+    const xcode = execFileSync('/usr/bin/which',['xcodebuild'],{encoding:'utf8'}).trim();
+    assert.equal(realpathSync(xcode),${JSON.stringify(join(compatibility.directory, 'bin/xcodebuild'))});
+    const version = execFileSync(xcode,['-version'],{encoding:'utf8',timeout:10000}).trim();
+    console.log(JSON.stringify({processIdentity:true,xcodeVersion:version}));`;
+  return JSON.parse(execute(process.execPath, ['--input-type=module', '-e', script]));
+}
+
+export function collectedNativeCompatibility(meta, worktree, fixture) {
+  const expected = meta.preflight?.nativeCompatibility;
+  if (!expected) return null;
+  try {
+    if (!meta.preflight.nativeCompatibilityProbe?.processIdentity)
+      throw new Error('sandbox compatibility probe missing');
+    verifyNativeCompatibility(
+      join(expected.directory, 'manifest.json'),
+      expected.manifestSha256,
+      worktree && existsSync(worktree) ? worktree : fixture,
+      join(expected.directory, 'agent-device/bin/agent-device.mjs'),
+    );
+    return { valid: true, manifestSha256: expected.manifestSha256 };
+  } catch (error) {
+    return { valid: false, reason: error.message };
+  }
+}

--- a/scripts/agent-benchmark/native-compat.mjs
+++ b/scripts/agent-benchmark/native-compat.mjs
@@ -151,6 +151,7 @@ export function prepareNativeCompatibility({
     originalJsiSha256: originalJsiHash,
     jsiSha256: fileHash(jsi),
     xcodebuildSha256: fileHash(join(destination, 'bin/xcodebuild')),
+    xcodebuildMode: lstatSync(join(destination, 'bin/xcodebuild')).mode & 0o777,
     bridgeSha256: fileHash(join(dist, 'ps-bridge.mjs')),
   };
   const path = join(destination, 'manifest.json');
@@ -172,7 +173,13 @@ export function verifyNativeCompatibility(path, expectedSha256, fixture, agentDe
   const packagePath = join(directory, 'agent-device');
   if (packageHash(packagePath) !== manifest.agentDevicePackageSha256)
     throw new Error('agent-device compatibility package changed');
-  if (fileHash(join(directory, 'bin/xcodebuild')) !== manifest.xcodebuildSha256)
+  const wrapper = join(directory, 'bin/xcodebuild');
+  const wrapperMode = lstatSync(wrapper).mode & 0o777;
+  if (
+    fileHash(wrapper) !== manifest.xcodebuildSha256 ||
+    wrapperMode !== manifest.xcodebuildMode ||
+    !(wrapperMode & 0o100)
+  )
     throw new Error('Xcode compatibility wrapper changed');
   if (fileHash(join(fixture, jsiRelative)) !== manifest.jsiSha256)
     throw new Error('ExpoModulesJSI compatibility patch missing or changed');
@@ -198,16 +205,17 @@ export function probeNativeCompatibility(compatibility, execute) {
   return JSON.parse(execute(process.execPath, ['--input-type=module', '-e', script]));
 }
 
-export function collectedNativeCompatibility(meta, worktree, fixture) {
+export function collectedNativeCompatibility(meta, worktree) {
   const expected = meta.preflight?.nativeCompatibility;
   if (!expected) return null;
   try {
     if (!meta.preflight.nativeCompatibilityProbe?.processIdentity)
       throw new Error('sandbox compatibility probe missing');
+    if (!worktree || !existsSync(worktree)) throw new Error('run worktree missing for compatibility validation');
     verifyNativeCompatibility(
       join(expected.directory, 'manifest.json'),
       expected.manifestSha256,
-      worktree && existsSync(worktree) ? worktree : fixture,
+      worktree,
       join(expected.directory, 'agent-device/bin/agent-device.mjs'),
     );
     return { valid: true, manifestSha256: expected.manifestSha256 };

--- a/scripts/agent-benchmark/native-compat.test.mjs
+++ b/scripts/agent-benchmark/native-compat.test.mjs
@@ -39,6 +39,7 @@ test('compatibility refuses changed package bytes, permissions, fixture patch, a
     writeFileSync(jsi, 'patched JSI');
     const wrapper = join(root, 'bin/xcodebuild');
     writeFileSync(wrapper, 'wrapper');
+    chmodSync(wrapper, 0o755);
     const manifest = join(root, 'manifest.json');
     writeFileSync(
       manifest,
@@ -47,6 +48,7 @@ test('compatibility refuses changed package bytes, permissions, fixture patch, a
         architecture: process.arch,
         agentDevicePackageSha256: packageHash(packagePath),
         xcodebuildSha256: fileHash(wrapper),
+        xcodebuildMode: 0o755,
         jsiSha256: fileHash(jsi),
       }),
     );
@@ -58,13 +60,12 @@ test('compatibility refuses changed package bytes, permissions, fixture patch, a
         nativeCompatibilityProbe: { processIdentity: true },
       },
     };
-    assert.equal(collectedNativeCompatibility(meta, null, fixture).valid, true);
+    assert.equal(collectedNativeCompatibility(meta, fixture).valid, true);
+    assert.equal(collectedNativeCompatibility(meta, null).valid, false);
+    assert.equal(collectedNativeCompatibility(meta, join(root, 'removed-worktree')).valid, false);
     assert.equal(
-      collectedNativeCompatibility(
-        { preflight: { nativeCompatibility: meta.preflight.nativeCompatibility } },
-        null,
-        fixture,
-      ).valid,
+      collectedNativeCompatibility({ preflight: { nativeCompatibility: meta.preflight.nativeCompatibility } }, fixture)
+        .valid,
       false,
     );
     assert(verifyNativeCompatibility(manifest, hash, fixture, entry));
@@ -72,12 +73,16 @@ test('compatibility refuses changed package bytes, permissions, fixture patch, a
     assert.throws(() => verifyNativeCompatibility(null, hash, fixture, entry), /missing/);
     assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, wrapper), /not the compatibility package/);
     writeFileSync(join(packagePath, 'implementation.js'), 'different implementation');
-    assert.equal(collectedNativeCompatibility(meta, null, fixture).valid, false);
+    assert.equal(collectedNativeCompatibility(meta, fixture).valid, false);
     assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /package changed/);
     writeFileSync(join(packagePath, 'implementation.js'), 'original implementation');
     chmodSync(entry, 0o700);
     assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /package changed/);
     chmodSync(entry, mode);
+    chmodSync(wrapper, 0o644);
+    assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /wrapper changed/);
+    assert.equal(collectedNativeCompatibility(meta, fixture).valid, false);
+    chmodSync(wrapper, 0o755);
     writeFileSync(jsi, 'unpatched JSI');
     assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /JSI compatibility/);
   } finally {

--- a/scripts/agent-benchmark/native-compat.test.mjs
+++ b/scripts/agent-benchmark/native-compat.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  chmodSync,
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  fileHash,
+  collectedNativeCompatibility,
+  packageHash,
+  patchedHostProcess,
+  patchedJsiBuild,
+  prepareNativeCompatibility,
+  probeNativeCompatibility,
+  verifyNativeCompatibility,
+} from './native-compat.mjs';
+
+test('compatibility refuses changed package bytes, permissions, fixture patch, and executable resolution', () => {
+  const root = mkdtempSync(join(tmpdir(), 'benchmark-compat-'));
+  try {
+    const packagePath = join(root, 'agent-device');
+    const entry = join(packagePath, 'bin/agent-device.mjs');
+    const fixture = join(root, 'fixture');
+    const jsi = join(fixture, 'node_modules/expo-modules-jsi/apple/scripts/build-xcframework.sh');
+    mkdirSync(join(packagePath, 'bin'), { recursive: true });
+    mkdirSync(join(root, 'bin'));
+    mkdirSync(join(fixture, 'node_modules/expo-modules-jsi/apple/scripts'), { recursive: true });
+    writeFileSync(entry, 'entry');
+    writeFileSync(join(packagePath, 'implementation.js'), 'original implementation');
+    writeFileSync(jsi, 'patched JSI');
+    const wrapper = join(root, 'bin/xcodebuild');
+    writeFileSync(wrapper, 'wrapper');
+    const manifest = join(root, 'manifest.json');
+    writeFileSync(
+      manifest,
+      JSON.stringify({
+        schema: 1,
+        architecture: process.arch,
+        agentDevicePackageSha256: packageHash(packagePath),
+        xcodebuildSha256: fileHash(wrapper),
+        jsiSha256: fileHash(jsi),
+      }),
+    );
+    const hash = fileHash(manifest);
+    const mode = lstatSync(entry).mode & 0o777;
+    const meta = {
+      preflight: {
+        nativeCompatibility: { directory: root, manifestSha256: hash },
+        nativeCompatibilityProbe: { processIdentity: true },
+      },
+    };
+    assert.equal(collectedNativeCompatibility(meta, null, fixture).valid, true);
+    assert.equal(
+      collectedNativeCompatibility(
+        { preflight: { nativeCompatibility: meta.preflight.nativeCompatibility } },
+        null,
+        fixture,
+      ).valid,
+      false,
+    );
+    assert(verifyNativeCompatibility(manifest, hash, fixture, entry));
+    assert.throws(() => verifyNativeCompatibility(manifest, 'wrong', fixture, entry), /manifest hash/);
+    assert.throws(() => verifyNativeCompatibility(null, hash, fixture, entry), /missing/);
+    assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, wrapper), /not the compatibility package/);
+    writeFileSync(join(packagePath, 'implementation.js'), 'different implementation');
+    assert.equal(collectedNativeCompatibility(meta, null, fixture).valid, false);
+    assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /package changed/);
+    writeFileSync(join(packagePath, 'implementation.js'), 'original implementation');
+    chmodSync(entry, 0o700);
+    assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /package changed/);
+    chmodSync(entry, mode);
+    writeFileSync(jsi, 'unpatched JSI');
+    assert.throws(() => verifyNativeCompatibility(manifest, hash, fixture, entry), /JSI compatibility/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('package hashing permits portable internal links but rejects escaping targets', () => {
+  const root = mkdtempSync(join(tmpdir(), 'benchmark-compat-links-'));
+  try {
+    mkdirSync(join(root, 'package'));
+    writeFileSync(join(root, 'package/source'), 'source');
+    symlinkSync('source', join(root, 'package/link'));
+    const hash = packageHash(join(root, 'package'));
+    writeFileSync(join(root, 'package/source'), 'changed source');
+    assert.notEqual(packageHash(join(root, 'package')), hash);
+    writeFileSync(join(root, 'outside'), 'outside');
+    symlinkSync('../outside', join(root, 'package/escape'));
+    assert.throws(() => packageHash(join(root, 'package')), /escapes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('version-specific patches refuse mismatches and duplicate application', () => {
+  assert.throws(() => patchedHostProcess('different package'), /exactly once/);
+  const source = 'xcodebuild \\\n  SWIFT_COMPILATION_MODE=wholemodule \\\n  "$@"';
+  const output = patchedJsiBuild(source);
+  assert.match(output, /IDEPackageSupportDisableManifestSandbox=1/);
+  assert.match(output, /OTHER_SWIFT_FLAGS=\$\(inherited\) -disable-sandbox/);
+  assert(output.endsWith('  "$@"'));
+  assert.throws(() => patchedJsiBuild(output), /already present/);
+  assert.throws(() => patchedJsiBuild('different package'), /exactly once/);
+});
+
+test(
+  'patched published agent-device keeps process identity in the real sandbox',
+  {
+    skip: process.platform !== 'darwin' || !process.env.BENCH_COMPAT_TEST_AGENT_DEVICE_PACKAGE,
+  },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), 'benchmark-compat-live-'));
+    try {
+      const fixture = join(root, 'fixture');
+      const target = join(fixture, 'node_modules/expo-modules-jsi/apple/scripts');
+      mkdirSync(target, { recursive: true });
+      copyFileSync(process.env.BENCH_COMPAT_TEST_JSI_SCRIPT, join(target, 'build-xcframework.sh'));
+      const source = process.env.BENCH_COMPAT_TEST_NATIVE_SOURCE;
+      const prepared = prepareNativeCompatibility({
+        destination: join(root, 'compat'),
+        fixture,
+        agentDevicePackage: process.env.BENCH_COMPAT_TEST_AGENT_DEVICE_PACKAGE,
+        nativeSource: source,
+        expectedNativeSourceSha256: fileHash(source),
+        sourceCommit: process.env.BENCH_COMPAT_TEST_SOURCE_COMMIT,
+      });
+      const entry = join(root, 'compat/agent-device/bin/agent-device.mjs');
+      const compatibility = verifyNativeCompatibility(prepared.path, prepared.sha256, fixture, entry);
+      assert(compatibility);
+      const probe = probeNativeCompatibility(compatibility, (file, args) =>
+        execFileSync('/usr/bin/sandbox-exec', ['-p', '(version 1)(allow default)', file, ...args], {
+          encoding: 'utf8',
+          timeout: 15_000,
+          env: { ...process.env, PATH: `${join(compatibility.directory, 'bin')}:${process.env.PATH}` },
+        }),
+      );
+      assert.equal(probe.processIdentity, true);
+      assert.match(probe.xcodeVersion, /^Xcode /);
+      const psStart = execFileSync('/bin/ps', ['-p', String(process.pid), '-o', 'lstart='], {
+        encoding: 'utf8',
+      }).trim();
+      const script = `import assert from 'node:assert/strict';
+      import {s as command,c as start,i as zombie,a as list} from ${JSON.stringify(`file://${join(root, 'compat/agent-device/dist/src/host-process.js')}`)};
+      assert.equal(start(${process.pid}), ${JSON.stringify(psStart)});
+      assert(command(${process.pid}));
+      assert.equal(zombie(${process.pid}), false);
+      assert((await list({timeoutMs:5000})).some(x => x.pid === ${process.pid}));
+      console.log('patched sandbox identity passed');`;
+      const output = execFileSync(
+        '/usr/bin/sandbox-exec',
+        ['-p', '(version 1)(allow default)', process.execPath, '--input-type=module', '-e', script],
+        { encoding: 'utf8', timeout: 15_000 },
+      );
+      assert.match(output, /patched sandbox identity passed/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Description

The isolated iOS recovery benchmark cannot finish recording when agent-device's process inspection is denied, and ExpoModulesJSI's nested SwiftPM sandbox blocks its build. Refs #469; the real campaign build/recording/cleanup preflight remains outstanding before timed runs.

## Solution

Prepare a hash-pinned local copy of agent-device 0.20.10 with the native process helper from [the upstream fix](https://github.com/callstack/agent-device/pull/2377), plus an explicit Xcode/JSI sandbox adapter. Both arms use the same copies; the outer benchmark isolation stays enforced. Unknown package bytes or later mutations fail validation.

This is benchmark-only compatibility, not a global install change. It adds a Node process per process query; new campaigns require fresh golden state and exact-toolchain preflight.

## Test plan

- The optional real macOS integration test prepares the published package, proves `ps` is denied while identity lookup works, and verifies Xcode resolves through the pinned wrapper.
- Tampering with package contents, permissions, symlinks, fixture patches, or the executable target fails validation.
- Untimed iOS validation under the existing isolation policy covered build, launch, injected-error capture, Settings recovery, video recording with patched 0.20.10, and cleanup.
