### PR TITLE
docs: remove readiness checks from benchmark overview

### DIFF
--- a/website/src/pages/benchmarks.module.css
+++ b/website/src/pages/benchmarks.module.css
@@ -545,11 +545,3 @@
     grid-template-columns: 1fr;
   }
 }
-.checkTable {
-  max-width: 100%;
-  overflow-x: auto;
-}
-
-.checkTable table {
-  width: 100%;
-}

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -2,22 +2,13 @@ import type { ReactNode } from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import {
-  benchmarks,
-  linkedBenchmarks,
-  readinessIntegrationChecks,
-  displayVariant,
-} from '@site/src/components/benchmarkCatalog';
+import { benchmarks, displayVariant } from '@site/src/components/benchmarkCatalog';
 import BenchmarkVideo from '@site/src/components/BenchmarkVideo';
 import { benchmarkModelLabel } from '@site/src/components/benchmarkSelection';
 import {
   benchmarkDisplayTitle,
   benchmarkOverview,
-  benchmarkSelectionSearch,
-  formatCost,
   formatSeconds,
-  formatTokens,
-  totalTokens,
   type BenchmarkData,
   type BenchmarkRun,
 } from '@site/src/components/benchmarkData';
@@ -116,69 +107,6 @@ export default function Benchmarks(): ReactNode {
               command-level audit and Settings-screen proof.
             </p>
           </header>
-
-          <section className={styles.overview} aria-labelledby="readiness-integration-title">
-            <Heading as="h2" id="readiness-integration-title">
-              Latest: Android readiness-integration checks
-            </Heading>
-            <p>
-              Recorded September 8, 2026 on a Mac mini (Apple M4, 16 GB), Android 36 arm64. These Stim-only
-              startup-error runs add optional early pending and post-splash ready logs. Every published run hit the
-              native artifact cache, reported the injected crash in the initial launch command, repaired the source, and
-              captured Settings proof. Times include worktree warming, emulator creation, diagnosis, repair, and
-              screenshot capture.
-            </p>
-            <p>
-              This is an integration check, not a new matched comparison: controls were not rerun with this fixture. The
-              comparison runs below are retained, with the same first-activity timing rule. Stim was built locally from
-              merged source{' '}
-              <a href="https://github.com/appandflow/stim/commit/a4832aa34d9573ea2898604f6f639c71ae5f9804">a4832aa</a>,
-              with package and executable hashes validated; it was not a new npm release.{' '}
-              <Link to="/docs/dev-server-and-logs#ask-your-agent-to-add-it">Add optional readiness logs</Link>.
-            </p>
-            <div className={styles.checkTable}>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Model / audit</th>
-                    <th>Diagnosis</th>
-                    <th>Settings proof</th>
-                    <th>Total tokens</th>
-                    <th>Total cost</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {readinessIntegrationChecks.map((benchmark) => {
-                    const run = benchmark.runs[0];
-                    const href = `/benchmarks/details${benchmarkSelectionSearch({ stage: benchmark.stage, runId: run.id }, linkedBenchmarks)}`;
-                    return (
-                      <tr key={benchmark.stage}>
-                        <td>
-                          <Link to={href}>{benchmarkModelLabel(run.model)}</Link>
-                        </td>
-                        <td>
-                          <Link to={href}>{formatSeconds(run.diagnosisSeconds ?? null)}</Link>
-                        </td>
-                        <td>
-                          <Link to={href}>{formatSeconds(run.settingsReadySeconds)}</Link>
-                        </td>
-                        <td>{formatTokens(totalTokens(run.usage))}</td>
-                        <td>{formatCost(run.estimatedTokenCostUsd)}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-            <p>
-              Opus had 1m 35s before Claude Code emitted its initialization event; its first recorded agent activity was
-              at 1m 36s. That lead-in is excluded from the displayed clock, with original dispatch timing retained in
-              the audit. Its initial Stim launch took 54s, similar to Sol and Luna (52-53s). Costs cover the full agent
-              turn, including work after the Settings screenshot: OpenAI costs are API-equivalent estimates; Claude
-              costs are CLI-reported. Each row is one validated run, not an average. Sonnet is a separately requested
-              repeat; its setup recovery remains in the timeline and elapsed time.
-            </p>
-          </section>
 
           {readinessPlatforms.map(({ platform, benchmarks: platformBenchmarks }) => (
             <section className={styles.overview} aria-labelledby={`${platform}-overview-title`} key={platform}>

--- a/website/src/pages/benchmarks/details.tsx
+++ b/website/src/pages/benchmarks/details.tsx
@@ -178,8 +178,7 @@ export default function BenchmarkDetails(): ReactNode {
               built locally (not a new npm release). The initial launch reported the injected crash and hit the native
               artifact cache. Controls were not rerun with this fixture, so this is not a matched speedup comparison.
               The clock starts at the first recorded agent message or shell command, excluding the initial lead-in.
-              Original dispatch timing is retained below.{' '}
-              <Link to="/benchmarks#readiness-integration-title">Read the check methodology</Link>.
+              Original dispatch timing is retained below.
             </p>
           ) : !benchmarks.includes(benchmark) ? (
             <p>


### PR DESCRIPTION
## Description

Remove the Stim-only readiness-integration section from the benchmark overview, as requested. It was added in [#540](https://github.com/appandflow/stim/commit/1f9fc1e87e5f15e3b215ea8fcd9236db8a60980b) to publish integration checks, not matched comparisons.

## Solution

Keep the overview focused on matched benchmarks. Existing audit URLs and recordings remain available; the backlink to the removed heading is gone.

Fixes #541.

## Test plan

Verified the production build in a browser: the introduction leads directly into iOS comparisons, with Android and launch-recovery charts retained. Website build and typecheck, repository formatting, lint, build, typecheck, and unit tests pass.

![Benchmark overview after removal](https://github.com/user-attachments/assets/0b99ae6b-eafd-4575-b75f-9f0453bd62dc)
