### PR TITLE
fix: distinguish pre-build refusals from missing benchmark ccache evidence

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -62,9 +62,9 @@ Collection records actual hits and misses, accepts proven artifact hits without
 C++ compilation, and flags missing or below-target compiler-cache evidence. A
 `stim android` invocation that exits 1 with a `STIM_NO_METRO` refusal and no
 build phase output stays in the timeline but does not count as missing
-compiler-cache evidence; another invocation must still produce build output, and
-a failed, interrupted, or crashed command that could have compiled still fails
-closed.
+compiler-cache evidence; another `stim android` invocation must still carry
+compiler statistics or a proven artifact hit, and a failed, interrupted, or
+crashed command that could have compiled still fails closed.
 Completed tool output triggers an immediate `CACHE ALERT` and preserves
 `cache-alerts.json`. A flagged attempt stays available for investigation and is
 excluded from published comparisons; investigate the cause before retrying.

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -59,7 +59,12 @@ Android native Stim cells also require `ccacheMinHitRatePercent`. Establish this
 machine/scenario threshold from a verified warm compiler-cache probe before
 dispatch; the example value is illustrative. Keep it fixed across models.
 Collection records actual hits and misses, accepts proven artifact hits without
-C++ compilation, and flags missing or below-target compiler-cache evidence.
+C++ compilation, and flags missing or below-target compiler-cache evidence. A
+`stim android` invocation that exits 1 with a `STIM_NO_METRO` refusal and no
+build phase output stays in the timeline but does not count as missing
+compiler-cache evidence; another invocation must still produce build output, and
+a failed, interrupted, or crashed command that could have compiled still fails
+closed.
 Completed tool output triggers an immediate `CACHE ALERT` and preserves
 `cache-alerts.json`. A flagged attempt stays available for investigation and is
 excluded from published comparisons; investigate the cause before retrying.

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -409,15 +409,27 @@ function artifactCacheHit(entry) {
   );
 }
 
