### PR TITLE
fix: align Android log timestamps with host time

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-parsers.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-parsers.test.ts
@@ -12,6 +12,7 @@ import {
   NOISE_RULES,
 } from '../collector/ios.ts';
 import {
+  androidClockOffset,
   levelForLogcat,
   levelFromLogcatLetter,
   logcatArgs,
@@ -32,6 +33,7 @@ import {
   TOOL_ERROR_PREFIX,
 } from '../collector/ios-device.ts';
 import { LEVELS, SOURCES } from '../ndjson.ts';
+import { makeExecutor } from './_factories.ts';
 
 function isNotNull<T>(value: T | null): value is T {
   return value !== null;
@@ -604,7 +606,64 @@ describe('android: logcat -v time', () => {
   });
 
   test('logcatArgs is the exact argv', () => {
-    expect(logcatArgs('emulator-5554', 3132)).toEqual(['-s', 'emulator-5554', 'logcat', '--pid', '3132', '-v', 'time']);
+    expect(logcatArgs('emulator-5554', 3132)).toEqual([
+      '-s',
+      'emulator-5554',
+      'logcat',
+      '--pid',
+      '3132',
+      '-v',
+      'time,epoch',
+    ]);
+  });
+
+  test('epoch logcat keeps device time and shifts timestamps without reviving buffered records', () => {
+    const launch = 1788902585000;
+    const line = '         1788902582.542 I/ReactNativeJS( 1247): [stim:readiness] pending';
+    const current = parseLogcatLine(line, { clockOffsetMs: 2739, now: () => launch });
+    expect(current).toMatchObject({
+      ts: 1788902585281,
+      deviceTs: 1788902582542,
+      clockOffsetMs: 2739,
+      proc: 'ReactNativeJS(1247)',
+      msg: '[stim:readiness] pending',
+      level: 'info',
+    });
+    expect(current!.ts! > launch).toBe(true);
+    const old = parseLogcatLine(line.replace('2582.542', '2570.542'), { clockOffsetMs: 2739, now: () => launch });
+    expect(old!.ts! < launch).toBe(true);
+    expect(parseLogcatLine(line, { clockOffsetMs: -2739 })!.ts).toBe(1788902579803);
+    expect(parseLogcatLine(line)).toMatchObject({ ts: 1788902582542, deviceTs: 1788902582542 });
+    expect(parseLogcatLine(line)).not.toHaveProperty('clockOffsetMs');
+    expect(parseLogcatLine(line.replace('.542', '.542987'))!.ts).toBe(1788902582542);
+  });
+
+  test('clock alignment uses the midpoint of a bounded adb sample and rejects unsupported or slow clocks', () => {
+    const before = 1788902585000;
+    let after = before + 40;
+    let output = '1788902582281\n';
+    let failed = false;
+    let calls = 0;
+    const exec = makeExecutor({
+      runFile: (file, args, opts) => {
+        expect([file, args, opts]).toEqual(['adb', ['-s', 'serial', 'shell', 'date', '+%s%3N'], { timeoutMs: 1000 }]);
+        if (failed) throw new Error('offline');
+        return output;
+      },
+    });
+    const sample = () => androidClockOffset('serial', { exec, now: () => (calls++ % 2 === 0 ? before : after) });
+    expect(sample()).toBe(2739);
+    output = '1788902587759';
+    expect(sample()).toBe(-2739);
+    output = '1788902582%3N';
+    expect(sample()).toBe(null);
+    output = '1788902582281';
+    after = before + 1001;
+    expect(sample()).toBe(null);
+    after = before - 1;
+    expect(sample()).toBe(null);
+    failed = true;
+    expect(sample()).toBe(null);
   });
 
   test('parsePidof reads the single pid, and nothing from empty output', () => {

--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -561,7 +561,7 @@ describe('the android collector, spawned for real against a fake adb', { timeout
         `case "$*" in`,
         `  '-s emulator-5554 shell pidof -s com.example.app')`,
         `    if [ -f "${join(shimDir, 'started')}" ]; then echo 3132; else touch "${join(shimDir, 'started')}"; fi ;;`,
-        `  '-s emulator-5554 logcat --pid 3132 -v time')`,
+        `  '-s emulator-5554 logcat --pid 3132 -v time,epoch')`,
         `    echo '--------- beginning of main'`,
         `    echo '08-21 17:51:19.507 I/ReactNativeJS(  3132): Running "App" with {"rootTag":11}'`,
         `    echo '08-21 17:51:20.100 E/ReactNativeJS(  3132): TypeError: undefined is not a function'`,
@@ -647,6 +647,35 @@ describe('the android collector, spawned for real against a fake adb', { timeout
 });
 
 describe('runCollector seams', () => {
+  test.each([2739, null])(
+    'keeps fresh and buffered device timestamps distinct with clock offset %s',
+    async (offset) => {
+      const child = makeChildProcess({ pid: 3132 });
+      const result = await runCollector({
+        platform: 'android',
+        root,
+        serial: 'test-serial',
+        packageName: 'com.example.app',
+        resolvePid: async () => ({ ok: true, pid: 3132 }),
+        resolveClockOffset: () => offset,
+        startStream: () => child,
+        pidOf: () => 3132,
+        pidWatchMs: 60000,
+        attachSignals: false,
+        onExit: () => {},
+      });
+      assert(result);
+      child.stdout!.emit('data', ' 1788902582.542 I/ReactNativeJS( 3132): [stim:readiness] pending\n');
+      child.stdout!.emit('data', ' 1788902570.542 I/ReactNativeJS( 3132): [stim:readiness] ready\n');
+      const records = deviceLog();
+      expect(records.find((r) => r.event === 'collector_clock')!.level).toBe(offset === null ? 'warn' : 'debug');
+      const logs = records.filter((r) => r.proc === 'ReactNativeJS(3132)');
+      expect(logs.map((r) => r.ts)).toEqual([1788902582542 + (offset ?? 0), 1788902570542 + (offset ?? 0)]);
+      expect(logs.map((r) => r.deviceTs)).toEqual([1788902582542, 1788902570542]);
+      result.finish(0, 'info', 'done', 'collector_stopped');
+    },
+  );
+
   test('an app whose pid never appears is an error record, exit 1, and no registration left behind', async () => {
     let code = null;
     const result = await runCollector({
@@ -704,10 +733,10 @@ describe('the android collector follows the app across a restart', { timeout: 30
         `case "$*" in`,
         `  '-s emulator-5554 shell pidof -s com.example.app')`,
         `    if [ -f "${join(shimDir, 'restarted')}" ]; then echo 4200; else echo 3132; fi ;;`,
-        `  '-s emulator-5554 logcat --pid 3132 -v time')`,
+        `  '-s emulator-5554 logcat --pid 3132 -v time,epoch')`,
         `    echo '08-21 17:51:19.507 I/ReactNativeJS(  3132): before the restart'`,
         `    exec sleep 30 ;;`,
-        `  '-s emulator-5554 logcat --pid 4200 -v time')`,
+        `  '-s emulator-5554 logcat --pid 4200 -v time,epoch')`,
         `    echo '08-21 17:51:29.507 I/ReactNativeJS(  4200): after the restart'`,
         `    exec sleep 30 ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
@@ -746,7 +775,7 @@ describe('the android collector follows the app across a restart', { timeout: 30
       [
         `case "$*" in`,
         `  '-s emulator-5554 shell pidof -s com.example.app') echo 3132 ;;`,
-        `  '-s emulator-5554 logcat --pid 3132 -v time')`,
+        `  '-s emulator-5554 logcat --pid 3132 -v time,epoch')`,
         `    echo '08-21 17:51:19.507 I/ReactNativeJS(  3132): steady'`,
         `    exec sleep 30 ;;`,
         `  *) echo "unexpected argv: $*" >&2; exit 9 ;;`,
@@ -772,12 +801,14 @@ describe('runCollector reattach seams', () => {
     const started: ChildProcess[] = [];
     let pid = 3132;
     let code = null;
+    let clockSamples = 0;
     const result = await runCollector({
       platform: 'android',
       root,
       serial: 'emulator-5554',
       packageName: 'com.example.app',
       resolvePid: async () => ({ ok: true, pid: 3132 }),
+      resolveClockOffset: () => (++clockSamples === 1 ? 2700 : 3000),
       pidOf: () => pid,
       pidWatchMs: 60000,
       startStream: ({ pid: streamPid }) => {
@@ -798,6 +829,11 @@ describe('runCollector reattach seams', () => {
     firstStarted.emit('exit', 0, null);
 
     expect(started.map((c) => c.pid)).toEqual([3132, 4200]);
+    expect(
+      deviceLog()
+        .filter((r) => r.event === 'collector_clock')
+        .map((r) => r.clockOffsetMs),
+    ).toEqual([2700, 3000]);
     expect(code).toBe(null);
     expect(deviceLog().some((r) => r.event === 'collector_reattached')).toBeTruthy();
     assert(result);
@@ -812,6 +848,7 @@ describe('runCollector reattach seams', () => {
       serial: 'emulator-5554',
       packageName: 'com.example.app',
       resolvePid: async () => ({ ok: true, pid: 3132 }),
+      resolveClockOffset: () => null,
       pidOf: () => null,
       pidWatchMs: 60000,
       startStream: ({ pid: streamPid }) => fakeChild(streamPid),
@@ -836,6 +873,7 @@ describe('runCollector reattach seams', () => {
       serial: 'emulator-5554',
       packageName: 'com.example.app',
       resolvePid: async () => ({ ok: true, pid: 3132 }),
+      resolveClockOffset: () => null,
       startStream: ({ pid }) => fakeChild(pid),
       watchPid: () => ({
         stop: () => {
@@ -873,6 +911,7 @@ describe('the collector never signals a pid it does not own', () => {
         serial: 'emulator-5554',
         packageName: 'com.example.app',
         resolvePid: async () => ({ ok: true, pid: 3132 }),
+        resolveClockOffset: () => null,
         pidOf: () => pid,
         pidWatchMs: 60000,
         startStream: ({ pid: streamPid }) => {

--- a/packages/stim-cli/src/collector/android.ts
+++ b/packages/stim-cli/src/collector/android.ts
@@ -41,6 +41,7 @@ export function levelForLogcat(letter: string, tag: string): string {
 }
 
 const LOGCAT_TIME = /^(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})\s+([A-Z])\/(.*?)\(\s*(\d+)\):\s?(.*)$/;
+const LOGCAT_EPOCH = /^\s*(\d+)\.(\d{3,6})\s+([A-Z])\/(.*?)\(\s*(\d+)\):\s?(.*)$/;
 
 export function parseLogcatTimestamp(
   {
@@ -61,8 +62,27 @@ export function parseLogcatTimestamp(
   return ts;
 }
 
-export function parseLogcatLine(line: string, { now = Date.now }: { now?: () => number } = {}): NdjsonRecord | null {
+export function parseLogcatLine(
+  line: string,
+  { now = Date.now, clockOffsetMs = null }: { now?: () => number; clockOffsetMs?: number | null } = {},
+): NdjsonRecord | null {
   if (typeof line !== 'string') return null;
+  const epoch = LOGCAT_EPOCH.exec(line.trimEnd());
+  if (epoch) {
+    const [, seconds, fraction, letter, tag, pid, msg] = epoch;
+    if (!letter || !tag || !msg?.trim()) return null;
+    const deviceTs = Number(seconds) * 1000 + Number(fraction!.slice(0, 3));
+    if (!Number.isSafeInteger(deviceTs)) return null;
+    return {
+      ts: deviceTs + (clockOffsetMs ?? 0),
+      deviceTs,
+      ...(clockOffsetMs === null ? {} : { clockOffsetMs }),
+      src: 'device',
+      level: levelForLogcat(letter, tag),
+      msg,
+      proc: `${tag.trim()}(${pid})`,
+    };
+  }
   const m = LOGCAT_TIME.exec(line.trimEnd());
   if (!m) return null;
   const [, month, day, hour, minute, second, millis, letter, tag, pid, msg] = m;
@@ -88,7 +108,22 @@ export function parseLogcatLine(line: string, { now = Date.now }: { now?: () => 
 }
 
 export function logcatArgs(serial: string, pid: number | string): string[] {
-  return ['-s', serial, 'logcat', '--pid', String(pid), '-v', 'time'];
+  return ['-s', serial, 'logcat', '--pid', String(pid), '-v', 'time,epoch'];
+}
+
+export function androidClockOffset(
+  serial: string,
+  { exec = getExecutor(), now = Date.now }: { exec?: Executor; now?: () => number } = {},
+): number | null {
+  const before = now();
+  try {
+    const output = exec.runFile('adb', ['-s', serial, 'shell', 'date', '+%s%3N'], { timeoutMs: 1000 }).trim();
+    const after = now();
+    if (!/^\d{13}$/.test(output) || after < before || after - before > 1000) return null;
+    return Math.round((before + after) / 2) - Number(output);
+  } catch {
+    return null;
+  }
 }
 
 export function parsePidof(text: unknown): number | null {

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -12,6 +12,7 @@ import { collectorProcessTitle } from './ownership.ts';
 import {
   type PidResolution,
   type PidWatcher,
+  androidClockOffset,
   parseLogcatLine,
   startAndroidLogcat,
   waitForAppPid,
@@ -146,6 +147,7 @@ export interface RunCollectorOptions {
   pidOf?: ((serial: string, packageName: string, opts: { exec?: Executor | null }) => number | null) | null;
   pidWatchMs?: number | null;
   watchPid?: typeof watchAppPid;
+  resolveClockOffset?: typeof androidClockOffset;
   now?: () => number;
   onExit?: (code: number) => void;
   attachSignals?: boolean;
@@ -207,6 +209,7 @@ export async function runCollector({
   pidOf = null,
   pidWatchMs = null,
   watchPid = watchAppPid,
+  resolveClockOffset = androidClockOffset,
   now = Date.now,
   onExit = (code: number) => process.exit(code),
   attachSignals = true,
@@ -302,14 +305,27 @@ export async function runCollector({
   });
 
   const parse = platform === 'ios' ? (physical ? parseDeviceConsoleLine : parseLogStreamLine) : parseLogcatLine;
-  const onLine = (line: string) => {
-    const record = parse(line, { now });
-    if (!record) return;
-    captured++;
-    writer.write({ ...record, platform });
-  };
-
   const attach = (streamPid: number | null): ChildProcess => {
+    const clockOffsetMs = platform === 'android' ? resolveClockOffset(serial as string, { now }) : null;
+    if (platform === 'android') {
+      writer.write({
+        src: 'device',
+        platform,
+        level: clockOffsetMs === null ? 'warn' : 'debug',
+        event: 'collector_clock',
+        clockOffsetMs,
+        msg:
+          clockOffsetMs === null
+            ? 'Could not align Android device time; log timestamps retain device time and may miss launch filters.'
+            : `Android log timestamps aligned to host time (offset ${clockOffsetMs}ms).`,
+      });
+    }
+    const onLine = (line: string) => {
+      const record = parse(line, { now, clockOffsetMs });
+      if (!record) return;
+      captured++;
+      writer.write({ ...record, platform });
+    };
     const spawned = startStream
       ? startStream({ platform, udid, appName, appExecutable, bundleId, serial, physical, payloadUrl, pid: streamPid })
       : platform === 'ios'

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -102,6 +102,10 @@ THE RECORD
     event    the producer's own event name (bundle_build_done, client_log, ...)
     stack    frames of { file, line, column, fn }, passed through as reported
     marker   true on the records that close an error window
+    deviceTs Android logcat's original epoch milliseconds; ts is aligned to
+             host time using a bounded clock query at each collector attachment
+    clockOffsetMs the offset added to deviceTs; absent if the query failed.
+             A collector_clock warning then says timestamps retain device time.
     raw      true when the level was inferred from a line of text rather than
              reported by the producer (every expo-child record)
 


### PR DESCRIPTION
## Description

An Android emulator resumed from a snapshot can have a different clock from the host. In a real readiness check the device lagged by about 2.7 seconds, so fresh pending/ready logs looked older than the launch and were discarded.

Fixes #536. Independent of the bundle-delivery fix in #537.

## Solution

Read epoch-formatted logcat timestamps and align them using a bounded device-clock query at each collector attachment. Keep the original device timestamp alongside the offset; buffered records remain old instead of being stamped with arrival time. If the query fails, collection continues with device timestamps and a warning that launch filtering may be affected. This does not change the device clock or iOS collection.

## Test plan

- Exercised the actual `adb shell date '+%s%3N'` query and `logcat -v time,epoch` on an owned Android 36 emulator. The sampler measured a 2,703ms offset and the parser preserved the corresponding device timestamps.
- A fresh repaired Trailhead process reported pending then ready in the initial `stim android` command (4.7s verification, artifact cache hit); before alignment those logs were filtered out.
- Regression coverage checks current versus buffered readiness logs, positive/negative offsets, malformed or slow clock samples, fallback warnings, and resampling after a PID change.
- Local checks and 66 end-to-end tests passed; 3,675 unit tests passed with known timeout #491 excluded. The unfiltered suite reproduced only that known timeout (3,678 passed, one skipped).
