### PR TITLE
fix: review completed launch-error benchmark evidence

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -282,3 +282,19 @@ checks every retained hash, the original source hash and checksum-only semantics
 It cannot clear other source changes, dependency changes or source-before-capture
 violations. Valid runs with setup or auxiliary warnings also require review before publication. The original
 `run.json` is never rewritten, and review records stay private.
+
+The coordinator may adjudicate source-inspection false positives with
+`diagnosticCommands` entries containing the exact `commandId`, `command`, and
+an `assessment`. Read the captured command and output before approving one:
+log search patterns and error-response files are diagnostics, but actual app
+source access before runtime capture remains invalid. This is an explicit
+manual classification, not a claim that the shell heuristic proves safety.
+Reviews are bound to the original record, metadata and current audit code;
+each diagnostic entry must also appear in the reviewed setup command set.
+
+A runner timeout after completed task evidence can be reviewed with a
+`completion.assessment`. The original deadline does not move: repair, Settings
+proof, recording copy, session close and every captured command must finish
+before it. A missing or late proof, a running command, or a different runner
+failure still rejects the run. The final conversational response is not a task
+completion requirement; its timeout remains recorded in the private evidence.

--- a/scripts/agent-benchmark/command-evidence.mjs
+++ b/scripts/agent-benchmark/command-evidence.mjs
@@ -47,10 +47,13 @@ export function reconstructCommandEvidence(runner, stamped) {
               command: `tool:${block.name} ${JSON.stringify(block.input ?? {})}`,
               startedAt: record.arrivedAt,
               endedAt: record.arrivedAt,
+              completedAt: null,
             });
           }
         }
         if (event.type !== 'user' || block.type !== 'tool_result') continue;
