### PR TITLE
fix: smooth the jar hover entry

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -313,11 +313,6 @@
 @media (prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine) {
   .heroIllustration img {
     transform: perspective(900px) rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg)) scale(1.1);
-    transition: transform 350ms ease-out;
-  }
-
-  .heroIllustration:hover img {
-    transition: none;
   }
 
   .primaryButton:hover:not(:active) {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -7,27 +7,63 @@ import Heading from '@theme/Heading';
 import { StimInstallTabs } from '@site/src/components/StimTabs';
 import styles from './index.module.css';
 
-function tiltIllustration({ currentTarget, clientX, clientY, pointerType }: PointerEvent<HTMLDivElement>) {
-  if (
-    pointerType !== 'mouse' ||
-    !window.matchMedia('(prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine)').matches
-  ) {
-    return;
-  }
-
-  const bounds = currentTarget.getBoundingClientRect();
-  currentTarget.style.setProperty('--tilt-x', `${(0.5 - (clientY - bounds.top) / bounds.height) * 12}deg`);
-  currentTarget.style.setProperty('--tilt-y', `${((clientX - bounds.left) / bounds.width - 0.5) * 12}deg`);
-}
-
-function resetTilt({ currentTarget }: PointerEvent<HTMLDivElement>) {
-  currentTarget.style.removeProperty('--tilt-x');
-  currentTarget.style.removeProperty('--tilt-y');
-}
-
 export default function Home(): ReactNode {
   const assetBase = useBaseUrl('/img/branding/');
   const contentRef = useRef<HTMLElement>(null);
+  const tilt = useRef({ x: 0, y: 0, targetX: 0, targetY: 0, frame: null as number | null });
+
+  useEffect(() => {
+    const motion = tilt.current;
+    return () => {
+      if (motion.frame !== null) cancelAnimationFrame(motion.frame);
+      motion.frame = null;
+    };
+  }, []);
+
+  function setTilt(element: HTMLDivElement, x: number, y: number) {
+    const motion = tilt.current;
+    motion.targetX = x;
+    motion.targetY = y;
+    if (motion.frame !== null) return;
+
+    let previousTime: number | undefined;
+    function animate(time: number) {
+      previousTime ??= time;
+      const blend = 1 - Math.exp(-(time - previousTime) / 60);
+      previousTime = time;
+      motion.x += (motion.targetX - motion.x) * blend;
+      motion.y += (motion.targetY - motion.y) * blend;
+      const settled = Math.hypot(motion.targetX - motion.x, motion.targetY - motion.y) < 0.01;
+      if (settled) {
+        motion.x = motion.targetX;
+        motion.y = motion.targetY;
+      }
+      element.style.setProperty('--tilt-x', `${motion.x}deg`);
+      element.style.setProperty('--tilt-y', `${motion.y}deg`);
+      motion.frame = settled ? null : requestAnimationFrame(animate);
+    }
+    motion.frame = requestAnimationFrame(animate);
+  }
+
+  function tiltIllustration({ currentTarget, clientX, clientY, pointerType }: PointerEvent<HTMLDivElement>) {
+    if (
+      pointerType !== 'mouse' ||
+      !window.matchMedia('(prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine)').matches
+    ) {
+      return;
+    }
+
+    const bounds = currentTarget.getBoundingClientRect();
+    setTilt(
+      currentTarget,
+      (0.5 - (clientY - bounds.top) / bounds.height) * 12,
+      ((clientX - bounds.left) / bounds.width - 0.5) * 12,
+    );
+  }
+
+  function resetTilt({ currentTarget }: PointerEvent<HTMLDivElement>) {
+    setTilt(currentTarget, 0, 0);
+  }
 
   useEffect(() => {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;


### PR DESCRIPTION
## Description

The jar jumps almost 6° in one frame when the pointer enters near its edge. The [hover rule added in #545](https://github.com/appandflow/stim/blob/6c7bb8a95b765c4690d617d3f5eb9bd50095e686/website/src/pages/index.module.css#L313-L321) removed easing to fix sluggish tracking, but also made entry abrupt.

Follow-up to #545. Related: #530.

## Solution

Ease from the current tilt toward the pointer using one animation loop, so entering, leaving, and re-entering share a continuous motion. This adds a short smoothing delay while keeping the full tilt range and avoiding repeated CSS transition restarts.

## Test plan

- Chromium 145, Firefox 146, and WebKit 26: enter at the edge, cross the border repeatedly, sweep across the jar, then leave. Entry steps fell from about 5.9° to at most 1.5° per sampled frame; the jar still reaches its full tilt and resets to neutral.
- Enable reduced motion: the jar stays still.

https://github.com/user-attachments/assets/19c5d572-7b1c-4498-bdb9-2dc9871e4a6e
