### PR TITLE
fix: probe isolation toolchain compatibility before timing

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -109,12 +109,14 @@ Coordinator metadata and transcripts remain outside those writable grants.
 Before timing starts, real read/write and child-process probes must verify the
 policy; an unavailable sandbox or overbroad grant refuses dispatch. Dispatch
 also probes toolchain compatibility under the exact policy: the macOS kernel
-refuses a nested `sandbox_apply` from any process whose policy denies
-anything, which breaks SwiftPM manifest and plugin sandboxes, and it refuses
-to execute `/bin/ps`, which agent-device's simulator recording needs for child
-process identity. An iOS run is refused before the clock starts when either
-probe fails and no pinned native compatibility adapter compensates. The policy,
-its digest, and the probe results are retained with the private run metadata.
+refuses a nested `sandbox_apply` of any profile that differs from the one a
+process already runs under, which breaks SwiftPM manifest and plugin sandboxes
+under every runner policy, and it refuses to execute `/bin/ps`, which
+agent-device's simulator recording needs for child process identity. An iOS
+run is refused before the clock starts when either probe fails and no pinned
+native compatibility adapter compensates. The policy, its digest, and the
+probe results are retained with the private run metadata; a refused run keeps
+its probe results in its run directory.
 
 This boundary prevents accidental benchmark-data access, not adversarial host
 access: native system services and pre-existing processes are not sandboxed by

--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -107,8 +107,14 @@ listings. Each run retains its own worktree, proof, temporary files, runner
 home, selected tools, and the configured shared native-cache/device state.
 Coordinator metadata and transcripts remain outside those writable grants.
 Before timing starts, real read/write and child-process probes must verify the
-policy; an unavailable sandbox or overbroad grant refuses dispatch. The policy
-and its digest are retained with the private run metadata.
+policy; an unavailable sandbox or overbroad grant refuses dispatch. Dispatch
+also probes toolchain compatibility under the exact policy: the macOS kernel
+refuses a nested `sandbox_apply` from any process whose policy denies
+anything, which breaks SwiftPM manifest and plugin sandboxes, and it refuses
+to execute `/bin/ps`, which agent-device's simulator recording needs for child
+process identity. An iOS run is refused before the clock starts when either
+probe fails and no pinned native compatibility adapter compensates. The policy,
+its digest, and the probe results are retained with the private run metadata.
 
 This boundary prevents accidental benchmark-data access, not adversarial host
 access: native system services and pre-existing processes are not sandboxed by

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -152,19 +152,26 @@ bytes. This does not replace a real untimed build, recording, and cleanup test
 before accepting a new toolchain combination.
 
 Dispatch also runs two untimed compatibility probes under the run's exact
-policy and refuses an iOS run without the adapter when either fails:
-`sandbox-exec -p '(version 1)(allow default)' /usr/bin/true`, the nested
-sandbox SwiftPM applies to manifests and plugins, and `/bin/ps -p <pid> -o
-lstart=`, the process identity agent-device reads for `simctl recordVideo`.
-The macOS kernel refuses `sandbox_apply` from any process whose policy
-contains a `deny` rule, whatever its operation, filter, or modifier; only a
-deny-free profile permits nesting, and `(with no-sandbox)` on `process-exec*`
-permits it only by letting the child escape the boundary, which exposes
-protected data. No policy rule keeps the forbidden-path denial and allows
-nesting, so the adapter's `-IDEPackageSupportDisableManifestSandbox=1`,
+policy and refuses an iOS run without the adapter when either fails: a nested
+`sandbox-exec` applying
+`(deny default)(import "system.sb")(allow file-read*)(allow process*)`, the
+head of the profile SwiftPM applies to manifests and plugins, and `/bin/ps -p
+<pid> -o lstart=`, the process identity agent-device reads for `simctl
+recordVideo`. The macOS kernel refuses a nested
+`sandbox_apply` unless the inner profile is equivalent to the one the process
+already runs under: a profile that differs in effect is refused in both
+directions, under deny-free and deny-containing outer profiles alike, while an
+equivalent profile nests at any depth. SwiftPM generates its profile per
+invocation from `(deny default)` with its own write grants, so no runner policy
+is equivalent to it, and `(with no-sandbox)` on `process-exec*` permits
+nesting only by letting the child escape the boundary, which exposes protected
+data. No `sandbox-exec` policy hosts SwiftPM's sandbox, so the adapter's
+`-IDEPackageSupportDisableManifestSandbox=1`,
 `-IDEPackageSupportDisablePluginExecutionSandbox=1`, and `-disable-sandbox`
 flags remain the compensation. Both probe results are recorded in the run's