+        const activity = activities.find((entry) => entry.id === block.tool_use_id);
+        if (activity) activity.completedAt = record.arrivedAt;
         const result = event.tool_use_result ?? {};
         const taskId = taskQueries.get(block.tool_use_id);
         if (taskId) {
@@ -112,13 +115,27 @@ export function reconstructCommandEvidence(runner, stamped) {
       continue;
     }
     const item = event.item;
-    if (event.type === 'item.started' && item?.type && item.type !== 'command_execution') {
+    const executableActivity = item?.type && !['command_execution', 'reasoning', 'agent_message'].includes(item.type);
+    if (event.type === 'item.started' && executableActivity) {
       activities.push({
         id: item.id,
         command: `tool:${item.type} ${JSON.stringify(item.changes ?? item)}`,
         startedAt: record.arrivedAt,
         endedAt: record.arrivedAt,
+        completedAt: null,
       });
+    }
+    if (event.type === 'item.completed' && executableActivity) {
+      const activity = activities.find((entry) => entry.id === item?.id);
+      if (activity) activity.completedAt = record.arrivedAt;
+      else
+        activities.push({
+          id: item.id,
+          command: `tool:${item.type} ${JSON.stringify(item.changes ?? item)}`,
+          startedAt: null,
+          endedAt: record.arrivedAt,
+          completedAt: record.arrivedAt,
+        });
     }
     if (event.type === 'item.started' && item?.type === 'command_execution') {
       started.set(item.id, { offset, at: record.arrivedAt, command: item.command });

--- a/scripts/agent-benchmark/command-evidence.test.mjs
+++ b/scripts/agent-benchmark/command-evidence.test.mjs
@@ -31,6 +31,43 @@ const setup = (runner, events) =>
   benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'ios' }, reconstructCommandEvidence(runner, events).commands);
 
 describe('command completion evidence', () => {
+  it('retains completed-only file changes for deadline and source access auditing', () => {
+    const evidence = reconstructCommandEvidence('codex', [
+      stamp(8, { type: 'item.completed', item: { id: 'edit', type: 'file_change', changes: [] } }),
+    ]);
+    expect(evidence.activities[0]).toMatchObject({ id: 'edit', startedAt: null, completedAt: stamp(8, {}).arrivedAt });
+  });
+  it('does not treat completed-only agent commentary as source access', () => {
+    const evidence = reconstructCommandEvidence(
+      'codex',
+      ['reasoning', 'agent_message'].flatMap((type) =>
+        ['item.started', 'item.completed'].map((event) =>
+          stamp(1, { type: event, item: { id: type, type, text: 'Read app/_layout.tsx next' } }),
+        ),
+      ),
+    );
+    expect(evidence.activities).toEqual([]);
+  });
+  it.each(['claude', 'codex'])('distinguishes a completed %s file edit from its tool start', (runner) => {
+    const begin =
+      runner === 'claude'
+        ? stamp(1, {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'tool_use', name: 'Edit', id: 'edit', input: { file_path: 'app/_layout.tsx' } }],
+            },
+          })
+        : stamp(1, { type: 'item.started', item: { id: 'edit', type: 'file_change', changes: [] } });
+    const end =
+      runner === 'claude'
+        ? result(8, 'edit', {})
+        : stamp(8, { type: 'item.completed', item: { id: 'edit', type: 'file_change' } });
+    expect(reconstructCommandEvidence(runner, [begin]).activities[0].completedAt).toBeNull();
+    expect(reconstructCommandEvidence(runner, [begin, end]).activities[0]).toMatchObject({
+      startedAt: stamp(1, {}).arrivedAt,
+      completedAt: stamp(8, {}).arrivedAt,
+    });
+  });
   it('retains unfinished Codex warm jobs so an earlier completed warm cannot hide overlap', () => {
     const events = [
       codex(0, 'guide', 'stim guide agent'),

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -201,7 +201,9 @@ export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
 }
 
 export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix, target) {
-  const segments = commands.flatMap((command) => shellCommandSegments(command.command));
+  const segments = commands.flatMap((command) =>
+    shellCommandSegments(command.command).map((segment) => segment.replace(/^do\s+/, '')),
+  );
   const auxiliary = new Set(
     agentDeviceAuxiliarySessions(commands, expectedPrefix, target).flatMap((session) =>
       session.commands.map((entry) => entry.command),

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -33,6 +33,19 @@ const build = (output) => [{ id: 'build', command: 'stim android', exitCode: 0, 
 describe('agent-device session isolation', () => {
   const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=bench-run agent-device ';
 
+  it('recognizes scoped loop bodies without allowing an unscoped iteration command', () => {
+    const scoped = `for i in 1 2 3; do ${prefix}press 'text="Open"' --settle 2>&1 | tail -4; done`;
+    expect(agentDeviceIsolationInvalidReasons([{ command: scoped }], prefix)).toEqual([]);
+    for (const command of [
+      scoped.replace('SESSION=bench-run', 'SESSION=default'),
+      scoped.replace('; done', '; agent-device close; done'),
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command }], prefix)).toContain(
+        'agent-device-run-session-not-applied',
+      );
+    }
+  });
+
   it('allows help output without letting help hide an unscoped device command', () => {
     expect(
       agentDeviceIsolationInvalidReasons(

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -866,7 +866,7 @@ function reviewedChecksumProof(runDir, record, meta) {
     : null;
 }
 
-function completedBeforeRunnerTimeout(runDir, record, meta, commands) {
+function completedBeforeRunnerTimeout(runDir, record, meta, { commands, activities }) {
   const seconds = meta.timingTarget?.runTimeoutSeconds;
   const deadline = Date.parse(meta.dispatchAt) + seconds * 1000;
   const proofIds = [
@@ -902,6 +902,11 @@ function completedBeforeRunnerTimeout(runDir, record, meta, commands) {
           (command) => command.id === id && command.exitCode === 0 && Date.parse(command.endedAt) <= deadline,
         ),
     ) &&
+    activities
+      .filter((activity) => !/^tool:(?:reasoning|agent_message) /.test(activity.command))
+      .every(
+        (activity) => Number.isFinite(Date.parse(activity.completedAt)) && Date.parse(activity.completedAt) <= deadline,
+      ) &&
     commands.every((command) => Number.isFinite(Date.parse(command.endedAt)) && Date.parse(command.endedAt) <= deadline)
   );
 }
@@ -928,7 +933,7 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false, revie
     record.invalidReasons?.some((reason) => reason === 'runner-exit-143' || reason === 'benchmark-run-timeout') &&
     (typeof review.completion?.assessment !== 'string' ||
       !review.completion.assessment.trim() ||
-      !completedBeforeRunnerTimeout(runDir, record, meta, commands))
+      !completedBeforeRunnerTimeout(runDir, record, meta, evidence))
   )
     return reject('task proof did not complete before runner timeout');
   let auxiliarySessions = [];
@@ -1183,7 +1188,7 @@ export function exportBenchmark(stageDir, outputPath, proofDir, machine = {}) {
             ? validateReadinessRecord(runDir, record, meta)
             : true,
         launchCrashValidation:
-          record.variant === 'launch-crash'
+          record.variant === 'launch-crash' && record.valid
             ? validateLaunchCrashRecord(
                 runDir,
                 record,

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -866,7 +866,47 @@ function reviewedChecksumProof(runDir, record, meta) {
     : null;
 }
 
-function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
+function completedBeforeRunnerTimeout(runDir, record, meta, commands) {
+  const seconds = meta.timingTarget?.runTimeoutSeconds;
+  const deadline = Date.parse(meta.dispatchAt) + seconds * 1000;
+  const proofIds = [
+    'openCommandId',
+    'recordStartCommandId',
+    'waitCommandId',
+    'screenshotCommandId',
+    'copyCommandId',
+    'recordStopCommandId',
+    'recordingCopyCommandId',
+    'closeCommandId',
+  ].map((key) => record.screen?.[key]);
+  const recording = join(runDir, 'proof', 'session.mp4');
+  return (
+    Number.isFinite(seconds) &&
+    seconds > 0 &&
+    Number.isFinite(deadline) &&
+    new Set(proofIds).size === proofIds.length &&
+    meta.runnerResult?.timedOut === true &&
+    meta.runnerResult.code === 143 &&
+    Date.parse(meta.finishedAt) >= deadline &&
+    record.proof?.valid === true &&
+    /^[a-f0-9]{64}$/.test(record.proof.sourceSha256 ?? '') &&
+    record.proof.sourceSha256 === meta.crash?.originalSha256 &&
+    record.screen?.valid === true &&
+    record.recording?.valid === true &&
+    existsSync(recording) &&
+    fileSha256(recording) === record.evidenceSha256?.recording &&
+    proofIds.every(
+      (id) =>
+        typeof id === 'string' &&
+        commands.some(
+          (command) => command.id === id && command.exitCode === 0 && Date.parse(command.endedAt) <= deadline,
+        ),
+    ) &&
+    commands.every((command) => Number.isFinite(Date.parse(command.endedAt)) && Date.parse(command.endedAt) <= deadline)
+  );
+}
+
+function validateLaunchCrashRecord(runDir, record, meta, rederive = false, review = {}) {
   const reject = (reason) => {
     if (process.env.STIM_BENCH_EXPORT_DEBUG === '1') {
       process.stderr.write(`${basename(runDir)}: ${reason}\n`);
@@ -884,6 +924,13 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
     readFileSync(eventsPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse),
   );
   const commands = evidence.commands;
+  if (
+    record.invalidReasons?.some((reason) => reason === 'runner-exit-143' || reason === 'benchmark-run-timeout') &&
+    (typeof review.completion?.assessment !== 'string' ||
+      !review.completion.assessment.trim() ||
+      !completedBeforeRunnerTimeout(runDir, record, meta, commands))
+  )
+    return reject('task proof did not complete before runner timeout');
   let auxiliarySessions = [];
   if (
     record.invalidReasons?.includes('stim-worktree-warm-missing-or-failed') &&
@@ -913,6 +960,7 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false) {
     platform: meta.platform ?? 'ios',
     activities: evidence.activities,
     setup: { worktree: record.worktree, avdConfig: meta.expectedControlAvdConfig },
+    reviewedDiagnostics: review.diagnosticCommands ?? [],
   });
   const recovery = launchCrashRecovery(commands, {
     diagnosis,
@@ -958,6 +1006,24 @@ function publicationRecord(runDir, meta) {
   const record = readJson(recordPath);
   if (record.variant === 'launch-crash') {
     const reviewPath = join(runDir, 'launch-error-audit-review.json');
+    const review = existsSync(reviewPath) ? readJson(reviewPath) : null;
+    const policyPath = fileURLToPath(new URL('./launch-crash-benchmark.mjs', import.meta.url));
+    const guardPath = fileURLToPath(new URL('./agent-benchmark/run-guards.mjs', import.meta.url));
+    if (
+      review &&
+      (review.schemaVersion !== 1 ||
+        review.runId !== record.runId ||
+        review.originalRecordSha256 !== fileSha256(recordPath) ||
+        review.metaSha256 !== fileSha256(join(runDir, 'meta.json')) ||
+        review.policySha256 !== fileSha256(policyPath) ||
+        review.shellParserSha256 !== fileSha256(guardPath) ||
+        (review.diagnosticCommands != null &&
+          (!Array.isArray(review.diagnosticCommands) ||
+            review.diagnosticCommands.some(
+              (entry) => !entry || typeof entry.assessment !== 'string' || !entry.assessment.trim(),
+            ))))
+    )
+      return { ...record, valid: false };
     const reviewableReasons = new Set([
       'launch-crash-pre-capture-command-not-allowed',
       'launch-crash-diagnosis-missing',
@@ -967,25 +1033,22 @@ function publicationRecord(runDir, meta) {
       'stim-worktree-warm-missing-or-failed',
       'launch-crash-unrelated-source-changes',
       'agent-device-run-session-not-applied',
+      'runner-exit-143',
+      'benchmark-run-timeout',
     ]);
     const eligible =
       record.valid ||
       (record.invalidReasons?.length > 0 && record.invalidReasons.every((reason) => reviewableReasons.has(reason)));
-    const derived = eligible ? validateLaunchCrashRecord(runDir, record, meta, true) : null;
+    const derived = eligible ? validateLaunchCrashRecord(runDir, record, meta, true, review ?? {}) : null;
     if (!derived) return record.valid ? { ...record, valid: false } : record;
     const warnings = derived.diagnosis.setupWarnings ?? [];
     if (!warnings.length && !derived.auxiliarySessions.length && !derived.checksumProof && record.valid) return record;
-    if (!existsSync(reviewPath)) return { ...record, valid: false };
-    const review = readJson(reviewPath);
-    const policyPath = fileURLToPath(new URL('./launch-crash-benchmark.mjs', import.meta.url));
-    const guardPath = fileURLToPath(new URL('./agent-benchmark/run-guards.mjs', import.meta.url));
+    if (!review) return { ...record, valid: false };
     if (
-      review.schemaVersion !== 1 ||
-      review.runId !== record.runId ||
-      review.originalRecordSha256 !== fileSha256(recordPath) ||
-      review.metaSha256 !== fileSha256(join(runDir, 'meta.json')) ||
-      review.policySha256 !== fileSha256(policyPath) ||
-      review.shellParserSha256 !== fileSha256(guardPath) ||
+      (review.diagnosticCommands ?? []).some(
+        (entry) =>
+          !warnings.some((warning) => entry.commandId === warning.commandId && entry.command === warning.command),
+      ) ||
       (derived.checksumProof &&
         (review.sourceChanges?.evidenceSha256 !== derived.checksumProof.evidenceSha256 ||
           typeof review.sourceChanges?.assessment !== 'string' ||
@@ -1120,7 +1183,17 @@ export function exportBenchmark(stageDir, outputPath, proofDir, machine = {}) {
             ? validateReadinessRecord(runDir, record, meta)
             : true,
         launchCrashValidation:
-          record.variant === 'launch-crash' ? validateLaunchCrashRecord(runDir, record, meta) : null,
+          record.variant === 'launch-crash'
+            ? validateLaunchCrashRecord(
+                runDir,
+                record,
+                meta,
+                false,
+                existsSync(join(runDir, 'launch-error-audit-review.json'))
+                  ? readJson(join(runDir, 'launch-error-audit-review.json'))
+                  : {},
+              )
+            : null,
       };
     })
     .filter(({ runDir, record, readinessValidation, launchCrashValidation }) => {

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1460,12 +1460,15 @@ describe('benchmark viewer export', () => {
       writeFileSync(reviewPath, JSON.stringify({ ...diagnosticReview, diagnosticCommands: [diagnosticEntry] }));
       expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90 });
       for (const entry of [
+        null,
         { ...diagnosticEntry, command: 'cat app/_layout.tsx' },
         { ...diagnosticEntry, assessment: '' },
       ]) {
         writeFileSync(reviewPath, JSON.stringify({ ...diagnosticReview, diagnosticCommands: [entry] }));
         expect(reviewedExport).toThrow('no valid benchmark runs found');
       }
+      writeFileSync(reviewPath, JSON.stringify({ ...diagnosticReview, diagnosticCommands: {} }));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
       writeFileSync(eventsPath, reviewedEvents);
       writeFileSync(recordPath, JSON.stringify(rejected));
       const metaPath = join(runDir, 'meta.json');
@@ -1542,6 +1545,41 @@ describe('benchmark viewer export', () => {
       writeFileSync(reviewPath, JSON.stringify(timeoutReview));
       expect(reviewedExport().runs[0]).toMatchObject({ valid: true, settingsReadySeconds: 150 });
       expect(JSON.parse(readFileSync(recordPath))).toEqual(timeoutRecord);
+      for (const completionSeconds of [160, 181, null]) {
+        const editEvents = [
+          stamp('2026-09-04T12:02:35Z', {
+            type: 'item.started',
+            item: { id: 'file-edit', type: 'file_change', changes: [] },
+          }),
+        ];
+        if (completionSeconds !== null)
+          editEvents.push(
+            stamp(new Date(Date.parse(timeoutMeta.dispatchAt) + completionSeconds * 1000).toISOString(), {
+              type: 'item.completed',
+              item: { id: 'file-edit', type: 'file_change', changes: [] },
+            }),
+          );
+        writeFileSync(eventsPath, timeoutEvents + editEvents.join('\n') + '\n');
+        writeFileSync(
+          recordPath,
+          JSON.stringify({
+            ...timeoutRecord,
+            evidenceSha256: { ...timeoutRecord.evidenceSha256, events: sha256(eventsPath) },
+          }),
+        );
+        writeFileSync(reviewPath, JSON.stringify({ ...timeoutReview, originalRecordSha256: sha256(recordPath) }));
+        let outcome;
+        try {
+          outcome = reviewedExport().runs[0].valid;
+        } catch (error) {
+          outcome = error.message.includes('no valid benchmark runs found') ? false : error.message;
+        }
+        expect(outcome).toBe(completionSeconds === 160);
+      }
+      writeFileSync(eventsPath, timeoutEvents);
+      writeFileSync(recordPath, JSON.stringify(timeoutRecord));
+      writeFileSync(reviewPath, JSON.stringify({ ...timeoutReview, completion: { assessment: 1 } }));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
       for (const changed of [
         { timingTarget: { runTimeoutSeconds: 150 } },
         { runnerResult: { code: 1, timedOut: false } },

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1430,6 +1430,137 @@ describe('benchmark viewer export', () => {
     }
     writeFileSync(eventsPath, reviewedEvents);
     writeFileSync(recordPath, JSON.stringify(rejected));
+    {
+      const diagnosticCommand = 'rg -n "\\.tsx" /tmp/metro.log';
+      const diagnosticEvents =
+        reviewedEvents
+          .trim()
+          .split('\n')
+          .map((line) => {
+            const stamped = JSON.parse(line),
+              event = JSON.parse(stamped.line);
+            if (event.item.id === 'metadata') event.item.command = diagnosticCommand;
+            return JSON.stringify({ ...stamped, line: JSON.stringify(event) });
+          })
+          .join('\n') + '\n';
+      writeFileSync(eventsPath, diagnosticEvents);
+      const diagnosticRecord = {
+        ...rejected,
+        evidenceSha256: { ...rejected.evidenceSha256, events: sha256(eventsPath) },
+      };
+      writeFileSync(recordPath, JSON.stringify(diagnosticRecord));
+      const diagnosticEntry = {
+        commandId: 'metadata',
+        command: diagnosticCommand,
+        assessment: 'Searches the runtime log, not source files.',
+      };
+      const diagnosticReview = { ...review, originalRecordSha256: sha256(recordPath), commands: [diagnosticEntry] };
+      writeFileSync(reviewPath, JSON.stringify(diagnosticReview));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
+      writeFileSync(reviewPath, JSON.stringify({ ...diagnosticReview, diagnosticCommands: [diagnosticEntry] }));
+      expect(reviewedExport().runs[0]).toMatchObject({ valid: true, diagnosisSeconds: 90 });
+      for (const entry of [
+        { ...diagnosticEntry, command: 'cat app/_layout.tsx' },
+        { ...diagnosticEntry, assessment: '' },
+      ]) {
+        writeFileSync(reviewPath, JSON.stringify({ ...diagnosticReview, diagnosticCommands: [entry] }));
+        expect(reviewedExport).toThrow('no valid benchmark runs found');
+      }
+      writeFileSync(eventsPath, reviewedEvents);
+      writeFileSync(recordPath, JSON.stringify(rejected));
+      const metaPath = join(runDir, 'meta.json');
+      const originalMeta = readFileSync(metaPath, 'utf8');
+      const originalSourceHash = createHash('sha256').update('restored source').digest('hex');
+      const timeoutMeta = {
+        ...JSON.parse(originalMeta),
+        timingTarget: { runTimeoutSeconds: 180 },
+        runnerResult: { code: 143, timedOut: true },
+        finishedAt: '2026-09-04T12:03:01Z',
+        crash: { originalSha256: originalSourceHash },
+      };
+      writeFileSync(metaPath, JSON.stringify(timeoutMeta));
+      const recordingPath = join(runDir, 'proof', 'session.mp4');
+      copyFileSync(
+        join(process.cwd(), 'website/static/benchmarks/luna-rc12/javascript-stim-interaction.mp4'),
+        recordingPath,
+      );
+      const proofSteps = [
+        ['open', 138, 'agent-device open com.app --foreground'],
+        ['record-start', 140, 'agent-device record start /tmp/session.mp4'],
+        ['wait', 149, 'agent-device wait text Settings'],
+        ['copy', 151, 'cp /tmp/settings.png proof/settings.png'],
+        ['record-stop', 152, 'agent-device record stop'],
+        ['record-copy', 153, 'cp /tmp/session.mp4 proof/session.mp4'],
+        ['close', 154, 'agent-device close'],
+      ];
+      const timeoutEvents =
+        [
+          ...reviewedEvents.trim().split('\n'),
+          ...proofSteps.flatMap(([id, seconds, command]) => {
+            const end = Date.parse(timeoutMeta.dispatchAt) + seconds * 1000;
+            return [
+              stamp(new Date(end - 500).toISOString(), {
+                type: 'item.started',
+                item: { id, type: 'command_execution', command },
+              }),
+              stamp(new Date(end).toISOString(), {
+                type: 'item.completed',
+                item: { id, type: 'command_execution', command, exit_code: 0, aggregated_output: '' },
+              }),
+            ];
+          }),
+        ]
+          .toSorted((a, b) => JSON.parse(a).arrivedAt.localeCompare(JSON.parse(b).arrivedAt))
+          .join('\n') + '\n';
+      writeFileSync(eventsPath, timeoutEvents);
+      const timeoutRecord = {
+        ...rejected,
+        invalidReasons: ['runner-exit-143', 'benchmark-run-timeout'],
+        proof: { ...rejected.proof, sourceSha256: originalSourceHash },
+        screen: {
+          ...rejected.screen,
+          openCommandId: 'open',
+          recordStartCommandId: 'record-start',
+          waitCommandId: 'wait',
+          copyCommandId: 'copy',
+          recordStopCommandId: 'record-stop',
+          recordingCopyCommandId: 'record-copy',
+          closeCommandId: 'close',
+        },
+        recording: { valid: true },
+        evidenceSha256: { ...rejected.evidenceSha256, events: sha256(eventsPath), recording: sha256(recordingPath) },
+      };
+      writeFileSync(recordPath, JSON.stringify(timeoutRecord));
+      const timeoutReview = {
+        ...review,
+        originalRecordSha256: sha256(recordPath),
+        metaSha256: sha256(metaPath),
+        completion: {
+          assessment: 'All task evidence completed before the original deadline; only final response timed out.',
+        },
+      };
+      writeFileSync(reviewPath, JSON.stringify(timeoutReview));
+      expect(reviewedExport().runs[0]).toMatchObject({ valid: true, settingsReadySeconds: 150 });
+      expect(JSON.parse(readFileSync(recordPath))).toEqual(timeoutRecord);
+      for (const changed of [
+        { timingTarget: { runTimeoutSeconds: 150 } },
+        { runnerResult: { code: 1, timedOut: false } },
+      ]) {
+        writeFileSync(metaPath, JSON.stringify({ ...timeoutMeta, ...changed }));
+        writeFileSync(reviewPath, JSON.stringify({ ...timeoutReview, metaSha256: sha256(metaPath) }));
+        expect(reviewedExport).toThrow('no valid benchmark runs found');
+      }
+      writeFileSync(metaPath, JSON.stringify(timeoutMeta));
+      writeFileSync(
+        recordPath,
+        JSON.stringify({ ...timeoutRecord, screen: { ...timeoutRecord.screen, closeCommandId: undefined } }),
+      );
+      writeFileSync(reviewPath, JSON.stringify({ ...timeoutReview, originalRecordSha256: sha256(recordPath) }));
+      expect(reviewedExport).toThrow('no valid benchmark runs found');
+      writeFileSync(metaPath, originalMeta);
+      writeFileSync(eventsPath, reviewedEvents);
+      writeFileSync(recordPath, JSON.stringify(rejected));
+    }
     for (const changed of [
       { originalRecordSha256: 'changed' },
       { metaSha256: 'changed' },

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -339,7 +339,7 @@ function allowedBeforeErrorCapture(command, arm, platform, setup = {}) {
 
 export function launchCrashDiagnosis(
   commands,
-  { dispatchAt, token, arm = 'stim', platform = 'ios', activities = [], setup = {} },
+  { dispatchAt, token, arm = 'stim', platform = 'ios', activities = [], setup = {}, reviewedDiagnostics = [] },
 ) {
   const ordered = orderedCommands(commands);
   const sourceMarkers = ['app/_layout.tsx', 'RootLayout'];
@@ -367,8 +367,16 @@ export function launchCrashDiagnosis(
       timestamp(command, 'startedAt') < captureEndedAt &&
       !allowedBeforeErrorCapture(command.command, arm, platform, setup),
   );
-  const disallowedBeforeCapture = unrecognizedBeforeCapture.filter((command) =>
-    sourceInspectionBeforeCapture(command.command, arm, platform),
+  const disallowedBeforeCapture = unrecognizedBeforeCapture.filter(
+    (command) =>
+      sourceInspectionBeforeCapture(command.command, arm, platform) &&
+      !reviewedDiagnostics.some(
+        (entry) =>
+          entry.commandId === command.id &&
+          entry.command === command.command &&
+          typeof entry.assessment === 'string' &&
+          entry.assessment.trim(),
+      ),
   );
   if (disallowedBeforeCapture.length) {
     return {

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -11,6 +11,56 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it('requires explicit coordinator review for diagnostics falsely flagged as source inspection', () => {
+    const diagnostic = {
+      id: 'diagnostic',
+      command: 'head -c 600 /tmp/testbundle.js',
+      output: '{"type":"UnableToResolveError","targetModuleName":"./index"}',
+      exitCode: 0,
+      endedAt: '2026-09-04T12:00:02Z',
+    };
+    const commands = [
+      {
+        id: 'launch',
+        command: 'xcrun simctl launch U1 com.app',
+        output: 'com.app: 123',
+        exitCode: 0,
+        endedAt: '2026-09-04T12:00:01Z',
+      },
+      diagnostic,
+      {
+        id: 'logs',
+        command: 'tail -40 /tmp/metro.log',
+        output: 'test-token RootLayout',
+        exitCode: 0,
+        endedAt: '2026-09-04T12:00:03Z',
+      },
+    ];
+    const options = { dispatchAt: '2026-09-04T12:00:00Z', token: 'test-token', arm: 'control', platform: 'ios' };
+    expect(launchCrashDiagnosis(commands, options).valid).toBe(false);
+    const review = {
+      commandId: diagnostic.id,
+      command: diagnostic.command,
+      assessment: 'Returned Metro HTTP404 error metadata, not a JavaScript bundle or application source.',
+    };
+    expect(launchCrashDiagnosis(commands, { ...options, reviewedDiagnostics: [review] })).toMatchObject({
+      valid: true,
+      dispatchToDiagnosisSeconds: 3,
+    });
+    for (const changed of [
+      { ...review, commandId: 'other' },
+      { ...review, command: 'cat app/_layout.tsx' },
+      { ...review, assessment: '' },
+    ]) {
+      expect(launchCrashDiagnosis(commands, { ...options, reviewedDiagnostics: [changed] }).valid).toBe(false);
+    }
+    expect(
+      launchCrashDiagnosis([...commands.slice(0, 2), { ...commands[2], output: 'no crash' }], {
+        ...options,
+        reviewedDiagnostics: [review],
+      }).valid,
+    ).toBe(false);
+  });
   it.skipIf(process.platform === 'win32')(
     'accepts reported Stim launch and log status only when the underlying command succeeded',
     () => {


### PR DESCRIPTION
## Description

Opus iOS control repaired the launch crash and saved Settings proof in 19m 38s, but was rejected for log-search patterns, scoped commands inside loops, and a timeout after proof completion. Fixes #518.

## Solution

Allow hash-bound coordinator review to classify flagged diagnostics by their actual command and output. This deliberately makes manual review authoritative for heuristic false positives; actual source access before crash capture remains disallowed. Wrong sessions still reject, while a loop's `do` keyword no longer hides the correct session prefix.

A timeout is reviewable only when exact repair, all required proof, session close and every executable command or tool finish before the unchanged deadline. This narrows the [original blanket timeout rejection](https://github.com/appandflow/stim/commit/e3410c2b9da2a356f832440ea09d3109b083ff0c): the final conversational response is not the measured task. Original records remain untouched; missing or late proof still fails.

## Test plan

- Re-derived the retained Opus commands: runtime diagnosis precedes source inspection, and both loop bodies use the pinned session. Screenshot/video and exact repair verified; recording copy and session close completed before the deadline.
- Export regressions exercise reviewed diagnostic false positives and post-proof timeout, rejecting changed review inputs, wrong sessions, late/missing proof, and other runner failures.
