### PR TITLE
fix: recognize scoped setup in launch-error audit

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -144,6 +144,9 @@ partition, system image, and default Quick Boot policy as Stim.
 Launch-error control may use runner-managed sessions instead of detached shell
 jobs and keeps the inherited Android SDK, AVD, Gradle, and emulator-report
 locations unchanged so device verification and cleanup see the same metadata.
+The launch-error audit recognizes scoped setup and log capture across shell
+quoting forms. It reports all rejected operations for investigation; source
+inspection before completed error capture still invalidates the attempt.
 Installing dependencies inside the timed interval, a failed `guide agent` or
 `worktree warm`, and an Android native build without Stim's `--build-cache`
 evidence invalidate the attempt.

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -184,6 +184,13 @@ for the separate completed error query and preserves the inherited Android SDK,
 AVD, Gradle, and emulator-report locations so observation and cleanup use the
 same metadata as the agent.
 
+The pre-capture audit decodes shell quoting without executing it and recognizes
+scoped setup operations, including local SDK tools, managed log pipelines, and
+the assigned AVD's configuration edit. Collection reports every rejected command
+in `diagnosis.violations`, retaining the first rejection in `commandId`. Unknown
+commands and source inspection still invalidate the attempt; this is not a
+replacement for the runner's filesystem isolation.
+
 A launch can finish before the JavaScript error reaches its log. Both arms must
 repeat standalone foreground log queries, without separate sleep or wait commands,
 until a completed query prints the error and source location before inspecting or

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -190,6 +190,9 @@ the assigned AVD's configuration edit. Collection reports every rejected command
 in `diagnosis.violations`, retaining the first rejection in `commandId`. Unknown
 commands and source inspection still invalidate the attempt; this is not a
 replacement for the runner's filesystem isolation.
+Build/launch pipelines ending in `tee` must enable `set -o pipefail` in the same
+shell command. Without it, zero exit status proves only the log writer finished,
+so the command cannot establish initial launch success.
 
 A launch can finish before the JavaScript error reaches its log. Both arms must
 repeat standalone foreground log queries, without separate sleep or wait commands,

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -1386,6 +1386,14 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     expectedParkedSimulator,
     expectedStimDevice,
     expectedControlSimulator,
+    expectedControlAvdConfig:
+      platform === 'android' && arm === 'control'
+        ? join(
+            process.env.ANDROID_AVD_HOME ?? join(process.env.HOME, '.android', 'avd'),
+            expectedControlSimulator.name + '.avd',
+            'config.ini',
+          )
+        : null,
     agentDevice,
     crash,
   };
@@ -2137,6 +2145,10 @@ function collect(runDir) {
           arm: meta.arm,
           platform: meta.platform ?? 'ios',
           activities: commandAudit.activities,
+          setup: {
+            worktree,
+            avdConfig: meta.expectedControlAvdConfig,
+          },
         })
       : null;
   const recovery =