-`preflight.isolationCompatibility`.
+`preflight.isolationCompatibility`; a refused run has no `meta.json`, so
+dispatch writes them to `isolation-compatibility.json` in the run directory
+before failing.
 
 Android launch-error control preparation carries dependencies and native outputs
 but leaves out the root `android/build` directory. Its generated autolinking cache

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -158,12 +158,12 @@ policy and refuses an iOS run without the adapter when either fails: a nested
 head of the profile SwiftPM applies to manifests and plugins, and `/bin/ps -p
 <pid> -o lstart=`, the process identity agent-device reads for `simctl
 recordVideo`. The macOS kernel refuses a nested
-`sandbox_apply` unless the inner profile is equivalent to the one the process
-already runs under: a profile that differs in effect is refused in both
-directions, under deny-free and deny-containing outer profiles alike, while an
-equivalent profile nests at any depth. SwiftPM generates its profile per
-invocation from `(deny default)` with its own write grants, so no runner policy
-is equivalent to it, and `(with no-sandbox)` on `process-exec*` permits
+`sandbox_apply` unless the inner profile compiles to the same sandbox the
+process already runs under (identical, reordered, duplicated, or redundant
+rules all nest, at any depth); any other profile is refused in both
+directions, even one that only adds a rule with no effect. SwiftPM generates
+its profile per invocation from `(deny default)` with its own write grants, so
+no runner policy compiles to the same sandbox, and `(with no-sandbox)` on `process-exec*` permits
 nesting only by letting the child escape the boundary, which exposes protected
 data. No `sandbox-exec` policy hosts SwiftPM's sandbox, so the adapter's
 `-IDEPackageSupportDisableManifestSandbox=1`,

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -151,6 +151,21 @@ profile before starting the clock; collection rejects changed compatibility
 bytes. This does not replace a real untimed build, recording, and cleanup test
 before accepting a new toolchain combination.
 
+Dispatch also runs two untimed compatibility probes under the run's exact
+policy and refuses an iOS run without the adapter when either fails:
+`sandbox-exec -p '(version 1)(allow default)' /usr/bin/true`, the nested
+sandbox SwiftPM applies to manifests and plugins, and `/bin/ps -p <pid> -o
+lstart=`, the process identity agent-device reads for `simctl recordVideo`.
+The macOS kernel refuses `sandbox_apply` from any process whose policy
+contains a `deny` rule, whatever its operation, filter, or modifier; only a
+deny-free profile permits nesting, and `(with no-sandbox)` on `process-exec*`
+permits it only by letting the child escape the boundary, which exposes
+protected data. No policy rule keeps the forbidden-path denial and allows
+nesting, so the adapter's `-IDEPackageSupportDisableManifestSandbox=1`,
+`-IDEPackageSupportDisablePluginExecutionSandbox=1`, and `-disable-sandbox`
+flags remain the compensation. Both probe results are recorded in the run's
+`preflight.isolationCompatibility`.
+
 Android launch-error control preparation carries dependencies and native outputs
 but leaves out the root `android/build` directory. Its generated autolinking cache
 contains absolute source-checkout paths and package checksums that survive a copy.

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -1364,11 +1364,21 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   const shellProvenance = verifyRunnerShell(arm, env);
   const claudeGuidance = runnerKind === 'claude' ? writeClaudeGuidance(codexHome, arm, runDir) : null;
   const isolation = prepareRunIsolation(runId, runDir, env, arm, crash, claudeGuidance);
