### PR TITLE
fix: accept benchmark command exit reports

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -212,6 +212,10 @@ with `; echo "PIPELINE_EXIT=$?"`, the captured output must contain exactly one
 `PIPELINE_EXIT=0` line: the echo's own zero exit does not prove build success.
 Retained launch-evidence rejections can be reviewed only when re-derived commands
 prove successful launch, separate error capture, repair and Settings proof.
+Ordinary commands may also append `; echo "EXIT=$?"`. The audit uses the single
+captured status line, not the echo's exit code; missing or ambiguous reports do
+not prove success. A retained warm-status rejection requires re-derived setup
+checks, including warm completion before start or build, before publication.
 
 A launch can finish before the JavaScript error reaches its log. Both arms must
 repeat standalone foreground log queries, without separate sleep or wait commands,

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -227,8 +227,19 @@ function commandSegmentsStartingWith(command, expected) {
   return shellCommandSegments(command).filter((segment) => segment === expected || segment.startsWith(`${expected} `));
 }
 
+export function commandWithReportedStatus(command) {
+  const source = topLevelShellCommand(command.command);
+  const report = /(?:;|\n)\s*echo "([A-Z_]+)=\$\?"\s*$/.exec(source);
+  if (!report || shellCommandSegments(source).at(-1) !== `echo "${report[1]}=$?"`) return command;
+  const body = source.slice(0, report.index).trim();
+  const statuses = [...String(command.output ?? '').matchAll(new RegExp(`^${report[1]}=(\\d+)\\s*$`, 'gm'))];
+  const valid = command.exitCode === 0 && !/[&|]$/.test(body) && statuses.length === 1;
+  return { ...command, command: body, exitCode: valid ? Number(statuses[0][1]) : null };
+}
+
 function successfulCommand(commands, expected) {
   return commands.some((command) => {
+    command = commandWithReportedStatus(command);
     if (command.exitCode !== 0) return false;
     const segments = shellCommandSegments(command.command);
     const final = segments.at(-1);

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
 import {
   agentDeviceIsolationInvalidReasons,
   agentDeviceAuxiliarySessions,
@@ -400,6 +401,37 @@ describe('benchmark run guards', () => {
       },
     ];
     expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'android' }, commands)).toEqual([]);
+  });
+
+  it.skipIf(process.platform === 'win32')('uses reported warm status without losing completion ordering', () => {
+    const meta = { arm: 'stim', platform: 'android' };
+    const guide = { command: 'stim guide agent', exitCode: 0 };
+    const start = { command: 'stim start', exitCode: 0, startEventOffset: 3 };
+    for (const code of [0, 7]) {
+      const command = 'cd /tmp && stim worktree warm; echo "EXIT=$?"';
+      const result = spawnSync('/bin/bash', ['-c', `stim() { return ${code}; }; ${command}`], {
+        encoding: 'utf8',
+        timeout: 5000,
+      });
+      expect(result.status).toBe(0);
+      const warm = { command, exitCode: result.status, output: result.stdout, endEventOffset: 2 };
+      expect(benchmarkSetupInvalidReasons(meta, [guide, warm, start])).toEqual(
+        code === 0 ? [] : ['stim-worktree-warm-missing-or-failed'],
+      );
+      if (code !== 0) continue;
+      expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, endEventOffset: 4 }, start])).toEqual([
+        'stim-worktree-warm-not-complete-before-use',
+      ]);
+      for (const output of ['', 'EXIT=0\nEXIT=0\n', 'EXIT=7\n']) {
+        expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, output }, start])).toContain(
+          'stim-worktree-warm-missing-or-failed',
+        );
+      }
+      const background = { ...warm, command: 'stim worktree warm &\necho "EXIT=$?"' };
+      expect(benchmarkSetupInvalidReasons(meta, [guide, background, start])).toContain(
+        'stim-worktree-warm-missing-or-failed',
+      );
+    }
   });
 
   it('audits Claude-style chained commands', () => {

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -18,6 +18,7 @@ import { reconstructCommandEvidence } from './agent-benchmark/command-evidence.m
 import {
   agentDeviceIsolationInvalidReasons,
   agentDeviceAuxiliarySessions,
+  benchmarkSetupInvalidReasons,
   topLevelShellCommand,
 } from './agent-benchmark/run-guards.mjs';
 
@@ -884,6 +885,11 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
   );
   const commands = evidence.commands;
   let auxiliarySessions = [];
+  if (
+    record.invalidReasons?.includes('stim-worktree-warm-missing-or-failed') &&
+    benchmarkSetupInvalidReasons({ ...meta, arm: record.arm }, commands).length
+  )
+    return reject('setup evidence missing or failed');
   if (meta.agentDevice?.session && meta.agentDevice?.stateDir) {
     const prefix = `env AGENT_DEVICE_STATE_DIR=${meta.agentDevice.stateDir} AGENT_DEVICE_SESSION=${meta.agentDevice.session} agent-device `;
     const target = { platform: meta.platform ?? 'ios', device: record.simulator?.udid };
@@ -957,6 +963,8 @@ function publicationRecord(runDir, meta) {
       'launch-crash-diagnosis-missing',
       'launch-crash-diagnosis-usage-missing',
       'launch-crash-initial-launch-evidence-missing',
+      'launch-crash-error-capture-missing',
+      'stim-worktree-warm-missing-or-failed',
       'launch-crash-unrelated-source-changes',
       'agent-device-run-session-not-applied',
     ]);

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1363,6 +1363,73 @@ describe('benchmark viewer export', () => {
     expect(reviewedExport).toThrow('no valid benchmark runs found');
     writeFileSync(eventsPath, reviewedEvents);
     writeFileSync(recordPath, JSON.stringify(rejected));
+    const statusEvents =
+      [
+        stamp('2026-09-04T12:00:07.100Z', {
+          type: 'item.completed',
+          item: { id: 'guide', type: 'command_execution', command: 'stim guide agent', exit_code: 0 },
+        }),
+        stamp('2026-09-04T12:00:08.000Z', {
+          type: 'item.started',
+          item: { id: 'warm', type: 'command_execution', command: 'stim worktree warm; echo "EXIT=$?"' },
+        }),
+        stamp('2026-09-04T12:00:09.000Z', {
+          type: 'item.completed',
+          item: {
+            id: 'warm',
+            type: 'command_execution',
+            command: 'stim worktree warm; echo "EXIT=$?"',
+            exit_code: 0,
+            aggregated_output: 'EXIT=0\n',
+          },
+        }),
+        ...reviewedEvents.trim().split('\n'),
+      ]
+        .toSorted((left, right) => JSON.parse(left).arrivedAt.localeCompare(JSON.parse(right).arrivedAt))
+        .join('\n') + '\n';
+    for (const failed of [false, true]) {
+      writeFileSync(eventsPath, failed ? statusEvents.replaceAll('EXIT=0', 'EXIT=7') : statusEvents);
+      const statusRejected = {
+        ...rejected,
+        invalidReasons: [
+          'stim-worktree-warm-missing-or-failed',
+          'launch-crash-error-capture-missing',
+          'launch-crash-diagnosis-missing',
+        ],
+        evidenceSha256: { ...rejected.evidenceSha256, events: sha256(eventsPath) },
+      };
+      writeFileSync(recordPath, JSON.stringify(statusRejected));
+      writeFileSync(
+        reviewPath,
+        JSON.stringify({
+          ...review,
+          originalRecordSha256: sha256(recordPath),
+          commands: [
+            ...review.commands,
+            {
+              commandId: 'warm',
+              command: 'stim worktree warm; echo "EXIT=$?"',
+              assessment: 'Warm completed successfully before launch; trailing echo reports its status.',
+            },
+          ],
+        }),
+      );
+      let result;
+      try {
+        const run = reviewedExport().runs[0];
+        result = {
+          valid: run.valid,
+          diagnosisSeconds: run.diagnosisSeconds,
+          settingsReadySeconds: run.settingsReadySeconds,
+        };
+      } catch (error) {
+        result = error.message.startsWith('no valid benchmark runs found') ? 'rejected' : error.message;
+      }
+      expect(result).toEqual(failed ? 'rejected' : { valid: true, diagnosisSeconds: 90, settingsReadySeconds: 150 });
+      expect(JSON.parse(readFileSync(recordPath))).toEqual(statusRejected);
+    }
+    writeFileSync(eventsPath, reviewedEvents);
+    writeFileSync(recordPath, JSON.stringify(rejected));
     for (const changed of [
       { originalRecordSha256: 'changed' },
       { metaSha256: 'changed' },

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -1,5 +1,9 @@
 import { createHash } from 'node:crypto';
-import { shellCommandSegments, topLevelShellCommand } from './agent-benchmark/run-guards.mjs';
+import {
+  commandWithReportedStatus,
+  shellCommandSegments,
+  topLevelShellCommand,
+} from './agent-benchmark/run-guards.mjs';
 
 export function launchCrashToken(runId) {
   const digest = createHash('sha256').update(runId).digest('hex').slice(0, 12).toUpperCase();
@@ -31,7 +35,7 @@ export function injectRootRenderCrash(source, token) {
 }
 
 function successful(command) {
-  return command.exitCode === 0;
+  return commandWithReportedStatus(command).exitCode === 0;
 }
 
 function successfulLaunch(command, arm, platform) {
@@ -70,7 +74,8 @@ function shellCommand(command) {
 
 function launchCommand(command, arm, platform) {
   command = shellCommand(command);
-  if (arm === 'stim') return new RegExp(`(?:^|\\s)stim\\s+${platform}(?:\\s|$)`).test(command);
+  if (arm === 'stim')
+    return shellCommandSegments(command).some((segment) => new RegExp(`^stim\\s+${platform}(?:\\s|$)`).test(segment));
   if (platform === 'android') {
     return (
       /(?:\bexpo|expo\/bin\/cli|node_modules\/\.bin\/expo)\s+run:android\b/.test(command) ||
@@ -85,7 +90,8 @@ function launchCommand(command, arm, platform) {
 
 function errorCaptureCommand(command, arm, platform) {
   command = shellCommand(command);
-  if (arm === 'stim') return /(?:^|\s)stim\s+logs\s+--errors(?:\s|$)/.test(command);
+  if (arm === 'stim')
+    return shellCommandSegments(command).some((segment) => /^stim\s+logs\s+--errors(?:\s|$)/.test(segment));
   const explicitLogFile =
     /\b(?:tail|rg|grep|sed|cat)\b[\s\S]*(?:\.log\b|(?:^|[\s'"])(?:\.?\/)?(?:tmp|logs?|\.expo\/dev\/logs)\/)/.test(
       command,

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -38,10 +38,17 @@ function successful(command) {
   return commandWithReportedStatus(command).exitCode === 0;
 }
 
+function completedStepCommand(command, arm) {
+  const body = topLevelShellCommand(commandWithReportedStatus(command).command);
+  if (arm !== 'stim') return body;
+  return /[&|]\s*$/.test(body) ? '' : (shellCommandSegments(body).at(-1) ?? '');
+}
+
 function successfulLaunch(command, arm, platform) {
-  if (!successful(command) || !launchCommand(command.command, arm, platform)) return false;
+  if (!successful(command)) return false;
   const value = shellCommand(command.command);
-  if (!/\|\s*tee\b/.test(value)) return true;
+  if (!/\|\s*tee\b/.test(value)) return launchCommand(completedStepCommand(command, arm), arm, platform);
+  if (!launchCommand(command.command, arm, platform)) return false;
   const prefix = value.match(
     /^(?:cd\s+(?:[^\s'"$`\\;&|]+|'[^'\n]+'|"[^"$`\n]+")\s*&&\s*)?set -(?:o|eo|euo) pipefail\s*(?:&&|;|\n)\s*/,
   );
@@ -344,7 +351,7 @@ export function launchCrashDiagnosis(
     (command, index) =>
       index > initialLaunchIndex &&
       successful(command) &&
-      errorCaptureCommand(command.command, arm, platform) &&
+      errorCaptureCommand(completedStepCommand(command, arm), arm, platform) &&
       typeof command.output === 'string' &&
       command.output.includes(token),
   );

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -11,6 +11,40 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it.skipIf(process.platform === 'win32')(
+    'accepts reported Stim launch and log status only when the underlying command succeeded',
+    () => {
+      for (const [launchCode, logCode] of [
+        [0, 0],
+        [7, 0],
+        [0, 7],
+      ]) {
+        const commands = [
+          ['stim ios', launchCode, ''],
+          ['stim logs --errors', logCode, 'test-token RootLayout'],
+        ].map(([body, code, output], index) => {
+          const command = `cd /tmp && ${body}; echo "EXIT=$?"`;
+          const result = spawnSync(
+            '/bin/bash',
+            ['-c', `stim() { printf '%s\\n' '${output}'; return ${code}; }; ${command}`],
+            { encoding: 'utf8', timeout: 5000 },
+          );
+          expect(result.status).toBe(0);
+          return {
+            id: String(index),
+            command,
+            exitCode: result.status,
+            output: result.stdout,
+            endedAt: `2026-09-04T12:00:0${index + 1}Z`,
+          };
+        });
+        expect(
+          launchCrashDiagnosis(commands, { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'stim' })
+            .valid,
+        ).toBe(launchCode === 0 && logCode === 0);
+      }
+    },
+  );
   it.skipIf(process.platform === 'win32')('uses the real pipeline status when a trailing echo exits zero', () => {
     for (const [code, prefix, valid] of [
       [0, 'cd /tmp && set -o pipefail &&', true],

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -43,6 +43,32 @@ describe('launch crash benchmark', () => {
             .valid,
         ).toBe(launchCode === 0 && logCode === 0);
       }
+      for (const suffix of ['; true', '; true; echo "EXIT=$?"', '||true; echo "EXIT=$?"']) {
+        for (const failedStep of [0, 1]) {
+          const commands = ['stim ios', 'stim logs --errors'].map((body, index) => {
+            const command = body + (index === failedStep ? suffix : '');
+            const result = spawnSync(
+              '/bin/bash',
+              [
+                '-c',
+                `stim() { printf '%s\\n' 'test-token RootLayout'; return ${index === failedStep ? 7 : 0}; }; ${command}`,
+              ],
+              { encoding: 'utf8', timeout: 5000 },
+            );
+            expect(result.status).toBe(0);
+            return {
+              command,
+              output: result.stdout,
+              exitCode: result.status,
+              endedAt: `2026-09-04T12:00:0${index + 1}Z`,
+            };
+          });
+          expect(
+            launchCrashDiagnosis(commands, { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'stim' })
+              .valid,
+          ).toBe(false);
+        }
+      }
     },
   );
   it.skipIf(process.platform === 'win32')('uses the real pipeline status when a trailing echo exits zero', () => {
@@ -68,6 +94,34 @@ describe('launch crash benchmark', () => {
       expect(diagnosis.valid).toBe(valid);
     }
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'retains Stim pipefail launch pipelines with and without a status report',
+    () => {
+      for (const suffix of ['', '; echo "PIPELINE_EXIT=$?"']) {
+        for (const code of [0, 7]) {
+          const command = `set -o pipefail; stim ios | tee /dev/null${suffix}`;
+          const result = spawnSync('/bin/bash', ['-c', `stim() { return ${code}; }; ${command}`], {
+            encoding: 'utf8',
+            timeout: 5000,
+          });
+          const commands = [
+            { command, exitCode: result.status, output: result.stdout, endedAt: '2026-09-04T12:00:01Z' },
+            {
+              command: 'stim logs --errors',
+              exitCode: 0,
+              output: 'test-token RootLayout',
+              endedAt: '2026-09-04T12:00:02Z',
+            },
+          ];
+          expect(
+            launchCrashDiagnosis(commands, { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'stim' })
+              .valid,
+          ).toBe(code === 0);
+        }
+      }
+    },
+  );
 
   it('accepts only checksum-row updates, not dependency changes or malformed lockfiles', () => {
     const before = `PODS:\n  - Core (1.0)\n\nSPEC CHECKSUMS:\n  Core: ${'a'.repeat(40)}\n\nCOCOAPODS: 1.16.2\n`;


### PR DESCRIPTION
## Description

Opus repaired the Android launch crash and reached Settings in 4m 45s, but the benchmark rejected `stim worktree warm; echo "EXIT=$?"` and `stim logs --errors; echo "EXIT=$?"` as missing steps. Fixes #516.

## Solution

Accept these status-reporting commands using the captured status, not the echo's exit code. Missing, duplicated or nonzero reports cannot establish success. Retained runs can be reviewed without rerunning them or rewriting their original records; warm ordering and runtime diagnosis must still be proven from the events. This changes benchmark validation only.

## Test plan

- Real Bash commands returning 0 and 7 both end with a successful echo; only the actual success passes. Overlapping warm still fails.
- Reconstructed all 14 retained workflows: existing diagnosis/recovery evidence remains valid, including the previously rejected Opus run (3m 57s diagnosis, 4m 45s Settings).
- Export regression accepts reviewed warm/log false rejections while rejecting failed warm and preserving the original record.