--- a/scripts/agent-benchmark/launch-crash-setup.mjs
+++ b/scripts/agent-benchmark/launch-crash-setup.mjs
@@ -24,7 +24,13 @@ export function launchCrashSetup({ platform, arm, systemImage }) {
       ? ' When carrying native outputs, exclude android/build/generated/autolinking from the copy. It caches absolute paths to the source checkout; let Gradle regenerate it in the new worktree before building.'
       : '';
   const control = `Use the project's local Expo and ${tooling} tooling and do not use Stim.${portableCopy} ${controlDevice} Before inspecting source or git diff, start Metro and run the initial native build/install/launch. Keep Metro and any emulator process alive in runner-managed shell sessions or supported background tasks; a shell background job is not required. Save Metro and native output to per-run logs under /tmp. Poll finite copy/build commands to completion before dependent commands. For long-lived servers, preserve the running session and wait for readiness instead of waiting for exit or stopping it. Once the app has launched and failed, run a separate foreground \`tail\`, \`rg\`, or ${logs} command that completes and prints the crash token and source location. Only after that explicit error-capture command completes may you inspect or edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${platform === 'ios' ? 'simulator' : 'emulator'}. Leave Metro and the app running until screenshot proof is complete. Do not rely on streamed output from a command that is still running as diagnosis evidence.`;
+  const pipelineRule =
+    ' For any build/launch pipeline ending in tee, enable set -o pipefail in that same shell command before the pipeline so its exit status proves the launch succeeded, not just the log writer.';
   const evidenceGate =
     'Do not inspect or edit source until a completed foreground log command prints the launch error and its source location. If the first log query is empty, repeat standalone foreground log queries without separate sleep or wait commands until the error and source location appear. A successful launch, a zero exit code, or an error visible only in a device snapshot does not satisfy this log-capture requirement.';
-  return { ignoredPaths, deviceKind, instructions: `${arm === 'stim' ? stim : control} ${evidenceGate}` };
+  return {
+    ignoredPaths,
+    deviceKind,
+    instructions: `${arm === 'stim' ? stim : control + pipelineRule} ${evidenceGate}`,
+  };
 }

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -62,11 +62,32 @@ export function benchmarkTarget(config, selection) {
 
 export function topLevelShellCommand(command) {
   const trimmed = String(command ?? '').trim();
-  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc (["'])([\s\S]*)\1$/);
+  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc\s+([\s\S]+)$/);
   if (!match) return trimmed;
-  const source =
-    match[1] === '"' ? match[2].replace(/\\(["\\$`\n])/g, (_, char) => (char === '\n' ? '' : char)) : match[2];
-  return source.trim();
+  const input = match[1];
+  let source = '';
+  let quote = null;
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (quote === "'") {
+      if (char === "'") quote = null;
+      else source += char;
+    } else if (char === '\\') {
+      const next = input[index + 1];
+      if (next === undefined) return trimmed;
+      if (!quote || /["\\$`\n]/.test(next)) {
+        if (next !== '\n') source += next;
+        index += 1;
+      } else source += char;
+    } else if (char === quote) {
+      quote = null;
+    } else if (!quote && (char === "'" || char === '"')) {
+      quote = char;
+    } else if (!quote && /\s|[;&|<>]/.test(char)) {
+      return trimmed;
+    } else source += char;
+  }
+  return quote ? trimmed : source.trim();
 }
 
 export function shellCommandSegments(command) {

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -274,6 +274,13 @@ describe('benchmark run guards', () => {
     const quotedNewline = "printf '%s' 'before" + '\\'.repeat(2) + "\nafter'";
     expect(topLevelShellCommand(`/bin/zsh -lc "${quotedNewline}"`)).toBe("printf '%s' 'before\\\nafter'");
     expect(topLevelShellCommand('/bin/zsh -lc "echo before\\\nafter"')).toBe('echo beforeafter');
+    const apostrophe = `printf '%s' "it's ready"`;
+    const quoted = "'" + apostrophe.replaceAll("'", "'\"'\"'") + "'";
+    expect(topLevelShellCommand(`/bin/zsh -lc ${quoted}`)).toBe(apostrophe);
+    expect(topLevelShellCommand('/bin/zsh -lc "echo ok"; cat app/_layout.tsx')).toBe(
+      '/bin/zsh -lc "echo ok"; cat app/_layout.tsx',
+    );
+    expect(topLevelShellCommand('/bin/zsh -lc "unterminated')).toBe('/bin/zsh -lc "unterminated');
   });
 
   it('rejects setup recovery inside the timer', () => {

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -35,11 +35,10 @@ function successful(command) {
 }
 
 function shellCommand(command) {
-  const value = String(command ?? '').trim();
-  const normalized = topLevelShellCommand(value);
-  if (normalized !== value || !/^\/bin\/(?:zsh|bash|sh) -lc\s+/.test(value)) return normalized;
-  const body = value.replace(/^\/bin\/(?:zsh|bash|sh) -lc\s+/, '');
-  return body.replace(/^["']/, '').replace(/["']$/, '').trim();
+  return topLevelShellCommand(command).replace(
+    /^"\$ANDROID_HOME\/(?:platform-tools\/(adb)|emulator\/(emulator)|cmdline-tools\/latest\/bin\/(avdmanager|sdkmanager))"(?=\s|$)/,
+    (_, adb, emulator, sdkTool) => adb ?? emulator ?? sdkTool,
+  );
 }
 
 function launchCommand(command, arm, platform) {
@@ -95,11 +94,69 @@ function sourceInspectionBeforeCapture(command, arm, platform) {
   return false;
 }
 
-function allowedBeforeErrorCapture(command, arm, platform) {
+function scopedCopyLoop(value, setup) {
+  const match = value.match(/^set -e\n([A-Za-z_]\w*)=([^\s;$`]+)\nfor ([A-Za-z_]\w*) in ([^;]+); do\n([\s\S]+)\ndone$/);
+  if (!match || !setup.worktree || match[2] !== setup.worktree) return false;
+  const [, destination, , item, paths, body] = match;
+  const allowedPaths = new Set([
+    'node_modules',
+    'android/.gradle',
+    'android/build',
+    'android/.cxx',
+    'android/app/build',
+    'android/app/.cxx',
+    'android/local.properties',
+    'ios/Pods',
+    'ios/build',
+  ]);
+  if (
+    !paths
+      .trim()
+      .split(/\s+/)
+      .every((path) => allowedPaths.has(path))
+  )
+    return false;
+  const expected = [
+    `if [ -e "$${item}" ]; then`,
+    `mkdir -p "$${destination}/$(dirname "$${item}")"`,
+    `rsync -a --exclude='generated/autolinking/' "$${item}" "$${destination}/$(dirname "$${item}")/"`,
+    'fi',
+  ];
+  return (
+    body
+      .split('\n')
+      .map((line) => line.trim())
+      .join('\n') === expected.join('\n')
+  );
+}
+
+function ownedAvdEdit(value, setup) {
+  if (!setup.avdConfig) return false;
+  const match = value.match(/^tool:(file_change|Edit|Write) ([\s\S]+)$/);
+  if (!match) return false;
+  try {
+    const payload = JSON.parse(match[2]);
+    const changes = match[1] === 'file_change' ? payload : [{ path: payload.file_path }];
+    return Array.isArray(changes) && changes.length > 0 && changes.every((change) => change.path === setup.avdConfig);
+  } catch {
+    return false;
+  }
+}
+
+function avdMetadataRead(value, setup) {
+  const query = value.replace(/\s+\|\|\s+true$/, '');
+  const match = query.match(/^(?:rg|grep|cat)\s+([\s\S]*?)([^\s'";]+\.ini)$/);
+  if (!match || /`|\$\(/.test(query) || shellCommandSegments(query).length !== 1) return false;
+  const target = match[2];
+  return target === setup.avdConfig || /^\/[^\s;]+\/TemporaryItems\/avd\/running\/pid_\d+\.ini$/.test(target);
+}
+
+function allowedBeforeErrorCapture(command, arm, platform, setup = {}) {
   const value = shellCommand(command);
   if (/^(?:stim\s+(?:guide|doctor|worktree\s+warm)\b|rsync\b|pgrep\b|sed\b|cat\b)/.test(value)) {
     const segments = shellCommandSegments(value);
-    if (segments.length > 1) return segments.every((segment) => allowedBeforeErrorCapture(segment, arm, platform));
+    if (segments.length > 1)
+      return segments.every((segment) => allowedBeforeErrorCapture(segment, arm, platform, setup));
   }
   if (/^tool:todo_list\b/.test(value)) return true;
   if (/^(?:env\s+)?(?:[^\s=]+=[^\s]+\s+)*agent-device\s+/.test(value)) return true;
@@ -112,6 +169,29 @@ function allowedBeforeErrorCapture(command, arm, platform) {
     return true;
   }
   if (sourceInspectionBeforeCapture(value, arm, platform)) return false;
+  if (arm === 'control') {
+    if (scopedCopyLoop(value, setup)) return true;
+    const architecture = value.replace(/^ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a\s+/, '');
+    if (architecture !== value) return allowedBeforeErrorCapture(architecture, arm, platform, setup);
+    const logged = value.match(/^([\s\S]+)\s+\|\s+tee(?:\s+-a)?\s+\/(?:private\/)?tmp\/[A-Za-z0-9_.-]+\.log$/);
+    if (logged) return allowedBeforeErrorCapture(logged[1], arm, platform, setup);
+    if (platform === 'android') {
+      if (
+        /^printenv(?:\s+(?:ANDROID_AVD_HOME|ANDROID_HOME|GRADLE_USER_HOME|ANDROID_EMU_CRASH_REPORTING_DATABASE))+$/.test(
+          value,
+        )
+      )
+        return true;
+      if (ownedAvdEdit(value, setup)) return true;
+      if (/^(?:rg|grep|cat)\s+[\s\S]*\.ini(?:\s+\|\|\s+true)?$/.test(value)) return avdMetadataRead(value, setup);
+      if (
+        /^adb\s+-s\s+[A-Za-z0-9_-]+\s+wait-for-device\s+shell\s+'until \[ "\$\(getprop sys\.boot_completed\)" = "1" \]; do sleep 1; done; getprop sys\.boot_completed'$/.test(
+          value,
+        )
+      )
+        return true;
+    }
+  }
   if (
     arm === 'control' &&
     /^(?:\.\/)?node_modules\/\.bin\/expo\s+start(?:\s|$)/.test(value) &&
@@ -187,9 +267,10 @@ function allowedBeforeErrorCapture(command, arm, platform) {
     )
       return true;
     const segments = shellCommandSegments(value);
-    if (segments.length > 1) return segments.every((segment) => allowedBeforeErrorCapture(segment, arm, platform));
+    if (segments.length > 1)
+      return segments.every((segment) => allowedBeforeErrorCapture(segment, arm, platform, setup));
     if (/^(?:avdmanager|emulator|sdkmanager)\b/.test(value)) return true;
-    if (/^(?:printf|echo)\s+['"]?(?:no|n)(?:\\n)?['"]?$/.test(value)) return true;
+    if (/^(?:printf|echo)\s+['"]?(?:no|n)(?:\\{1,2}n)?['"]?$/.test(value)) return true;
     if (
       /^(?:printf|echo)\s+['"]disk\.dataPartition\.size=8589934592(?:\\n)?['"]\s*>>?\s*[^;&|]+\/config\.ini['"]?$/.test(
         value,
@@ -206,7 +287,10 @@ function allowedBeforeErrorCapture(command, arm, platform) {
   );
 }
 
-export function launchCrashDiagnosis(commands, { dispatchAt, token, arm = 'stim', platform = 'ios', activities = [] }) {
+export function launchCrashDiagnosis(
+  commands,
+  { dispatchAt, token, arm = 'stim', platform = 'ios', activities = [], setup = {} },
+) {
   const ordered = orderedCommands(commands);
   const sourceMarkers = ['app/_layout.tsx', 'RootLayout'];
   const initialLaunchIndex = ordered.findIndex(
@@ -230,15 +314,17 @@ export function launchCrashDiagnosis(commands, { dispatchAt, token, arm = 'stim'
   const preCaptureActivity = [...ordered, ...activities].toSorted(
     (left, right) => timestamp(left, 'startedAt') - timestamp(right, 'startedAt'),
   );
-  const disallowedBeforeCapture = preCaptureActivity.find(
+  const disallowedBeforeCapture = preCaptureActivity.filter(
     (command) =>
-      timestamp(command, 'startedAt') < captureEndedAt && !allowedBeforeErrorCapture(command.command, arm, platform),
+      timestamp(command, 'startedAt') < captureEndedAt &&
+      !allowedBeforeErrorCapture(command.command, arm, platform, setup),
   );
-  if (disallowedBeforeCapture) {
+  if (disallowedBeforeCapture.length) {
     return {
       valid: false,
       reason: 'launch-crash-pre-capture-command-not-allowed',
-      commandId: disallowedBeforeCapture.id,
+      commandId: disallowedBeforeCapture[0].id,
+      violations: disallowedBeforeCapture.map(({ id, command }) => ({ commandId: id, command })),
     };
   }
   const capture = ordered[errorCaptureIndex];

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -34,6 +34,12 @@ function successful(command) {
   return command.exitCode === 0;
 }
 
+function successfulLaunch(command, arm, platform) {
+  if (!successful(command) || !launchCommand(command.command, arm, platform)) return false;
+  const value = shellCommand(command.command);
+  return !/\|\s*tee\b/.test(value) || /^set -(?:o|eo|euo) pipefail\s*(?:;|\n)/.test(value);
+}
+
 function shellCommand(command) {
   return topLevelShellCommand(command).replace(
     /^"\$ANDROID_HOME\/(?:platform-tools\/(adb)|emulator\/(emulator)|cmdline-tools\/latest\/bin\/(avdmanager|sdkmanager))"(?=\s|$)/,
@@ -145,9 +151,11 @@ function ownedAvdEdit(value, setup) {
 
 function avdMetadataRead(value, setup) {
   const query = value.replace(/\s+\|\|\s+true$/, '');
-  const match = query.match(/^(?:rg|grep|cat)\s+([\s\S]*?)([^\s'";]+\.ini)$/);
+  const match = query.match(
+    /^(?:cat(?:\s+-n)?|(?:rg|grep)(?:\s+-[nEiFv]+)*\s+(?:'[^']*'|"[^"$`]*"|[A-Za-z0-9_.^=:-]+))\s+([^\s'";]+\.ini)$/,
+  );
   if (!match || /`|\$\(/.test(query) || shellCommandSegments(query).length !== 1) return false;
-  const target = match[2];
+  const target = match[1];
   return target === setup.avdConfig || /^\/[^\s;]+\/TemporaryItems\/avd\/running\/pid_\d+\.ini$/.test(target);
 }
 
@@ -170,6 +178,8 @@ function allowedBeforeErrorCapture(command, arm, platform, setup = {}) {
   }
   if (sourceInspectionBeforeCapture(value, arm, platform)) return false;
   if (arm === 'control') {
+    const pipefail = value.replace(/^set -(?:o|eo|euo) pipefail\s*(?:;|\n)\s*/, '');
+    if (pipefail !== value) return allowedBeforeErrorCapture(pipefail, arm, platform, setup);
     if (scopedCopyLoop(value, setup)) return true;
     const architecture = value.replace(/^ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a\s+/, '');
     if (architecture !== value) return allowedBeforeErrorCapture(architecture, arm, platform, setup);
@@ -293,9 +303,7 @@ export function launchCrashDiagnosis(
 ) {
   const ordered = orderedCommands(commands);
   const sourceMarkers = ['app/_layout.tsx', 'RootLayout'];
-  const initialLaunchIndex = ordered.findIndex(
-    (command) => successful(command) && launchCommand(command.command, arm, platform),
-  );
+  const initialLaunchIndex = ordered.findIndex((command) => successfulLaunch(command, arm, platform));
   if (initialLaunchIndex === -1) {
     return { valid: false, reason: 'launch-crash-initial-launch-evidence-missing' };
   }

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -41,7 +41,7 @@ done`;
     const launch = {
       id: 'launch',
       command:
-        'ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a ./node_modules/.bin/expo run:android --device emulator-5554 --no-bundler 2>&1 | tee -a /tmp/native.log',
+        'set -o pipefail; ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a ./node_modules/.bin/expo run:android --device emulator-5554 --no-bundler 2>&1 | tee -a /tmp/native.log',
       exitCode: 0,
       startedAt: '2026-09-04T12:00:03Z',
       endedAt: '2026-09-04T12:00:10Z',
@@ -71,6 +71,20 @@ done`;
       valid: true,
       errorCaptureCommandId: 'logs',
     });
+    const masked = {
+      ...launch,
+      id: 'masked',
+      command: './node_modules/.bin/expo run:android --bad-option 2>&1 | tee /tmp/native.log',
+      output: 'CommandError: unsupported flag',
+    };
+    expect(launchCrashDiagnosis([...before, masked, logs], options)).toMatchObject({
+      valid: false,
+      reason: 'launch-crash-initial-launch-evidence-missing',
+    });
+    expect(launchCrashDiagnosis([...before, masked, launch, logs], options)).toMatchObject({
+      valid: true,
+      initialLaunchCommandId: 'launch',
+    });
     expect(launchCrashDiagnosis([...before, launch, logs], { ...options, setup: {} })).toMatchObject({ valid: false });
     for (const command of [
       copy.replace('rsync -a', 'cat package.json\n    rsync -a'),
@@ -79,6 +93,9 @@ done`;
       './node_modules/.bin/expo start | tee /tmp/metro.log; cat package.json',
       './node_modules/.bin/expo start --port $(cat private-port) | tee /tmp/metro.log',
       'rg anything /tmp/other.avd/config.ini',
+      `cat package.json ${setup.avdConfig}`,
+      `rg -n . package.json ${setup.avdConfig}`,
+      `cat ./app/_layout.t\\sx ${setup.avdConfig}`,
       `tool:file_change ${JSON.stringify([{ path: '/tmp/other.avd/config.ini', kind: 'update' }])}`,
     ]) {
       expect(launchCrashDiagnosis([{ ...before[0], command, id: 'bad' }, launch, logs], options)).toMatchObject({

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -9,6 +9,95 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it('audits a complete managed Android setup and reports every out-of-scope operation', () => {
+    const token = launchCrashToken('managed-setup');
+    const setup = { worktree: '/tmp/run', avdConfig: '/tmp/avds/Trailhead_run.avd/config.ini' };
+    const copy = `set -e
+run=/tmp/run
+for rel in node_modules android/.gradle android/build android/app/build android/app/.cxx ios/Pods; do
+  if [ -e "$rel" ]; then
+    mkdir -p "$run/$(dirname "$rel")"
+    rsync -a --exclude='generated/autolinking/' "$rel" "$run/$(dirname "$rel")/"
+  fi
+done`;
+    const inputs = [
+      copy,
+      `printf 'no\\n' | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd -n Trailhead_run -k 'system-images;android-36;google_apis_playstore_ps16k;arm64-v8a'`,
+      'printenv ANDROID_AVD_HOME',
+      `rg '^disk\\.dataPartition\\.size=' ${setup.avdConfig} || true`,
+      '"$ANDROID_HOME/emulator/emulator" -avd Trailhead_run 2>&1 | tee /tmp/emulator.log',
+      './node_modules/.bin/expo start --dev-client --port 8081 2>&1 | tee /tmp/metro.log',
+      `rg '^(port\\.serial|avd\\.name|pid)=' /Users/example/Library/Caches/TemporaryItems/avd/running/pid_123.ini`,
+      `"$ANDROID_HOME/platform-tools/adb" -s emulator-5554 wait-for-device shell 'until [ "$(getprop sys.boot_completed)" = "1" ]; do sleep 1; done; getprop sys.boot_completed'`,
+      '"$ANDROID_HOME/platform-tools/adb" -s emulator-5554 reverse tcp:8081 tcp:8081',
+    ];
+    const before = inputs.map((command, index) => ({
+      id: `setup-${index}`,
+      command: `/bin/zsh -lc '` + command.replaceAll("'", "'\"'\"'") + "'",
+      exitCode: 0,
+      startedAt: '2026-09-04T12:00:01Z',
+      endedAt: '2026-09-04T12:00:02Z',
+    }));
+    const launch = {
+      id: 'launch',
+      command:
+        'ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a ./node_modules/.bin/expo run:android --device emulator-5554 --no-bundler 2>&1 | tee -a /tmp/native.log',
+      exitCode: 0,
+      startedAt: '2026-09-04T12:00:03Z',
+      endedAt: '2026-09-04T12:00:10Z',
+    };
+    const logs = {
+      id: 'logs',
+      command: 'rg -n -i -C 8 "error|exception" /tmp/metro.log',
+      output: `${token}\napp/_layout.tsx:27`,
+      exitCode: 0,
+      startedAt: '2026-09-04T12:00:11Z',
+      endedAt: '2026-09-04T12:00:12Z',
+    };
+    const edit = {
+      id: 'config',
+      command: `tool:file_change ${JSON.stringify([{ path: setup.avdConfig, kind: 'update' }])}`,
+      startedAt: '2026-09-04T12:00:01Z',
+    };
+    const options = {
+      dispatchAt: '2026-09-04T12:00:00Z',
+      token,
+      arm: 'control',
+      platform: 'android',
+      setup,
+      activities: [edit],
+    };
+    expect(launchCrashDiagnosis([...before, launch, logs], options)).toMatchObject({
+      valid: true,
+      errorCaptureCommandId: 'logs',
+    });
+    expect(launchCrashDiagnosis([...before, launch, logs], { ...options, setup: {} })).toMatchObject({ valid: false });
+    for (const command of [
+      copy.replace('rsync -a', 'cat package.json\n    rsync -a'),
+      copy.replace('node_modules android/.gradle', 'app node_modules android/.gradle'),
+      'printenv SECRET_KEY',
+      './node_modules/.bin/expo start | tee /tmp/metro.log; cat package.json',
+      './node_modules/.bin/expo start --port $(cat private-port) | tee /tmp/metro.log',
+      'rg anything /tmp/other.avd/config.ini',
+      `tool:file_change ${JSON.stringify([{ path: '/tmp/other.avd/config.ini', kind: 'update' }])}`,
+    ]) {
+      expect(launchCrashDiagnosis([{ ...before[0], command, id: 'bad' }, launch, logs], options)).toMatchObject({
+        valid: false,
+        commandId: 'bad',
+      });
+    }
+    const violations = launchCrashDiagnosis(
+      [
+        { ...before[0], id: 'first', command: 'cat app/_layout.tsx' },
+        { ...before[0], id: 'second', command: 'printenv SECRET_KEY' },
+        launch,
+        logs,
+      ],
+      options,
+    );
+    expect(violations.violations.map((item) => item.commandId)).toEqual(['first', 'second']);
+  });
+
   it.each(['ios', 'android'])(
     'accepts a live managed Metro session without accepting unfinished %s launch evidence',
     (platform) => {
@@ -262,6 +351,7 @@ describe('launch crash benchmark', () => {
       valid: false,
       reason: 'launch-crash-pre-capture-command-not-allowed',
       commandId: 'inspect',
+      violations: [{ commandId: 'inspect', command: commands[0].command }],
     });
   });
 
@@ -364,6 +454,7 @@ describe('launch crash benchmark', () => {
         valid: false,
         reason: 'launch-crash-pre-capture-command-not-allowed',
         commandId: 'inspect',
+        violations: [{ commandId: 'inspect', command }],
       });
     }
   });
@@ -695,6 +786,7 @@ describe('launch crash benchmark', () => {
         valid: false,
         reason: 'launch-crash-pre-capture-command-not-allowed',
         commandId: 'mixed',
+        violations: [{ commandId: 'mixed', command }],
       });
     }
   });


### PR DESCRIPTION
## Description

Launch-error control can recover the app correctly but fail its audit on ordinary setup syntax: `set -e` copy loops, quoted SDK paths, and `tee` logging. Codex's concatenated shell quotes also expose a decoding bug in normalization shared by other benchmark audits.

The [original pre-capture allowlist](https://github.com/appandflow/stim/commit/a19b03a4476c9490c162275541e2df4f0980c039) deliberately prevents source inspection before diagnosis. This keeps that rule while recognizing more of the setup the benchmark itself requests.

## Solution

Decode one shell-wrapper layer without execution, recognize scoped control setup, and report every rejected operation instead of only the first. AVD edits must target the configuration path recorded at dispatch; the copy-loop allowance is limited to recognized native/dependency inputs and the run worktree.

A launch piped through `tee` counts only when that shell enables `pipefail`; otherwise zero exit status proves only the log writer succeeded. The control prompt requires this explicitly.

This is benchmark-only. Unknown operations remain rejected, and filesystem isolation remains the security boundary. Historical invalid results stay unchanged; the timed retry has not run yet.

## Test plan

- Replay retained control evidence read-only: setup forms are recognized, but its `tee` launches lack upstream exit evidence and remain unqualified.
- Exercise a complete synthetic managed Android setup plus rejection cases for hidden source reads, substitutions, another AVD, and multiple violations. Existing shell quoting and proof-boundary cases still pass.
- After merge, retry Sol Android control with version, cache, device, timing and proof gates unchanged.

Fixes #498