-  preflightReport.isolationCompatibility = verifyIsolationCompatibility(isolation, {
-    platform,
-    nativeCompatibility: preflightReport.nativeCompatibility,
-    execute: (file, args) => run(file, args, { cwd: crash?.fixtureCheckout ?? main, env, timeout: 30_000 }),
-  });
+  try {
+    preflightReport.isolationCompatibility = verifyIsolationCompatibility(isolation, {
+      platform,
+      nativeCompatibility: preflightReport.nativeCompatibility,
+      execute: (file, args) => run(file, args, { cwd: crash?.fixtureCheckout ?? main, env, timeout: 30_000 }),
+    });
+  } catch (error) {
+    if (error.isolationCompatibility) {
+      writeFileSync(
+        join(runDir, 'isolation-compatibility.json'),
+        `${JSON.stringify(error.isolationCompatibility, null, 2)}\n`,
+      );
+    }
+    throw error;
+  }
   preflightReport.nativeCompatibilityProbe = probeNativeCompatibility(
     preflightReport.nativeCompatibility,
     (file, args) => {

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -38,7 +38,12 @@ import {
   matchesExpectedIosSimulator,
 } from './watch-app-selection.mjs';
 import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
-import { isolatedRunnerInvocation, prepareRunnerIsolation, runnerIsolationPolicy } from './runner-isolation.mjs';
+import {
+  isolatedRunnerInvocation,
+  prepareRunnerIsolation,
+  runnerIsolationPolicy,
+  verifyIsolationCompatibility,
+} from './runner-isolation.mjs';
 import {
   agentDeviceIsolationInvalidReasons,
   agentDeviceAuxiliarySessions,
@@ -1359,6 +1364,11 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   const shellProvenance = verifyRunnerShell(arm, env);
   const claudeGuidance = runnerKind === 'claude' ? writeClaudeGuidance(codexHome, arm, runDir) : null;
   const isolation = prepareRunIsolation(runId, runDir, env, arm, crash, claudeGuidance);
+  preflightReport.isolationCompatibility = verifyIsolationCompatibility(isolation, {
+    platform,
+    nativeCompatibility: preflightReport.nativeCompatibility,
+    execute: (file, args) => run(file, args, { cwd: crash?.fixtureCheckout ?? main, env, timeout: 30_000 }),
+  });
   preflightReport.nativeCompatibilityProbe = probeNativeCompatibility(
     preflightReport.nativeCompatibility,
     (file, args) => {

--- a/scripts/agent-benchmark/runner-isolation.mjs
+++ b/scripts/agent-benchmark/runner-isolation.mjs
@@ -151,3 +151,33 @@ export function isolatedRunnerInvocation(isolation, command, args) {
   }
   return { command: launcher, args: ['-p', policy, command, ...args] };
 }
+
+const compatibilityProbes = {
+  nestedSandbox: [launcher, ['-p', '(version 1)(allow default)', '/usr/bin/true']],
+  processIdentity: ['/bin/sh', ['-c', '/bin/ps -p "$$" -o lstart=']],
+};
+
+export function verifyIsolationCompatibility(isolation, { platform, nativeCompatibility, execute }) {
+  const record = {};
+  for (const [name, [command, args]] of Object.entries(compatibilityProbes)) {
+    const invocation = isolatedRunnerInvocation(isolation, command, args);
+    try {
+      execute(invocation.command, invocation.args);
+      record[name] = { permitted: true };
+    } catch (error) {
+      record[name] = { permitted: false, error: String(error.stderr ?? '').trim() || error.message };
+    }
+  }
+  if (platform !== 'ios' || nativeCompatibility) return record;
+  if (!record.nestedSandbox.permitted) {
+    throw new Error(
+      `benchmark isolation refuses nested sandboxes (${record.nestedSandbox.error}); iOS SwiftPM manifest and plugin sandboxes cannot build under the runner policy without the native compatibility adapter`,
+    );
+  }
+  if (!record.processIdentity.permitted) {
+    throw new Error(
+      `benchmark isolation denies ps process identity (${record.processIdentity.error}); agent-device simulator recording cannot run under the runner policy without the native compatibility adapter`,
+    );
+  }
+  return record;
+}

--- a/scripts/agent-benchmark/runner-isolation.mjs
+++ b/scripts/agent-benchmark/runner-isolation.mjs
@@ -152,8 +152,11 @@ export function isolatedRunnerInvocation(isolation, command, args) {
   return { command: launcher, args: ['-p', policy, command, ...args] };
 }
 
+// Head of the profile swift-package-manager's Sources/Basics/Sandbox.swift applies to manifests and plugins.
+const swiftpmSandboxProfile = '(version 1)(deny default)(import "system.sb")(allow file-read*)(allow process*)';
+
 const compatibilityProbes = {
-  nestedSandbox: [launcher, ['-p', '(version 1)(allow default)', '/usr/bin/true']],
+  nestedSandbox: [launcher, ['-p', swiftpmSandboxProfile, '/usr/bin/true']],
   processIdentity: ['/bin/sh', ['-c', '/bin/ps -p "$$" -o lstart=']],
 };
 
@@ -169,13 +172,16 @@ export function verifyIsolationCompatibility(isolation, { platform, nativeCompat
     }
   }
   if (platform !== 'ios' || nativeCompatibility) return record;
+  const refuse = (message) => {
+    throw Object.assign(new Error(message), { isolationCompatibility: record });
+  };
   if (!record.nestedSandbox.permitted) {
-    throw new Error(
+    refuse(
       `benchmark isolation refuses nested sandboxes (${record.nestedSandbox.error}); iOS SwiftPM manifest and plugin sandboxes cannot build under the runner policy without the native compatibility adapter`,
     );
   }
   if (!record.processIdentity.permitted) {
-    throw new Error(
+    refuse(
       `benchmark isolation denies ps process identity (${record.processIdentity.error}); agent-device simulator recording cannot run under the runner policy without the native compatibility adapter`,
     );
   }

--- a/scripts/agent-benchmark/runner-isolation.test.mjs
+++ b/scripts/agent-benchmark/runner-isolation.test.mjs
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isolatedRunnerInvocation, prepareRunnerIsolation, runnerIsolationPolicy } from './runner-isolation.mjs';
+import {
+  isolatedRunnerInvocation,
+  prepareRunnerIsolation,
+  runnerIsolationPolicy,
+  verifyIsolationCompatibility,
+} from './runner-isolation.mjs';
 
 const roots = [];
 afterEach(() => {
@@ -25,13 +31,27 @@ function fixture() {
   return { root, golden, results, run, tools, privateFile, policy };
 }
 
+function verifiedIsolation(directory, policy) {
+  mkdirSync(directory, { recursive: true });
+  const profilePath = join(directory, 'runner-isolation.sb');
+  writeFileSync(profilePath, policy);
+  return {
+    backend: 'macos-sandbox-exec',
+    verified: true,
+    profilePath,
+    profileSha256: createHash('sha256').update(policy).digest('hex'),
+  };
+}
+
+const realExecute = (file, args) => execFileSync(file, args, { encoding: 'utf8', timeout: 10_000, stdio: 'pipe' });
+
 function prepare(paths, policy = paths.policy) {
   return prepareRunnerIsolation({
     policy,
     profilePath: join(paths.root, 'runner-isolation.sb'),
     probeRoots: [paths.root, paths.golden, paths.results],
     probeParent: paths.run,
-    execute: (file, args) => execFileSync(file, args, { encoding: 'utf8', timeout: 10_000, stdio: 'pipe' }),
+    execute: realExecute,
   });
 }
 
@@ -161,6 +181,86 @@ describe('benchmark runner filesystem isolation', () => {
         });
         expect(() => prepare(paths, policy)).toThrow('protected benchmark access was allowed');
       }
+    },
+  );
+
+  it('refuses iOS timing when the exact policy blocks nested sandboxes or ps identity and no adapter compensates', () => {
+    const paths = fixture();
+    const isolation = verifiedIsolation(paths.root, paths.policy);
+    const refusals = {
+      nested: 'sandbox-exec: sandbox_apply: Operation not permitted',
+      ps: '/bin/sh: /bin/ps: Operation not permitted',
+    };
+    const calls = [];
+    const execute = (denied) => (file, args) => {
+      calls.push([file, args]);
+      const command = args.slice(2).join(' ');
+      const key = command.includes('/usr/bin/true') ? 'nested' : command.includes('/bin/ps') ? 'ps' : 'unknown';
+      if (!denied.includes(key)) return '';
+      throw Object.assign(new Error('Command failed'), { status: 71, stderr: `${refusals[key]}\n` });
+    };
+    expect(() =>
+      verifyIsolationCompatibility(isolation, {
+        platform: 'ios',
+        nativeCompatibility: null,
+        execute: execute(['nested', 'ps']),
+      }),
+    ).toThrow('sandbox-exec: sandbox_apply: Operation not permitted');
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [file, args] of calls) {
+      expect(file).toBe('/usr/bin/sandbox-exec');
+      expect(args.slice(0, 2)).toEqual(['-p', paths.policy]);
+    }
+    expect(() =>
+      verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: execute(['ps']) }),
+    ).toThrow('/bin/sh: /bin/ps: Operation not permitted');
+    const compensated = {
+      nestedSandbox: { permitted: false, error: refusals.nested },
+      processIdentity: { permitted: false, error: refusals.ps },
+    };
+    expect(
+      verifyIsolationCompatibility(isolation, {
+        platform: 'ios',
+        nativeCompatibility: { manifestSha256: 'pinned' },
+        execute: execute(['nested', 'ps']),
+      }),
+    ).toEqual(compensated);
+    expect(
+      verifyIsolationCompatibility(isolation, {
+        platform: 'android',
+        nativeCompatibility: null,
+        execute: execute(['nested', 'ps']),
+      }),
+    ).toEqual(compensated);
+    expect(
+      verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: execute([]) }),
+    ).toEqual({ nestedSandbox: { permitted: true }, processIdentity: { permitted: true } });
+  });
+
+  it.skipIf(process.platform !== 'darwin')(
+    'detects the real nested-sandbox and ps refusals under the exact policy but not under a deny-free one',
+    () => {
+      const paths = fixture();
+      const isolation = prepare(paths);
+      expect(() =>
+        verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: realExecute }),
+      ).toThrow('sandbox-exec: sandbox_apply: Operation not permitted');
+      const record = verifyIsolationCompatibility(isolation, {
+        platform: 'android',
+        nativeCompatibility: null,
+        execute: realExecute,
+      });
+      expect(record.nestedSandbox).toEqual({
+        permitted: false,
+        error: 'sandbox-exec: sandbox_apply: Operation not permitted',
+      });
+      expect(record.processIdentity.permitted).toBe(false);
+      expect(record.processIdentity.error).toContain('/bin/ps: Operation not permitted');
+      const open = verifiedIsolation(join(paths.root, 'open'), '(version 1)\n(allow default)\n');
+      expect(
+        verifyIsolationCompatibility(open, { platform: 'android', nativeCompatibility: null, execute: realExecute })
+          .nestedSandbox,
+      ).toEqual({ permitted: true });
     },
   );
 });

