### PR TITLE
fix: recognize completed benchmark launch pipelines

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -207,6 +207,11 @@ shell programs are safe or replace the runner's filesystem isolation.
 Build/launch pipelines ending in `tee` must enable `set -o pipefail` in the same
 shell command. Without it, zero exit status proves only the log writer finished,
 so the command cannot establish initial launch success.
+The pipeline may follow `cd <worktree> && set -o pipefail && ...`. If it ends
+with `; echo "PIPELINE_EXIT=$?"`, the captured output must contain exactly one
+`PIPELINE_EXIT=0` line: the echo's own zero exit does not prove build success.
+Retained launch-evidence rejections can be reviewed only when re-derived commands
+prove successful launch, separate error capture, repair and Settings proof.
 
 A launch can finish before the JavaScript error reaches its log. Both arms must
 repeat standalone foreground log queries, without separate sleep or wait commands,

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -956,6 +956,7 @@ function publicationRecord(runDir, meta) {
       'launch-crash-pre-capture-command-not-allowed',
       'launch-crash-diagnosis-missing',
       'launch-crash-diagnosis-usage-missing',
+      'launch-crash-initial-launch-evidence-missing',
       'launch-crash-unrelated-source-changes',
       'agent-device-run-session-not-applied',
     ]);

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1345,6 +1345,24 @@ describe('benchmark viewer export', () => {
     writeFileSync(reviewPath, JSON.stringify(review));
     expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90, settingsReadySeconds: 150 });
     expect(JSON.parse(readFileSync(recordPath))).toEqual(rejected);
