### PR TITLE
fix: review harmless launch-error benchmark deviations

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -256,7 +256,20 @@ unrecognized setup command. It contains `schemaVersion: 1`, `runId`,
 `shellParserSha256` (run-guards), and ordered `commands` entries with `commandId`,
 the exact `command`, and a nonempty `assessment`. Export re-derives diagnosis,
 recovery and diagnosis-time usage from hash-verified retained evidence. A review
-can clear only setup-syntax rejection and its missing-diagnosis/usage consequences;
-it cannot clear other failure reasons or source-before-capture violations. Valid
-runs with setup warnings also require review before publication. The original
+can clear setup-syntax rejection and its missing-diagnosis/usage consequences.
+Read-only agent-device help does not need a session. An auxiliary diagnostic
+session must use the exact run namespace and state directory, open the assigned
+device, and close successfully before the pinned proof session opens. Its
+`auxiliarySessions` review entries name each `session` and a nonempty `assessment`.
+Default or foreign sessions, device overrides, missing closure and daemon
+interference remain failures.
+
+An iOS `Podfile.lock` update is reviewable only when every difference is a valid
+`SPEC CHECKSUMS` value for an existing pod. Dependency versions and all other
+content must match. Collection retains base/final lockfiles and the exact repaired
+source under `raw/`, with hashes in `auxiliary-audit-evidence.json`. A review's
+`sourceChanges` contains that file's `evidenceSha256` and an `assessment`; export
+checks every retained hash, the original source hash and checksum-only semantics.
+It cannot clear other source changes, dependency changes or source-before-capture
+violations. Valid runs with setup or auxiliary warnings also require review before publication. The original
 `run.json` is never rewritten, and review records stay private.

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -25,6 +25,7 @@ import {
   launchCrashRecovery,
   launchCrashRepair,
   launchCrashToken,
+  podfileChecksumChanges,
 } from '../launch-crash-benchmark.mjs';
 import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
 import { reconstructCommandEvidence } from './command-evidence.mjs';
@@ -40,6 +41,7 @@ import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
 import { isolatedRunnerInvocation, prepareRunnerIsolation, runnerIsolationPolicy } from './runner-isolation.mjs';
 import {
   agentDeviceIsolationInvalidReasons,
+  agentDeviceAuxiliarySessions,
   benchmarkSetupInvalidReasons,
   benchmarkTarget,
   benchmarkTiming,
@@ -153,7 +155,7 @@ function run(file, args, options = {}) {
     maxBuffer: options.maxBuffer ?? 64 * 1024 * 1024,
     stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
   });
-  return typeof output === 'string' ? output.trim() : '';
+  return typeof output === 'string' ? (options.trim === false ? output : output.trim()) : '';
 }
 
 function jsonRun(file, args, options) {
@@ -1599,7 +1601,7 @@ function tokensFromUsage(usage) {
   };
 }
 