--- a/scripts/agent-benchmark/runner-isolation.test.mjs
+++ b/scripts/agent-benchmark/runner-isolation.test.mjs
@@ -199,56 +199,68 @@ describe('benchmark runner filesystem isolation', () => {
       if (!denied.includes(key)) return '';
       throw Object.assign(new Error('Command failed'), { status: 71, stderr: `${refusals[key]}\n` });
     };
+    const bothRefused = {
+      nestedSandbox: { permitted: false, error: refusals.nested },
+      processIdentity: { permitted: false, error: refusals.ps },
+    };
     expect(() =>
       verifyIsolationCompatibility(isolation, {
         platform: 'ios',
         nativeCompatibility: null,
         execute: execute(['nested', 'ps']),
       }),
-    ).toThrow('sandbox-exec: sandbox_apply: Operation not permitted');
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('sandbox-exec: sandbox_apply: Operation not permitted'),
+        isolationCompatibility: bothRefused,
+      }),
+    );
     expect(calls.length).toBeGreaterThan(0);
     for (const [file, args] of calls) {
       expect(file).toBe('/usr/bin/sandbox-exec');
       expect(args.slice(0, 2)).toEqual(['-p', paths.policy]);
     }
+    const nested = calls.find(([, args]) => args.at(-1) === '/usr/bin/true')[1];
+    expect(nested.slice(2, 4)).toEqual(['/usr/bin/sandbox-exec', '-p']);
+    expect(nested[4]).toContain('(deny default)');
     expect(() =>
       verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: execute(['ps']) }),
     ).toThrow('/bin/sh: /bin/ps: Operation not permitted');