+const preBuildRefusalCodes = ['STIM_NO_METRO'];
+
+function preBuildRefusal(entry) {
+  return (
+    entry.exitCode === 1 &&
+    !/build\s+compiling|compilation cache|"ccache"\s*:/.test(entry.output) &&
+    preBuildRefusalCodes.some((code) =>
+      new RegExp(`"code"\\s*:\\s*"${code}"|^\\s*error\\s+${code}:`, 'm').test(entry.output),
+    )
+  );
+}
+
 export function benchmarkCcache(meta, commands) {
   const minimum = meta.timingTarget?.ccacheMinHitRatePercent ?? null;
   const result = { minimumHitRatePercent: minimum, status: 'not-applicable', builds: [], invalidReasons: [] };
   if (meta.arm !== 'stim' || meta.platform !== 'android') return result;
   if (meta.variant === 'native' && minimum == null) result.invalidReasons.push('ccache-target-missing');
-  const platformRuns = commands.filter(
-    (entry) => commandSegmentsStartingWith(entry.command, 'stim android').length > 0,
+  const attemptedBuilds = commands.filter(
+    (entry) => commandSegmentsStartingWith(entry.command, 'stim android').length > 0 && !preBuildRefusal(entry),
   );
-  for (const entry of platformRuns) {
+  for (const entry of attemptedBuilds) {
     const measurements = ccacheMeasurements(entry.output);
     result.builds.push(...measurements.map((measurement) => ({ commandId: entry.id ?? null, ...measurement })));
     if (
@@ -448,7 +460,7 @@ export function benchmarkCcache(meta, commands) {
     result.invalidReasons.push('stale-cmake-launcher-state');
   }
   result.invalidReasons = [...new Set(result.invalidReasons)];
-  if (!platformRuns.length) result.invalidReasons.push('ccache-evidence-missing');
+  if (!attemptedBuilds.length) result.invalidReasons.push('ccache-evidence-missing');
   result.invalidReasons = [...new Set(result.invalidReasons)];
   result.status = result.invalidReasons.length ? 'investigate' : result.builds.length ? 'measured' : 'artifact-hit';
   return result;

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -29,6 +29,7 @@ const targetConfig = parseBenchmarkTargets({
 });
 
 const build = (output) => [{ id: 'build', command: 'stim android', exitCode: 0, output }];
+const refusal = (output, exitCode = 1) => [{ id: 'refusal', command: 'stim android', exitCode, output }];
 
 describe('agent-device session isolation', () => {
   const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=bench-run agent-device ';
@@ -253,6 +254,60 @@ describe('compiler cache health', () => {
     expect(
       benchmarkCcache(meta, [...build(''), ...build('compilation cache 80 hits / 20 misses (80%)')]).invalidReasons,
     ).toContain('ccache-evidence-missing');
+  });
+
+  const noMetro =
+    '  error       STIM_NO_METRO: No Metro port is reserved for this workspace.\n  remedy      Run `stim start` first.';
+  const artifactHit = build(
+    'fingerprint abcdef.. hit (1s)\ncompilation cache not run; artifact cache supplied the app',
+  );
+
+  it('does not blame the compiler cache for a STIM_NO_METRO refusal that precedes an artifact hit', () => {
+    expect(benchmarkCcache(meta, [...refusal(noMetro), ...artifactHit])).toMatchObject({
+      status: 'artifact-hit',
+      invalidReasons: [],
+    });
+    const structured = JSON.stringify({ code: 'STIM_NO_METRO', message: 'Port 8082 is not held.', remedy: null });
+    expect(benchmarkCcache(meta, [...refusal(structured), ...artifactHit])).toMatchObject({
+      status: 'artifact-hit',
+      invalidReasons: [],
+    });
+  });
+
+  it('still flags a failed build that reports no compiler statistics', () => {
+    const failed = 'build       compiling debug with Gradle\n  error       STIM_BUILD_FAILED: Gradle failed.';
+    expect(benchmarkCcache(meta, [...refusal(failed), ...artifactHit]).invalidReasons).toContain(
+      'ccache-evidence-missing',
+    );
+    expect(
+      benchmarkCcache(meta, [...refusal(`${noMetro}\n  build       compiling debug with Gradle`), ...artifactHit])
+        .invalidReasons,
+    ).toContain('ccache-evidence-missing');
+  });
+
+  it('still flags an interrupted, killed, or crashed command that could have compiled', () => {
+    expect(
+      benchmarkCcache(meta, [...refusal('build       compiling debug with Gradle', null), ...artifactHit])
+        .invalidReasons,
+    ).toContain('ccache-evidence-missing');
+    expect(benchmarkCcache(meta, [...refusal('', 137), ...artifactHit]).invalidReasons).toContain(
+      'ccache-evidence-missing',
+    );
+    expect(
+      benchmarkCcache(meta, [...refusal('TypeError: boom\n    at runAndroid (android.ts:1)'), ...artifactHit])
+        .invalidReasons,
+    ).toContain('ccache-evidence-missing');
+    expect(benchmarkCcache(meta, [...refusal(noMetro, 0), ...artifactHit]).invalidReasons).toContain(
+      'ccache-evidence-missing',
+    );
+  });
+
+  it('still flags a refusal that is the only platform run', () => {
+    expect(benchmarkCcache(meta, refusal(noMetro))).toMatchObject({
+      status: 'investigate',
+      builds: [],
+      invalidReasons: ['ccache-evidence-missing'],
+    });
   });
 
   it('measures structured Stim output for both collection and immediate alerts', () => {


### PR DESCRIPTION
## Description

The Android benchmark cache audit (`benchmarkCcache` in `scripts/agent-benchmark/run-guards.mjs`) requires compiler-cache statistics or an artifact hit from every `stim android` invocation. A `stim android` that refuses with `STIM_NO_METRO` has neither, so a timeline of an exit-1 `STIM_NO_METRO` refusal followed by an exit-0 artifact hit (`compilation cache not run`) is marked `investigate` with `ccache-evidence-missing`. That blames compiler-cache health for a Metro setup failure.

## Solution

An invocation is a proven pre-build refusal when it exited 1, its output carries a listed refusal code, and nothing in the output shows a build phase (`build compiling`, a `compilation cache` line, or a `"ccache"` facts block). Only those invocations skip the per-invocation evidence requirement; the command timeline is untouched.

At least one non-refusal invocation must still exist, so a refusal that is the only platform run stays `ccache-evidence-missing`.

Only `STIM_NO_METRO` is listed, the code the report observed. Its two emission sites are inside [`resolveMetroPort`](https://github.com/appandflow/stim/blob/aefe6ecee173fdaf902b61c1f02116913ac1628d/packages/stim-cli/src/commands/android.ts#L846-L888), which `runAndroid` leaves before the fingerprint step and the [Gradle build phase](https://github.com/appandflow/stim/blob/aefe6ecee173fdaf902b61c1f02116913ac1628d/packages/stim-cli/src/commands/android.ts#L1404). Both forms [`fail` prints](https://github.com/appandflow/stim/blob/aefe6ecee173fdaf902b61c1f02116913ac1628d/packages/stim-cli/src/commands/android.ts#L697-L704) are recognized: the stderr `error  STIM_NO_METRO:` line and the `--json` `{"code":"STIM_NO_METRO",...}` payload.

`STIM_NO_PROJECT`, `STIM_WORKSPACE_STATE`, and `STIM_BAD_ARG` also fire before the build but are deliberately not listed: none was observed, and each needs its own emission-site proof.

Not handled: a wrapper that appends `echo "STATUS=$?"` records exit 0 for the shell, so a refusal run that way still fails closed, as before.

## Test plan

- `scripts/agent-benchmark/run-guards.test.mjs`: the reported sequence is `artifact-hit` with no invalid reasons, in both refusal forms; a failed build without statistics, an interrupted (`exitCode: null`), killed (137), crashed, or exit-0 command, and a lone refusal still report `ccache-evidence-missing`. The first test fails on `main` with `status: 'investigate'`; all 36 pass with the change.
- Real refusal: built the CLI and ran `stim android` and `stim android --json` in a minimal React Native fixture with no `stim start`. Both printed `error       STIM_NO_METRO: No Metro port is reserved for this workspace.`, `--json` added the `{"code":"STIM_NO_METRO",...}` payload, exit 1. `benchmarkCcache` on that captured output plus an exit-0 artifact hit returns `artifact-hit`; on the refusal alone, `investigate` with `ccache-evidence-missing`.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip`: pass.
- `pnpm test` (with `NODE_USE_SYSTEM_CA` unset): 3705 passed, 3 failed, all pre-existing and unrelated. `gc.test.ts` timed out under load and passes alone; two `engine-ios-device.test.ts` tests assert `tmpdir()` holds no `stim-devicectl-*` entries and this machine has leftovers.

Fixes #494
