### PR TITLE
docs: document build optimization options on the website

### DIFF
--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -18,6 +18,9 @@ Stim shares four types of work across projects and git worktrees:
 | Gradle caches and output | Repeating Android dependency and task work                |
 | Metro transform cache    | Transforming the same JavaScript modules in each worktree |
 
+See [build optimizations](./build-optimizations.md) for switches, defaults, and
+tradeoffs for each layer, including Android ccache, PCH, and experimental CAS.
+
 ## Native artifact cache
 
 Stim uses `@expo/fingerprint` to identify native inputs in both Expo and bare

--- a/website/docs/build-optimizations.md
+++ b/website/docs/build-optimizations.md
@@ -1,0 +1,152 @@
+---
+title: 'Build optimizations'
+description: 'Control native artifact reuse, compiler caches, PCH, and Metro caching'
+---
+
+import StimTabs from '@site/src/components/StimTabs';
+
+Commands use `stim`. If it is not installed globally, replace `stim` with
+`npx stim-cli`.
+
+Stim enables build optimizations by default. Use the `optimizations` settings to
+disable individual layers when debugging or to opt into experimental compiler
+caching. For an overview of the layers, see [build speed and caches](./build-caches.md).
+
+## Configure optimizations
+
+Put an `optimizations` object at the top level of `~/.stim/config.json` (or
+`$STIM_HOME/config.json`) to set machine defaults without changing a project.
+Merge it into the existing file, preserving project and device records. The same
+object in the repository's `.stim.json`, or in repository or project settings,
+overrides individual values using the [settings layers](./settings.md#settings-layers).
+
+These are the defaults; you only need to include values you want to change:
+
+```json
+{
+  "optimizations": {
+    "buildCache": true,
+    "remoteBuildCache": true,
+    "releaseBundleSwap": true,
+    "metroSharedCache": true,
+    "ios": {
+      "compilationCache": true,
+      "swiftCompilationCache": false,
+      "prefixMapping": true
+    },
+    "android": {
+      "compilerCache": "auto",
+      "pch": "auto",
+      "gradleBuildCache": true,
+      "targetAbiOnly": true
+    }
+  }
+}
+```
+
+An explicit `false` overrides a lower layer's `true`. Removing a key inherits the
+next layer. Changes apply on the next build or Metro restart. These settings
+control Stim's invocations; they do not edit Xcode, Gradle, CMake, or Metro source
+configuration, and direct builds outside Stim keep their own settings.
+
+## Shared options
+
+All keys below are inside `optimizations`.
+
+| Option              | Default | What it does                                                                                                                                                                                                                                     |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `buildCache`        | `true`  | Reads and stores complete native build artifacts. Set to `false` to skip both local and remote artifact reads and writes. Compiler caches remain independent.                                                                                    |
+| `remoteBuildCache`  | `true`  | Allows configured remote artifact cache providers. Set to `false` to skip remote lookup, upload, provider loading, and authentication while keeping the local artifact cache. It does not configure a provider by itself.                        |
+| `releaseBundleSwap` | `true`  | Allows supported Release artifact hits to reuse native code with the current JavaScript and assets inserted into a copy. If swapping fails, Stim builds fresh. Set to `false` to build Release from source; fresh artifacts can still be stored. |
+| `metroSharedCache`  | `true`  | Adds Stim's shared Metro transform store for Expo and bare React Native. Set to `false` to stop adding it; stores configured by the project remain.                                                                                              |
+
+The older machine setting `caches.injectMetroStore: false` is still supported as
+a fallback. An explicit `optimizations.metroSharedCache` value takes precedence.
+
+## iOS options
+
+These keys are inside `optimizations.ios`. They apply to Xcode 26 or newer when
+the project does not enable its own ccache integration. Older or unrecognized
+Xcode versions and projects using ccache retain their own compiler settings.
+
+| Option                  | Default | What it does                                                                                                                                                                           |
+| ----------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compilationCache`      | `true`  | Enables Xcode's compilation cache so unchanged native compilation can be reused across builds and worktrees. Set to `false` to disable the compilation cache, including Swift caching. |
+| `swiftCompilationCache` | `false` | Opts into experimental Swift compilation caching. Requires `compilationCache: true`.                                                                                                   |
+| `prefixMapping`         | `true`  | Maps checkout and DerivedData paths to stable Clang paths for reuse across worktrees. Set to `false` to disable Stim's prefix mapping and clear its mappings.                          |
+
+## Android options
+
+These keys are inside `optimizations.android`.
+
+| Option             | Default  | What it does                                                                                                                                                                                                                                                |
+| ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compilerCache`    | `"auto"` | Selects `"auto"`, `"ccache"`, `"cas"`, or `"none"`. Auto uses CAS when a toolchain manifest is supplied, otherwise ccache when available. Explicit `"ccache"` keeps ccache even if a CAS manifest is configured. `"none"` disables Stim's compiler caching. |
+| `casToolchain`     | Unset    | Absolute path to the experimental Android CAS toolchain manifest. `STIM_ANDROID_CAS_TOOLCHAIN` overrides this path. Required when `compilerCache` resolves to `"cas"`.                                                                                      |
+| `pch`              | `"auto"` | Selects `"auto"`, `"on"`, or `"off"` for precompiled headers. Auto preserves library and project policy, but defaults PCH off when Stim supplies ccache and the project has no explicit PCH argument. See the PCH behavior below.                           |
+| `gradleBuildCache` | `true`   | Passes `--build-cache` to Gradle to reuse cacheable task outputs. Set to `false` to pass Gradle's `--no-build-cache`, overriding `org.gradle.caching=true`.                                                                                                 |
+| `targetAbiOnly`    | `true`   | Narrows Debug builds to the target device's ABI to avoid compiling unused architectures. Set to `false` to stop narrowing Debug builds. Release builds remain universal, subject to the project's ABI filters.                                              |
+
+### ccache and precompiled headers
+
+The default backend uses the Android NDK compiler with ccache when ccache is
+installed and the project does not already supply its own compiler launcher.
+Stim defaults PCH off in this mode because stock ccache cannot reliably reuse
+these PCH builds across worktrees. This lets ordinary compiled objects stay warm.
+
+`pch: "on"` and `pch: "off"` override Gradle's
+`CMAKE_DISABLE_PRECOMPILE_HEADERS` arguments; target-level CMake settings can
+still override them. `"on"` permits libraries to use PCH; it does not create PCH
+targets or fix stock ccache's PCH portability. Stim does not combine its ccache
+and CAS backends.
+
+### Experimental Android CAS
+
+CAS uses an Apple Clang toolchain to cache compilation results and PCH with
+content-addressed inputs. The current integration requires macOS and a prepared
+compatible toolchain. Stim does not download or build it. Follow the
+[Android CAS setup and limitations](https://github.com/appandflow/stim/blob/24435399f111997c04be97c95367d0dd9875b115/docs/android-cas-poc.md)
+before opting in; the Xcode compiler alone is not the complete setup.
+
+Merge this into the machine config, replacing the path with your manifest:
+
+```json
+{
+  "optimizations": {
+    "android": {
+      "compilerCache": "cas",
+      "casToolchain": "/absolute/path/to/android-cas-toolchain.json",
+      "pch": "auto"
+    }
+  }
+}
+```
+
+CAS keeps the libraries' PCH policy under `"auto"`. Selecting `"ccache"` returns
+to the NDK compiler and the default PCH-off policy even if the manifest path
+remains configured. Selecting `"cas"` without a manifest refuses the build.
+
+## Compare compiler settings
+
+A native artifact hit skips compilation, so bypass it when comparing compiler
+caches. For a single invocation, use:
+
+<StimTabs code={`stim android --no-build-cache
+stim ios --no-build-cache`} />
+
+This flag skips Stim's artifact reads but still stores the fresh build. Use
+`optimizations.buildCache: false` to skip both reads and writes. Gradle task
+caching and existing native outputs can still avoid compilation; a fast build
+alone does not prove a compiler-cache hit.
+
+Android CAS, explicit PCH modes, and changed iOS compiler options use separate
+native artifact keys. Android ccache and `"none"` share an artifact key when
+their PCH mode matches, so bypass artifact reuse to exercise a backend change.
+Legacy Expo cache providers cannot distinguish these custom compiler profiles
+and are skipped for them; providers using Stim's cache-key contract remain usable.
+
+Android compiler and PCH profiles also use separate generated CMake directories
+under each module's `.cxx/stim-<profile>` or its custom staging root. Switching
+profiles keeps previous output for reuse. These directories can accumulate;
+there is no profile-pruning command. Remove obsolete generated profiles only
+after all native builds have stopped, or let worktree removal reclaim them.

--- a/website/docs/build-optimizations.md
+++ b/website/docs/build-optimizations.md
@@ -58,16 +58,18 @@ All keys below are inside `optimizations`.
 | `buildCache`        | `true`  | Reads and stores complete native build artifacts. Set to `false` to skip both local and remote artifact reads and writes. Compiler caches remain independent.                                                                                    |
 | `remoteBuildCache`  | `true`  | Allows configured remote artifact cache providers. Set to `false` to skip remote lookup, upload, provider loading, and authentication while keeping the local artifact cache. It does not configure a provider by itself.                        |
 | `releaseBundleSwap` | `true`  | Allows supported Release artifact hits to reuse native code with the current JavaScript and assets inserted into a copy. If swapping fails, Stim builds fresh. Set to `false` to build Release from source; fresh artifacts can still be stored. |
-| `metroSharedCache`  | `true`  | Adds Stim's shared Metro transform store for Expo and bare React Native. Set to `false` to stop adding it; stores configured by the project remain.                                                                                              |
+| `metroSharedCache`  | `true`  | Adds Stim's shared Metro transform store for Expo SDK 54+ and bare React Native. Set to `false` to stop adding it; stores configured by the project remain.                                                                                      |
 
 The older machine setting `caches.injectMetroStore: false` is still supported as
 a fallback. An explicit `optimizations.metroSharedCache` value takes precedence.
 
 ## iOS options
 
-These keys are inside `optimizations.ios`. They apply to Xcode 26 or newer when
-the project does not enable its own ccache integration. Older or unrecognized
-Xcode versions and projects using ccache retain their own compiler settings.
+These keys are inside `optimizations.ios`. They apply to Xcode 26 or newer unless
+`apple.ccacheEnabled` is `"true"` in `ios/Podfile.properties.json`. Older or
+unrecognized Xcode versions and projects with that ccache setting retain their
+own compiler settings. Custom ccache integrations using other mechanisms are
+not detected by this guard.
 
 | Option                  | Default | What it does                                                                                                                                                                           |
 | ----------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -79,13 +81,13 @@ Xcode versions and projects using ccache retain their own compiler settings.
 
 These keys are inside `optimizations.android`.
 
-| Option             | Default  | What it does                                                                                                                                                                                                                                                |
-| ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `compilerCache`    | `"auto"` | Selects `"auto"`, `"ccache"`, `"cas"`, or `"none"`. Auto uses CAS when a toolchain manifest is supplied, otherwise ccache when available. Explicit `"ccache"` keeps ccache even if a CAS manifest is configured. `"none"` disables Stim's compiler caching. |
-| `casToolchain`     | Unset    | Absolute path to the experimental Android CAS toolchain manifest. `STIM_ANDROID_CAS_TOOLCHAIN` overrides this path. Required when `compilerCache` resolves to `"cas"`.                                                                                      |
-| `pch`              | `"auto"` | Selects `"auto"`, `"on"`, or `"off"` for precompiled headers. Auto preserves library and project policy, but defaults PCH off when Stim supplies ccache and the project has no explicit PCH argument. See the PCH behavior below.                           |
-| `gradleBuildCache` | `true`   | Passes `--build-cache` to Gradle to reuse cacheable task outputs. Set to `false` to pass Gradle's `--no-build-cache`, overriding `org.gradle.caching=true`.                                                                                                 |
-| `targetAbiOnly`    | `true`   | Narrows Debug builds to the target device's ABI to avoid compiling unused architectures. Set to `false` to stop narrowing Debug builds. Release builds remain universal, subject to the project's ABI filters.                                              |
+| Option             | Default  | What it does                                                                                                                                                                                                                                                                     |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compilerCache`    | `"auto"` | Selects `"auto"`, `"ccache"`, `"cas"`, or `"none"`. Auto uses CAS when a toolchain manifest is supplied, otherwise ccache when available. Explicit `"ccache"` keeps ccache even if a CAS manifest is configured. `"none"` disables Stim's compiler caching and inherited ccache. |
+| `casToolchain`     | Unset    | Absolute path to the experimental Android CAS toolchain manifest. `STIM_ANDROID_CAS_TOOLCHAIN` overrides this path. Required when `compilerCache` resolves to `"cas"`.                                                                                                           |
+| `pch`              | `"auto"` | Selects `"auto"`, `"on"`, or `"off"` for precompiled headers. Auto preserves library and project policy, but defaults PCH off when Stim supplies ccache and the project has no explicit PCH argument. See the PCH behavior below.                                                |
+| `gradleBuildCache` | `true`   | Passes `--build-cache` to Gradle to reuse cacheable task outputs. Set to `false` to pass Gradle's `--no-build-cache`, overriding `org.gradle.caching=true`.                                                                                                                      |
+| `targetAbiOnly`    | `true`   | Narrows Debug builds to the target device's ABI to avoid compiling unused architectures. Set to `false` to stop narrowing Debug builds. Release builds remain universal, subject to the project's ABI filters.                                                                   |
 
 ### ccache and precompiled headers
 
@@ -129,7 +131,7 @@ remains configured. Selecting `"cas"` without a manifest refuses the build.
 ## Compare compiler settings
 
 A native artifact hit skips compilation, so bypass it when comparing compiler
-caches. For a single invocation, use:
+caches. For a single invocation, use the command for your platform:
 
 <StimTabs code={`stim android --no-build-cache
 stim ios --no-build-cache`} />

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -17,11 +17,14 @@ Stim reads the first value found in this order:
 1. Project settings in `~/.stim/config.json`, keyed by absolute path.
 2. Repository settings in the same machine file, keyed by the git common dir.
 3. Committed `.stim.json` at the repository root.
-4. The Stim default.
+4. Machine defaults under top-level `optimizations` in the same file (for
+   optimization settings only).
+5. The Stim default.
 
 Nested objects merge by key. Arrays replace lower-precedence arrays. Unknown
 keys produce a warning. Every key below takes one type: a string, an array of
-strings, a number, or, for `android.avdConfig` and `cache.options`, an object.
+strings, a number, a boolean, or an object such as `android.avdConfig`,
+`cache.options`, and the nested `optimizations` settings.
 A value of the wrong type is refused by name on every command that resolves
 settings, so a wrong shape never falls back to a default silently. `stim doctor`
 reports it as a finding instead of refusing.
@@ -30,31 +33,32 @@ reports it as a finding instead of refusing.
 
 `.stim.json` supports these keys:
 
-| Key                           | Purpose                                              |
-| ----------------------------- | ---------------------------------------------------- |
-| `ios.deviceType`              | iOS Simulator device type                            |
-| `ios.runtime`                 | iOS Simulator runtime                                |
-| `ios.configuration`           | Xcode configuration, such as `Debug` or `Release`    |
-| `ios.remote`                  | Default remote backend, `proxy` or `eas`             |
-| `ios.simslimProfile`          | SimSlim profile for local iOS devices                |
-| `ios.signingIdentity`         | Keychain identity used to re-seal a device build     |
-| `ios.signingIdentitySha1`     | SHA-1 of that identity, when two share a name        |
-| `ios.lanHost`                 | Address a phone uses to reach this workspace's Metro |
-| `android.systemImage`         | Android SDK system image                             |
-| `android.dataPartitionSizeGb` | AVD data partition size                              |
-| `android.avdConfigFile`       | Additional AVD config file                           |
-| `android.avdConfig`           | Validated AVD config values                          |
-| `android.variant`             | Gradle build variant                                 |
-| `android.keystore`            | Release keystore path                                |
-| `android.keystorePassword`    | Release keystore password source                     |
-| `android.remote`              | Default remote backend, `proxy` or `eas`             |
-| `metro.tunnel`                | Remote tunnel mode                                   |
-| `metro.ngrokUrl`              | Existing ngrok URL                                   |
-| `metro.publicUrl`             | Existing public Metro URL                            |
-| `worktree.exclude`            | Ignored paths skipped by `worktree warm`             |
-| `cache.provider`              | Optional second-tier cache provider module           |
-| `cache.options`               | Options passed to that provider                      |
-| `caches`                      | Additional cache paths reported by `gc`              |
+| Key                           | Purpose                                                              |
+| ----------------------------- | -------------------------------------------------------------------- |
+| `ios.deviceType`              | iOS Simulator device type                                            |
+| `ios.runtime`                 | iOS Simulator runtime                                                |
+| `ios.configuration`           | Xcode configuration, such as `Debug` or `Release`                    |
+| `ios.remote`                  | Default remote backend, `proxy` or `eas`                             |
+| `ios.simslimProfile`          | SimSlim profile for local iOS devices                                |
+| `ios.signingIdentity`         | Keychain identity used to re-seal a device build                     |
+| `ios.signingIdentitySha1`     | SHA-1 of that identity, when two share a name                        |
+| `ios.lanHost`                 | Address a phone uses to reach this workspace's Metro                 |
+| `android.systemImage`         | Android SDK system image                                             |
+| `android.dataPartitionSizeGb` | AVD data partition size                                              |
+| `android.avdConfigFile`       | Additional AVD config file                                           |
+| `android.avdConfig`           | Validated AVD config values                                          |
+| `android.variant`             | Gradle build variant                                                 |
+| `android.keystore`            | Release keystore path                                                |
+| `android.keystorePassword`    | Release keystore password source                                     |
+| `android.remote`              | Default remote backend, `proxy` or `eas`                             |
+| `metro.tunnel`                | Remote tunnel mode                                                   |
+| `metro.ngrokUrl`              | Existing ngrok URL                                                   |
+| `metro.publicUrl`             | Existing public Metro URL                                            |
+| `worktree.exclude`            | Ignored paths skipped by `worktree warm`                             |
+| `cache.provider`              | Optional second-tier cache provider module                           |
+| `cache.options`               | Options passed to that provider                                      |
+| `caches`                      | Additional cache paths reported by `gc`                              |
+| `optimizations`               | [Build optimization switches and defaults](./build-optimizations.md) |
 
 `worktree warm` reads settings from the main checkout. A nonempty
 `.worktreeexclude` in main replaces its resolved `worktree.exclude` setting;
@@ -105,17 +109,21 @@ The committed `.stim.json` `caches` key and this machine-file `caches` key are
 different shapes: the committed key is an array of extra paths for `gc` to
 report, and this machine-file key is an object of named cache locations.
 
+Use a top-level [`optimizations` object](./build-optimizations.md) in this file to
+control build optimizations on this machine without changing project files.
+
 ## Environment variables
 
-| Variable                   | Purpose                                |
-| -------------------------- | -------------------------------------- |
-| `STIM_HOME`                | Runtime state root. Default: `~/.stim` |
-| `STIM_BUILD_CACHE`         | Native artifact cache root             |
-| `STIM_METRO_CACHE`         | Metro transform cache root             |
-| `STIM_MAX_BUILDS`          | Maximum concurrent native builds       |
-| `STIM_MAX_DEVICES`         | Maximum booted owned devices           |
-| `STIM_POOL_IOS_PARKED_MAX` | Maximum parked simulators              |
-| `STIM_METRO_PUBLIC_URL`    | Public Metro URL for remote use        |
+| Variable                     | Purpose                                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `STIM_HOME`                  | Runtime state root. Default: `~/.stim`                                                                   |
+| `STIM_BUILD_CACHE`           | Native artifact cache root                                                                               |
+| `STIM_METRO_CACHE`           | Metro transform cache root                                                                               |
+| `STIM_MAX_BUILDS`            | Maximum concurrent native builds                                                                         |
+| `STIM_MAX_DEVICES`           | Maximum booted owned devices                                                                             |
+| `STIM_POOL_IOS_PARKED_MAX`   | Maximum parked simulators                                                                                |
+| `STIM_METRO_PUBLIC_URL`      | Public Metro URL for remote use                                                                          |
+| `STIM_ANDROID_CAS_TOOLCHAIN` | Absolute path to the [Android CAS toolchain manifest](./build-optimizations.md#experimental-android-cas) |
 
 Proxy remote devices also use `AGENT_DEVICE_DAEMON_BASE_URL` and
 `AGENT_DEVICE_DAEMON_AUTH_TOKEN`. Those variables belong to the optional proxy

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -17,7 +17,7 @@ Stim reads the first value found in this order:
 1. Project settings in `~/.stim/config.json`, keyed by absolute path.
 2. Repository settings in the same machine file, keyed by the git common dir.
 3. Committed `.stim.json` at the repository root.
-4. Machine defaults under top-level `optimizations` in the same file (for
+4. Machine defaults under top-level `optimizations` in `~/.stim/config.json` (for
    optimization settings only).
 5. The Stim default.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -14,7 +14,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Reference',
       collapsed: false,
-      items: ['commands', 'settings', 'requirements', 'agent-skills', 'cache-packages'],
+      items: ['commands', 'settings', 'build-optimizations', 'requirements', 'agent-skills', 'cache-packages'],
     },
     'changelog',
   ],


### PR DESCRIPTION
## Description

The website explains cache layers but has no reference for the build optimization switches. Fixes #504.

## Solution

Add a Build optimizations reference covering shared, iOS, and Android options, defaults, configuration precedence, and the CAS/PCH tradeoffs. Link it from Settings, Build caches, and the sidebar. Documentation only; runtime defaults stay unchanged.

## Test plan

- `pnpm --filter website run build` and `pnpm --filter website run typecheck` pass.
- Browser-verified option tables, Settings/sidebar links, CAS anchor, and Global/npx examples.
- Repository format, lint, build, typecheck, knip, and runtime checks pass; 3,631 unit tests and 66 E2E tests pass (one existing unit test skipped).
- CI passes on Node 22, Node 24, and the Node 20.19.4 published runtime.