-    const compensated = {
-      nestedSandbox: { permitted: false, error: refusals.nested },
-      processIdentity: { permitted: false, error: refusals.ps },
-    };
     expect(
       verifyIsolationCompatibility(isolation, {
         platform: 'ios',
         nativeCompatibility: { manifestSha256: 'pinned' },
         execute: execute(['nested', 'ps']),
       }),
-    ).toEqual(compensated);
+    ).toEqual(bothRefused);
     expect(
       verifyIsolationCompatibility(isolation, {
         platform: 'android',
         nativeCompatibility: null,
         execute: execute(['nested', 'ps']),
       }),
-    ).toEqual(compensated);
+    ).toEqual(bothRefused);
     expect(
       verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: execute([]) }),
     ).toEqual({ nestedSandbox: { permitted: true }, processIdentity: { permitted: true } });
   });
 
   it.skipIf(process.platform !== 'darwin')(
-    'detects the real nested-sandbox and ps refusals under the exact policy but not under a deny-free one',
+    'detects the real nested-sandbox and ps refusals under the exact policy with an inner profile that runs on its own',
     () => {
       const paths = fixture();
       const isolation = prepare(paths);
       expect(() =>
         verifyIsolationCompatibility(isolation, { platform: 'ios', nativeCompatibility: null, execute: realExecute }),
       ).toThrow('sandbox-exec: sandbox_apply: Operation not permitted');
+      const calls = [];
       const record = verifyIsolationCompatibility(isolation, {
         platform: 'android',
         nativeCompatibility: null,
-        execute: realExecute,
+        execute: (file, args) => {
+          calls.push(args);
+          return realExecute(file, args);
+        },
       });
       expect(record.nestedSandbox).toEqual({
         permitted: false,
@@ -256,11 +268,9 @@ describe('benchmark runner filesystem isolation', () => {
       });
       expect(record.processIdentity.permitted).toBe(false);
       expect(record.processIdentity.error).toContain('/bin/ps: Operation not permitted');
-      const open = verifiedIsolation(join(paths.root, 'open'), '(version 1)\n(allow default)\n');
-      expect(
-        verifyIsolationCompatibility(open, { platform: 'android', nativeCompatibility: null, execute: realExecute })
-          .nestedSandbox,
-      ).toEqual({ permitted: true });
+      const nested = calls.find((args) => args.at(-1) === '/usr/bin/true');
+      expect(nested[2]).toBe('/usr/bin/sandbox-exec');
+      expect(() => realExecute(nested[2], nested.slice(3))).not.toThrow();
     },
   );
 });


