### PR TITLE
fix: keep Android benchmark autolinking local

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -129,6 +129,14 @@ profile before starting the clock; collection rejects changed compatibility
 bytes. This does not replace a real untimed build, recording, and cleanup test
 before accepting a new toolchain combination.
 
+Android launch-error control preparation carries dependencies and native outputs
+but leaves out the root `android/build` directory. Its generated autolinking cache
+contains absolute source-checkout paths and package checksums that survive a copy.
+The control prompt also requires excluding `android/build/generated/autolinking`
+when the agent creates its run worktree. Gradle regenerates this metadata locally;
+`android/app/build` remains available for native output reuse. Verify the generated
+project and dependency roots belong to the run worktree before accepting a pilot.
+
 ## Run a cell
 
 Prepare the platform golden, then dispatch, collect, and clean one cell:

--- a/scripts/agent-benchmark/launch-crash-setup.mjs
+++ b/scripts/agent-benchmark/launch-crash-setup.mjs
@@ -9,14 +9,7 @@ export function launchCrashSetup({ platform, arm, systemImage }) {
   const ignoredPaths =
     platform === 'ios'
       ? ['node_modules', 'ios/Pods', 'ios/build']
-      : [
-          'node_modules',
-          'android/.gradle',
-          'android/.cxx',
-          'android/build',
-          'android/app/build',
-          'android/local.properties',
-        ];
+      : ['node_modules', 'android/.gradle', 'android/.cxx', 'android/app/build', 'android/local.properties'];
   const platformCommand = platform === 'ios' ? 'stim ios' : `stim android --system-image '${systemImage}'`;
   const device = platform === 'ios' ? 'adopted simulator' : 'owned emulator';
   const stim = `Use the Stim skill and only the pinned command available on PATH as exactly \`stim\`. Keep the inherited STIM_HOME unchanged. Before inspecting source or git diff, run \`stim start\` and then \`${platformCommand}\` so the benchmark observes the failure. Preserve that launch output, then immediately run \`stim logs --errors\` as its own command. Diagnose the launch failure from those results. Only after the diagnostic commands may you inspect and edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${device}. Leave Metro and the app running until screenshot proof is complete. Do not use npx, an absolute Stim path, raw Expo launch commands, or stop Stim.`;
@@ -26,6 +19,10 @@ export function launchCrashSetup({ platform, arm, systemImage }) {
       : `Create a new AVD with the exact required name from ${JSON.stringify(systemImage)} using avdmanager's default hardware profile, matching Stim. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim. Boot this new emulator with default Quick Boot policy and wait for Android boot completion; do not use an existing emulator. Use its exact serial for Expo launch and every adb command. Build only the default Debug variant and arm64-v8a architecture. Use adb reverse for the app's Metro port before launch.`;
   const tooling = platform === 'ios' ? 'Apple' : 'Android SDK';
   const logs = platform === 'ios' ? 'simulator-log' : '`adb -s <run serial> logcat -d`';
-  const control = `Use the project's local Expo and ${tooling} tooling and do not use Stim. ${controlDevice} Before inspecting source or git diff, start Metro as a detached process with its PID and log under /tmp. Start the initial native build/install/launch as a detached shell process with its PID and log under /tmp, then poll it with short foreground shell commands such as \`kill -0 <pid>\` and \`tail\`. Once the app has launched and failed, run a separate foreground \`tail\`, \`rg\`, or ${logs} command that completes and prints the crash token and source location. Only after that explicit error-capture command completes may you inspect or edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${platform === 'ios' ? 'simulator' : 'emulator'}. Leave Metro and the app running until screenshot proof is complete. Do not use a long-running foreground shell command, concurrent shell tool calls, or rely on streamed output from a command that is still running as diagnosis evidence.`;
+  const portableCopy =
+    platform === 'android'
+      ? ' When carrying native outputs, exclude android/build/generated/autolinking from the copy. It caches absolute paths to the source checkout; let Gradle regenerate it in the new worktree before building.'
+      : '';
+  const control = `Use the project's local Expo and ${tooling} tooling and do not use Stim.${portableCopy} ${controlDevice} Before inspecting source or git diff, start Metro as a detached process with its PID and log under /tmp. Start the initial native build/install/launch as a detached shell process with its PID and log under /tmp, then poll it with short foreground shell commands such as \`kill -0 <pid>\` and \`tail\`. Once the app has launched and failed, run a separate foreground \`tail\`, \`rg\`, or ${logs} command that completes and prints the crash token and source location. Only after that explicit error-capture command completes may you inspect or edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${platform === 'ios' ? 'simulator' : 'emulator'}. Leave Metro and the app running until screenshot proof is complete. Do not use a long-running foreground shell command, concurrent shell tool calls, or rely on streamed output from a command that is still running as diagnosis evidence.`;
   return { ignoredPaths, deviceKind, instructions: arm === 'stim' ? stim : control };
 }

--- a/scripts/agent-benchmark/launch-crash-setup.test.mjs
+++ b/scripts/agent-benchmark/launch-crash-setup.test.mjs
@@ -1,4 +1,7 @@
 import { expect, it } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { launchCrashSetup } from './launch-crash-setup.mjs';
 
 const systemImage = 'system-images;android-36;google_apis_playstore_ps16k;arm64-v8a';
@@ -6,14 +9,6 @@ const systemImage = 'system-images;android-36;google_apis_playstore_ps16k;arm64-
 it('selects Android fixture inputs and owned-device launch instructions for both arms', () => {
   for (const arm of ['stim', 'control']) {
     const setup = launchCrashSetup({ platform: 'android', arm, systemImage });
-    expect(setup.ignoredPaths).toEqual([
-      'node_modules',
-      'android/.gradle',
-      'android/.cxx',
-      'android/build',
-      'android/app/build',
-      'android/local.properties',
-    ]);
     expect(setup.deviceKind).toBe('AVD');
     expect(setup.instructions).toContain(systemImage);
     expect(setup.instructions).not.toContain('stim ios');
@@ -24,6 +19,40 @@ it('selects Android fixture inputs and owned-device launch instructions for both
     'ios/Pods',
     'ios/build',
   ]);
+});
+
+it('carries reusable Android outputs without importing a sibling autolinking cache', () => {
+  const root = mkdtempSync(join(tmpdir(), 'bench-android-carry-'));
+  const source = join(root, 'source');
+  const target = join(root, 'target');
+  const paths = [
+    'node_modules/native-lib/package.json',
+    'android/.gradle/cache.bin',
+    'android/.cxx/config.bin',
+    'android/app/build/outputs/apk/debug/app-debug.apk',
+    'android/local.properties',
+    'android/build/generated/autolinking/autolinking.json',
+    'android/build/generated/autolinking/package.json.sha',
+  ];
+  try {
+    for (const path of paths) {
+      mkdirSync(dirname(join(source, path)), { recursive: true });
+      writeFileSync(join(source, path), 'source checkout bytes');
+    }
+    for (const path of launchCrashSetup({ platform: 'android', arm: 'control', systemImage }).ignoredPaths) {
+      mkdirSync(dirname(join(target, path)), { recursive: true });
+      cpSync(join(source, path), join(target, path), { recursive: true });
+    }
+    for (const path of paths.slice(0, 5)) {
+      expect(readFileSync(join(target, path), 'utf8')).toBe('source checkout bytes');
+    }
+    for (const path of paths.slice(5)) {
+      expect(existsSync(join(target, path))).toBe(false);
+      expect(readFileSync(join(source, path), 'utf8')).toBe('source checkout bytes');
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 it('refuses missing, non-arm64, or shell-injectable Android image pins', () => {


### PR DESCRIPTION
## Description

Android launch-error control fixtures copy autolinking metadata containing absolute source-checkout paths. Gradle can then build against a sibling fixture because the copied package checksums still match. Fixes #488.

## Solution

Leave root `android/build` out of coordinator carry-over and require control agents to exclude its generated autolinking cache when creating their run worktree. Installed dependencies and `android/app/build` remain reusable. This changes benchmark setup only, not the CLI.

## Test plan

A filesystem regression carries representative native outputs while proving autolinking metadata is absent from the destination and intact in the source. The untimed RC.21 Android probe regenerated local project/dependency roots after removing this stale cache and built successfully.
