### PR TITLE
docs: explain benchmark comparisons in plain language

### DIFF
--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -611,9 +611,6 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
             <span>Run recording</span>
             <h2>Simulator playback</h2>
             <p>The run-scoped recording starts after the app session opens and includes onboarding and navigation.</p>
-            <a href={recordingSrc} download>
-              Download MP4
-            </a>
           </div>
           <video controls preload="metadata" poster={proofSrc} aria-label={`Simulator recording for ${run.id}`}>
             <source src={recordingSrc} type="video/mp4" />

--- a/website/src/components/BenchmarkVideo.module.css
+++ b/website/src/components/BenchmarkVideo.module.css
@@ -27,12 +27,6 @@
   font-size: 1.5rem;
 }
 
-.heading a {
-  font-size: 0.85rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
 .frame {
   overflow: hidden;
   border: 1px solid var(--ifm-color-emphasis-300);
@@ -60,10 +54,5 @@
 
   .heading {
     display: block;
-  }
-
-  .heading a {
-    display: inline-block;
-    margin-top: 0.65rem;
   }
 }

--- a/website/src/components/BenchmarkVideo.tsx
+++ b/website/src/components/BenchmarkVideo.tsx
@@ -6,7 +6,6 @@ import styles from './BenchmarkVideo.module.css';
 export default function BenchmarkVideo(): ReactNode {
   const video = useBaseUrl('/benchmarks/luna-rc12/javascript-stim-web.mp4');
   const poster = useBaseUrl('/benchmarks/luna-rc12/javascript-stim-video-poster.png');
-  const social = useBaseUrl('/benchmarks/luna-rc12/javascript-stim-social.mp4');
   const audit = useBaseUrl('/benchmarks/details#audit-title');
 
   return (
@@ -18,9 +17,6 @@ export default function BenchmarkVideo(): ReactNode {
             Watch the Luna JavaScript run unfold
           </Heading>
         </div>
-        <a href={social} download>
-          Download 4:5 social video
-        </a>
       </div>
       <div className={styles.frame}>
         <video

--- a/website/src/pages/benchmarks.tsx
+++ b/website/src/pages/benchmarks.tsx
@@ -157,60 +157,58 @@ export default function Benchmarks(): ReactNode {
             <div>
               <span className={styles.eyebrow}>Methodology</span>
               <Heading as="h2" id="methodology-title">
-                What these numbers measure
+                How the comparisons work
               </Heading>
               <p>
-                Readiness comparisons use the same clean app fixture, requested model, machine, and fixed code change.
-                The primary endpoint starts at the first recorded agent message or shell-command start and stops only
-                after agent-device finds the expected text on Settings and saves a screenshot. Each current run also
-                records onboarding and navigation from the exact run device.
-              </p>
-              <p>
-                Both arms exclude time before that first activity, including runner startup and any unobserved initial
-                reasoning. Every timeline and milestone uses the same shifted origin; original dispatch timings remain
-                available in the audit. This is not prompt-to-result latency. Tokens and cost still cover the full turn.
-                Existing recordings are unchanged.
+                We compare Stim with standard Expo and native build tools on the same app. The goal is to measure how
+                long an agent takes to complete a task and check the result in a running app.
               </p>
               <a href="https://github.com/appandflow/stim/blob/main/docs/agent-benchmark.md">Read the full protocol</a>
             </div>
             <dl>
               <div>
-                <dt>Separate tasks</dt>
-                <dd>JavaScript-only changes, native changes, and launch-error recovery run as separate passes.</dd>
-              </div>
-              <div>
-                <dt>Two arms</dt>
+                <dt>Same task, same agent</dt>
                 <dd>
-                  Stim uses its pinned published build; control uses local Expo and native platform tooling. iOS reuses
-                  a prepared parked simulator, while both Android arms create a fresh matched AVD.
+                  Each comparison uses the same starting code, requested change, AI model, and model settings. The agent
+                  works with Stim in one run and without it in the other.
                 </dd>
               </div>
               <div>
-                <dt>Proof, not process liveness</dt>
-                <dd>The reported time is the validated Settings screenshot, not the earlier app-process marker.</dd>
-              </div>
-              <div>
-                <dt>Prepared caches</dt>
+                <dt>Same hardware</dt>
                 <dd>
-                  Installed dependencies and cache preparation are outside the timer. Android runs start from clean
-                  generated native state, with a seeded Stim APK and compiler cache and shared warmed Gradle caches.
-                  Both Android arms create their worktree and device inside the timer.
+                  Runs use the same Mac mini and run one at a time, so they do not compete for resources. The device
+                  model and OS version are matched within each comparison.
                 </dd>
               </div>
               <div>
-                <dt>Launch-failure suite</dt>
+                <dt>Both setups start prepared</dt>
                 <dd>
-                  Eight matched comparisons cover Luna, Sol, Sonnet and Opus on iOS and Android. Diagnosis time and
-                  repaired Settings proof are reported separately from readiness results. Runs execute sequentially on a
-                  Mac mini with Apple M4 and 16 GB memory; each audit includes its toolchain details.
+                  Dependencies are installed and build caches are warmed before timing starts. Stim can reuse saved
+                  builds and, on iOS, an existing simulator. We are measuring reuse during development, not first-time
+                  setup.
                 </dd>
               </div>
               <div>
-                <dt>Audited attempts</dt>
+                <dt>Consistent timing</dt>
                 <dd>
-                  Transcript rules, device identity, isolation, and proof are checked; invalid runs are excluded, not
-                  retried simply for a better result. Android native Stim runs also require verified compiler-cache
-                  reuse against a fixed threshold established before dispatch.
+                  Each clock runs from the agent's first recorded action until it has checked the result and saved a
+                  screenshot. The same start and finish rules apply with and without Stim.
+                </dd>
+              </div>
+              <div>
+                <dt>Different kinds of work</dt>
+                <dd>
+                  We test JavaScript changes, native changes, and fixing an app that fails to launch. Results stay
+                  separate by task, model, and platform, so a quick JavaScript change is not compared with a native
+                  rebuild.
+                </dd>
+              </div>
+              <div>
+                <dt>Results you can inspect</dt>
+                <dd>
+                  Each bar represents one checked run, not an average or the fastest of several attempts. Open it to see
+                  the commands, logs, and screenshots. Runs that fail the protocol checks are excluded; the full
+                  protocol explains those rules.
                 </dd>
               </div>
             </dl>


### PR DESCRIPTION
## Description

Rewrite the benchmark methodology in plain language so readers can understand the comparison without knowing the benchmark internals. The detailed timing explanation added in [#540](https://github.com/appandflow/stim/commit/1f9fc1e87e5f15e3b215ea8fcd9236db8a60980b) stays in the linked protocol rather than the overview.

## Solution

Explain the matched task and agent, hardware, prepared setups, timing, separate workloads, and inspectable results. Keep the differences clear: Stim can reuse builds and an iOS simulator, and each bar is an individual checked run. No benchmark data or timing rules change.

Remove the explicit video download links from the overview and detailed replay, while retaining embedded playback and all media assets.

Fixes #543.

## Test plan

Read the methodology on the production-built benchmark page and check that all six points are visible, the removed technical passages are absent, and the full-protocol link still works. Run repository formatting, lint, build, typecheck, and unit tests, plus the website build and typecheck.

Verified the production build in a browser and passed all listed checks (3,704 tests passed, one skipped).

Verified both download links are absent from the rebuilt preview and both video players remain available.

![Plain-language methodology](https://github.com/user-attachments/assets/f6e32b44-52cd-4eb6-a557-a29395f80cac)

![Embedded replay without a download link](https://github.com/user-attachments/assets/43793d74-a9f1-4896-aa41-8e207746f19d)
