### PR TITLE
fix: wait for bundle delivery before launch stability

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -62,7 +62,9 @@ readiness. Plain output streams progress and reports the complete result. Use
 Launch evidence does not prove that the UI is interactive. Apps can optionally
 [declare readiness with two debug log messages](https://appandflow.github.io/stim/docs/dev-server-and-logs#optional-app-declared-readiness),
 without a package or SDK. A captured pending message extends the default
-three-second stability window to a bounded wait for ready. Run
+three-second stability window after bundle delivery to a bounded wait for ready.
+Managed Metro response capture distinguishes a finished build from a finished
+response; servers without capture use the build-complete marker. Run
 `stim guide lifecycle readiness` for implementation instructions; verify the
 expected screen separately.
 

--- a/packages/stim-cli/shim/bundle-response.cjs
+++ b/packages/stim-cli/shim/bundle-response.cjs
@@ -1,0 +1,46 @@
+'use strict';
+
+const { randomUUID } = require('node:crypto');
+
+function bundleResponseMiddleware(write) {
+  return (req, res, next) => {
+    let url;
+    try {
+      url = new URL(req.url, 'http://localhost');
+    } catch {
+      return next();
+    }
+    const platform = url.searchParams.get('platform');
+    if (req.method !== 'GET' || !/\.bundle\/*$/.test(url.pathname) || !['ios', 'android'].includes(platform)) {
+      return next();
+    }
+    const requestId = randomUUID();
+    const emit = (event, statusCode) => {
+      try {
+        write({
+          ts: Date.now(),
+          src: 'metro',
+          level: event === 'bundle_response_failed' ? 'error' : 'debug',
+          event,
+          platform,
+          requestId,
+          statusCode,
+          msg: `${platform} bundle response ${event.slice('bundle_response_'.length)}`,
+        });
+      } catch {}
+    };
+    emit('bundle_response_started');
+    let ended = false;
+    const finish = (complete) => {
+      if (ended) return;
+      ended = true;
+      const success = complete && (res.statusCode === 200 || res.statusCode === 304);
+      emit(success ? 'bundle_response_finished' : 'bundle_response_failed', res.statusCode);
+    };
+    res.once('finish', () => finish(true));
+    res.once('close', () => finish(false));
+    return next();
+  };
+}
+
+module.exports = { bundleResponseMiddleware };

--- a/packages/stim-cli/shim/bundle-response.d.cts
+++ b/packages/stim-cli/shim/bundle-response.d.cts
@@ -1,0 +1,5 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export function bundleResponseMiddleware(
+  write: (record: Record<string, unknown>) => unknown,
+): (req: IncomingMessage, res: ServerResponse, next: () => unknown) => unknown;

--- a/packages/stim-cli/shim/expo-metro-config.cjs
+++ b/packages/stim-cli/shim/expo-metro-config.cjs
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { createRequire } = require('node:module');
 const { pathToFileURL } = require('node:url');
+const { bundleResponseMiddleware } = require('./bundle-response.cjs');
 
 const projectRoot = process.env.STIM_PROJECT_ROOT;
 const storeRoot = process.env.STIM_METRO_STORE;
@@ -120,9 +121,21 @@ function storeAtRoot(store) {
 function appendStore(config, defaultConfig) {
   const output = config && typeof config === 'object' ? config : {};
   const configuredStores = output.cacheStores != null ? output.cacheStores : defaultConfig.cacheStores;
+  const server = { ...defaultConfig.server, ...output.server };
+  const enhanceMiddleware = server.enhanceMiddleware;
 
   return {
     ...output,
+    server: {
+      ...server,
+      enhanceMiddleware(middleware, metroServer) {
+        const enhanced = enhanceMiddleware ? enhanceMiddleware(middleware, metroServer) : middleware;
+        const observe = bundleResponseMiddleware((record) =>
+          process.stderr.write(`stim-bundle-response: ${JSON.stringify(record)}\n`),
+        );
+        return (req, res, next) => observe(req, res, () => enhanced(req, res, next));
+      },
+    },
     cacheStores(MetroCache) {
       const resolved = typeof configuredStores === 'function' ? configuredStores(MetroCache) : configuredStores;
       const stores = Array.isArray(resolved) ? resolved : [];

--- a/packages/stim-cli/shim/expo-metro-config.cjs
+++ b/packages/stim-cli/shim/expo-metro-config.cjs
@@ -124,7 +124,7 @@ function appendStore(config, defaultConfig) {
   const server = { ...defaultConfig.server, ...output.server };
   const enhanceMiddleware = server.enhanceMiddleware;
 
-  return {
+  const observed = {
     ...output,
     server: {
       ...server,
@@ -136,6 +136,10 @@ function appendStore(config, defaultConfig) {
         return (req, res, next) => observe(req, res, () => enhanced(req, res, next));
       },
     },
+  };
+  if (!storeRoot) return observed;
+  return {
+    ...observed,
     cacheStores(MetroCache) {
       const resolved = typeof configuredStores === 'function' ? configuredStores(MetroCache) : configuredStores;
       const stores = Array.isArray(resolved) ? resolved : [];
@@ -162,7 +166,7 @@ function appendStore(config, defaultConfig) {
   };
 }
 
-if (!projectRoot || !storeRoot) {
+if (!projectRoot) {
   module.exports = {};
 } else {
   const projectRequire = createRequire(path.join(projectRoot, 'package.json'));

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2674,11 +2674,15 @@ describe('launch verification', () => {
     expect(h.stderr.join('\n')).toMatch(/run `stim android` again.*Metro reload cannot restart an exited app/);
   });
 
-  test('a Metro build failure with a live native process recommends reload instead of another native run', async () => {
+  test.each([
+    ['bundle_build_failed', 'Metro could not build the bundle', 'Fix the JavaScript'],
+    ['bundle_response_failed', 'Metro bundle delivery failed', 'Check the Metro logs and device connection'],
+  ])('a Metro failure (%s) with a live process recommends reload', async (event, reason, remedy) => {
     const h = harness({
       verifyLaunched: async () => ({
         fatal: true,
         processAlive: true,
+        record: { event },
         errors: [{ src: 'metro', msg: 'Unable to resolve module ./missing' }],
       }),
     });
@@ -2686,6 +2690,9 @@ describe('launch verification', () => {
     const text = h.stderr.join('\n');
     expect(result.ok).toBe(false);
     expect(text).toMatch(/native app is still running/);
+    expect(text).toContain(reason);
+    expect(text).toContain(remedy);
+    expect(text.includes('Fix the JavaScript')).toBe(event === 'bundle_build_failed');
     expect(text).toContain('stim reload android');
     expect(text).toMatch(/Do not run `stim android` unless native inputs changed or the app process exits/);
   });

--- a/packages/stim-cli/src/__tests__/bundle-response.test.ts
+++ b/packages/stim-cli/src/__tests__/bundle-response.test.ts
@@ -1,0 +1,83 @@
+import { once } from 'node:events';
+import { createServer, get, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { bundleResponseMiddleware } from '../../shim/bundle-response.cjs';
+import { recordFromLine } from '../supervisor/server-expo.ts';
+
+let server: Server;
+afterEach(async () => {
+  server?.closeAllConnections();
+  if (server?.listening) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function listen(handler: (res: ServerResponse) => void) {
+  const records: Record<string, unknown>[] = [];
+  const middleware = bundleResponseMiddleware((record) => records.push(record));
+  server = createServer((req, res) => middleware(req, res, () => handler(res)));
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { records, url: `http://127.0.0.1:${(server.address() as AddressInfo).port}` };
+}
+
+test('completion follows the actual HTTP response, preserving platform and request identity', async () => {
+  let response: ServerResponse;
+  const { records, url } = await listen((res) => {
+    response = res;
+    res.write('first chunk');
+  });
+  const request = get(`${url}/index.bundle?platform=android`);
+  const [incoming] = await once(request, 'response');
+  incoming.resume();
+  expect(records.map((r) => r.event)).toEqual(['bundle_response_started']);
+  const ended = once(incoming, 'end');
+  response!.end('last chunk');
+  await ended;
+  expect(records).toHaveLength(2);
+  expect(records[1]).toMatchObject({
+    event: 'bundle_response_finished',
+    platform: 'android',
+    statusCode: 200,
+    requestId: records[0]!.requestId,
+  });
+  const line = `stim-bundle-response: ${JSON.stringify(records[1])}`;
+  expect(recordFromLine(line, { stream: 'stderr' })).toEqual(records[1]);
+  expect(recordFromLine(line)?.event).toBe('expo_stdout');
+});
+
+test('an aborted response cannot report completion', async () => {
+  const { records, url } = await listen((res) => res.write('partial'));
+  const request = get(`${url}/index.bundle?platform=ios`);
+  const [incoming] = await once(request, 'response');
+  const closed = once(incoming, 'close');
+  incoming.destroy();
+  await closed;
+  await vi.waitFor(() => expect(records).toHaveLength(2));
+  expect(records[1]).toMatchObject({ event: 'bundle_response_failed', platform: 'ios', level: 'error' });
+});
+
+test.each([304, 500])('HTTP status %s is classified without trusting a build marker', async (status) => {
+  const { records, url } = await listen((res) => {
+    res.statusCode = status;
+    res.end();
+  });
+  const request = get(`${url}/index.bundle?platform=ios`);
+  const [incoming] = await once(request, 'response');
+  incoming.resume();
+  await once(incoming, 'end');
+  expect(records[1]).toMatchObject({
+    event: status === 304 ? 'bundle_response_finished' : 'bundle_response_failed',
+    statusCode: status,
+  });
+});
+
+test.each(['/index.map?platform=ios', '/assets/icon.png?platform=ios', '/index.bundle?platform=web', '/index.bundle'])(
+  'ignores non-native bundle request %s',
+  async (path) => {
+    const { records, url } = await listen((res) => res.end());
+    const request = get(`${url}${path}`);
+    const [incoming] = await once(request, 'response');
+    incoming.resume();
+    await once(incoming, 'end');
+    expect(records).toEqual([]);
+  },
+);

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -787,6 +787,150 @@ describe('verifyLaunch', () => {
 });
 
 describe('optional app readiness', () => {
+  test.each(['ready', 'error', 'absent', 'stalled'] as const)(
+    'Android queued evaluation must start before stability: %s',
+    async (outcome) => {
+      const clock = fakeClock();
+      const metro: NdjsonRecord[] = [
+        { ts: 1000, src: 'metro', platform: 'android', event: 'bundle_response_started', requestId: 'a' },
+        { ts: 2000, src: 'metro', platform: 'android', event: 'bundle_build_done' },
+        { ts: 7500, src: 'metro', platform: 'android', event: 'bundle_response_finished', requestId: 'a' },
+      ];
+      const device: NdjsonRecord[] = [
+        {
+          ts: 9000,
+          src: 'device',
+          platform: 'android',
+          proc: 'unknown:BridgelessReact(123)',
+          level: 'warn',
+          msg: 'ReactHost{0}.getOrCreateReactInstanceTask(): Loading JS Bundle',
+        },
+        ...(outcome === 'stalled'
+          ? []
+          : [
+              {
+                ts: 12000,
+                src: 'device',
+                platform: 'android',
+                proc: 'ReactNativeJS(123)',
+                level: 'info',
+                msg: outcome === 'absent' ? 'Running "main"' : '[stim:readiness] pending',
+              },
+              outcome === 'error'
+                ? {
+                    ts: 16000,
+                    src: 'device',
+                    platform: 'android',
+                    proc: 'ReactNativeJS(123)',
+                    level: 'error',
+                    msg: 'startup failed',
+                  }
+                : { ts: 16000, src: 'device', platform: 'android', level: 'info', msg: '[stim:readiness] ready' },
+            ]),
+      ];
+      const result = await verifyLaunch({
+        since: 1000,
+        platform: 'android',
+        now: clock.now,
+        sleep: clock.sleep,
+        readRecords: () => metro.filter((r) => Number(r.ts) <= clock.at()),
+        readDeviceRecords: () => device.filter((r) => Number(r.ts) <= clock.at()),
+        readClientRecords: () => [],
+        processAlive: () => true,
+      });
+      expect(result).toMatchObject(
+        outcome === 'stalled'
+          ? { verified: false, requested: true, timedOut: true, waitedMs: VERIFY_TIMEOUT_MS }
+          : { verified: true, waitedMs: outcome === 'absent' ? 14000 : 15000 },
+      );
+      expect(result.readiness).toBe(outcome === 'ready' || outcome === 'error' ? outcome : undefined);
+    },
+  );
+
+  test.each(['ready', 'error', 'absent'] as const)(
+    'cold delivery does not miss an early-entry signal: %s',
+    async (outcome) => {
+      const clock = fakeClock();
+      const records: NdjsonRecord[] = [
+        { ts: 1000, src: 'metro', platform: 'android', event: 'bundle_response_started', requestId: 'a' },
+        { ts: 2000, src: 'metro', platform: 'android', event: 'bundle_build_done' },
+        { ts: 3000, src: 'metro', platform: 'ios', event: 'bundle_response_finished', requestId: 'a' },
+        { ts: 3500, src: 'metro', platform: 'android', event: 'bundle_response_finished', requestId: 'other' },
+        { ts: 7500, src: 'metro', platform: 'android', event: 'bundle_response_finished', requestId: 'a' },
+      ];
+      const device: NdjsonRecord[] =
+        outcome === 'absent'
+          ? []
+          : [
+              { ts: 9500, src: 'device', platform: 'android', level: 'info', msg: '[stim:readiness] pending' },
+              outcome === 'ready'
+                ? { ts: 14000, src: 'device', platform: 'android', level: 'info', msg: '[stim:readiness] ready' }
+                : {
+                    ts: 14000,
+                    src: 'device',
+                    platform: 'android',
+                    proc: 'ReactNativeJS(123)',
+                    level: 'error',
+                    msg: 'startup failed',
+                  },
+            ];
+      const result = await verifyLaunch({
+        since: 1000,
+        platform: 'android',
+        now: clock.now,
+        sleep: clock.sleep,
+        readRecords: () => records.filter((r) => Number(r.ts) <= clock.at()),
+        readDeviceRecords: () => device.filter((r) => Number(r.ts) <= clock.at()),
+        readClientRecords: () => [],
+        processAlive: () => true,
+      });
+      expect(result).toMatchObject({
+        verified: true,
+        waitedMs: outcome === 'absent' ? 9500 : 13000,
+        record: { event: 'bundle_response_finished', requestId: 'a', ts: 7500 },
+      });
+      expect(result.readiness).toBe(outcome === 'absent' ? undefined : outcome);
+    },
+  );
+
+  test.each(['stalled', 'failed'])(
+    'a %s bundle response cannot become verified from a build marker',
+    async (outcome) => {
+      const clock = fakeClock();
+      const records: NdjsonRecord[] = [
+        { ts: 1000, platform: 'android', event: 'bundle_response_started', requestId: 'a' },
+        { ts: 2000, platform: 'android', event: 'bundle_build_done' },
+        ...(outcome === 'failed'
+          ? [
+              {
+                ts: 2500,
+                platform: 'android',
+                event: 'bundle_response_failed',
+                requestId: 'a',
+                level: 'error',
+                msg: 'delivery failed',
+              },
+            ]
+          : []),
+      ];
+      const result = await verifyLaunch({
+        since: 1000,
+        platform: 'android',
+        now: clock.now,
+        sleep: clock.sleep,
+        readRecords: () => records.filter((r) => Number(r.ts) <= clock.at()),
+        readDeviceRecords: () => [],
+        readClientRecords: () => [],
+      });
+      expect(result.verified).toBe(false);
+      expect(result).toMatchObject(
+        outcome === 'stalled'
+          ? { requested: true, timedOut: true, waitedMs: VERIFY_TIMEOUT_MS }
+          : { fatal: true, waitedMs: 1500, errors: [{ msg: 'delivery failed' }] },
+      );
+    },
+  );
+
   function signal(ts: number, state: string, extra: Partial<NdjsonRecord> = {}): NdjsonRecord {
     return { ts, src: 'device', platform: 'ios', level: 'info', msg: `[stim:readiness] ${state}`, ...extra };
   }

--- a/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
+++ b/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
@@ -52,6 +52,48 @@ function run(extraEnv: Record<string, string> = {}) {
 }
 
 describe('the Expo Metro config adapter', () => {
+  test('observes delivery without replacing the project middleware or server settings', () => {
+    writeFileSync(
+      join(project, 'metro.config.cjs'),
+      `module.exports = { server: {
+      port: 8123,
+      enhanceMiddleware(middleware) { return (req, res, next) => {
+        res.setHeader('x-project', 'kept'); return middleware(req, res, next);
+      }; }
+    } };`,
+    );
+    const script = `
+      const http = require('node:http');
+      Promise.resolve(require(process.env.ADAPTER)).then(config => {
+        const middleware = config.server.enhanceMiddleware((req, res) => res.end('bundle'), {});
+        const server = http.createServer((req, res) => middleware(req, res, () => {}));
+        server.listen(0, '127.0.0.1', () => {
+          http.get('http://127.0.0.1:' + server.address().port + '/index.bundle?platform=android', res => {
+            let body = ''; res.on('data', chunk => body += chunk);
+            res.on('end', () => {
+              console.log(JSON.stringify({ body, project: res.headers['x-project'], port: config.server.port }));
+              server.close();
+            });
+          });
+        });
+      });
+    `;
+    const result = spawnSync(process.execPath, ['-e', script], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, ADAPTER: adapter, STIM_PROJECT_ROOT: project, STIM_METRO_STORE: '/cache/adapter-test' },
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ body: 'bundle', project: 'kept', port: 8123 });
+    const records = result.stderr
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line.slice('stim-bundle-response: '.length)));
+    expect(records.map((record) => record.event)).toEqual(['bundle_response_started', 'bundle_response_finished']);
+    expect(records[1]).toMatchObject({ platform: 'android', requestId: records[0].requestId });
+  });
+
   test('ships with Stim and is discoverable from source builds', () => {
     expect(adapter.endsWith(join('shim', 'expo-metro-config.cjs'))).toBe(true);
     expect(expoMetroConfigPath('file:///nowhere/at/all/x.js')).toBe(null);

--- a/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
+++ b/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
@@ -52,19 +52,22 @@ function run(extraEnv: Record<string, string> = {}) {
 }
 
 describe('the Expo Metro config adapter', () => {
-  test('observes delivery without replacing the project middleware or server settings', () => {
-    writeFileSync(
-      join(project, 'metro.config.cjs'),
-      `module.exports = { server: {
+  test.each(['/cache/adapter-test', ''])(
+    'observes delivery without replacing project settings (shared store: %s)',
+    (storeRoot) => {
+      writeFileSync(
+        join(project, 'metro.config.cjs'),
+        `module.exports = { cacheStores: [{ _root: '/project/store' }], server: {
       port: 8123,
       enhanceMiddleware(middleware) { return (req, res, next) => {
         res.setHeader('x-project', 'kept'); return middleware(req, res, next);
       }; }
     } };`,
-    );
-    const script = `
+      );
+      const script = `
       const http = require('node:http');
       Promise.resolve(require(process.env.ADAPTER)).then(config => {
+        if (!process.env.STIM_METRO_STORE && config.cacheStores[0]._root !== '/project/store') throw new Error('project cache changed');
         const middleware = config.server.enhanceMiddleware((req, res) => res.end('bundle'), {});
         const server = http.createServer((req, res) => middleware(req, res, () => {}));
         server.listen(0, '127.0.0.1', () => {
@@ -78,21 +81,22 @@ describe('the Expo Metro config adapter', () => {
         });
       });
     `;
-    const result = spawnSync(process.execPath, ['-e', script], {
-      cwd: project,
-      encoding: 'utf-8',
-      env: { ...process.env, ADAPTER: adapter, STIM_PROJECT_ROOT: project, STIM_METRO_STORE: '/cache/adapter-test' },
-      timeout: 5000,
-    });
-    expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({ body: 'bundle', project: 'kept', port: 8123 });
-    const records = result.stderr
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line.slice('stim-bundle-response: '.length)));
-    expect(records.map((record) => record.event)).toEqual(['bundle_response_started', 'bundle_response_finished']);
-    expect(records[1]).toMatchObject({ platform: 'android', requestId: records[0].requestId });
-  });
+      const result = spawnSync(process.execPath, ['-e', script], {
+        cwd: project,
+        encoding: 'utf-8',
+        env: { ...process.env, ADAPTER: adapter, STIM_PROJECT_ROOT: project, STIM_METRO_STORE: storeRoot },
+        timeout: 5000,
+      });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ body: 'bundle', project: 'kept', port: 8123 });
+      const records = result.stderr
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line.slice('stim-bundle-response: '.length)));
+      expect(records.map((record) => record.event)).toEqual(['bundle_response_started', 'bundle_response_finished']);
+      expect(records[1]).toMatchObject({ platform: 'android', requestId: records[0].requestId });
+    },
+  );
 
   test('ships with Stim and is discoverable from source builds', () => {
     expect(adapter.endsWith(join('shim', 'expo-metro-config.cjs'))).toBe(true);

--- a/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
@@ -379,7 +379,8 @@ describe('startBareServer wiring', () => {
     expect(typeof calls.createDevMiddleware.logger.error).toBe('function');
     const middlewares = calls.runServer.options.unstable_extraMiddleware as unknown[];
     expect(typeof middlewares[0]).toBe('function');
-    expect(middlewares.slice(1)).toEqual(['community-mw', 'dev-mw']);
+    expect(typeof middlewares[1]).toBe('function');
+    expect(middlewares.slice(2)).toEqual(['community-mw', 'dev-mw']);
     expect(calls.runServer.options.websocketEndpoints).toEqual({ '/message': 'm', '/inspector': 'i' });
     expect('host' in calls.runServer.options).toBe(false);
   });

--- a/packages/stim-cli/src/__tests__/supervisor-expo.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-expo.test.ts
@@ -592,7 +592,8 @@ describe('the Metro store injected into an Expo child', () => {
       });
       const env = calls[0]?.opts.env as Record<string, string>;
       expect(env.NODE_OPTIONS).toBe('--enable-source-maps');
-      expect(env.STIM_METRO_STORE).toBe(undefined);
+      expect(env.STIM_METRO_STORE).toBe('');
+      expect(env.EXPO_OVERRIDE_METRO_CONFIG).toBe(expoMetroConfigPath());
       const records = parseNdjsonText(readFileSync(join(logsDir, 'metro.ndjson'), 'utf-8'));
       expect(records.some((r) => r.event === 'cache_store_skipped')).toBe(true);
     },

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -194,7 +194,7 @@ async function verifyAndroidRun({
   if (verification?.requested) {
     phase(
       'verify',
-      `BUNDLING: the app asked port ${metroPort} for its bundle and Metro was still building it ` +
+      `BUNDLING: the app asked port ${metroPort} for its bundle; build, delivery, or JavaScript loading was still pending ` +
         `after ${formatDuration(verification.waitedMs ?? 0)} (a cold bundle on a large graph outlasts this window)`,
     );
     phase(

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -140,7 +140,13 @@ async function verifyAndroidRun({
   if (verification.readiness)
     phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
-    const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
+    const deliveryFailed = verification.record?.event === 'bundle_response_failed';
+    const reason =
+      verification.processAlive === false
+        ? 'the app process exited'
+        : deliveryFailed
+          ? 'Metro bundle delivery failed'
+          : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
     for (const record of verification.errors ?? []) {
       if (record.msg) phase('', chalk.red(String(record.msg)));
@@ -157,7 +163,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error, then ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
         ),
       );
     }

--- a/packages/stim-cli/src/commands/android/types.ts
+++ b/packages/stim-cli/src/commands/android/types.ts
@@ -61,6 +61,7 @@ export interface LaunchResultLike {
 }
 
 export interface VerifyLaunchResultLike {
+  record?: Record<string, unknown>;
   readiness?: 'ready' | 'timed-out' | 'error';
   verified?: boolean;
   skipped?: boolean;

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -206,7 +206,7 @@ async function verifyIosRun({
   if (verification?.requested) {
     phase(
       'verify',
-      `BUNDLING: the app asked port ${metroPort} for its bundle and Metro was still building it ` +
+      `BUNDLING: the app asked port ${metroPort} for its bundle; build or delivery was still pending ` +
         `after ${formatDuration(verification.waitedMs ?? 0)} (a cold bundle on a large graph outlasts this window)`,
     );
     note(

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -147,7 +147,13 @@ async function verifyIosRun({
   if (verification.readiness)
     phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
-    const reason = verification.processAlive === false ? 'the app process exited' : 'Metro could not build the bundle';
+    const deliveryFailed = verification.record?.event === 'bundle_response_failed';
+    const reason =
+      verification.processAlive === false
+        ? 'the app process exited'
+        : deliveryFailed
+          ? 'Metro bundle delivery failed'
+          : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
     for (const record of verification.errors ?? []) {
       if (record.msg) note(chalk.red(phaseLine('', String(record.msg))));
@@ -167,7 +173,7 @@ async function verifyIosRun({
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error, then ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );

--- a/packages/stim-cli/src/commands/ios/types.ts
+++ b/packages/stim-cli/src/commands/ios/types.ts
@@ -54,6 +54,7 @@ export interface BuildIosResultLike {
 }
 
 export interface VerifyLaunchResultLike {
+  record?: Record<string, unknown>;
   readiness?: 'ready' | 'timed-out' | 'error';
   verified?: boolean;
   skipped?: boolean;

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -726,6 +726,9 @@ const BUNDLE_EVENTS = new Set([
   'bundle_build_failed',
   'bundling_error',
   'transformer_error',
+  'bundle_response_started',
+  'bundle_response_finished',
+  'bundle_response_failed',
 ]);
 
 export function isBundleProof(
@@ -811,26 +814,73 @@ export async function verifyLaunch({
   let activity: NdjsonRecord | null = null;
   let stabilityDeadline: number | null = null;
   let pendingAt: number | null = null;
+  let deliveryId: string | null = null;
+  let runtimeLoadingAt: number | null = null;
+  let runtimeStartedAt: number | null = null;
   while (true) {
     const metroRecords = read().filter((record) => after(record, since));
     const deviceRecords = readDevice().filter((record) => after(record, since));
     const clientRecords = readClient().filter((record) => after(record, since));
+    if (deliveryId === null) {
+      const request = metroRecords.find(
+        (record) =>
+          record.event === 'bundle_response_started' &&
+          typeof record.requestId === 'string' &&
+          isBundleProof(record, since, platform),
+      );
+      if (request) {
+        deliveryId = request.requestId as string;
+        proof = null;
+        stabilityDeadline = null;
+      }
+    }
     for (const record of metroRecords) {
       if (isBundleProof(record, since, platform)) activity = record;
-      if (!proof && isBundleReadyProof(record, since, platform)) {
+      const completed =
+        deliveryId === null
+          ? isBundleReadyProof(record, since, platform)
+          : record.event === 'bundle_response_finished' &&
+            record.requestId === deliveryId &&
+            isBundleProof(record, since, platform);
+      if (!proof && completed) {
         proof = record;
         stabilityDeadline = Number(record.ts) + Math.max(0, stabilityMs);
       }
     }
-    const readinessDeadline = proof ? Number(proof.ts) + APP_READINESS_TIMEOUT_MS : bundleDeadline;
     const signals = deviceRecords
       .filter((record) => Number(record.ts) <= now())
       .toSorted((a, b) => Number(a.ts) - Number(b.ts));
+    if (platform === 'android' && runtimeLoadingAt === null) {
+      // ReactHostImpl's Loading JS Bundle state precedes asynchronous ReactInstance.loadJSBundle evaluation.
+      const loading = signals.find(
+        (record) =>
+          record.src === 'device' &&
+          record.platform === 'android' &&
+          /^(?:unknown:)?BridgelessReact\(\d+\)$/.test(String(record.proc)) &&
+          /^ReactHost\{\d+\}\.getOrCreateReactInstanceTask\(\): Loading JS Bundle$/.test(String(record.msg)) &&
+          (stabilityDeadline === null || Number(record.ts) <= stabilityDeadline),
+      );
+      if (loading) runtimeLoadingAt = Number(loading.ts);
+    }
+    if (runtimeLoadingAt !== null && runtimeStartedAt === null) {
+      const executing = signals.find(
+        (record) =>
+          record.src === 'device' &&
+          record.platform === 'android' &&
+          Number(record.ts) >= runtimeLoadingAt! &&
+          (/^ReactNativeJS\(\d+\)$/.test(String(record.proc)) || appReadinessSignal(record, platform) !== null),
+      );
+      if (executing) runtimeStartedAt = Number(executing.ts);
+    }
+    const runtimeWaiting = runtimeLoadingAt !== null && runtimeStartedAt === null;
+    const completedAt = proof ? Math.max(Number(proof.ts), runtimeStartedAt ?? 0) : null;
+    if (completedAt !== null) stabilityDeadline = completedAt + Math.max(0, stabilityMs);
+    const readinessDeadline = completedAt !== null ? completedAt + APP_READINESS_TIMEOUT_MS : bundleDeadline;
     if (pendingAt === null) {
       const pending = signals.find(
         (record) =>
           appReadinessSignal(record, platform) === 'pending' &&
-          (stabilityDeadline === null || Number(record.ts) <= stabilityDeadline),
+          (runtimeWaiting || stabilityDeadline === null || Number(record.ts) <= stabilityDeadline),
       );
       if (pending) {
         pendingAt = Number(pending.ts);
@@ -845,7 +895,14 @@ export async function verifyLaunch({
           Number(record.ts) <= readinessDeadline &&
           appReadinessSignal(record, platform) === 'ready',
       );
-    const bundleErrors = metroRecords.filter((record) => isFatalLaunchError(record, platform));
+    const bundleErrors = metroRecords.filter(
+      (record) =>
+        isFatalLaunchError(record, platform) ||
+        (deliveryId !== null &&
+          record.event === 'bundle_response_failed' &&
+          record.requestId === deliveryId &&
+          isBundleProof(record, since, platform)),
+    );
     if (bundleErrors.length) {
       const alive = processAlive ? processAlive() : null;
       const fatalRecord = bundleErrors[bundleErrors.length - 1];
@@ -889,7 +946,7 @@ export async function verifyLaunch({
       }
       const actionableErrors = errors.filter((record) => !isIosConnectionRefusal(record, platform));
       const appErrors = actionableErrors.some(isAppLaunchError);
-      if (pendingAt === null || appErrors || ready || now() >= readinessDeadline) {
+      if ((!runtimeWaiting && pendingAt === null) || appErrors || ready || now() >= readinessDeadline) {
         return {
           verified: true,
           record: proof,
@@ -902,7 +959,7 @@ export async function verifyLaunch({
       }
     }
 
-    if (!proof && now() >= bundleDeadline) {
+    if ((!proof || runtimeWaiting) && now() >= bundleDeadline) {
       const requested = findBundleRequest(deviceRecords, since, metroPort, platform) ?? activity;
       const waitedMs = now() - startedAt;
       if (requested) {
@@ -917,7 +974,11 @@ export async function verifyLaunch({
       }
       return { verified: false, timedOut: true, mode, waitedMs };
     }
-    const deadline = proof && pendingAt !== null ? readinessDeadline : (stabilityDeadline ?? bundleDeadline);
+    const deadline = runtimeWaiting
+      ? bundleDeadline
+      : proof && pendingAt !== null
+        ? readinessDeadline
+        : (stabilityDeadline ?? bundleDeadline);
     await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
   }
 }

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -103,7 +103,7 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
                   the bundle would cost more than installing it
   launched        true, "bundling", or "unverified". THE THREE ARE DIFFERENT
                   FACTS and only the last one is a problem.
-                    true         Metro finished the bundle, then the app stayed
+                    true         Metro finished the bundle response, then the app stayed
                                  alive through a three-second stability window.
                                  The command checks process liveness when the
                                  platform exposes it. Errors from that window
@@ -124,7 +124,7 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
                                  does not change this field. See
                                  \`guide lifecycle readiness\`
                     "bundling"   the request DID arrive and Metro was still
-                                 building when the bundle timeout closed.
+                                 building or delivering when the bundle timeout closed.
                                  The wiring is proven; the JS has simply not
                                  run yet (a cold bundle of ~10k modules takes
                                  longer than the window). Nothing to do --

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -147,8 +147,13 @@ Metro verification enabled, not release builds or --no-metro-check.
    a missing ready message, and a startup error. Retain the relevant output.
 
 Without an observed pending, Stim keeps its default 3-second stability window
-after bundle completion. Pending must be observed before that window closes.
-It opts into waiting for ready until 30 seconds after bundle completion.
+after bundle delivery. Managed Metro servers report the native bundle response
+finishing; build-complete output alone does not close an observed request.
+Without response capture, Stim falls back to the build-complete marker.
+When Android reports queued JavaScript loading, Stim waits for a device
+JavaScript log before starting stability, bounded by the bundle timeout.
+Pending must be observed before the stability window closes. It opts into
+waiting for ready until 30 seconds after the same completion signal.
 Repeated pending messages never extend the deadline. Ready can end the wait
 early; an app error or process exit interrupts it. No ready means readiness
 not confirmed, not a crash or successful readiness.

--- a/packages/stim-cli/src/supervisor/server-bare.ts
+++ b/packages/stim-cli/src/supervisor/server-bare.ts
@@ -4,6 +4,7 @@ import { projectMetroSharedCache } from '../settings.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { appendCacheStore, metroStoreRoot, registerMetroStore } from './metro-store.ts';
 import { supervisorError } from './errors.ts';
+import { bundleResponseMiddleware } from '../../shim/bundle-response.cjs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type BareModule = any;
@@ -346,7 +347,12 @@ export async function startBareServer({
   });
 
   const httpServer = await metro.runServer(config, {
-    unstable_extraMiddleware: [symbolicationReporterMiddleware(reporter), communityMiddleware, middleware],
+    unstable_extraMiddleware: [
+      bundleResponseMiddleware((record) => writer?.write(record)),
+      symbolicationReporterMiddleware(reporter),
+      communityMiddleware,
+      middleware,
+    ],
     websocketEndpoints: { ...communityWebsocketEndpoints, ...websocketEndpoints },
   });
 

--- a/packages/stim-cli/src/supervisor/server-expo.ts
+++ b/packages/stim-cli/src/supervisor/server-expo.ts
@@ -145,6 +145,19 @@ export function cleanLine(line: unknown): string {
 export function recordFromLine(line: unknown, { stream = 'stdout' }: { stream?: string } = {}): NdjsonRecord | null {
   const msg = cleanLine(line);
   if (!msg.trim()) return null;
+  if (stream === 'stderr' && msg.startsWith('stim-bundle-response: ')) {
+    try {
+      const record = JSON.parse(msg.slice('stim-bundle-response: '.length));
+      if (
+        record.src === 'metro' &&
+        ['bundle_response_started', 'bundle_response_finished', 'bundle_response_failed'].includes(record.event) &&
+        ['ios', 'android'].includes(record.platform) &&
+        typeof record.requestId === 'string' &&
+        Number.isFinite(record.ts)
+      )
+        return record;
+    } catch {}
+  }
   const confirmed = metroStoreConfirmedRoot(msg);
   if (confirmed) {
     return {

--- a/packages/stim-cli/src/supervisor/server-expo.ts
+++ b/packages/stim-cli/src/supervisor/server-expo.ts
@@ -215,14 +215,14 @@ function resolveMetroStoreInjection(
   root: string,
   { log, env }: { log: NdjsonWriter; env: NodeJS.ProcessEnv },
 ): Record<string, string> | null {
-  if (!projectMetroSharedCache(root)) {
+  const sharedCache = projectMetroSharedCache(root);
+  if (!sharedCache) {
     log.write({
       src: 'metro',
       level: 'debug',
       event: 'cache_store_skipped',
       msg: 'the shared Metro transform store is off in configuration',
     });
-    return null;
   }
   const sdkMajor = expoSdkMajor(root);
   if (sdkMajor === null || sdkMajor < 54) {
@@ -247,13 +247,14 @@ function resolveMetroStoreInjection(
     });
     return null;
   }
-  const storeRoot = metroStoreRoot(root);
+  const storeRoot = sharedCache ? metroStoreRoot(root) : '';
   const additions = expoMetroStoreEnv({
     root,
     storeRoot,
     adapterPath,
     existingOverride: env.EXPO_OVERRIDE_METRO_CONFIG,
   });
+  if (!sharedCache) return additions;
   registerMetroStore(storeRoot);
   log.write({
     src: 'metro',

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -79,8 +79,13 @@ imported modules, emit `pending` from an earlier app entry module before loading
 that work. An error before `pending` still uses the default check.
 
 Without an observed `pending`, Stim keeps its default three-second stability
-window after bundle completion. A `pending` observed before that window closes
-opts into waiting for `ready`, up to 30 seconds after bundle completion.
+window after bundle delivery. Managed Metro servers report when the native
+bundle response finishes; build-complete output alone does not close an observed
+request. Without response capture, Stim falls back to the build-complete marker.
+When Android reports queued JavaScript loading, Stim waits for device JavaScript
+activity before starting stability, bounded by the bundle timeout.
+A `pending` observed before that window closes opts into waiting for `ready`, up
+to 30 seconds after the same completion signal.
 Repeated `pending` logs do not extend the deadline. A matching `ready` can end
 the wait early; an app error or process exit interrupts it. A missing `ready`
 prints **readiness not confirmed**, not success or an inferred crash.


### PR DESCRIPTION
## Description

Cold Android launches can finish Stim's stability check before JavaScript executes, hiding startup errors from the initial command. Fixes #535.

## Solution

Start the existing three-second stability window after bundle delivery in managed Expo and bare Metro, rather than the [original build-marker clock](https://github.com/appandflow/stim/commit/c0641215a8ea08eb3710d71a650f9c06fd8728be). If Android reports queued JavaScript loading, the existing bundle timeout bounds waiting for device JavaScript activity before stability begins. Optional readiness keeps its bounded wait.

Requests are matched by identity and platform; interrupted responses cannot become launch success and receive delivery-specific recovery guidance. Project middleware remains composed, including when shared caching is disabled; servers without response capture retain the build-marker fallback.

## Test plan

Native checks also used the independent clock-alignment fix #538, which prevents fresh Android device logs being filtered out on resumed emulators.

- Reproduced the missed exception with a cached Android36 / Expo58 app; the updated initial command observes pending and prints the injected JavaScript error with the process still alive (10.5s verification).
- Combined Android check: cold-start initial command caught the render error in 5.2s verification. iOS26.5: normal pending-to-ready in 6.4s, injected root-render error caught in the initial command in 2.5s; error-screen screenshot and logs retained locally.
- Real HTTP tests cover delayed/aborted responses, status handling, and existing Expo middleware. Launch tests cover foreign requests/platforms, queued evaluation, readiness/error, and bounded stalls.
- All 66 e2e pass. The full local suite hits the previously documented #491 fingerprint timeout; all other unit tests and local checks pass.
