### PR TITLE
feat: wait for optional app readiness logs

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -59,11 +59,12 @@ Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.
 
-Launch evidence does not prove that the UI is interactive. Apps already using
-Sentry or Expo Observe can optionally
-[report readiness through that SDK](https://appandflow.github.io/stim/docs/dev-server-and-logs#optional-app-declared-readiness).
-Stim does not currently consume those metrics or change its wait based on SDK
-installation; verify the expected screen separately.
+Launch evidence does not prove that the UI is interactive. Apps can optionally
+[declare readiness with two debug log messages](https://appandflow.github.io/stim/docs/dev-server-and-logs#optional-app-declared-readiness),
+without a package or SDK. A captured pending message extends the default
+three-second stability window to a bounded wait for ready. Run
+`stim guide lifecycle readiness` for implementation instructions; verify the
+expected screen separately.
 
 `stim reload [ios|android]` requests a JavaScript reload in the live app on this
 workspace's owned local device. Use it after a failed first bundle load, when

--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -135,12 +135,14 @@ describe('ios: log stream ndjson', () => {
       'ndjson',
       '--predicate',
       'processImagePath ENDSWITH "/MyApp.app/MyApp"',
+      '--level',
+      'info',
     ]);
   });
 
   test('logStreamArgs anchors to CFBundleExecutable when it differs from the .app basename', () => {
     const args = logStreamArgs('U1', 'MyAppDev', 'MyApp');
-    expect(args[args.length - 1]).toBe('processImagePath ENDSWITH "/MyAppDev.app/MyApp"');
+    expect(args[args.indexOf('--predicate') + 1]).toBe('processImagePath ENDSWITH "/MyAppDev.app/MyApp"');
   });
 
   test('logStreamArgs falls back to the .app basename as the executable when none is given', () => {

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -283,7 +283,7 @@ describe('the ios collector, spawned for real against a fake xcrun', { timeout: 
       'xcrun',
       [
         `case "$*" in`,
-        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyApp.app/MyApp"') ;;`,
+        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyApp.app/MyApp" --level info') ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
         `esac`,
         `echo "${banner}" >&2`,
@@ -338,7 +338,7 @@ describe('the ios collector, spawned for real against a fake xcrun', { timeout: 
       'xcrun',
       [
         `case "$*" in`,
-        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyAppDev.app/MyApp"') ;;`,
+        `  'simctl spawn UDID-1 log stream --style ndjson --predicate processImagePath ENDSWITH "/MyAppDev.app/MyApp" --level info') ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
         `esac`,
         ...iosShimLines().map((l) => `cat <<'LINE'\n${l}\nLINE`),

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -10,6 +10,8 @@ import {
   shortHash,
   shortUdid,
 } from '../command-output.ts';
+import { parseLogcatLine } from '../collector/android.ts';
+import { parseLogStreamLine } from '../collector/ios.ts';
 
 test('formatDuration uses one format for every command', () => {
   expect(formatDuration(0)).toBe('0ms');
@@ -116,6 +118,21 @@ test('the count never depends on the process a record names', () => {
   expect(named.summary).toBe(unnamed.summary);
   expect(named.summary).toBe('1 error-level record in the device log during launch (logs --errors --source device)');
   expect(named.lines).toEqual([]);
+});
+
+test('device JavaScript failures remain visible without a client or Metro copy', () => {
+  const android = parseLogcatLine('09-08 15:00:00.000 E/ReactNativeJS( 123): startup failed');
+  const ios = parseLogStreamLine(
+    JSON.stringify({
+      eventType: 'logEvent',
+      messageType: 'Error',
+      eventMessage: 'startup failed',
+      subsystem: 'com.facebook.react.log',
+      category: 'javascript',
+    }),
+  );
+  expect(launchErrorReport([{ ...android, platform: 'android' }]).lines).toEqual(['startup failed']);
+  expect(launchErrorReport([{ ...ios, platform: 'ios' }]).lines).toEqual(['startup failed']);
 });
 
 test('no device record means no count line at all', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -879,6 +879,28 @@ describe('optional app readiness', () => {
     expect(result).toMatchObject({ verified: false, fatal: true, readiness: 'error', waitedMs: 0 });
   });
 
+  test.each([
+    { platform: 'android' as const, proc: 'ReactNativeJS(123)' },
+    { platform: 'ios' as const, subsystem: 'com.facebook.react.log', category: 'javascript' },
+  ])('a device JavaScript error interrupts readiness without a Metro/client copy: %j', async (origin) => {
+    const error = { ts: 6500, src: 'device', level: 'error', msg: 'startup failed', ...origin };
+    const { result } = await run([signal(1000, 'pending', origin), error, signal(7000, 'ready', origin)], {
+      platform: origin.platform,
+      readRecords: () => [{ ts: 1000, event: 'bundle_build_done', platform: origin.platform }],
+    });
+    expect(result).toMatchObject({ readiness: 'error', waitedMs: 5500, errors: [error] });
+  });
+
+  test('unattributed OS error records do not interrupt readiness', async () => {
+    const { result } = await run([
+      signal(1000, 'pending'),
+      { ts: 1500, src: 'device', platform: 'ios', level: 'error', msg: 'OS subsystem warning' },
+      signal(6500, 'ready'),
+    ]);
+    expect(result).toMatchObject({ readiness: 'ready', waitedMs: 5500 });
+    expect(result.errors).toHaveLength(1);
+  });
+
   test('readiness signals alone cannot prove a bundle launch', async () => {
     const { result } = await run([signal(1000, 'pending'), signal(1500, 'ready')], { readRecords: () => [] });
     expect(result).toMatchObject({ verified: false, timedOut: true, waitedMs: 20000 });

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -786,6 +786,106 @@ describe('verifyLaunch', () => {
   });
 });
 
+describe('optional app readiness', () => {
+  function signal(ts: number, state: string, extra: Partial<NdjsonRecord> = {}): NdjsonRecord {
+    return { ts, src: 'device', platform: 'ios', level: 'info', msg: `[stim:readiness] ${state}`, ...extra };
+  }
+
+  async function run(records: NdjsonRecord[], options: Partial<Parameters<typeof verifyLaunch>[0]> = {}) {
+    const clock = fakeClock();
+    let pendingNotices = 0;
+    const result = await verifyLaunch({
+      since: 1000,
+      platform: 'ios',
+      now: clock.now,
+      sleep: clock.sleep,
+      readRecords: () => [{ ts: 1000, event: 'bundle_build_done', platform: 'ios' }],
+      readDeviceRecords: () => records.filter((record) => Number(record.ts) <= clock.at()),
+      readClientRecords: () => [],
+      processAlive: () => true,
+      onReadinessPending: () => {
+        pendingNotices += 1;
+      },
+      ...options,
+    });
+    return { result, pendingNotices };
+  }
+
+  test.each(['ios', 'android'] as const)('waits past 3 seconds for %s app readiness', async (platform) => {
+    const { result, pendingNotices } = await run(
+      [signal(1500, 'pending', { platform }), signal(6500, 'ready', { platform })],
+      { platform, readRecords: () => [{ ts: 1000, event: 'bundle_build_done', platform }] },
+    );
+    expect(result).toMatchObject({ verified: true, processAlive: true, readiness: 'ready', waitedMs: 5500 });
+    expect(pendingNotices).toBe(1);
+  });
+
+  test('a fast ready replaces the default stability delay', async () => {
+    const { result } = await run([signal(1000, 'pending'), signal(1500, 'ready', { msg: "'[stim:readiness] ready'" })]);
+    expect(result).toMatchObject({ readiness: 'ready', waitedMs: 500 });
+  });
+
+  test('missing ready is bounded and repeated pending cannot extend the deadline', async () => {
+    const { result, pendingNotices } = await run([
+      signal(1000, 'pending'),
+      signal(3000, 'pending'),
+      signal(30000, 'pending'),
+      signal(31500, 'ready'),
+    ]);
+    expect(result).toMatchObject({ verified: true, readiness: 'timed-out', waitedMs: 30000 });
+    expect(pendingNotices).toBe(1);
+  });
+
+  test.each([
+    signal(500, 'pending'),
+    signal(1500, 'pending', { platform: 'android' }),
+    signal(1500, 'pending', { platform: undefined }),
+    signal(1500, 'pending', { src: 'metro' }),
+    signal(1500, 'pending', { src: 'build' }),
+    signal(1500, 'pending', { level: 'error' }),
+    signal(1500, 'pending', { msg: 'example: [stim:readiness] pending' }),
+    signal(1500, 'pending', { msg: '[stim:readiness] pending\nother log' }),
+  ])('does not opt in from stale, ambiguous, or embedded evidence: %j', async (record) => {
+    const { result, pendingNotices } = await run([record, signal(5000, 'ready')]);
+    expect(result).toMatchObject({ verified: true, waitedMs: 3000 });
+    expect(result.readiness).toBeUndefined();
+    expect(pendingNotices).toBe(0);
+  });
+
+  test('ignores a future-dated pending record already present in the log', async () => {
+    const { result } = await run([], { readDeviceRecords: () => [signal(9000, 'pending')] });
+    expect(result).toMatchObject({ verified: true, waitedMs: 3000 });
+    expect(result.readiness).toBeUndefined();
+  });
+
+  test('ready without pending does not opt in, and ready before pending cannot satisfy the wait', async () => {
+    expect((await run([signal(1000, 'ready')])).result).toMatchObject({ waitedMs: 3000 });
+    expect((await run([signal(1000, 'ready'), signal(1500, 'pending')])).result).toMatchObject({
+      readiness: 'timed-out',
+      waitedMs: 30000,
+    });
+  });
+
+  test('an app error interrupts the wait even when ready is present', async () => {
+    const { result } = await run([signal(1000, 'pending'), signal(1500, 'ready')], {
+      readClientRecords: () => [{ ts: 1000, src: 'client', platform: 'ios', level: 'error', msg: 'startup failed' }],
+    });
+    expect(result).toMatchObject({ verified: true, readiness: 'error', processAlive: true, waitedMs: 0 });
+    expect(result.errors?.[0]?.msg).toBe('startup failed');
+  });
+
+  test('a process exit interrupts a pending wait', async () => {
+    const { result } = await run([signal(1000, 'pending')], { processAlive: () => false });
+    expect(result).toMatchObject({ verified: false, fatal: true, readiness: 'error', waitedMs: 0 });
+  });
+
+  test('readiness signals alone cannot prove a bundle launch', async () => {
+    const { result } = await run([signal(1000, 'pending'), signal(1500, 'ready')], { readRecords: () => [] });
+    expect(result).toMatchObject({ verified: false, timedOut: true, waitedMs: 20000 });
+    expect(result.readiness).not.toBe('ready');
+  });
+});
+
 describe('unverifiedLaunchLines', () => {
   test('iOS names the picker and the exact command to retry without an alert step', () => {
     const url = devClientUrl('io.tlon.groups', 8082);
@@ -1605,7 +1705,7 @@ describe('verifyLaunch: still bundling', () => {
       },
     });
     expect(result.verified).toBe(true);
-    expect(deviceReads).toBe(1);
+    expect(deviceReads).toBeGreaterThan(1);
     expect(result.waitedMs).toBe(STABILITY_WINDOW_MS);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
-import { STABILITY_WINDOW_MS, VERIFY_TIMEOUT_MS } from '../engine/app-install.ts';
+import { VERIFY_TIMEOUT_MS } from '../engine/app-install.ts';
+import { APP_READINESS_TIMEOUT_MS } from '../engine/app-readiness.ts';
 import { deviceLeasePath, parseLease, takeLease, type LeaseIo, type WorkspaceLeases } from '../engine/device-lease.ts';
 import {
   DEBUG_VERIFY_STEP_MS,
@@ -118,7 +119,7 @@ describe('the flags that steer the wait', () => {
     expect(leaseStepMs(0)).toBe(LEASE_STEP_FLOOR_MS);
     expect(leaseStepMs(1000)).toBe(LEASE_STEP_FLOOR_MS);
     expect(leaseStepMs(INSTALL_MS)).toBe(INSTALL_MS);
-    expect(DEBUG_VERIFY_STEP_MS).toBe(VERIFY_TIMEOUT_MS + STABILITY_WINDOW_MS);
+    expect(leaseStepMs(DEBUG_VERIFY_STEP_MS)).toBeGreaterThanOrEqual(VERIFY_TIMEOUT_MS + APP_READINESS_TIMEOUT_MS);
   });
 });
 
@@ -426,13 +427,13 @@ describe('the per-step raise', () => {
     expect(lease.expiresAt).toBe(before);
   });
 
-  test('the verification raise outlasts the bundle deadline plus the stability window', async () => {
+  test('the verification raise outlasts the bundle deadline plus the optional readiness wait', async () => {
     const h = harness();
     const lease = await leased(h);
     h.advance(INSTALL_MS);
     lease.raise(DEBUG_VERIFY_STEP_MS);
 
-    h.advance(VERIFY_TIMEOUT_MS + STABILITY_WINDOW_MS);
+    h.advance(VERIFY_TIMEOUT_MS + APP_READINESS_TIMEOUT_MS);
     expect(Date.parse(lease.expiresAt as string)).toBeGreaterThan(h.now());
   });
 

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -303,6 +303,9 @@ test('the agent workflow checks errors before and after edits, before cleanup', 
   expect(normalWorkflow.lastIndexOf('stim logs --errors')).toBeLessThan(normalWorkflow.lastIndexOf('stim stop'));
   expect(agent).toContain('stim guide lifecycle verification');
   expect(renderSection('lifecycle', 'verification')).toBeTruthy();
+  expect(agent).toContain('stim guide lifecycle readiness');
+  expect(renderSection('lifecycle', 'readiness')).toContain('[stim:readiness] pending');
+  expect(renderSection('lifecycle', 'readiness')).toContain('[stim:readiness] ready');
 });
 
 test('the agent guide routes to every detailed topic', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -2329,6 +2329,7 @@ describe('the collector', () => {
     expect(calls.args.replaceCollector.appName).toBe('FixtureDev');
     expect(calls.args.replaceCollector.bundleId).toBe('com.example.app');
     expect(calls.args.replaceCollector.udid).toBe(UDID);
+    expect(calls.order.indexOf('replaceCollector')).toBeLessThan(calls.order.indexOf('launchIosApp'));
   });
 
   test('the command hands the collector CFBundleExecutable, so the log predicate can anchor to it', async () => {

--- a/packages/stim-cli/src/collector/ios.ts
+++ b/packages/stim-cli/src/collector/ios.ts
@@ -126,6 +126,8 @@ function recordFromLogEvent(
   };
   const proc = procFromImagePath(event.processImagePath);
   if (proc) record.proc = proc;
+  if (typeof event.subsystem === 'string') record.subsystem = event.subsystem;
+  if (typeof event.category === 'string') record.category = event.category;
   return record;
 }
 
@@ -154,6 +156,8 @@ export function logStreamArgs(udid: string, appName: string, executableName?: st
     'ndjson',
     '--predicate',
     `processImagePath ENDSWITH "/${appName}.app/${exe}"`,
+    '--level',
+    'info',
   ];
 }
 

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -103,6 +103,7 @@ export const OUTPUT_LABELS: readonly string[] = [
   'port',
   'prebuild',
   'project',
+  'readiness',
   'ready',
   'remedy',
   'removed',
@@ -148,6 +149,12 @@ export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summ
       ? null
       : `${plural(fromDevice.length, 'error-level record')} in the device log during launch (logs --errors --source device)`;
   return { summary, lines };
+}
+
+export function appReadinessMessage(status: 'ready' | 'timed-out' | 'error', waitedMs: number): string {
+  if (status === 'ready') return `app reported ready (${formatDuration(waitedMs)} verification total)`;
+  if (status === 'error') return 'not confirmed: an app error or process exit interrupted the readiness wait';
+  return 'not confirmed: no ready log within 30s of bundle load; inspect the UI and logs';
 }
 
 export const SLOW_STEP_MS = 2000;

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -134,6 +134,15 @@ export interface LaunchErrorRecord {
   [key: string]: unknown;
 }
 
+export function isAppLaunchError(record: LaunchErrorRecord): boolean {
+  return (
+    record.src !== 'device' ||
+    record.level === 'fatal' ||
+    (record.platform === 'android' && typeof record.proc === 'string' && /^ReactNativeJS\(\d+\)$/.test(record.proc)) ||
+    (record.platform === 'ios' && record.subsystem === 'com.facebook.react.log' && record.category === 'javascript')
+  );
+}
+
 /**
  * Splits the error-level records a verified launch collected into the device
  * log the run counts and the records it still prints one by one.
@@ -141,7 +150,7 @@ export interface LaunchErrorRecord {
 export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summary: string | null; lines: string[] } {
   const fromDevice = records.filter((record) => record.src === 'device');
   const lines = records
-    .filter((record) => record.src !== 'device')
+    .filter(isAppLaunchError)
     .map((record) => (record.msg === undefined || record.msg === null ? '' : String(record.msg)))
     .filter((msg) => msg !== '');
   const summary =

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -20,7 +20,7 @@ import {
   RELEASE_VERIFY_WAIT_MS,
   installConflictKind,
 } from '../../engine/app-install.ts';
-import { formatDuration, launchErrorReport, phaseLine, stepTimer } from '../../command-output.ts';
+import { appReadinessMessage, formatDuration, launchErrorReport, phaseLine, stepTimer } from '../../command-output.ts';
 import { MODE_BARE, MODE_EXPO, writeWorkspaceLaunch, writeWorkspaceState } from '../../supervisor/state.ts';
 import type {
   VerifyLaunchResultLike,
@@ -125,6 +125,7 @@ async function verifyAndroidRun({
 
   const verification: VerifyLaunchResultLike = metroCheck
     ? await verifyLaunched({
+        onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,
         metroPort,
@@ -136,6 +137,8 @@ async function verifyAndroidRun({
         },
       })
     : { verified: false, skipped: true };
+  if (verification.readiness)
+    phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
     const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
@@ -165,7 +168,7 @@ async function verifyAndroidRun({
       'verify',
       `bundle loaded` +
         (verification.processAlive === true ? ', process alive' : '') +
-        `, stable for 3s -- the first screen may still be rendering` +
+        (verification.readiness ? '' : ', stable for 3s -- the first screen may still be rendering') +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
     const report = launchErrorReport(verification.errors ?? []);

--- a/packages/stim-cli/src/commands/android/types.ts
+++ b/packages/stim-cli/src/commands/android/types.ts
@@ -61,6 +61,7 @@ export interface LaunchResultLike {
 }
 
 export interface VerifyLaunchResultLike {
+  readiness?: 'ready' | 'timed-out' | 'error';
   verified?: boolean;
   skipped?: boolean;
   requested?: boolean;

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -16,6 +16,7 @@ import {
 import type { IosDeps } from './dependencies.ts';
 import {
   formatDuration,
+  appReadinessMessage,
   phaseLine,
   launchErrorReport,
   type LaunchErrorRecord,
@@ -126,6 +127,7 @@ async function verifyIosRun({
 
   const verification: VerifyLaunchResultLike = metroCheck
     ? await d.verifyLaunch({
+        onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,
         metroPort,
@@ -142,6 +144,8 @@ async function verifyIosRun({
               },
       })
     : { verified: false, skipped: true };
+  if (verification.readiness)
+    phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
     const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
@@ -175,7 +179,7 @@ async function verifyIosRun({
       'verify',
       `bundle loaded` +
         (verification.processAlive === true ? ', process alive' : '') +
-        `, stable for 3s -- the first screen may still be rendering` +
+        (verification.readiness ? '' : ', stable for 3s -- the first screen may still be rendering') +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
     const hasAppErrors = reportLaunchErrors(verification.errors ?? [], note);
@@ -596,6 +600,7 @@ export async function finishIosRun({
 
     dropSwapDir();
 
+    if (!remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
     const launchTimer = stepTimer(d.now);
     launchedAt = d.now();
     launched = d.launchIosApp({ udid, bundleId: bundleId!, metroPort, devClientScheme: scheme });
@@ -635,7 +640,7 @@ export async function finishIosRun({
         (launched?.mode === 'openurl' || launched?.mode === 'payload-url' ? ' (expo-dev-client)' : ''),
   });
 
-  if (!physical) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
+  if (remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const launchState = await verifyIosRun({

--- a/packages/stim-cli/src/commands/ios/types.ts
+++ b/packages/stim-cli/src/commands/ios/types.ts
@@ -54,6 +54,7 @@ export interface BuildIosResultLike {
 }
 
 export interface VerifyLaunchResultLike {
+  readiness?: 'ready' | 'timed-out' | 'error';
   verified?: boolean;
   skipped?: boolean;
   requested?: boolean;

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { isAppLaunchError } from '../command-output.ts';
 import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
@@ -887,7 +888,7 @@ export async function verifyLaunch({
         };
       }
       const actionableErrors = errors.filter((record) => !isIosConnectionRefusal(record, platform));
-      const appErrors = actionableErrors.some((record) => record.src !== 'device' || record.level === 'fatal');
+      const appErrors = actionableErrors.some(isAppLaunchError);
       if (pendingAt === null || appErrors || ready || now() >= readinessDeadline) {
         return {
           verified: true,

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -5,6 +5,7 @@ import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
 import { DEV_MENU_LAUNCH_ARGS } from '../collector/ios-device.ts';
 import { listUserApps, uninstallIosApp } from '../sim/ios.ts';
+import { APP_READINESS_TIMEOUT_MS, appReadinessSignal, type AppReadiness } from './app-readiness.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
 export const LAUNCH_ERROR = 'STIM_LAUNCH_FAILED';
@@ -608,6 +609,7 @@ export type VerifyLaunchResult = {
   requested?: boolean;
   mode: string | null;
   waitedMs: number;
+  readiness?: AppReadiness;
 };
 
 export const RELEASE_VERIFY_WAIT_MS = 3000;
@@ -779,6 +781,7 @@ export async function verifyLaunch({
   readDeviceRecords = null,
   readClientRecords = null,
   processAlive = null,
+  onReadinessPending = null,
   now = Date.now,
   sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
 }: {
@@ -794,6 +797,7 @@ export async function verifyLaunch({
   readDeviceRecords?: (() => NdjsonRecord[]) | null;
   readClientRecords?: (() => NdjsonRecord[]) | null;
   processAlive?: (() => boolean | null) | null;
+  onReadinessPending?: (() => void) | null;
   now?: () => number;
   sleep?: (ms: number) => Promise<unknown>;
 } = {}): Promise<VerifyLaunchResult> {
@@ -805,8 +809,11 @@ export async function verifyLaunch({
   let proof: NdjsonRecord | null = null;
   let activity: NdjsonRecord | null = null;
   let stabilityDeadline: number | null = null;
+  let pendingAt: number | null = null;
   while (true) {
     const metroRecords = read().filter((record) => after(record, since));
+    const deviceRecords = readDevice().filter((record) => after(record, since));
+    const clientRecords = readClient().filter((record) => after(record, since));
     for (const record of metroRecords) {
       if (isBundleProof(record, since, platform)) activity = record;
       if (!proof && isBundleReadyProof(record, since, platform)) {
@@ -814,6 +821,29 @@ export async function verifyLaunch({
         stabilityDeadline = Number(record.ts) + Math.max(0, stabilityMs);
       }
     }
+    const readinessDeadline = proof ? Number(proof.ts) + APP_READINESS_TIMEOUT_MS : bundleDeadline;
+    const signals = deviceRecords
+      .filter((record) => Number(record.ts) <= now())
+      .toSorted((a, b) => Number(a.ts) - Number(b.ts));
+    if (pendingAt === null) {
+      const pending = signals.find(
+        (record) =>
+          appReadinessSignal(record, platform) === 'pending' &&
+          (stabilityDeadline === null || Number(record.ts) <= stabilityDeadline),
+      );
+      if (pending) {
+        pendingAt = Number(pending.ts);
+        onReadinessPending?.();
+      }
+    }
+    const ready =
+      pendingAt !== null &&
+      signals.some(
+        (record) =>
+          Number(record.ts) >= pendingAt! &&
+          Number(record.ts) <= readinessDeadline &&
+          appReadinessSignal(record, platform) === 'ready',
+      );
     const bundleErrors = metroRecords.filter((record) => isFatalLaunchError(record, platform));
     if (bundleErrors.length) {
       const alive = processAlive ? processAlive() : null;
@@ -831,17 +861,16 @@ export async function verifyLaunch({
         record: fatalRecord,
         mode,
         waitedMs: now() - startedAt,
+        ...(pendingAt !== null ? { readiness: 'error' as const } : {}),
       };
     }
 
-    if (proof && stabilityDeadline !== null && now() >= stabilityDeadline) {
-      const errorSince = Number(proof.ts ?? since ?? 0);
-      const deviceRecords = readDevice().filter((record) => after(record, errorSince));
-      const clientRecords = readClient().filter((record) => after(record, errorSince));
+    if (proof && stabilityDeadline !== null && (pendingAt !== null || now() >= stabilityDeadline)) {
+      const errorSince = pendingAt === null ? Number(proof.ts ?? since ?? 0) : Number(since ?? 0);
       const errors = [
         ...metroRecords.filter((record) => after(record, errorSince) && recordCouldBelongToPlatform(record, platform)),
-        ...deviceRecords.filter((record) => recordCouldBelongToPlatform(record, platform)),
-        ...clientRecords,
+        ...deviceRecords.filter((record) => after(record, errorSince) && recordCouldBelongToPlatform(record, platform)),
+        ...clientRecords.filter((record) => after(record, errorSince) && recordCouldBelongToPlatform(record, platform)),
       ].filter((record) => isLaunchError(record, platform));
       const alive = processAlive ? processAlive() : null;
       const waitedMs = now() - startedAt;
@@ -854,14 +883,25 @@ export async function verifyLaunch({
           record: proof,
           mode,
           waitedMs,
+          ...(pendingAt !== null ? { readiness: 'error' as const } : {}),
         };
       }
       const actionableErrors = errors.filter((record) => !isIosConnectionRefusal(record, platform));
-      return { verified: true, record: proof, errors: actionableErrors, processAlive: alive, mode, waitedMs };
+      const appErrors = actionableErrors.some((record) => record.src !== 'device' || record.level === 'fatal');
+      if (pendingAt === null || appErrors || ready || now() >= readinessDeadline) {
+        return {
+          verified: true,
+          record: proof,
+          errors: actionableErrors,
+          processAlive: alive,
+          mode,
+          waitedMs,
+          ...(pendingAt !== null ? { readiness: appErrors ? 'error' : ready ? 'ready' : 'timed-out' } : {}),
+        };
+      }
     }
 
     if (!proof && now() >= bundleDeadline) {
-      const deviceRecords = readDevice().filter((record) => after(record, since));
       const requested = findBundleRequest(deviceRecords, since, metroPort, platform) ?? activity;
       const waitedMs = now() - startedAt;
       if (requested) {
@@ -876,7 +916,7 @@ export async function verifyLaunch({
       }
       return { verified: false, timedOut: true, mode, waitedMs };
     }
-    const deadline = stabilityDeadline ?? bundleDeadline;
+    const deadline = proof && pendingAt !== null ? readinessDeadline : (stabilityDeadline ?? bundleDeadline);
     await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
   }
 }

--- a/packages/stim-cli/src/engine/app-readiness.ts
+++ b/packages/stim-cli/src/engine/app-readiness.ts
@@ -1,0 +1,17 @@
+import type { NdjsonRecord } from '../ndjson.ts';
+
+export const APP_READINESS_TIMEOUT_MS = 30_000;
+export type AppReadiness = 'ready' | 'timed-out' | 'error';
+
+export function appReadinessSignal(
+  record: NdjsonRecord,
+  platform: 'ios' | 'android' | null,
+): 'pending' | 'ready' | null {
+  if (record.src !== 'device' || !platform || record.platform !== platform) return null;
+  if (record.level !== 'info' && record.level !== 'debug') return null;
+  if (typeof record.msg !== 'string') return null;
+  const text = record.msg.trim();
+  const message = /^(?:'[^']*'|"[^"]*")$/.test(text) ? text.slice(1, -1) : text;
+  const match = /^\[stim:readiness\] (pending|ready)$/.exec(message);
+  return (match?.[1] as 'pending' | 'ready' | undefined) ?? null;
+}

--- a/packages/stim-cli/src/engine/device-lease-run.ts
+++ b/packages/stim-cli/src/engine/device-lease-run.ts
@@ -1,5 +1,6 @@
 import { clockTime, formatElapsed } from '../command-output.ts';
-import { STABILITY_WINDOW_MS, VERIFY_TIMEOUT_MS } from './app-install.ts';
+import { VERIFY_TIMEOUT_MS } from './app-install.ts';
+import { APP_READINESS_TIMEOUT_MS } from './app-readiness.ts';
 import {
   deviceLeasePath,
   fileLeaseIo,
@@ -15,7 +16,7 @@ import {
 } from './device-lease.ts';
 
 export const LEASE_STEP_FLOOR_MS = 60_000;
-export const DEBUG_VERIFY_STEP_MS: number = VERIFY_TIMEOUT_MS + STABILITY_WINDOW_MS;
+export const DEBUG_VERIFY_STEP_MS: number = VERIFY_TIMEOUT_MS + APP_READINESS_TIMEOUT_MS;
 export const DEFAULT_DEVICE_WAIT_SECONDS = 60;
 export const DEVICE_WAIT_POLL_MS = 2_000;
 export const DEVICE_WAIT_LINE_MS = 30_000;

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -173,6 +173,7 @@ LOAD ADVANCED GUIDANCE WHEN NEEDED
   stim guide errors fallbacks     # swap, cache, and install notes on a release cache hit
   stim guide lifecycle            # the ordered flow, consent rules, and capacity
   stim guide lifecycle verification # reproduce, edit, verify the UI, and retain proof
+  stim guide lifecycle readiness  # add optional app readiness logs; no package required
   stim guide lifecycle builds     # build optimizations, optional cache warm-up, fingerprints
   stim guide lifecycle concurrency # shared builds, wait timeouts, capacity limits
   stim guide lifecycle options    # every flag, Android variants, --device-type, --system-image

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -119,7 +119,10 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
                                  reads \`bundle loaded, process alive, stable
                                  for 3s -- the first screen may still be
                                  rendering\`. Poll the UI before you trust a
-                                 screenshot
+                                 screenshot. Optional app-declared readiness
+                                 adds a separate stderr readiness phase; it
+                                 does not change this field. See
+                                 \`guide lifecycle readiness\`
                     "bundling"   the request DID arrive and Metro was still
                                  building when the bundle timeout closed.
                                  The wiring is proven; the JS has simply not

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -136,6 +136,9 @@ Metro verification enabled, not release builds or --no-metro-check.
    expo-splash-screen. Keep the pending log outside the component at module
    scope, before startup work. Use the project's existing splash lifecycle;
    do not add a splash dependency to a bare app just for this integration.
+   Static imports run before module-scope statements. If imported startup work
+   must opt into the wait, emit pending from an earlier app entry module before
+   loading that work. A failure before pending keeps the default check.
    Cover login, onboarding, and deep links. Do not report ready merely on
    root mount, on a timer, in a failure handler, or in finally.
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -105,6 +105,61 @@ TWO REPORTS, TWO QUESTIONS
   the machine, with a hit rate and an estimate of the time saved (see
   \`guide facts stats\`).`,
   sections: {
+    readiness: {
+      summary: 'implement optional pending/ready app logs, deadlines, errors, and platform isolation',
+      body: () => `OPTIONAL APP READINESS
+
+No package or SDK is needed. This applies to debug ios/android launches with
+Metro verification enabled, not release builds or --no-metro-check.
+
+1. Add this at app startup, before essential initialization:
+
+     if (__DEV__) console.info('[stim:readiness] pending');
+
+2. Use the app's real ready state: essential initialization succeeded, usable
+   content rendered, and the splash screen hidden. From that success path:
+
+     if (__DEV__) console.info('[stim:readiness] ready');
+
+   In an Expo root component with an existing isReady state:
+
+     useEffect(() => {
+       if (!isReady) return;
+       let active = true;
+       SplashScreen.hideAsync().then(() => {
+         if (active && __DEV__) console.info('[stim:readiness] ready');
+       }).catch(console.error);
+       return () => { active = false; };
+     }, [isReady]);
+
+   Import useEffect from react and SplashScreen as a namespace from
+   expo-splash-screen. Keep the pending log outside the component at module
+   scope, before startup work. Use the project's existing splash lifecycle;
+   do not add a splash dependency to a bare app just for this integration.
+   Cover login, onboarding, and deep links. Do not report ready merely on
+   root mount, on a timer, in a failure handler, or in finally.
+
+3. Run the platform command from the app directory. Check for the readiness
+   phase and inspect the UI on the reported device. Exercise a slow success,
+   a missing ready message, and a startup error. Retain the relevant output.
+
+Without an observed pending, Stim keeps its default 3-second stability window
+after bundle completion. Pending must be observed before that window closes.
+It opts into waiting for ready until 30 seconds after bundle completion.
+Repeated pending messages never extend the deadline. Ready can end the wait
+early; an app error or process exit interrupts it. No ready means readiness
+not confirmed, not a crash or successful readiness.
+
+Only exact standalone info/debug messages captured from this app's device log
+for this platform and current launch are accepted. Stale, other-platform,
+error-level, and embedded example messages are ignored. Unlabelled shared
+Metro output cannot identify a platform. If pending is not captured in time,
+including when device logs are unavailable, the default check applies.
+
+The app declares readiness; Stim does not inspect a rendered frame. This does
+not change launched JSON semantics or the need to inspect the expected UI and
+stim logs --errors. A reload request does not run this launch check.`,
+    },
     verification: {
       summary: 'reproduce the affected behavior, verify the change on the reported device, and retain proof',
       body: () => `VERIFY THE CHANGE
@@ -155,7 +210,8 @@ result as proof instead of requiring an unrelated screenshot.`,
     install     installs    ip.txt      lan         launch      lease
     log
     logs        meaning     metro       pods        port        prebuild
-    project     ready       remedy      removed     resolved    result
+    project     readiness   ready       remedy      removed     resolved
+    result
     services
     setting     settings    setup       state       stats       stop
     storage     swap        verify      version     workspace

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -111,9 +111,11 @@ WHAT WRITES WHAT
                        In expo-child mode everything Expo prints lands in
                        metro.ndjson with raw: true, so \`--source client\`
                        returns nothing there.
-  device.ndjson        the device-log collector \`ios\` / \`android\` attaches
-                       after launch: \`simctl log stream\` predicated on the
-                       app, or \`adb logcat\` filtered to the app's pid. This
+  device.ndjson        the device-log collector uses \`simctl log stream\`
+                       predicated on the app, or \`adb logcat\` filtered to
+                       the app's pid. Local iOS simulator capture starts
+                       before launch; Android attaches once the pid is known
+                       and reads buffered logcat records. This
                        is where a native crash that never reached JS shows up
                        -- and, on iOS, where every Apple framework running in
                        the app's process also logs. The proven noise sources

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -121,31 +121,18 @@ WHAT WRITES WHAT
                        the app's process also logs. The proven noise sources
                        are recorded at info rather than error; the rest is why
                        --errors leaves this source out unless asked. A VERIFIED
-                       LAUNCH prints NONE of these records one by one. It counts
-                       them and prints one line instead:
+                       LAUNCH counts these records and prints one line:
 
                          launch      9 error-level records in the device log
                                      during launch
                                      (logs --errors --source device)
 
-                       THE COUNT IS NOT ATTRIBUTED TO ANYTHING, and that is the
-                       point. Both collectors already narrow the stream to the
-                       app: the simulator's \`log stream\` runs under a
-                       processImagePath predicate, and \`adb logcat\` is filtered
-                       to the app's pid. So every record left is MEANT to be
-                       inside the app's own process, and the error-level ones
-                       are the Apple frameworks running there -- "Failed to send
-                       CA Event for app launch measurements", "NSBundle (null)
-                       initWithPath failed", the TCP refusal. Nothing about the
-                       record says which of them wrote it, so the run does not
-                       guess; a count plus the command that shows the records is
-                       the honest report. The iOS predicate matches on a
-                       substring of the process path today, which a short app
-                       name can widen past the app -- appandflow/stim#264
-                       anchors it. Until it lands, read the records rather than
-                       trusting the count to be the app's alone. The app's OWN errors are not in this
-                       number: a redbox or a console.error arrives on the client
-                       or metro source and still prints line by line.
+                       The count does not attribute unknown OS errors to the app.
+                       Known JavaScript errors also print individually: Android
+                       ReactNativeJS records, and iOS com.facebook.react.log /
+                       javascript records. These can interrupt an optional
+                       readiness wait even without a client or Metro copy.
+                       Client and Metro errors still print individually.
 
                        The connection refusal \`TCP Conn ... Failed :
                        error 0:61 [61]\` (61 is ECONNREFUSED) is not even

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -74,6 +74,10 @@ Use the app's real readiness condition, not an arbitrary timer or merely a
 mounted root. Cover login, onboarding, and deep-link destinations. Never emit
 `ready` from a failure handler or a `finally` block.
 
+Static imports run before module-scope statements. To cover initialization in
+imported modules, emit `pending` from an earlier app entry module before loading
+that work. An error before `pending` still uses the default check.
+
 Without an observed `pending`, Stim keeps its default three-second stability
 window after bundle completion. A `pending` observed before that window closes
 opts into waiting for `ready`, up to 30 seconds after bundle completion.

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -33,63 +33,84 @@ and decide whether the change caused it.
 
 ### Optional app-declared readiness
 
-If your app already uses Sentry or Expo Observe, use its readiness API to
-record when the initial screen becomes usable. Neither SDK is required by
-Stim, and no additional Stim package is needed.
+No package or monitoring SDK is required. In a debug app, emit this once at
+startup, before initialization that can block the first screen:
 
-**Current Stim support:** these APIs report readiness to their SDK, not to Stim. Stim does not currently
-consume their readiness metrics or extend its launch wait when either SDK is
-installed. Keep verifying the expected UI on the reported device; a successful
-launch summary is not a full-render guarantee.
+```ts
+if (__DEV__) console.info('[stim:readiness] pending');
+```
 
-**Expo Observe:** after configuring the SDK and wrapping your root with
-`ObserveRoot`, call `markInteractive()` from `useObserve()` when the screen is
-ready (SDK 56 and later):
+Emit the second line when essential initialization succeeds, usable content is
+rendered, and the splash screen is hidden:
+
+```ts
+if (__DEV__) console.info('[stim:readiness] ready');
+```
+
+For example, in an Expo root layout with an existing `isReady` state:
 
 ```tsx
-const { markInteractive } = useObserve();
+import { useEffect } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
 
+if (__DEV__) console.info('[stim:readiness] pending');
+
+// Inside the root component:
 useEffect(() => {
-  if (isReady) markInteractive();
-}, [isReady, markInteractive]);
+  if (!isReady) return;
+  let active = true;
+  SplashScreen.hideAsync()
+    .then(() => {
+      if (active && __DEV__) console.info('[stim:readiness] ready');
+    })
+    .catch(console.error);
+  return () => {
+    active = false;
+  };
+}, [isReady]);
 ```
 
-Import `useObserve` from `expo-observe` and `useEffect` from `react`. Follow
-the [Expo Observe setup guide](https://docs.expo.dev/eas/observe/get-started/)
-for SDK 55's API and the complete integration. Metrics are not dispatched from
-debug builds by default; use Expo's development configuration when validating
-SDK reporting, rather than interpreting missing metrics as a launch failure.
+Use the app's real readiness condition, not an arbitrary timer or merely a
+mounted root. Cover login, onboarding, and deep-link destinations. Never emit
+`ready` from a failure handler or a `finally` block.
 
-**Sentry:** with your existing tracing and navigation integration configured,
-render its full-display marker in the screen:
+Without an observed `pending`, Stim keeps its default three-second stability
+window after bundle completion. A `pending` observed before that window closes
+opts into waiting for `ready`, up to 30 seconds after bundle completion.
+Repeated `pending` logs do not extend the deadline. A matching `ready` can end
+the wait early; an app error or process exit interrupts it. A missing `ready`
+prints **readiness not confirmed**, not success or an inferred crash.
 
-```tsx
-<Sentry.TimeToFullDisplay record={isReady} />
+Stim reads exact standalone messages from this app's platform-specific device
+log, after the current launch. Stale, other-platform, error-level, and embedded
+example messages are ignored. Unlabelled shared Metro output cannot identify
+which platform is ready. If device-log capture is unavailable or `pending` is
+not captured in time, the default check applies. Release runs and
+`--no-metro-check` do not use this debug-only integration.
+
+This is the app declaring readiness, not visual verification. It does not alter
+the `launched` JSON field: bundle/process evidence remains separate. Continue
+checking the expected UI and `stim logs --errors`. For agent implementation
+instructions, run `stim guide lifecycle readiness`.
+
+#### Ask your agent to add it
+
+Copy this prompt into your coding agent:
+
+```text
+Add optional Stim app-readiness logs to this app. Read `stim guide agent`,
+then follow `stim guide lifecycle readiness` from the installed CLI. If Stim
+is not installed globally, use `npx stim-cli` instead of `stim`.
+
+Use the app's existing initialization and splash-screen lifecycle without
+adding a package or monitoring SDK. Cover its real startup destinations,
+including login, onboarding, and deep links; never report ready after failure.
+
+Verify a normal launch, a slow successful launch, a missing ready signal, and
+a startup error on the supported platforms. Remove temporary test delays and
+errors afterward. Report the changes, observed readiness output, and any
+validation you could not complete.
 ```
-
-Import Sentry with `import * as Sentry from '@sentry/react-native'`. SDK
-versions that expose `Sentry.reportFullyDisplayed()` also support an imperative
-call. Follow [Sentry's Time to Display guide](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/time-to-display/)
-for the required instrumentation and version-specific API.
-
-Choose `isReady` based on usable content, completed essential initialization,
-and a dismissed splash screen, not just a mounted root or a live native
-process. Cover each launch destination, including login, onboarding, and deep
-links. Do not report success from a cleanup or `finally` block after a startup
-error.
-
-On Android, the platform's first-frame signal is not the same as
-[`reportFullyDrawn()`](https://developer.android.com/topic/performance/vitals/launch-time),
-which needs an explicit call. Do not assume a similarly named SDK API emits
-that Android signal. On iOS, Apple's standard launch measurement ends at the
-first frame; later preparation can use
-[custom signposts](https://developer.apple.com/documentation/xcode/reducing-your-app-s-launch-time).
-Neither first-frame measurement proves that React content is interactive.
-
-An app can fail before sending a readiness marker while its native process
-remains alive. Inspect captured errors independently. An absent marker can
-also mean disabled instrumentation or a reporting deadline, so absence alone
-does not establish a crash or a successful launch.
 
 ## Query the timeline
 


### PR DESCRIPTION
## Description

A loaded bundle and live process do not prove the app finished initialization. Debug launches currently finish their stability check after three seconds, which can miss a later startup error.

## Solution

Apps can opt into a bounded wait with standalone `[stim:readiness] pending` and `ready` logs, without installing an SDK. Pending keeps verification open until ready, an app error/process exit, or 30 seconds after bundle completion. Apps without pending keep the existing check; the `launched` JSON contract is unchanged. Only current-launch, platform-matched device logs can declare readiness. Local iOS simulator capture starts before launch and includes Info-level records to observe the markers. Recognized device JavaScript errors interrupt readiness and remain visible without a Metro/client copy; unattributed OS errors remain a count.

Guides and the website document integration, including a copy-paste prompt for a coding agent.

## Test plan

Tested Trailhead on an iPhone 17 / iOS 26.5 simulator using an independent agent following only the guide:

- Without markers: existing three-second stability check and usable trail list.
- Normal launch: accepted platform-matched device markers, ready at 2s verification.
- Temporary 8s initialization delay: waited for ready, 10.5s verification.
- Missing ready: stopped at the 30s deadline without claiming readiness; app remained usable.
- Startup throw after pending: interrupted at 1.8s, printed the error, native process still alive, no ready.

Temporary test fixtures are removed from the Trailhead integration. Android benchmark reruns follow merge.

Fixes #522