-function commandEvidence(meta, eventsPath, runDir) {
+function commandEvidence(meta, eventsPath, runDir, device) {
   if (!existsSync(eventsPath)) {
     return { commands: [], activities: [], completedEvents: [], invalidReasons: [] };
   }
@@ -1637,8 +1639,11 @@ function commandEvidence(meta, eventsPath, runDir) {
   ) {
     invalidReasons.push('android-native-control-used-release-build');
   }
-  invalidReasons.push(...agentDeviceIsolationInvalidReasons(commands, agentDeviceCommand(meta, '')));
-  return { commands, activities, completedEvents, invalidReasons };
+  const target =
+    meta.variant === launchCrashVariant ? { platform: meta.platform ?? 'ios', device: device?.udid } : null;
+  invalidReasons.push(...agentDeviceIsolationInvalidReasons(commands, agentDeviceCommand(meta, ''), target));
+  const auxiliarySessions = agentDeviceAuxiliarySessions(commands, agentDeviceCommand(meta, ''), target);
+  return { commands, activities, completedEvents, invalidReasons, auxiliarySessions };
 }
 
 function agentDeviceOpenCommand(meta, appAlive) {
@@ -1992,7 +1997,40 @@ function proofFor(meta, appAlive, runDir, worktree, commandItems) {
       run('git', ['diff', '--name-only', '-z', 'HEAD'], { cwd: worktree }),
       run('git', ['ls-files', '--others', '--exclude-standard', '-z'], { cwd: worktree }),
     );
-    if (changedPaths.length !== 1 || changedPaths[0] !== meta.crash.sourceRelative) {
+    let checksumChanges = null;
+    if (
+      (meta.platform ?? 'ios') === 'ios' &&
+      changedPaths.length === 2 &&
+      changedPaths.includes(meta.crash.sourceRelative) &&
+      changedPaths.includes('ios/Podfile.lock')
+    ) {
+      const before = run('git', ['show', 'HEAD:ios/Podfile.lock'], { cwd: worktree, trim: false });
+      const after = readFileSync(join(worktree, 'ios/Podfile.lock'), 'utf8');
+      checksumChanges = podfileChecksumChanges(before, after);
+      if (checksumChanges?.length) {
+        const raw = join(runDir, 'raw');
+        mkdirSync(raw, { recursive: true });
+        writeFileSync(join(raw, 'Podfile.lock.base'), before);
+        writeFileSync(join(raw, 'Podfile.lock.final'), after);
+        writeFileSync(join(raw, 'launch-crash-source-final.tsx'), source);
+        const names = ['Podfile.lock.base', 'Podfile.lock.final', 'launch-crash-source-final.tsx'];
+        writeFileSync(
+          join(raw, 'auxiliary-audit-evidence.json'),
+          JSON.stringify(
+            {
+              schemaVersion: 1,
+              runId: meta.runId,
+              metaSha256: sha256(join(runDir, 'meta.json')),
+              files: Object.fromEntries(names.map((name) => [name, sha256(join(raw, name))])),
+              changedPaths,
+            },
+            null,
+            2,
+          ) + '\n',
+        );
+      }
+    }
+    if ((changedPaths.length !== 1 || changedPaths[0] !== meta.crash.sourceRelative) && !checksumChanges?.length) {
       return {
         valid: false,
         reason: 'launch-crash-unrelated-source-changes',
@@ -2007,6 +2045,7 @@ function proofFor(meta, appAlive, runDir, worktree, commandItems) {
       target: sourcePath,
       sourceSha256,
       changedPaths,
+      ...(checksumChanges?.length ? { checksumChanges } : {}),
     };
   }
   if (appAlive.proof?.valid && existsSync(appAlive.proof.target)) {
@@ -2122,7 +2161,7 @@ function collect(runDir) {
     ? JSON.parse(readFileSync(appAlivePath, 'utf8'))
     : { error: 'missing-app-alive-record' };
   const eventsPath = join(runDir, 'events.jsonl');
-  const commandAudit = commandEvidence(meta, eventsPath, runDir);
+  const commandAudit = commandEvidence(meta, eventsPath, runDir, appAlive.simulator);
   const ccache = benchmarkCcache(meta, commandAudit.commands);
   const screen = screenEvidence(meta, appAlive, commandAudit.commands, runDir);
   const timing = benchmarkTiming(
@@ -2218,6 +2257,7 @@ function collect(runDir) {
     diagnosisTokens: tokensFromUsage(diagnosisUsage),
     diagnosis,
     recovery,
+    auxiliarySessions: commandAudit.auxiliarySessions,
     simulator: appAlive.simulator ?? null,
     worktree,
     worktreeEvidence: worktreeRecord,

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -128,18 +128,68 @@ export function shellCommandSegments(command) {
   return segments;
 }
 
-export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix) {
+export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
+  if (!target?.device || !['ios', 'android'].includes(target.platform)) return [];
+  const prefix = expectedPrefix.match(
+    /^(env AGENT_DEVICE_STATE_DIR=\S+ AGENT_DEVICE_SESSION=)([\w.-]+)( agent-device )$/,
+  );
+  if (!prefix) return [];
+  const groups = new Map();
+  const proofOpen = commands.findIndex((entry) =>
+    topLevelShellCommand(entry.command).startsWith(`${expectedPrefix}open `),
+  );
+  if (proofOpen < 0) return [];
+  commands.forEach((entry, index) => {
+    const command = topLevelShellCommand(entry.command);
+    if (!command.startsWith(`${prefix[1]}${prefix[2]}-`)) return;
+    const match = command.slice(prefix[1].length).match(/^([\w.-]+) agent-device ([\s\S]+)$/);
+    if (!match || !new RegExp(`^${prefix[2].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-[a-z][a-z0-9-]*$`).test(match[1]))
+      return;
+    const group = groups.get(match[1]) ?? [];
+    group.push({ ...entry, command, body: match[2], index });
+    groups.set(match[1], group);
+  });
+  const open = `open com.appandflow.trailhead --foreground --platform ${target.platform} ${target.platform === 'ios' ? '--udid' : '--serial'} ${target.device}`;
+  return [...groups.entries()].flatMap(([session, entries]) => {
+    if (
+      entries.length < 2 ||
+      entries[0].body !== open ||
+      entries[0].exitCode !== 0 ||
+      entries.at(-1).body !== 'close' ||
+      entries.at(-1).exitCode !== 0 ||
+      entries.at(-1).index >= proofOpen ||
+      entries.some((entry) => shellCommandSegments(entry.command).length !== 1 || /[$`]/.test(entry.command)) ||
+      entries
+        .slice(1, -1)
+        .some(
+          (entry) =>
+            !/^(?:click|press|fill|snapshot|wait|screenshot|back|scroll)(?:\s|$)/.test(entry.body) ||
+            /--(?:session|state-dir|udid|serial|platform|device)(?:[=\s]|$)/.test(entry.body),
+        )
+    )
+      return [];
+    return [{ session, commands: entries.map(({ id, command }) => ({ commandId: id, command })) }];
+  });
+}
+
+export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix, target) {
   const segments = commands.flatMap((command) => shellCommandSegments(command.command));
+  const auxiliary = new Set(
+    agentDeviceAuxiliarySessions(commands, expectedPrefix, target).flatMap((session) =>
+      session.commands.map((entry) => entry.command),
+    ),
+  );
   const reasons = [];
   const lookup =
     /^(?:command\s+-[vV]|which|type|whence)\s+(?:[\w./-]+\s+)*agent-device(?:\s+[\w./-]+)*(?:\s+(?:\d*>|&>)\s*(?:&\d+|[\w./-]+))?$/;
+  const help = /^agent-device(?:\s+--help|\s+help(?:\s+[\w-]+)*)(?:\s+(?:\d*>|&>)\s*(?:&\d+|[\w./-]+))?$/;
   const deviceCommands = segments.filter(
-    (command) => /(?:^|[\s(`])agent-device(?:\s|[)`]|$)/.test(command) && !lookup.test(command),
+    (command) => /(?:^|[\s(`])agent-device(?:\s|[)`]|$)/.test(command) && !lookup.test(command) && !help.test(command),
   );
   if (deviceCommands.some((command) => /(?:^|[\s(`])agent-device\s+daemon\s+stop(?:\s|[)`]|$)/.test(command))) {
     reasons.push('agent-device-daemon-recovery-inside-timer');
   }
-  if (deviceCommands.some((command) => !command.startsWith(expectedPrefix))) {
+  if (deviceCommands.some((command) => !command.startsWith(expectedPrefix) && !auxiliary.has(command))) {
     reasons.push('agent-device-run-session-not-applied');
   }
   return reasons;

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -128,6 +128,32 @@ export function shellCommandSegments(command) {
   return segments;
 }
 
+function literalShellArguments(command) {
+  const words = [];
+  let word = '';
+  let quote = null;
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (char === '\\' && quote !== "'") {
+      const next = command[++index];
+      if (next == null) return null;
+      if (quote === '"' && !['$', '`', '"', '\\', '\n'].includes(next)) word += '\\';
+      if (next !== '\n') word += next;
+    } else if (quote) {
+      if (char === quote) quote = null;
+      else word += char;
+    } else if (char === "'" || char === '"') quote = char;
+    else if (/\s/.test(char)) {
+      if (word) words.push(word);
+      word = '';
+    } else if (/[<>*?[\]{}~()]/.test(char)) return null;
+    else word += char;
+  }
+  if (quote) return null;
+  if (word) words.push(word);
+  return words;
+}
+
 export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
   if (!target?.device || !['ios', 'android'].includes(target.platform)) return [];
   const prefix = expectedPrefix.match(
@@ -135,18 +161,18 @@ export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
   );
   if (!prefix) return [];
   const groups = new Map();
-  const proofOpen = commands.findIndex((entry) =>
-    topLevelShellCommand(entry.command).startsWith(`${expectedPrefix}open `),
+  const proofOpens = commands.filter((entry) =>
+    shellCommandSegments(entry.command).some((segment) => segment.startsWith(`${expectedPrefix}open `)),
   );
-  if (proofOpen < 0) return [];
-  commands.forEach((entry, index) => {
+  if (!proofOpens.length) return [];
+  commands.forEach((entry) => {
     const command = topLevelShellCommand(entry.command);
     if (!command.startsWith(`${prefix[1]}${prefix[2]}-`)) return;
     const match = command.slice(prefix[1].length).match(/^([\w.-]+) agent-device ([\s\S]+)$/);
     if (!match || !new RegExp(`^${prefix[2].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-[a-z][a-z0-9-]*$`).test(match[1]))
       return;
     const group = groups.get(match[1]) ?? [];
-    group.push({ ...entry, command, body: match[2], index });
+    group.push({ ...entry, command, body: match[2] });
     groups.set(match[1], group);
   });
   const open = `open com.appandflow.trailhead --foreground --platform ${target.platform} ${target.platform === 'ios' ? '--udid' : '--serial'} ${target.device}`;
@@ -157,15 +183,17 @@ export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
       entries[0].exitCode !== 0 ||
       entries.at(-1).body !== 'close' ||
       entries.at(-1).exitCode !== 0 ||
-      entries.at(-1).index >= proofOpen ||
+      proofOpens.some((proof) => !commandCompletedBefore(entries.at(-1), proof)) ||
+      entries.slice(1).some((entry, index) => !commandCompletedBefore(entries[index], entry)) ||
       entries.some((entry) => shellCommandSegments(entry.command).length !== 1 || /[$`]/.test(entry.command)) ||
-      entries
-        .slice(1, -1)
-        .some(
-          (entry) =>
-            !/^(?:click|press|fill|snapshot|wait|screenshot|back|scroll)(?:\s|$)/.test(entry.body) ||
-            /--(?:session|state-dir|udid|serial|platform|device)(?:[=\s]|$)/.test(entry.body),
-        )
+      entries.slice(1, -1).some((entry) => {
+        const args = literalShellArguments(entry.body);
+        return (
+          !args ||
+          !/^(?:click|press|fill|snapshot|wait|screenshot|back|scroll)$/.test(args[0]) ||
+          args.some((arg) => /^--(?:session|state-dir|udid|serial|platform|device)(?:=|$)/.test(arg))
+        );
+      })
     )
       return [];
     return [{ session, commands: entries.map(({ id, command }) => ({ commandId: id, command })) }];

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -65,7 +65,7 @@ describe('agent-device session isolation', () => {
         command: `${prefix}open com.appandflow.trailhead --foreground --platform ios --udid U1`,
         exitCode: 0,
       },
-    ];
+    ].map((entry, index) => Object.assign(entry, { startEventOffset: index * 2, endEventOffset: index * 2 + 1 }));
     const target = { platform: 'ios', device: 'U1' };
     expect(agentDeviceIsolationInvalidReasons(commands, prefix, target)).toEqual([]);
     expect(agentDeviceAuxiliarySessions(commands, prefix, target)).toEqual([
@@ -85,14 +85,36 @@ describe('agent-device session isolation', () => {
       })),
       [{ ...commands[0], command: commands[0].command.replace('--udid U1', '--udid U2') }, ...commands.slice(1)],
       [...commands.slice(0, 2), commands[3]],
-      [commands[0], commands[1], commands[3], commands[2]],
+      [
+        commands[0],
+        commands[1],
+        { ...commands[3], startEventOffset: 4, endEventOffset: 5 },
+        { ...commands[2], startEventOffset: 6, endEventOffset: 7 },
+      ],
       [commands[0], commands[1], { ...commands[2], exitCode: 1 }, commands[3]],
       [commands[0], { ...commands[1], command: `${auxiliary}click @e3 --session default` }, ...commands.slice(2)],
+      [commands[0], { ...commands[1], command: `${auxiliary}snapshot '--session' default` }, ...commands.slice(2)],
+      [commands[0], { ...commands[1], command: `${auxiliary}snapshot --se'ssion' default` }, ...commands.slice(2)],
+      [commands[0], { ...commands[1], command: `${auxiliary}snapshot --ses\\sion default` }, ...commands.slice(2)],
+      [...commands.slice(0, 3), { ...commands[3], startEventOffset: commands[2].startEventOffset }],
+      [
+        ...commands.slice(0, 2),
+        { ...commands[3], command: `sleep 1; ${commands[3].command}`, startEventOffset: 3, endEventOffset: 4 },
+        ...commands.slice(2),
+      ],
+      [commands[0], commands[1], { ...commands[2], parallelTimingAmbiguous: true }, commands[3]],
       [commands[0], { ...commands[1], command: `${auxiliary}click $(agent-device snapshot)` }, ...commands.slice(2)],
     ])
       expect(agentDeviceIsolationInvalidReasons(changed, prefix, target)).toContain(
         'agent-device-run-session-not-applied',
       );
+    expect(
+      agentDeviceIsolationInvalidReasons(
+        [commands[0], { ...commands[1], command: `${auxiliary}fill @e3 "hello there"` }, ...commands.slice(2)],
+        prefix,
+        target,
+      ),
+    ).toEqual([]);
   });
 
   it('accepts delayed scoped navigation without splitting quoted separators', () => {

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   agentDeviceIsolationInvalidReasons,
+  agentDeviceAuxiliarySessions,
   benchmarkSetupInvalidReasons,
   benchmarkTarget,
   benchmarkTiming,
@@ -30,6 +31,69 @@ const build = (output) => [{ id: 'build', command: 'stim android', exitCode: 0, 
 
 describe('agent-device session isolation', () => {
   const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=bench-run agent-device ';
+
+  it('allows help output without letting help hide an unscoped device command', () => {
+    expect(
+      agentDeviceIsolationInvalidReasons(
+        [{ command: 'which agent-device; agent-device --help 2>&1 | head -20\nagent-device help open' }],
+        prefix,
+      ),
+    ).toEqual([]);
+    for (const command of [
+      'agent-device help; agent-device snapshot',
+      'agent-device help $(agent-device snapshot)',
+      'agent-device --help `agent-device snapshot`',
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command }], prefix)).toContain(
+        'agent-device-run-session-not-applied',
+      );
+    }
+  });
+
+  it('requires auxiliary diagnosis to open the same device and close before pinned proof', () => {
+    const auxiliary = prefix.replace('SESSION=bench-run ', 'SESSION=bench-run-diag ');
+    const commands = [
+      {
+        id: 'diag-open',
+        command: `${auxiliary}open com.appandflow.trailhead --foreground --platform ios --udid U1`,
+        exitCode: 0,
+      },
+      { id: 'diag-click', command: `${auxiliary}click @e3 --settle`, exitCode: 0 },
+      { id: 'diag-close', command: `${auxiliary}close`, exitCode: 0 },
+      {
+        id: 'proof',
+        command: `${prefix}open com.appandflow.trailhead --foreground --platform ios --udid U1`,
+        exitCode: 0,
+      },
+    ];
+    const target = { platform: 'ios', device: 'U1' };
+    expect(agentDeviceIsolationInvalidReasons(commands, prefix, target)).toEqual([]);
+    expect(agentDeviceAuxiliarySessions(commands, prefix, target)).toEqual([
+      {
+        session: 'bench-run-diag',
+        commands: commands.slice(0, 3).map(({ id, command }) => ({ commandId: id, command })),
+      },
+    ]);
+    for (const changed of [
+      commands.map((entry) => ({
+        ...entry,
+        command: entry.command.replace('SESSION=bench-run-diag ', 'SESSION=default '),
+      })),
+      commands.map((entry) => ({
+        ...entry,
+        command: entry.command.replace('STATE_DIR=/tmp/bench-state ', 'STATE_DIR=/tmp/other '),
+      })),
+      [{ ...commands[0], command: commands[0].command.replace('--udid U1', '--udid U2') }, ...commands.slice(1)],
+      [...commands.slice(0, 2), commands[3]],
+      [commands[0], commands[1], commands[3], commands[2]],
+      [commands[0], commands[1], { ...commands[2], exitCode: 1 }, commands[3]],
+      [commands[0], { ...commands[1], command: `${auxiliary}click @e3 --session default` }, ...commands.slice(2)],
+      [commands[0], { ...commands[1], command: `${auxiliary}click $(agent-device snapshot)` }, ...commands.slice(2)],
+    ])
+      expect(agentDeviceIsolationInvalidReasons(changed, prefix, target)).toContain(
+        'agent-device-run-session-not-applied',
+      );
+  });
 
   it('accepts delayed scoped navigation without splitting quoted separators', () => {
     for (const command of [

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -13,9 +13,13 @@ import { basename, dirname, join, relative, resolve } from 'node:path';
 import { userInfo } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { stripVTControlCharacters } from 'node:util';
-import { launchCrashDiagnosis, launchCrashRecovery } from './launch-crash-benchmark.mjs';
+import { launchCrashDiagnosis, launchCrashRecovery, podfileChecksumChanges } from './launch-crash-benchmark.mjs';
 import { reconstructCommandEvidence } from './agent-benchmark/command-evidence.mjs';
-import { agentDeviceIsolationInvalidReasons, topLevelShellCommand } from './agent-benchmark/run-guards.mjs';
+import {
+  agentDeviceIsolationInvalidReasons,
+  agentDeviceAuxiliarySessions,
+  topLevelShellCommand,
+} from './agent-benchmark/run-guards.mjs';
 
 const modelPricing = {
   'gpt-5.6-luna': {
@@ -832,6 +836,35 @@ function sameUsage(left, right) {
   );
 }
 
+function reviewedChecksumProof(runDir, record, meta) {
+  const path = join(runDir, 'raw', 'auxiliary-audit-evidence.json');
+  if (!existsSync(path) || (meta.platform ?? 'ios') !== 'ios') return null;
+  const evidence = readJson(path);
+  const names = ['Podfile.lock.base', 'Podfile.lock.final', 'launch-crash-source-final.tsx'];
+  if (
+    evidence.schemaVersion !== 1 ||
+    evidence.runId !== record.runId ||
+    evidence.metaSha256 !== fileSha256(join(runDir, 'meta.json')) ||
+    !meta.crash?.originalSha256 ||
+    JSON.stringify(evidence.changedPaths) !==
+      JSON.stringify([meta.crash.sourceRelative, 'ios/Podfile.lock'].toSorted()) ||
+    JSON.stringify(evidence.changedPaths) !== JSON.stringify(record.proof?.changedPaths) ||
+    names.some(
+      (name) =>
+        !existsSync(join(runDir, 'raw', name)) || evidence.files?.[name] !== fileSha256(join(runDir, 'raw', name)),
+    ) ||
+    evidence.files['launch-crash-source-final.tsx'] !== meta.crash.originalSha256
+  )
+    return null;
+  const changes = podfileChecksumChanges(
+    readFileSync(join(runDir, 'raw', 'Podfile.lock.base'), 'utf8'),
+    readFileSync(join(runDir, 'raw', 'Podfile.lock.final'), 'utf8'),
+  );
+  return changes?.length
+    ? { sourceSha256: meta.crash.originalSha256, checksumChanges: changes, evidenceSha256: fileSha256(path) }
+    : null;
+}
+
 function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
   const reject = (reason) => {
     if (process.env.STIM_BENCH_EXPORT_DEBUG === '1') {
@@ -850,6 +883,19 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
     readFileSync(eventsPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse),
   );
   const commands = evidence.commands;
+  let auxiliarySessions = [];
+  if (meta.agentDevice?.session && meta.agentDevice?.stateDir) {
+    const prefix = `env AGENT_DEVICE_STATE_DIR=${meta.agentDevice.stateDir} AGENT_DEVICE_SESSION=${meta.agentDevice.session} agent-device `;
+    const target = { platform: meta.platform ?? 'ios', device: record.simulator?.udid };
+    if (meta.agentDevice.session !== meta.runId || agentDeviceIsolationInvalidReasons(commands, prefix, target).length)
+      return reject('agent-device isolation mismatch');
+    auxiliarySessions = agentDeviceAuxiliarySessions(commands, prefix, target);
+  } else if (record.invalidReasons?.includes('agent-device-run-session-not-applied'))
+    return reject('agent-device identity missing');
+  const needsChecksumReview =
+    record.proof?.checksumChanges?.length || record.invalidReasons?.includes('launch-crash-unrelated-source-changes');
+  const checksumProof = needsChecksumReview ? reviewedChecksumProof(runDir, record, meta) : null;
+  if (needsChecksumReview && !checksumProof) return reject('checksum-only source evidence missing or changed');
   const token = [record.proof?.expected, ...commands.map((command) => command.output)]
     .join('\n')
     .match(/STIM_BENCH_LAUNCH_CRASH_[0-9A-F]{12}/)?.[0];
@@ -878,7 +924,7 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
   if (!existsSync(transcriptPath)) return reject('transcript missing');
   if (record.evidenceSha256?.transcript !== fileSha256(transcriptPath)) return reject('transcript hash mismatch');
   if (runner !== 'claude' && !diagnosisUsage) return reject('diagnosis usage missing');
-  if (rederive) return { diagnosis, recovery, diagnosisUsage, screenReadySeconds };
+  if (rederive) return { diagnosis, recovery, diagnosisUsage, screenReadySeconds, auxiliarySessions, checksumProof };
   if (
     record.diagnosis?.observedAt !== diagnosis.observedAt ||
     record.dispatchToDiagnosisSeconds !== diagnosis.dispatchToDiagnosisSeconds ||
@@ -898,7 +944,7 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
   ) {
     return reject('evidence command ids mismatch');
   }
-  return { diagnosis, recovery, diagnosisUsage, screenReadySeconds };
+  return { diagnosis, recovery, diagnosisUsage, screenReadySeconds, auxiliarySessions, checksumProof };
 }
 
 function publicationRecord(runDir, meta) {
@@ -910,6 +956,8 @@ function publicationRecord(runDir, meta) {
       'launch-crash-pre-capture-command-not-allowed',
       'launch-crash-diagnosis-missing',
       'launch-crash-diagnosis-usage-missing',
+      'launch-crash-unrelated-source-changes',
+      'agent-device-run-session-not-applied',
     ]);
     const eligible =
       record.valid ||
@@ -917,7 +965,7 @@ function publicationRecord(runDir, meta) {
     const derived = eligible ? validateLaunchCrashRecord(runDir, record, meta, true) : null;
     if (!derived) return record.valid ? { ...record, valid: false } : record;
     const warnings = derived.diagnosis.setupWarnings ?? [];
-    if (!warnings.length && record.valid) return record;
+    if (!warnings.length && !derived.auxiliarySessions.length && !derived.checksumProof && record.valid) return record;
     if (!existsSync(reviewPath)) return { ...record, valid: false };
     const review = readJson(reviewPath);
     const policyPath = fileURLToPath(new URL('./launch-crash-benchmark.mjs', import.meta.url));
@@ -929,6 +977,19 @@ function publicationRecord(runDir, meta) {
       review.metaSha256 !== fileSha256(join(runDir, 'meta.json')) ||
       review.policySha256 !== fileSha256(policyPath) ||
       review.shellParserSha256 !== fileSha256(guardPath) ||
+      (derived.checksumProof &&
+        (review.sourceChanges?.evidenceSha256 !== derived.checksumProof.evidenceSha256 ||
+          typeof review.sourceChanges?.assessment !== 'string' ||
+          !review.sourceChanges.assessment.trim())) ||
+      (derived.auxiliarySessions.length > 0 &&
+        (!Array.isArray(review.auxiliarySessions) ||
+          review.auxiliarySessions.length !== derived.auxiliarySessions.length ||
+          derived.auxiliarySessions.some(
+            (session, index) =>
+              review.auxiliarySessions[index]?.session !== session.session ||
+              typeof review.auxiliarySessions[index]?.assessment !== 'string' ||
+              !review.auxiliarySessions[index].assessment.trim(),
+          ))) ||
       !Array.isArray(review.commands) ||
       review.commands.length !== warnings.length ||
       warnings.some(
@@ -946,6 +1007,18 @@ function publicationRecord(runDir, meta) {
       ...record,
       valid: true,
       invalidReasons: [],
+      ...(derived.checksumProof
+        ? {
+            proof: {
+              ...record.proof,
+              valid: true,
+              kind: 'launch-crash-source-repair',
+              sourceSha256: derived.checksumProof.sourceSha256,
+              checksumChanges: derived.checksumProof.checksumChanges,
+            },
+          }
+        : {}),
+      auxiliarySessions: derived.auxiliarySessions,
       diagnosis: derived.diagnosis,
       recovery: derived.recovery,
       dispatchToDiagnosisSeconds: derived.diagnosis.dispatchToDiagnosisSeconds,

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1383,6 +1383,114 @@ describe('benchmark viewer export', () => {
       );
     }
     writeFileSync(recordPath, JSON.stringify(original));
+    const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=private-run-id agent-device ';
+    const auxiliaryPrefix = prefix.replace('SESSION=private-run-id ', 'SESSION=private-run-id-diag ');
+    const open = 'open com.appandflow.trailhead --foreground --platform ios --udid U1';
+    const extraEvents = [
+      ['aux-open', 100, `${auxiliaryPrefix}${open}`],
+      ['aux-close', 110, `${auxiliaryPrefix}close`],
+      ['proof-open', 140, `${prefix}${open}`],
+    ].flatMap(([id, seconds, command]) => [
+      stamp(new Date(Date.parse('2026-09-04T12:00:00Z') + seconds * 1000).toISOString(), {
+        type: 'item.started',
+        item: { id, type: 'command_execution', command },
+      }),
+      stamp(new Date(Date.parse('2026-09-04T12:00:00Z') + (seconds + 1) * 1000).toISOString(), {
+        type: 'item.completed',
+        item: { id, type: 'command_execution', command, aggregated_output: 'ok', exit_code: 0 },
+      }),
+    ]);
+    const scopedEvents =
+      originalEvents
+        .trim()
+        .split('\n')
+        .map((line) => {
+          const stamped = JSON.parse(line);
+          const event = JSON.parse(stamped.line);
+          if (event.item.command.startsWith('agent-device '))
+            event.item.command = prefix + event.item.command.slice('agent-device '.length);
+          return JSON.stringify({ ...stamped, line: JSON.stringify(event) });
+        })
+        .concat(extraEvents)
+        .toSorted((a, b) => JSON.parse(a).arrivedAt.localeCompare(JSON.parse(b).arrivedAt))
+        .join('\n') + '\n';
+    writeFileSync(eventsPath, scopedEvents);
+    const raw = join(runDir, 'raw');
+    mkdirSync(raw);
+    const source = 'export default function RootLayout() { return null; }\n';
+    const lock = `PODS:\n  - Core (1.0)\n\nSPEC CHECKSUMS:\n  Core: ${'a'.repeat(40)}\n\nCOCOAPODS: 1.16.2\n`;
+    writeFileSync(join(raw, 'Podfile.lock.base'), lock);
+    writeFileSync(join(raw, 'Podfile.lock.final'), lock.replace('a'.repeat(40), 'b'.repeat(40)));
+    writeFileSync(join(raw, 'launch-crash-source-final.tsx'), source);
+    const metaPath = join(runDir, 'meta.json');
+    const scopedMeta = {
+      ...JSON.parse(readFileSync(metaPath)),
+      runId: original.runId,
+      agentDevice: { stateDir: '/tmp/bench-state', session: original.runId },
+      crash: { sourceRelative: 'app/_layout.tsx', originalSha256: sha256(join(raw, 'launch-crash-source-final.tsx')) },
+    };
+    writeFileSync(metaPath, JSON.stringify(scopedMeta));
+    const changedPaths = ['app/_layout.tsx', 'ios/Podfile.lock'];
+    const auxiliaryRecord = {
+      ...original,
+      valid: false,
+      invalidReasons: ['launch-crash-unrelated-source-changes', 'agent-device-run-session-not-applied'],
+      simulator: { udid: 'U1' },
+      proof: { ...original.proof, valid: false, changedPaths },
+      evidenceSha256: { ...original.evidenceSha256, events: sha256(eventsPath) },
+    };
+    writeFileSync(recordPath, JSON.stringify(auxiliaryRecord));
+    const evidencePath = join(raw, 'auxiliary-audit-evidence.json');
+    const refreshEvidence = () =>
+      writeFileSync(
+        evidencePath,
+        JSON.stringify({
+          schemaVersion: 1,
+          runId: original.runId,
+          metaSha256: sha256(metaPath),
+          changedPaths,
+          files: Object.fromEntries(
+            ['Podfile.lock.base', 'Podfile.lock.final', 'launch-crash-source-final.tsx'].map((name) => [
+              name,
+              sha256(join(raw, name)),
+            ]),
+          ),
+        }),
+      );
+    refreshEvidence();
+    const auxiliaryReview = {
+      ...review,
+      commands: [],
+      originalRecordSha256: sha256(recordPath),
+      metaSha256: sha256(metaPath),
+      sourceChanges: {
+        evidenceSha256: sha256(evidencePath),
+        assessment: 'Only a spec checksum changed; source bytes match the original.',
+      },
+      auxiliarySessions: [{ session: 'private-run-id-diag', assessment: 'Same device, closed before proof.' }],
+    };
+    writeFileSync(reviewPath, JSON.stringify(auxiliaryReview));
+    expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90, settingsReadySeconds: 150 });
+    expect(JSON.parse(readFileSync(recordPath))).toEqual(auxiliaryRecord);
+    for (const change of [
+      { sourceChanges: undefined },
+      { auxiliarySessions: [] },
+      { sourceChanges: { ...auxiliaryReview.sourceChanges, evidenceSha256: 'changed' } },
+      { auxiliarySessions: [{ session: 'private-run-id-diag', assessment: '' }] },
+    ]) {
+      writeFileSync(reviewPath, JSON.stringify({ ...auxiliaryReview, ...change }));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
+    }
+    writeFileSync(join(raw, 'Podfile.lock.final'), lock.replace('(1.0)', '(2.0)'));
+    refreshEvidence();
+    writeFileSync(
+      reviewPath,
+      JSON.stringify({
+        ...auxiliaryReview,
+        sourceChanges: { ...auxiliaryReview.sourceChanges, evidenceSha256: sha256(evidencePath) },
+      }),
+    );
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
   });
 
   it('refuses a launch-crash record without audited recovery proof', () => {

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -393,6 +393,36 @@ export function launchCrashRepair(source, token, expectedSha256) {
   return { valid: true, sourceSha256 };
 }
 
+function parsePodfileChecksums(source) {
+  const parts = source.split('SPEC CHECKSUMS:\n');
+  if (parts.length !== 2) return null;
+  const end = parts[1].indexOf('\n\n');
+  if (end < 0) return null;
+  const rows = parts[1]
+    .slice(0, end)
+    .split('\n')
+    .map((line) => line.match(/^  ([\w/.+-]+): ([0-9a-f]{40})$/));
+  if (!rows.length || rows.some((row) => !row) || new Set(rows.map((row) => row[1])).size !== rows.length) return null;
+  return { prefix: parts[0], suffix: parts[1].slice(end), rows };
+}
+
+export function podfileChecksumChanges(before, after) {
+  const left = parsePodfileChecksums(before);
+  const right = parsePodfileChecksums(after);
+  if (
+    !left ||
+    !right ||
+    left.prefix !== right.prefix ||
+    left.suffix !== right.suffix ||
+    left.rows.length !== right.rows.length
+  )
+    return null;
+  if (left.rows.some((row, index) => row[1] !== right.rows[index][1])) return null;
+  return left.rows.flatMap((row, index) =>
+    row[2] === right.rows[index][2] ? [] : [{ pod: row[1], before: row[2], after: right.rows[index][2] }],
+  );
+}
+
 export function launchCrashRecovery(commands, { diagnosis, screen }) {
   if (!diagnosis?.valid) return { valid: false, reason: 'launch-crash-diagnosis-missing' };
   const ordered = orderedCommands(commands);

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -5,10 +5,29 @@ import {
   launchCrashDiagnosis,
   launchCrashRecovery,
   launchCrashRepair,
+  podfileChecksumChanges,
   launchCrashToken,
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it('accepts only checksum-row updates, not dependency changes or malformed lockfiles', () => {
+    const before = `PODS:\n  - Core (1.0)\n\nSPEC CHECKSUMS:\n  Core: ${'a'.repeat(40)}\n\nCOCOAPODS: 1.16.2\n`;
+    const after = before.replace('a'.repeat(40), 'b'.repeat(40));
+    expect(podfileChecksumChanges(before, after)).toEqual([
+      { pod: 'Core', before: 'a'.repeat(40), after: 'b'.repeat(40) },
+    ]);
+    expect(podfileChecksumChanges(before, before)).toEqual([]);
+    for (const changed of [
+      after.replace('(1.0)', '(2.0)'),
+      after.replace('Core:', 'Other:'),
+      after.replace('1.16.2', '1.17.0'),
+      after.replace('b'.repeat(40), 'invalid'),
+      after.replace('\n\nCOCOAPODS', `\n  Added: ${'c'.repeat(40)}\n\nCOCOAPODS`),
+      after.replace('SPEC CHECKSUMS:', 'OTHER:'),
+    ]) {
+      expect(podfileChecksumChanges(before, changed)).toBeNull();
+    }
+  });
   it('warns on unfamiliar setup while rejecting source inspection before runtime diagnosis', () => {
     const token = launchCrashToken('managed-setup');
     const setup = { worktree: '/tmp/run', avdConfig: '/tmp/avds/Trailhead_run.avd/config.ini' };


### PR DESCRIPTION
## Description

A Sonnet iOS control run repaired the launch crash and reached Settings in 13m 22s, but validation rejected a checksum-only `Podfile.lock` update and a closed diagnostic session named `<runId>-diag`. Fixes #512.

The [source-only rule](https://github.com/appandflow/stim/commit/a19b03a4476c9490c162275541e2df4f0980c039) and [literal session guard](https://github.com/appandflow/stim/commit/782b8c5046cf300fb54dddf509ca9240cdb61cf5) intentionally enforce repair scope and isolation; these cases preserve that intent without matching the syntax.

## Solution

Allow checksum-only CocoaPods updates and same-run, same-device diagnostic sessions that close before the proof session, with explicit review required for either arm. Help queries need no session. Retained evidence is hash-checked and revalidated before publication; original verdicts remain untouched.

This changes benchmark acceptance, not Stim runtime behavior. A mistaken exemption could admit an incomparable run; wrong/default sessions, changed dependencies or source, missing proof, and daemon interference still fail.

## Test plan

Re-exported the retained Sonnet run locally: its existing diagnosis and Settings proof are accepted without another timed attempt. Regression cases reject changed dependency versions, wrong devices, missing session closure, and altered or incomplete review evidence.