### PR DESCRIPTION
## Description

Refs #469 (does not close it: whether the pinned adapter is the accepted design, and whether a real untimed build/recording campaign check is still wanted on top of these probes, stays open there). The benchmark's `sandbox-exec` runner policy passes its filesystem probes but breaks two ordinary iOS operations, and nothing checked either before the clock started. This PR adds detection, not a new isolation design: dispatch refuses an iOS run before timing when the exact policy fails either probe and no native compatibility adapter is pinned, instead of failing inside the timed build or recording. Policy rules, grants, device ownership, version pins, the frozen campaign and published results are untouched.

The two operations:

- SwiftPM manifest and plugin sandboxes (the nested `xcodebuild` in the SDK 58 ExpoModulesJSI XCFramework build) fail with `sandbox-exec: sandbox_apply: Operation not permitted`.
- agent-device 0.20.10 reports `simctl recordVideo did not expose a complete process identity` because it reads the recorder's identity through `/bin/ps`, and the kernel refuses to exec `/bin/ps` from any sandboxed process.

**No profile rule fixes the nesting.** On macOS 26.5 only a profile that compiles to the same sandbox as the one already applied nests, and SwiftPM generates its own `(deny default)` profile per invocation, so no runner policy can match it; the pinned adapter from #483 (`-IDEPackageSupportDisable*Sandbox=1`, `-disable-sandbox`, the `ps` bridge) stays the only compensation.

<details>
<summary>Measurements: outer profile / nested profile / exit code</summary>

