### PR TITLE
fix: sanitize simulator container paths before export

### DIFF
--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -181,6 +181,8 @@ export function sanitizeBenchmarkText(value, replacements = []) {
   text = text.replace(agentDeviceBundlePattern, '<agent-device-helper>');
   text = text.replace(adbPublicKeyMessagePattern, '$1<adb-public-key>$2');
   text = text.replace(adbPublicKeyBootArgumentPattern, '$1<adb-public-key>');
+  text = text.replace(simulatorIdPattern, (id, offset, input) => (input[offset - 1] === '/' ? 'simulator-udid' : id));
+  text = text.replace(/(?<=\/)<simulator-udid>/g, 'simulator-udid');
   text = text.replace(fileUrlAbsolutePathPattern, (_match, path) => `file:///${replacementLabel(path)}`);
   text = text.replace(compilerFlagAbsolutePathPattern, (_match, flag, path) => `${flag}${replacementLabel(path)}`);
   text = text.replace(
@@ -458,7 +460,7 @@ function assertPortable(payload) {
       `benchmark export contains a nested absolute machine path root: ${leakedNestedPrivatePath}\n${field}`,
     );
   }
-  const leakedRoot = [
+  for (const root of [
     '/Applications',
     '/Library',
     '/System',
@@ -470,17 +472,16 @@ function assertPortable(payload) {
     '/opt',
     '/Pods.build',
     '/XPCServices',
-  ].find((root) => {
+  ]) {
     const escaped = root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return (
-      new RegExp(`(?<![A-Za-z0-9._/])${escaped}(?![A-Za-z0-9._+-])`).test(serialized) ||
-      new RegExp(`-[FLI]${escaped}(?![A-Za-z0-9._+-])`).test(serialized)
-    );
-  });
-  if (leakedRoot) {
-    const at = serialized.indexOf(leakedRoot);
-    const field = serialized.slice(Math.max(0, at - 80), Math.min(serialized.length, at + 240));
-    throw new Error(`benchmark export contains an absolute machine path root: ${leakedRoot}\n${field}`);
+    const match =
+      new RegExp(`(?<![A-Za-z0-9._/])${escaped}(?![A-Za-z0-9._+-])`).exec(serialized) ??
+      new RegExp(`-[FLI]${escaped}(?![A-Za-z0-9._+-])`).exec(serialized);
+    if (match) {
+      const at = match.index;
+      const field = serialized.slice(Math.max(0, at - 80), Math.min(serialized.length, at + 240));
+      throw new Error(`benchmark export contains an absolute machine path root: ${root}\n${field}`);
+    }
   }
   const leakedSystemPath = serialized.match(systemAbsolutePathPattern)?.[0];
   if (leakedSystemPath) {

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -380,6 +380,18 @@ describe('benchmark viewer export', () => {
     );
   });
 
+  it('keeps redacted simulator containers as path segments before sanitizing roots', () => {
+    const udid = 'A35AFE7E-06D9-4E4B-A14D-0451595A13BC';
+    const appId = 'B35AFE7E-06D9-4E4B-A14D-0451595A13BC';
+    const paths =
+      `/Users/alice/Library/Developer/CoreSimulator/Devices/${udid}/data/Containers/Data/Application/${appId}/Library/HTTPStorages/example.app ` +
+      `worktree/project/${appId}/Library/data /System/Library/EventTimingProfiles/Sim.Touch.plist`;
+    expect(sanitizeBenchmarkText(paths, [[udid, '<simulator-udid>']])).toBe(
+      'workspace/example.app worktree/project/simulator-udid/Library/data system/System/Library/EventTimingProfiles/Sim.Touch.plist',
+    );
+    expect(sanitizeBenchmarkText(`--udid ${udid}`, [[udid, '<simulator-udid>']])).toBe('--udid <simulator-udid>');
+  });
+
   it('preserves URL path separators while sanitizing hosts', () => {
     expect(sanitizeBenchmarkText('http://127.0.0.1:8081/tmp/foo')).toBe('http://<local-ip>:8081/tmp/foo');
     expect(sanitizeBenchmarkText('https://example.com/opt/page')).toBe('https://example.com/opt/page');
@@ -625,9 +637,26 @@ describe('benchmark viewer export', () => {
         dispatchToScreenReadySeconds: 1,
         commandCount: 0,
         screen: { valid: true, expected: 'Offline maps', dimensions: { width: 402, height: 874 } },
+        simulator: { udid: 'A35AFE7E-06D9-4E4B-A14D-0451595A13BC' },
       }),
     );
     writeFileSync(join(validRunDir, 'proof', 'settings.png'), 'valid proof');
+    writeFileSync(
+      join(validRunDir, 'events.jsonl'),
+      stamp('2026-09-03T20:00:02.500Z', {
+        type: 'item.completed',
+        item: {
+          id: 'logs',
+          type: 'command_execution',
+          command: 'cat app.log',
+          aggregated_output:
+            '/Users/alice/Library/Developer/CoreSimulator/Devices/A35AFE7E-06D9-4E4B-A14D-0451595A13BC/data/Containers/Data/Application/B35AFE7E-06D9-4E4B-A14D-0451595A13BC/Library/HTTPStorages/example.app ' +
+            'worktree/project/B35AFE7E-06D9-4E4B-A14D-0451595A13BC/Library/data ' +
+            '/System/Library/EventTimingProfiles/Sim.Touch.plist -L/Volumes/private/lib file:///Users/alice/private.log',
+          exit_code: 0,
+        },
+      }),
+    );
 
     const proofDir = join(root, 'proof');
     mkdirSync(proofDir, { recursive: true });
@@ -640,6 +669,10 @@ describe('benchmark viewer export', () => {
 
     expect(payload.runs.map((run) => run.id)).toEqual(['fixture-control']);
     expect(payload.recordedOn).toBe('2026-09-03');
+    expect(payload.runs[0].commands[0].output).toBe(
+      'workspace/example.app worktree/project/simulator-udid/Library/data ' +
+        'system/System/Library/EventTimingProfiles/Sim.Touch.plist -Lworkspace/lib file:///workspace/private.log',
+    );
     expect(readdirSync(proofDir)).toEqual(['fixture-control.png']);
   });
 


### PR DESCRIPTION
## Description

Valid iOS benchmark exports were rejected as leaking `/Library` after simulator IDs became angle-bracket placeholders. The closing `>` made the remaining relative path look like a new absolute path.

## Solution

Keep redacted IDs inside paths as ordinary path segments before sanitizing machine roots. Standalone device arguments retain their existing placeholder format. Privacy checks remain intact, and rejection excerpts now point to the actual match rather than an earlier innocent substring.

## Test plan

Exported both previously blocked iOS result sets successfully from retained evidence without changing their verdicts. Regression coverage exercises container paths with known and unknown IDs through the complete exporter, alongside system paths, compiler flags and file URLs that must still be redacted.

Fixes #503.
