### PR TITLE
fix: review unfamiliar benchmark setup

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -145,8 +145,10 @@ Launch-error control may use runner-managed sessions instead of detached shell
 jobs and keeps the inherited Android SDK, AVD, Gradle, and emulator-report
 locations unchanged so device verification and cleanup see the same metadata.
 The launch-error audit recognizes scoped setup and log capture across shell
-quoting forms. It reports all rejected operations for investigation; source
-inspection before completed error capture still invalidates the attempt.
+quoting forms. Unfamiliar setup syntax produces review notes rather than an
+automatic failure. Those notes are reviewed before publication. Detected source
+inspection before completed error capture still invalidates the attempt, as do
+failed version, isolation, device, exact-repair and screenshot/video proof checks.
 Installing dependencies inside the timed interval, a failed `guide agent` or
 `worktree warm`, and an Android native build without Stim's `--build-cache`
 evidence invalidate the attempt.

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -186,10 +186,14 @@ same metadata as the agent.
 
 The pre-capture audit decodes shell quoting without executing it and recognizes
 scoped setup operations, including local SDK tools, managed log pipelines, and
-the assigned AVD's configuration edit. Collection reports every rejected command
-in `diagnosis.violations`, retaining the first rejection in `commandId`. Unknown
-commands and source inspection still invalidate the attempt; this is not a
-replacement for the runner's filesystem isolation.
+the assigned AVD's configuration edit. Unrecognized setup syntax is retained in
+`diagnosis.setupWarnings` for review, not automatically treated as a failed task.
+Review these commands before publication; a warning is not a safety approval.
+Detected source inspection before completed log capture remains a hard failure,
+with every offending command in `diagnosis.violations` and the first in `commandId`.
+Version, isolation, warm ordering, device, exact repair, timing, screenshot and
+recording gates remain unchanged. This heuristic audit does not prove arbitrary
+shell programs are safe or replace the runner's filesystem isolation.
 Build/launch pipelines ending in `tee` must enable `set -o pipefail` in the same
 shell command. Without it, zero exit status proves only the log writer finished,
 so the command cannot establish initial launch success.
@@ -235,3 +239,14 @@ and `correctionSourceSha256`. Export matches every command against the retained
 events and reruns the current session audit. It can clear only the sole
 `agent-device-run-session-not-applied` reason; every evidence check still applies.
 Keep the original verdict and correction provenance private, outside Git.
+
+For launch-error runs, `launch-error-audit-review.json` records a review of each
+unrecognized setup command. It contains `schemaVersion: 1`, `runId`,
+`originalRecordSha256`, `metaSha256`, `policySha256` (the launch-crash audit source),
+`shellParserSha256` (run-guards), and ordered `commands` entries with `commandId`,
+the exact `command`, and a nonempty `assessment`. Export re-derives diagnosis,
+recovery and diagnosis-time usage from hash-verified retained evidence. A review
+can clear only setup-syntax rejection and its missing-diagnosis/usage consequences;
+it cannot clear other failure reasons or source-before-capture violations. Valid
+runs with setup warnings also require review before publication. The original
+`run.json` is never rewritten, and review records stay private.

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -14,6 +14,7 @@ import { userInfo } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { stripVTControlCharacters } from 'node:util';
 import { launchCrashDiagnosis, launchCrashRecovery } from './launch-crash-benchmark.mjs';
