### PR TITLE
test: fix the intermittent supervisor handoff timeout

### DIFF
--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -34,6 +34,7 @@ import { IMPOSSIBLE_PID, asProcessExit, makeChildProcess } from './_factories.ts
 
 let tmpHome: string;
 let root: string;
+const originalCwd = process.cwd();
 
 const successfulTunnelCleanup = async () => ({ status: 'stopped' as const });
 
@@ -164,7 +165,6 @@ async function runAction(opts: Record<string, unknown>, register: (cmd: Command)
   const origLog = console.log;
   const origErr = console.error;
   const origExit = process.exit;
-  const cwd = process.cwd();
   let exitCode = null;
   console.log = (l) => logs.push(String(l));
   console.error = (l) => errs.push(String(l));
@@ -175,7 +175,7 @@ async function runAction(opts: Record<string, unknown>, register: (cmd: Command)
   try {
     await run(opts);
   } finally {
-    process.chdir(cwd);
+    process.chdir(originalCwd);
     console.log = origLog;
     console.error = origErr;
     process.exit = origExit;
@@ -191,7 +191,6 @@ async function runConcurrentActions(opts: Record<string, unknown>, register: (cm
   const origLog = console.log;
   const origErr = console.error;
   const origExit = process.exit;
-  const cwd = process.cwd();
   console.log = (line) => logs.push(String(line));
   console.error = (line) => errs.push(String(line));
   process.exit = asProcessExit((code) => exits.push(code));
@@ -199,7 +198,7 @@ async function runConcurrentActions(opts: Record<string, unknown>, register: (cm
   try {
     await Promise.all([run(opts), run(opts)]);
   } finally {
-    process.chdir(cwd);
+    process.chdir(originalCwd);
     console.log = origLog;
     console.error = origErr;
     process.exit = origExit;

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -1329,7 +1329,7 @@ describe('action: spawning the supervisor', () => {
           return true;
         },
       }),
-      { pid: 4242 },
+      { pid: IMPOSSIBLE_PID },
     );
     exec.spawn = (cmd, args, opts) => {
       exec.calls.spawn.push({ cmd, args, opts });


### PR DESCRIPTION
## Description

`start.test.ts > a supervisor handoff write failure reaps a child that ignores SIGTERM` intermittently times out on the Node 22 CI job, and the next test then fails with `ENOENT ... chdir` while restoring its cwd ([run 34175922752, attempt 1](https://github.com/appandflow/stim/actions/runs/34175922752/attempts/1)).

The timeout is a pid collision, not load. The fake child used `pid: 4242`; when a real process holds that pid on the runner, [`waitForSupervisorHandoff`](https://github.com/appandflow/stim/blob/31af77d8f76bc73f1993008c45a13fd6d04895f1/packages/stim-cli/src/commands/start.ts#L461-L470) polls `isPidAlive` for its full, uninjected 5 s before the reap starts, and the test exceeds vitest's 5000 ms. `isPidAlive` counts anything but `ESRCH` as alive, and whether pid 4242 is in use on a fresh runner is nondeterministic, which is why the rerun passed.

The ENOENT is fallout: the timed-out `runAction` is still chdir'ed into its test's temp root when `afterEach` removes it, so the next helper captures a deleted directory as the cwd it restores in `finally`.

## Solution

The fake child uses `IMPOSSIBLE_PID` (above every kernel's `pid_max`), so the handoff wait returns on its first check and the SIGTERM-to-SIGKILL escalation runs on injected timing only. The `['SIGTERM', 'SIGKILL']` assertion and the reap are unchanged; this is the path the test already took whenever pid 4242 happened to be free.

`runAction` and `runConcurrentActions` restore a cwd captured once at module load, so a timed-out test cannot hand the next one a deleted directory.

**Not addressed:** an orphaned action can still fire its `console.log`/`process.exit` after the next test has installed its own mocks, which is inherent to a test that keeps running past its timeout; and the other test files use the same per-call cwd pattern, but none of their tests is known to time out, so they are left alone.

## Test plan

Linux Node 22 was not reproduced locally (no Docker daemon on this machine). Evidence instead:

- Forcing a live pid on macOS (`{ pid: process.pid }` in place of `4242`, not committed) reproduces both CI failures on the base branch: a `5011ms` timeout, then ENOENT at `start.test.ts:202` (CI: `5021ms`, same line), plus 5 knock-on failures and `EADDRINUSE` unhandled errors. With only the cwd change applied, the run drops to the forced timeout plus the next test failing with `process.exit unexpectedly called with "1"`, the pollution the ENOENT had been masking.
- `pnpm test`: 3702 passed, 2 failed in `engine-ios-device.test.ts`. Those assert the shared OS tmpdir has no `stim-devicectl-*` entries and three leftovers dated Sep 5 exist there; they fail the same way alone and are outside this diff.
- `pnpm exec vitest run packages/stim-cli/src/__tests__/start.test.ts -t "handoff write failure"`, 20 iterations while four other agents ran suites on the machine: 20/20 before (11-15 ms) and after (11-37 ms). pid 4242 is free on this Mac, so the loop cannot show the failure by itself.
- `pnpm exec vitest run packages/stim-cli/src/__tests__/start.test.ts`: 76 passed. `format:check`, `lint`, `typecheck`, `knip`, `build`: pass.

Fixes #500

