### PR TITLE
fix: isolate doctor tests from machine settings

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -47,6 +47,18 @@ import {
 
 const testStimVersions = analyzeStimVersions('1.2.3', '/tools/stim-cli', []);
 
+let testHome: string;
+
+beforeEach(() => {
+  testHome = mkdtempSync(join(tmpdir(), 'stim-doctor-test-home-'));
+  process.env.STIM_HOME = testHome;
+});
+
+afterEach(() => {
+  delete process.env.STIM_HOME;
+  rmSync(testHome, { recursive: true, force: true });
+});
+
 test('checkMainCheckout reports missing dependencies, Pods, and native output', () => {
   const project = mkdtempSync(join(tmpdir(), 'stim-doctor-source-cold-'));
   try {


### PR DESCRIPTION
## Description

Three doctor tests fail when Android CAS is enabled in the developer's machine config because they expect the default ccache diagnostics.

## Solution

Give each doctor test a temporary Stim home and remove it afterward. Runtime behavior and machine settings are unchanged.

## Test plan

The unit suite passes all 3664 tests with this Mac's CAS configuration still enabled. Before the fix, the three doctor cases failed on the same machine. Formatting, lint, build, typecheck, knip, all 66 E2E tests, and the runtime check also pass.

Fixes #485.