`/usr/bin/sandbox-exec -p <outer> /usr/bin/sandbox-exec -p <inner> /usr/bin/true` on macOS 26.5 (25F71). A profile that does not compile to the same sandbox as the outer one is refused in both directions, whether or not either profile contains a `deny` rule and even when the only difference is a rule with no effect; the same sandbox nests at any depth. `swiftpm` below is `(version 1)(deny default)(import "system.sb")(allow file-read*)(allow process*)`, the head of the profile [Sandbox.swift](https://github.com/swiftlang/swift-package-manager/blob/b59818e6e5b2976d49798b42b8b7cb86c658470a/Sources/Basics/Sandbox.swift#L118-L131) generates with per-invocation write grants; it exits 0 on its own.

| outer | inner | exit |
| --- | --- | --- |
| `(allow default)` | `(allow default)`, with or without redundant `allow`s | 0 |
| `(allow default)` | swiftpm | 71 |
| `(allow default)` | `(allow default)` plus one `deny` | 71 |
| exact `runnerIsolationPolicy` output | swiftpm, `(allow default)`, or any other profile tried | 71 |
| `(allow default)` plus `deny` X | the same profile, also reordered, duplicated, or with redundant `allow`s | 0 |
| `(allow default)` plus `deny` X | `(allow default)` plus `deny` Y, or plus `deny` X and Y | 71 |
| `(allow default)` plus `deny` X and Y | `(allow default)` plus `deny` X | 71 |
| swiftpm | swiftpm, also three levels deep | 0 |
| swiftpm | swiftpm plus one `(allow file-write* ...)`, and the reverse | 71 |
| a `deny` plus `(allow process-exec* (with no-sandbox) (literal "/usr/bin/sandbox-exec"))` | `(allow default)` | 0, but the nested child read the protected file: an escape, rejected |

</details>

## Solution

[`verifyIsolationCompatibility`](https://github.com/appandflow/stim/blob/f4951d8bb960c6d0ff48c02c1e4206a0d9159666/scripts/agent-benchmark/runner-isolation.mjs#L155-L189) runs two untimed probes through `isolatedRunnerInvocation`, so they execute under the run's exact verified policy: a nested `sandbox-exec` applying the head of SwiftPM's profile, and `/bin/sh -c '/bin/ps -p "$$" -o lstart='`, the query agent-device makes for the recorder. The nested probe applies SwiftPM's `(deny default)` shape rather than a deny-free profile because only a profile that compiles to the same sandbox nests: a deny-free inner profile passes under any deny-free outer while SwiftPM's still fails there, so its `permitted: true` would not mean SwiftPM can build.

Dispatch calls it right after `prepareRunIsolation`, before the adapter probe, the profile smoke and the clock, and stores the record in the run's `preflight.isolationCompatibility`. **It refuses only an `ios` run with no verified adapter** (`preflight.nativeCompatibility` null); Android and adapter-pinned runs keep the record as evidence (Gradle does not nest sandboxes, Android recording reads `/proc` on the device, and the adapter's own probe proves the patched identity path). **A refusal writes the record to `isolation-compatibility.json` in the run directory** ([driver](https://github.com/appandflow/stim/blob/f4951d8bb960c6d0ff48c02c1e4206a0d9159666/scripts/agent-benchmark/driver.mjs#L1367-L1381)) because a refused run never gets a `meta.json`; the error names the failing probe and its stderr and carries the record.

**The probe cannot run earlier:** the policy grants the run's fixture checkout, guidance file, `STIM_HOME` and tmp paths, which the setup before it creates, so a refused iOS dispatch still pays for the load gate and the golden copies, like every other refusal after the run directory exists.

## Test plan

- `scripts/agent-benchmark/runner-isolation.test.mjs`, injected `execute`: every probe call goes to `/usr/bin/sandbox-exec -p <exact policy>` and the nested probe applies a `(deny default)` profile (catches a probe that runs outside the policy or with a deny-free inner profile and reports a false pass); the refusal message and the record attached to the error; no refusal with the adapter pinned or on Android; a clean record when both pass.
- Same file, real macOS (darwin-only, like the existing denial tests): a real verified policy yields `sandbox-exec: sandbox_apply: Operation not permitted` and `/bin/sh: /bin/ps: Operation not permitted`, iOS without the adapter throws, and the probe's own inner command run unsandboxed exits 0, so the refusal is the nesting rather than a broken invocation. The refusal assertions pin current kernel behavior on purpose: if Apple changes it, the adapter's premise changed and the test says so.
- Real tool calls (invariant 9) on macOS 26.5 (25F71): the matrix above; both probes with the driver's `execFileSync` options (status 71 and 126 with those messages under the exact profile); unpatched agent-device 0.20.10 `host-process.js` identity primitives under the exact profile: `{"start":null,"command":null,"listError":"spawn EPERM"}`.
- **Not exercised:** `bench.mjs dispatch` end to end (needs a benchmark root, pins, golden state and a runner), so the `isolation-compatibility.json` write is covered only by the unit test of the record on the error; a real `simctl recordVideo` (no simulator was booted, and I did not boot one); real `xcodebuild` package resolution and the full ExpoModulesJSI XCFramework build. The probes cover the mechanism each operation depends on, not the operation itself.
- `pnpm test`: 3704 passed; the 2 failures in `engine-ios-device.test.ts` are pre-existing on this machine (stale `stim-devicectl-*` directories in `TMPDIR`) and unrelated to this diff.