+    const launchRejected = {
+      ...rejected,
+      invalidReasons: ['launch-crash-initial-launch-evidence-missing', 'launch-crash-diagnosis-missing'],
+    };
+    writeFileSync(recordPath, JSON.stringify(launchRejected));
+    writeFileSync(reviewPath, JSON.stringify({ ...review, originalRecordSha256: sha256(recordPath) }));
+    expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90, settingsReadySeconds: 150 });
+    expect(JSON.parse(readFileSync(recordPath))).toEqual(launchRejected);
+    const missingLaunch = reviewedEvents.replaceAll('stim ios', 'echo no-launch');
+    writeFileSync(eventsPath, missingLaunch);
+    writeFileSync(
+      recordPath,
+      JSON.stringify({ ...launchRejected, evidenceSha256: { ...rejected.evidenceSha256, events: sha256(eventsPath) } }),
+    );
+    writeFileSync(reviewPath, JSON.stringify({ ...review, originalRecordSha256: sha256(recordPath) }));
+    expect(reviewedExport).toThrow('no valid benchmark runs found');
+    writeFileSync(eventsPath, reviewedEvents);
+    writeFileSync(recordPath, JSON.stringify(rejected));
     for (const changed of [
       { originalRecordSha256: 'changed' },
       { metaSha256: 'changed' },

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -42,6 +42,7 @@ function successfulLaunch(command, arm, platform) {
     /^(?:cd\s+(?:[^\s'"$`\\;&|]+|'[^'\n]+'|"[^"$`\n]+")\s*&&\s*)?set -(?:o|eo|euo) pipefail\s*(?:&&|;|\n)\s*/,
   );
   if (!prefix) return false;
+  if (/^cd\s/.test(prefix[0]) && !/&&\s*$/.test(prefix[0])) return false;
   let pipeline = value.slice(prefix[0].length);
   const report = /;\s*echo "PIPELINE_EXIT=\$\?"\s*$/.exec(pipeline);
   if (report) {

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -37,7 +37,27 @@ function successful(command) {
 function successfulLaunch(command, arm, platform) {
   if (!successful(command) || !launchCommand(command.command, arm, platform)) return false;
   const value = shellCommand(command.command);
-  return !/\|\s*tee\b/.test(value) || /^set -(?:o|eo|euo) pipefail\s*(?:;|\n)/.test(value);
+  if (!/\|\s*tee\b/.test(value)) return true;
+  const prefix = value.match(
+    /^(?:cd\s+(?:[^\s'"$`\\;&|]+|'[^'\n]+'|"[^"$`\n]+")\s*&&\s*)?set -(?:o|eo|euo) pipefail\s*(?:&&|;|\n)\s*/,
+  );
+  if (!prefix) return false;
+  let pipeline = value.slice(prefix[0].length);
+  const report = /;\s*echo "PIPELINE_EXIT=\$\?"\s*$/.exec(pipeline);
+  if (report) {
+    const statuses = [...String(command.output ?? '').matchAll(/^PIPELINE_EXIT=(\d+)\s*$/gm)];
+    if (statuses.length !== 1 || statuses[0][1] !== '0') return false;
+    pipeline = pipeline.slice(0, report.index);
+  }
+  const [launch, ...filters] = pipeline.replace(/\s+2>&1(?=\s|$)/g, '').split(/\s*\|\s*/);
+  const group = /^\{\s*([\s\S]*?);\s*\}$/.exec(launch);
+  const launches = group ? shellCommandSegments(group[1]) : [launch];
+  return (
+    launches.length > 0 &&
+    launches.every((entry) => launchCommand(entry, arm, platform) && !/[;&\n$`]/.test(entry)) &&
+    filters.length > 0 &&
+    filters.every((filter) => /^(?:tee(?: -a)? [\w/.-]+|(?:tail|head) -(?:\d+|n \d+))\s*$/.test(filter))
+  );
 }
 
 function shellCommand(command) {

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
 import {
   changedPathsFromGitOutputs,
   injectRootRenderCrash,
@@ -10,6 +11,26 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it.skipIf(process.platform === 'win32')('uses the real pipeline status when a trailing echo exits zero', () => {
+    for (const code of [0, 7]) {
+      const command =
+        'cd /tmp && set -o pipefail && npx expo run:android 2>&1 | tee /dev/null | tail -40; echo "PIPELINE_EXIT=$?"';
+      const result = spawnSync('/bin/bash', ['-c', `npx() { return ${code}; }; ${command}`], {
+        encoding: 'utf8',
+        timeout: 5000,
+      });
+      expect(result.status).toBe(0);
+      const diagnosis = launchCrashDiagnosis(
+        [
+          { command, exitCode: result.status, output: result.stdout, endedAt: '2026-09-04T12:00:01Z' },
+          { command: 'adb logcat -d', exitCode: 0, output: 'test-token RootLayout', endedAt: '2026-09-04T12:00:02Z' },
+        ],
+        { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'control', platform: 'android' },
+      );
+      expect(diagnosis.valid).toBe(code === 0);
+    }
+  });
+
   it('accepts only checksum-row updates, not dependency changes or malformed lockfiles', () => {
     const before = `PODS:\n  - Core (1.0)\n\nSPEC CHECKSUMS:\n  Core: ${'a'.repeat(40)}\n\nCOCOAPODS: 1.16.2\n`;
     const after = before.replace('a'.repeat(40), 'b'.repeat(40));
@@ -90,6 +111,38 @@ done`;
       valid: true,
       errorCaptureCommandId: 'logs',
     });
+    const pipeline = {
+      ...launch,
+      command:
+        'cd /tmp/run && set -o pipefail && npx expo run:android --no-bundler --variant debug --device emulator-5554 2>&1 | tee /tmp/native.log | tail -40; echo "PIPELINE_EXIT=$?"',
+      output: 'BUILD SUCCESSFUL\nPIPELINE_EXIT=0\nShell cwd was reset to /tmp/fixture',
+    };
+    expect(launchCrashDiagnosis([...before, pipeline, logs], options)).toMatchObject({ valid: true });
+    expect(
+      launchCrashDiagnosis(
+        [
+          {
+            ...launch,
+            command:
+              'set -o pipefail; { xcrun simctl launch U1 com.appandflow.trailhead; xcrun simctl openurl U1 trailhead://app; } 2>&1 | tee /tmp/launch.log',
+          },
+          logs,
+        ],
+        { ...options, platform: 'ios' },
+      ),
+    ).toMatchObject({ valid: true });
+    for (const changed of [
+      { output: 'BUILD SUCCESSFUL\nPIPELINE_EXIT=1' },
+      { output: 'BUILD SUCCESSFUL' },
+      { output: 'PIPELINE_EXIT=1\nPIPELINE_EXIT=0' },
+      { command: pipeline.command.replace('set -o pipefail', 'set +o pipefail') },
+      { command: pipeline.command.replace('npx expo', 'set +o pipefail; npx expo') },
+      { command: pipeline.command.replace('; echo', '; true; echo') },
+    ])
+      expect(launchCrashDiagnosis([...before, { ...pipeline, ...changed }, logs], options)).toMatchObject({
+        valid: false,
+        reason: 'launch-crash-initial-launch-evidence-missing',
+      });
     const masked = {
       ...launch,
       id: 'masked',

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -12,9 +12,13 @@ import {
 
 describe('launch crash benchmark', () => {
   it.skipIf(process.platform === 'win32')('uses the real pipeline status when a trailing echo exits zero', () => {
-    for (const code of [0, 7]) {
-      const command =
-        'cd /tmp && set -o pipefail && npx expo run:android 2>&1 | tee /dev/null | tail -40; echo "PIPELINE_EXIT=$?"';
+    for (const [code, prefix, valid] of [
+      [0, 'cd /tmp && set -o pipefail &&', true],
+      [7, 'cd /tmp && set -o pipefail &&', false],
+      [7, 'cd /dev/null/not-a-directory && set -o pipefail;', false],
+      [7, 'cd /dev/null/not-a-directory && set -o pipefail\n', false],
+    ]) {
+      const command = `${prefix} npx expo run:android 2>&1 | tee /dev/null | tail -40; echo "PIPELINE_EXIT=$?"`;
       const result = spawnSync('/bin/bash', ['-c', `npx() { return ${code}; }; ${command}`], {
         encoding: 'utf8',
         timeout: 5000,
@@ -27,7 +31,7 @@ describe('launch crash benchmark', () => {
         ],
         { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'control', platform: 'android' },
       );
-      expect(diagnosis.valid).toBe(code === 0);
+      expect(diagnosis.valid).toBe(valid);
     }
   });
 


### PR DESCRIPTION
## Description

Opus repaired the Android launch crash and reached Settings in 7m 42s, but the validator rejected `cd <worktree> && set -o pipefail && ... | tee <log>; echo "PIPELINE_EXIT=$?"`. It only recognized pipefail at the start of the command with a semicolon or newline. Fixes #514.

The [original pipeline check](https://github.com/appandflow/stim/commit/44fed2eb5f42e2d589e9cfc6df5df954cb6ae4d7) prevents `tee` from masking launch failure; this retains that intent while accepting directory setup and explicit pipeline-status reports.

## Solution

Recognize those completed pipelines and require exactly one zero status report when a trailing echo masks the shell exit. Missing/disabled pipefail and failed or ambiguous status reports still fail.

Previously rejected runs can pass review when their recorded evidence revalidates; original records remain unchanged. No Stim runtime change.

## Test plan

Re-derived diagnosis for the retained Opus run (6m 23s) and verified all 12 earlier runs retain their event graphs and timings. Real Bash regression cases both exit zero at the shell level but accept only the successful upstream pipeline. Export regression accepts reviewed retained evidence and still rejects missing launch evidence.
