### PR TITLE
fix: keep Claude benchmarks in the active turn

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -97,6 +97,16 @@ wrapper returning is not proof its shell process exited. Collection rejects Stim
 start, platform, or dependency-install commands that overlap worktree warm or lack
 proof of an earlier successful warm. Explicitly detached control processes retain
 their separate PID/log monitoring.
+Claude runs in one-shot print mode, which the coordinator does not resume after
+a scheduled wakeup. Both arms set `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` and
+`CLAUDE_CODE_DISABLE_CRON=1` so finite shell work stays in the active turn rather
+than depending on a later notification. The available tools are restricted with
+`--tools` to the same set as `--allowedTools`; auto-approval alone does not remove
+scheduling tools. The environment settings are recorded in each run's profile.
+Explicit shell detachment for servers remains available; agents
+must check readiness and keep working in the current turn. See the
+[Claude environment-variable reference](https://code.claude.com/docs/en/env-vars).
+
 Unfinished shell commands remain in the audit with unknown completion. Claude
 background-task submission is not command completion: a correlated terminal
 TaskOutput result must provide the shell exit status before the audit accepts it.

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -1317,6 +1317,8 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     writeFileSync(join(runDir, 'avds-before.json'), `${JSON.stringify(androidAvdSnapshot(), null, 2)}\n`);
   }
   const runnerKind = runnerForModel(model);
+  const runnerEnvironment =
+    runnerKind === 'claude' ? { CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1', CLAUDE_CODE_DISABLE_CRON: '1' } : {};
   const { codexHome } = makeRunnerHome(runDir, arm);
   const runTmp = join(runDir, 'tmp');
   mkdirSync(runTmp, { recursive: true });
@@ -1326,6 +1328,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   });
   const baseEnv = {
     ...cleanRubyEnvironment(process.env),
+    ...runnerEnvironment,
     CODEX_HOME: codexHome,
     STIM_HOME: join(runDir, 'stim-home'),
     TMPDIR: runTmp,
@@ -1381,7 +1384,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     preflight: preflightReport,
     expectedStimShellProvenance: arm === 'stim' ? expectedStimShellProvenance() : null,
     stimShellProvenance: shellProvenance,
-    profile: { ...profile, claudeGuidance, isolation },
+    profile: { ...profile, claudeGuidance, isolation, runnerEnvironment },
     expectedBuildCache,
     expectedParkedSimulator,
     expectedStimDevice,
@@ -1443,6 +1446,8 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
           'false',
           '--append-system-prompt-file',
           claudeGuidance.path,
+          '--tools',
+          variant === launchCrashVariant ? 'Bash' : 'Bash,Edit,Read',
           '--allowedTools',
           variant === launchCrashVariant ? 'Bash' : 'Bash,Edit,Read',
         ]


### PR DESCRIPTION
## Description

A headless Claude benchmark ended its turn waiting for `ScheduleWakeup` while its native build was unfinished. The coordinator does not resume scheduled turns, so the attempt never reached crash recovery or Settings proof.

## Solution

Both Claude arms disable automatic background tasks and scheduling, and expose only their existing auto-approved tool set. Explicit shell detachment and PID/log monitoring for servers remain available. This changes the benchmark runner only; it does not change Stim, native caches, or validation.

## Test plan

With Claude Code 2.1.257 under benchmark filesystem isolation, ran a 12-second finite shell command followed by a second command and received both results before exit 0. Verified the restricted initialization tool list contains only `Bash` for the launch-crash scenario. The scheduler environment switch alone still exposed `ScheduleWakeup`, which is why the explicit tool restriction is necessary.

Fixes #507.