+import { reconstructCommandEvidence } from './agent-benchmark/command-evidence.mjs';
 import { agentDeviceIsolationInvalidReasons, topLevelShellCommand } from './agent-benchmark/run-guards.mjs';
 
 const modelPricing = {
@@ -801,40 +802,6 @@ function validateReadinessRecord(runDir, record, meta) {
   return { screenReadySeconds };
 }
 
-function nonShellActivitiesFor(runDir) {
-  const eventsPath = join(runDir, 'events.jsonl');
-  if (!existsSync(eventsPath)) return [];
-  const activities = [];
-  for (const record of readFileSync(eventsPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse)) {
-    let event;
-    try {
-      event = JSON.parse(record.line);
-    } catch {
-      continue;
-    }
-    const item = event.item;
-    if (event.type === 'item.started' && item?.type && item.type !== 'command_execution') {
-      activities.push({
-        id: item.id,
-        command: `tool:${item.type} ${JSON.stringify(item.changes ?? item)}`,
-        startedAt: record.arrivedAt,
-        endedAt: record.arrivedAt,
-      });
-    }
-    for (const block of event.message?.content ?? []) {
-      if (event.type === 'assistant' && block.type === 'tool_use' && block.name !== 'Bash') {
-        activities.push({
-          id: block.id,
-          command: `tool:${block.name} ${JSON.stringify(block.input ?? {})}`,
-          startedAt: record.arrivedAt,
-          endedAt: record.arrivedAt,
-        });
-      }
-    }
-  }
-  return activities;
-}
-
 function usageAtOrBefore(path, observedAt) {
   if (!path || !existsSync(path)) return null;
   const cutoff = Date.parse(observedAt);
@@ -864,7 +831,7 @@ function sameUsage(left, right) {
   );
 }
 
-function validateLaunchCrashRecord(runDir, record, meta) {
+function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
   const reject = (reason) => {
     if (process.env.STIM_BENCH_EXPORT_DEBUG === '1') {
       process.stderr.write(`${basename(runDir)}: ${reason}\n`);
@@ -877,13 +844,11 @@ function validateLaunchCrashRecord(runDir, record, meta) {
     return reject('invalid evidence files');
   if (record.evidenceSha256?.events !== fileSha256(eventsPath)) return reject('events hash mismatch');
   if (record.evidenceSha256?.settingsPng !== fileSha256(proofPath)) return reject('screenshot hash mismatch');
-  const eventData = eventsFor(runDir, meta.dispatchAt, []);
-  const commands = eventData.commands.map((command) =>
-    Object.assign({}, command, {
-      startedAt: new Date(Date.parse(meta.dispatchAt) + command.startSeconds * 1000).toISOString(),
-      endedAt: new Date(Date.parse(meta.dispatchAt) + command.endSeconds * 1000).toISOString(),
-    }),
+  const evidence = reconstructCommandEvidence(
+    record.runner ?? meta.runner,
+    readFileSync(eventsPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse),
   );
+  const commands = evidence.commands;
   const token = [record.proof?.expected, ...commands.map((command) => command.output)]
     .join('\n')
     .match(/STIM_BENCH_LAUNCH_CRASH_[0-9A-F]{12}/)?.[0];
@@ -893,7 +858,8 @@ function validateLaunchCrashRecord(runDir, record, meta) {
     token,
     arm: record.arm,
     platform: meta.platform ?? 'ios',
-    activities: nonShellActivitiesFor(runDir),
+    activities: evidence.activities,
+    setup: { worktree: record.worktree, avdConfig: meta.expectedControlAvdConfig },
   });
   const recovery = launchCrashRecovery(commands, {
     diagnosis,
@@ -910,6 +876,8 @@ function validateLaunchCrashRecord(runDir, record, meta) {
   const diagnosisUsage = runner === 'claude' ? null : usageAtOrBefore(transcriptPath, diagnosis.observedAt);
   if (!existsSync(transcriptPath)) return reject('transcript missing');
   if (record.evidenceSha256?.transcript !== fileSha256(transcriptPath)) return reject('transcript hash mismatch');
+  if (runner !== 'claude' && !diagnosisUsage) return reject('diagnosis usage missing');
+  if (rederive) return { diagnosis, recovery, diagnosisUsage, screenReadySeconds };
   if (
     record.diagnosis?.observedAt !== diagnosis.observedAt ||
     record.dispatchToDiagnosisSeconds !== diagnosis.dispatchToDiagnosisSeconds ||
@@ -935,6 +903,63 @@ function validateLaunchCrashRecord(runDir, record, meta) {
 function publicationRecord(runDir, meta) {
   const recordPath = join(runDir, 'run.json');
   const record = readJson(recordPath);
+  if (record.variant === 'launch-crash') {
+    const reviewPath = join(runDir, 'launch-error-audit-review.json');
+    const reviewableReasons = new Set([
+      'launch-crash-pre-capture-command-not-allowed',
+      'launch-crash-diagnosis-missing',
+      'launch-crash-diagnosis-usage-missing',
+    ]);
+    const eligible =
+      record.valid ||
+      (record.invalidReasons?.length > 0 && record.invalidReasons.every((reason) => reviewableReasons.has(reason)));
+    const derived = eligible ? validateLaunchCrashRecord(runDir, record, meta, true) : null;
+    if (!derived) return record.valid ? { ...record, valid: false } : record;
+    const warnings = derived.diagnosis.setupWarnings ?? [];
+    if (!warnings.length && record.valid) return record;
+    if (!existsSync(reviewPath)) return { ...record, valid: false };
+    const review = readJson(reviewPath);
+    const policyPath = fileURLToPath(new URL('./launch-crash-benchmark.mjs', import.meta.url));
+    const guardPath = fileURLToPath(new URL('./agent-benchmark/run-guards.mjs', import.meta.url));
+    if (
+      review.schemaVersion !== 1 ||
+      review.runId !== record.runId ||
+      review.originalRecordSha256 !== fileSha256(recordPath) ||
+      review.metaSha256 !== fileSha256(join(runDir, 'meta.json')) ||
+      review.policySha256 !== fileSha256(policyPath) ||
+      review.shellParserSha256 !== fileSha256(guardPath) ||
+      !Array.isArray(review.commands) ||
+      review.commands.length !== warnings.length ||
+      warnings.some(
+        (warning, index) =>
+          review.commands[index]?.commandId !== warning.commandId ||
+          review.commands[index]?.command !== warning.command ||
+          typeof review.commands[index]?.assessment !== 'string' ||
+          !review.commands[index].assessment.trim(),
+      )
+    ) {
+      return { ...record, valid: false };
+    }
+    const usage = derived.diagnosisUsage;
+    return {
+      ...record,
+      valid: true,
+      invalidReasons: [],
+      diagnosis: derived.diagnosis,
+      recovery: derived.recovery,
+      dispatchToDiagnosisSeconds: derived.diagnosis.dispatchToDiagnosisSeconds,
+      diagnosisCommandCount: derived.diagnosis.commandCount,
+      diagnosisUsage: usage,
+      diagnosisTokens: usage
+        ? {
+            uncachedInput: Math.max(0, (usage.input_tokens ?? 0) - (usage.cached_input_tokens ?? 0)),
+            cachedInput: usage.cached_input_tokens ?? 0,
+            output: usage.output_tokens ?? 0,
+            reasoningOutput: usage.reasoning_output_tokens ?? 0,
+          }
+        : null,
+    };
+  }
   const correctionPath = join(runDir, 'lookup-audit-correction.json');
   if (record.valid || !existsSync(correctionPath)) return record;
   const correction = readJson(correctionPath);

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1257,6 +1257,85 @@ describe('benchmark viewer export', () => {
     });
 
     const original = JSON.parse(readFileSync(recordPath, 'utf8'));
+    const eventsPath = join(runDir, 'events.jsonl');
+    const originalEvents = readFileSync(eventsPath, 'utf8');
+    const unfamiliar = `/bin/zsh -lc "printf 'SETUP_COMPLETE\\n'"`;
+    const reviewedEvents =
+      originalEvents
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          const stamped = JSON.parse(line);
+          const event = JSON.parse(stamped.line);
+          if (event.item.id === 'metadata') event.item.command = unfamiliar;
+          return JSON.stringify({ ...stamped, line: JSON.stringify(event) });
+        })
+        .join('\n') + '\n';
+    writeFileSync(eventsPath, reviewedEvents);
+    const rejected = {
+      ...original,
+      valid: false,
+      invalidReasons: [
+        'launch-crash-pre-capture-command-not-allowed',
+        'launch-crash-diagnosis-missing',
+        'launch-crash-diagnosis-usage-missing',
+      ],
+      diagnosis: { valid: false, reason: 'launch-crash-pre-capture-command-not-allowed' },
+      recovery: { valid: false, reason: 'launch-crash-diagnosis-missing' },
+      dispatchToDiagnosisSeconds: null,
+      diagnosisUsage: null,
+      diagnosisCommandCount: null,
+      evidenceSha256: { ...original.evidenceSha256, events: sha256(eventsPath) },
+    };
+    writeFileSync(recordPath, JSON.stringify(rejected));
+    const reviewedExport = () => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'proof'));
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
+    writeFileSync(recordPath, JSON.stringify({ ...original, evidenceSha256: rejected.evidenceSha256 }));
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
+    writeFileSync(recordPath, JSON.stringify(rejected));
+    const reviewPath = join(runDir, 'launch-error-audit-review.json');
+    const review = {
+      schemaVersion: 1,
+      runId: rejected.runId,
+      originalRecordSha256: sha256(recordPath),
+      metaSha256: sha256(join(runDir, 'meta.json')),
+      policySha256: sha256(join(process.cwd(), 'scripts/launch-crash-benchmark.mjs')),
+      shellParserSha256: sha256(join(process.cwd(), 'scripts/agent-benchmark/run-guards.mjs')),
+      commands: [
+        {
+          commandId: 'metadata',
+          command: unfamiliar,
+          assessment: 'Prints a literal setup-complete message; no source access.',
+        },
+      ],
+    };
+    writeFileSync(reviewPath, JSON.stringify(review));
+    expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90, settingsReadySeconds: 150 });
+    expect(JSON.parse(readFileSync(recordPath))).toEqual(rejected);
+    for (const changed of [
+      { originalRecordSha256: 'changed' },
+      { metaSha256: 'changed' },
+      { policySha256: 'changed' },
+      { shellParserSha256: 'changed' },
+      { commands: [] },
+      { commands: [{ ...review.commands[0], command: 'different' }] },
+      { commands: [{ ...review.commands[0], assessment: '' }] },
+    ]) {
+      writeFileSync(reviewPath, JSON.stringify({ ...review, ...changed }));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
+    }
+    writeFileSync(
+      recordPath,
+      JSON.stringify({ ...rejected, invalidReasons: [...rejected.invalidReasons, 'control-emulator-mismatch'] }),
+    );
+    writeFileSync(reviewPath, JSON.stringify({ ...review, originalRecordSha256: sha256(recordPath) }));
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
+    writeFileSync(recordPath, JSON.stringify(rejected));
+    writeFileSync(reviewPath, JSON.stringify(review));
+    writeFileSync(eventsPath, reviewedEvents.replaceAll('SETUP_COMPLETE', 'app/_layout.tsx'));
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
+    writeFileSync(eventsPath, originalEvents);
+    rmSync(reviewPath);
     for (const mutate of [
       (record) => (record.dispatchToDiagnosisSeconds = 1),
       (record) => (record.diagnosisCommandCount = 1),

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -88,8 +88,14 @@ function orderedCommands(commands) {
 }
 
 function sourceInspectionBeforeCapture(command, arm, platform) {
-  const value = shellCommand(command);
+  const value = shellCommand(command).replace(/\\([A-Za-z_.])/g, '$1');
   if (/(?:\/(?:skills|skill)\/[^\s]+\/|(?:^|\s)workspace\/)SKILL\.md\b/.test(value)) return false;
+  if (
+    shellCommandSegments(value).some(
+      (segment) => /^(?:rg|grep)\b/.test(segment) && /\s(?:\.|app|src)\/?\s*$/.test(segment),
+    )
+  )
+    return true;
   if (/(?:^|[;&|]\s*)git\s+(?:diff|show)(?!-ref)(?:\s|$)/.test(value)) return true;
   if (/(?:^|[;&|]\s*)(?:\/[^\s]+\/)?(?:node|python\d*|ruby|perl)\s+(?:-[^-\s]*[ec]|--eval)\b/.test(value)) {
     return true;
@@ -322,10 +328,13 @@ export function launchCrashDiagnosis(
   const preCaptureActivity = [...ordered, ...activities].toSorted(
     (left, right) => timestamp(left, 'startedAt') - timestamp(right, 'startedAt'),
   );
-  const disallowedBeforeCapture = preCaptureActivity.filter(
+  const unrecognizedBeforeCapture = preCaptureActivity.filter(
     (command) =>
       timestamp(command, 'startedAt') < captureEndedAt &&
       !allowedBeforeErrorCapture(command.command, arm, platform, setup),
+  );
+  const disallowedBeforeCapture = unrecognizedBeforeCapture.filter((command) =>
+    sourceInspectionBeforeCapture(command.command, arm, platform),
   );
   if (disallowedBeforeCapture.length) {
     return {
@@ -361,6 +370,9 @@ export function launchCrashDiagnosis(
   }
   return {
     valid: true,
+    ...(unrecognizedBeforeCapture.length
+      ? { setupWarnings: unrecognizedBeforeCapture.map((entry) => ({ commandId: entry.id, command: entry.command })) }
+      : {}),
     observedAt,
     dispatchToDiagnosisSeconds,
     commandCount: ordered.filter((candidate) => timestamp(candidate, 'endedAt') <= Date.parse(observedAt)).length,

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -9,7 +9,7 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
-  it('audits a complete managed Android setup and reports every out-of-scope operation', () => {
+  it('warns on unfamiliar setup while rejecting source inspection before runtime diagnosis', () => {
     const token = launchCrashToken('managed-setup');
     const setup = { worktree: '/tmp/run', avdConfig: '/tmp/avds/Trailhead_run.avd/config.ini' };
     const copy = `set -e
@@ -85,28 +85,39 @@ done`;
       valid: true,
       initialLaunchCommandId: 'launch',
     });
-    expect(launchCrashDiagnosis([...before, launch, logs], { ...options, setup: {} })).toMatchObject({ valid: false });
+    expect(launchCrashDiagnosis([...before, launch, logs], { ...options, setup: {} })).toMatchObject({
+      valid: true,
+      setupWarnings: expect.arrayContaining([{ commandId: before[0].id, command: before[0].command }]),
+    });
     for (const command of [
       copy.replace('rsync -a', 'cat package.json\n    rsync -a'),
-      copy.replace('node_modules android/.gradle', 'app node_modules android/.gradle'),
       'printenv SECRET_KEY',
       './node_modules/.bin/expo start | tee /tmp/metro.log; cat package.json',
       './node_modules/.bin/expo start --port $(cat private-port) | tee /tmp/metro.log',
       'rg anything /tmp/other.avd/config.ini',
       `cat package.json ${setup.avdConfig}`,
       `rg -n . package.json ${setup.avdConfig}`,
-      `cat ./app/_layout.t\\sx ${setup.avdConfig}`,
       `tool:file_change ${JSON.stringify([{ path: '/tmp/other.avd/config.ini', kind: 'update' }])}`,
     ]) {
-      expect(launchCrashDiagnosis([{ ...before[0], command, id: 'bad' }, launch, logs], options)).toMatchObject({
+      expect(launchCrashDiagnosis([{ ...before[0], command, id: 'unfamiliar' }, launch, logs], options)).toMatchObject({
+        valid: true,
+        setupWarnings: [{ commandId: 'unfamiliar', command }],
+      });
+    }
+    for (const command of [
+      copy.replace('rsync -a', 'cat app/_layout.tsx\n    rsync -a'),
+      `cat ./app/_layout.t\\sx ${setup.avdConfig}`,
+      'node -e "require(\'fs\').readFileSync(process.argv[1])" secret-source',
+    ]) {
+      expect(launchCrashDiagnosis([{ ...before[0], command, id: 'source' }, launch, logs], options)).toMatchObject({
         valid: false,
-        commandId: 'bad',
+        commandId: 'source',
       });
     }
     const violations = launchCrashDiagnosis(
       [
         { ...before[0], id: 'first', command: 'cat app/_layout.tsx' },
-        { ...before[0], id: 'second', command: 'printenv SECRET_KEY' },
+        { ...before[0], id: 'second', command: 'git diff' },
         launch,
         logs,
       ],
@@ -154,9 +165,8 @@ done`;
       ).toMatchObject({ valid: false, reason: 'launch-crash-initial-launch-evidence-missing' });
       for (const command of [
         './node_modules/.bin/expo start; cat app/_layout.tsx',
-        './node_modules/.bin/expo start; cat package.json',
-        './node_modules/.bin/expo start --port $(cat private-port)',
-        './node_modules/.bin/expo start --port `cat private-port`',
+        './node_modules/.bin/expo start --port $(cat app/_layout.tsx)',
+        './node_modules/.bin/expo start --port `cat app/_layout.tsx`',
       ]) {
         expect(launchCrashDiagnosis([{ ...commands[0], command }, ...commands.slice(1)], options)).toMatchObject({
           valid: false,


### PR DESCRIPTION
## Description

Sol completed launch-error recovery, but the benchmark discarded the run because its copy, boot-wait and metadata commands used unfamiliar shell syntax. Fixes #501.

The strict allowlist introduced in [the original launch-crash benchmark](https://github.com/appandflow/stim/commit/a19b03a4476c9490c162275541e2df4f0980c039) deliberately rejected every unknown pre-capture command. That rule conflates unsupported audit syntax with an actual task violation.

## Solution

Unrecognized setup now produces review notes for both arms. Detected source access before completed error capture remains a hard failure, including chained repository searches and escaped source paths. Other collection gates are unchanged.

Previously rejected runs can be recovered from retained evidence without changing the original `run.json`. Publication requires a hash-bound assessment of each unfamiliar command and re-derives diagnosis, recovery and usage from raw events, not display-formatted commands.

This trades automatic rejection for explicit reviewer judgment; the shell audit remains heuristic, not a security boundary. No CLI runtime or release change.

## Test plan

Replay retained launch-error command events: unfamiliar setup produces notes, while early source reads, missing logs and unproven launch pipelines still fail. Exercise publication with missing/stale reviews, changed evidence, mismatched commands and an unrelated device failure; none may be published through this review path. Verify the original result remains byte-for-byte unchanged.

Private replay exported both Sol Android arms (Settings: Stim 239.117s, control 547.721s) and retained earlier genuine failures as excluded. The control screenshot shows Settings, its MP4 is playable (62.43s), and the original record hash is unchanged.
