### PR TITLE
feat: recycle Android emulators across worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,9 +190,12 @@ remain `stim-<label>`. Both are recorded with `owned: true`. Never do any of
 those actions to a user-created emulator or simulator. Keep a device record
 when teardown fails so `gc` can find the device later.
 
-Stim parks an owned simulator it no longer needs instead of deleting it, up to a
-configured maximum, and adopts a parked one before creating. Parked simulators
-are Stim-owned and listed in the pool record. Delete them only by eviction,
+Stim parks an eligible owned simulator or emulator it no longer needs instead
+of deleting it, up to a per-platform configured maximum, and adopts a compatible
+parked one before creating. Parked devices are Stim-owned and listed in the pool
+record. Android adoption matches the system image and recorded AVD creation
+settings, keeps the AVD name, clears app data and removes other third-party apps
+before launch. Skip Android installation only after verifying the APK bytes. Delete them only by eviction,
 adoption-time reconciliation of a listed unavailable simulator, or `gc
 --delete`; every route uses centralized teardown and ownership revalidation.
 

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -249,3 +249,17 @@ Two workflows under `.github/workflows/`:
   the thing most likely to end that run early; if it does, `--skip-race` drops
   it to two worktrees at the cost of the `single-flight` and `pods-reuse`
   checks (both of which then report SKIP with that reason).
+
+### Android emulator recycling
+
+After `pnpm run build`, run the pool smoke test against an existing debuggable APK:
+
+```bash
+node --experimental-strip-types test/e2e/native/run-android-pool-e2e.mjs /absolute/path/app-debug.apk
+```
+
+It creates an owned emulator in a temporary Stim home, records fresh and adopted
+setup timings, seeds and clears app data, verifies an unchanged APK skips
+installation, and checks that GC deletes the parked AVD. It uses separate launch
+and cleanup processes, like the CLI. The test removes its own devices and prints
+the temporary directory containing `result.json` and emulator logs.

--- a/packages/stim-cli/src/__tests__/__snapshots__/gc-output.test.ts.snap
+++ b/packages/stim-cli/src/__tests__/__snapshots__/gc-output.test.ts.snap
@@ -58,6 +58,7 @@ exports[`a cache-scoped report preserves its serialized shape without inspecting
     "deletionSafe": true
   },
   "parkedSims": [],
+  "parkedAvds": [],
   "caches": [],
   "cacheScope": "gc-output-test-no-matching-cache",
   "olderThan": null,

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -453,13 +453,14 @@ test('an invalid Android pool bound refuses before device creation and emits one
 describe('adopted Android installs', () => {
   afterEach(() => resetExecutor());
 
-  test.each(['same', 'different', 'cleanup-failed'] as const)(
+  test.each(['same', 'different', 'signature', 'downgrade', 'cleanup-failed', 'install-failed'] as const)(
     'cleanup precedes install and only matching APK bytes skip installation: %s',
     async (mode) => {
       const apkPath = fakeApk();
       const device = { avdName: 'stim-adopted', consolePort: 5584, owned: true, adoptionPending: true, adopted: true };
       upsertProject(root, { platforms: { android: device } });
       const commands: string[] = [];
+      let installs = 0;
       setExecutor(
         makeExecutor({
           run(cmd) {
@@ -478,28 +479,35 @@ describe('adopted Android installs', () => {
             if (args.includes('uninstall')) return 'Success';
             if (args.includes('path')) return 'package:/data/app/base.apk';
             if (args.includes('sha256sum'))
-              return `${mode === 'different' ? '0'.repeat(64) : hashFile(apkPath)}  /data/app/base.apk`;
-            if (args.includes('install')) return 'Success';
+              return `${mode === 'same' ? hashFile(apkPath) : '0'.repeat(64)}  /data/app/base.apk`;
+            if (args.includes('install')) {
+              installs++;
+              if (mode === 'install-failed') throw new Error('INSTALL_FAILED_INSUFFICIENT_STORAGE');
+              if (installs === 1 && mode === 'signature') throw new Error('INSTALL_FAILED_UPDATE_INCOMPATIBLE');
+              if (installs === 1 && mode === 'downgrade') throw new Error('INSTALL_FAILED_VERSION_DOWNGRADE');
+              return 'Success';
+            }
             throw new Error(`Unexpected runFile: ${cmd}`);
           },
         }),
       );
       const h = harness({ ensureDevice: async () => device, resolveCached: () => apkPath, install: installAndroidApp });
       const result = await h.run();
-      expect(result.ok).toBe(mode !== 'cleanup-failed');
+      const failed = mode === 'cleanup-failed' || mode === 'install-failed';
+      expect(result.ok).toBe(!failed);
       expect(result.error?.message?.includes('Could not clean com.example.app')).toBe(
-        mode === 'cleanup-failed' ? true : undefined,
+        mode === 'cleanup-failed' ? true : mode === 'install-failed' ? false : undefined,
       );
-      expect(h.calls.launch.length).toBe(mode === 'cleanup-failed' ? 0 : 1);
+      expect(h.calls.launch.length).toBe(failed ? 0 : 1);
       const clear = commands.indexOf('adb -s emulator-5584 shell pm clear com.example.app');
       const hash = commands.indexOf('adb -s emulator-5584 shell pm path com.example.app');
       expect(clear).toBeGreaterThanOrEqual(0);
       expect(hash > clear).toBe(mode !== 'cleanup-failed');
-      expect(commands.some((command) => command.includes(' install -r '))).toBe(mode === 'different');
+      const conflict = mode === 'signature' || mode === 'downgrade';
+      expect(installs).toBe(mode === 'same' || mode === 'cleanup-failed' ? 0 : conflict ? 2 : 1);
+      expect(commands.includes('adb -s emulator-5584 uninstall com.example.app')).toBe(conflict);
       expect(h.stderr.some((line) => line.includes('already has this build'))).toBe(mode === 'same');
-      expect(loadConfig()?.projects[root]?.platforms?.android?.adoptionPending).toBe(
-        mode === 'cleanup-failed' ? true : undefined,
-      );
+      expect(loadConfig()?.projects[root]?.platforms?.android?.adoptionPending).toBe(failed ? true : undefined);
     },
   );
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1,3 +1,5 @@
+import { hashFile } from '../engine/installed-artifact.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
 import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
 import { once } from 'node:events';
@@ -42,7 +44,7 @@ import {
 } from '../commands/android.ts';
 import { newestBuildTools } from '../sim/android.ts';
 import { BUILD_ERROR } from '../engine/gradle.ts';
-import { ADB_INSTALL_TIMEOUT_MS, LAUNCH_UNVERIFIED } from '../engine/app-install.ts';
+import { ADB_INSTALL_TIMEOUT_MS, LAUNCH_UNVERIFIED, installAndroidApp } from '../engine/app-install.ts';
 import type { AssetManifest } from '../engine/asset-manifest.ts';
 import { PREBUILD_ERROR } from '../engine/prebuild.ts';
 import type { RecordStatsResult, StatsRun } from '../engine/stats.ts';
@@ -432,6 +434,75 @@ function harness(overrides = {}) {
   };
   return { calls, stderr, stdout, run: () => runAndroid(options) };
 }
+
+test('an invalid Android pool bound refuses before device creation and emits one JSON error', async () => {
+  process.env.STIM_POOL_ANDROID_PARKED_MAX = '-1';
+  try {
+    const h = harness({ json: true });
+    const result = await h.run();
+    expect(result.error?.code).toBe('STIM_BAD_ARG');
+    expect(result.error?.message).toContain('STIM_POOL_ANDROID_PARKED_MAX');
+    expect(h.calls.ensureDevice).toEqual([]);
+    expect(h.stdout).toHaveLength(1);
+    expect(JSON.parse(h.stdout[0]!)).toMatchObject({ code: 'STIM_BAD_ARG' });
+  } finally {
+    delete process.env.STIM_POOL_ANDROID_PARKED_MAX;
+  }
+});
+
+describe('adopted Android installs', () => {
+  afterEach(() => resetExecutor());
+
+  test.each(['same', 'different', 'cleanup-failed'] as const)(
+    'cleanup precedes install and only matching APK bytes skip installation: %s',
+    async (mode) => {
+      const apkPath = fakeApk();
+      const device = { avdName: 'stim-adopted', consolePort: 5584, owned: true, adoptionPending: true, adopted: true };
+      upsertProject(root, { platforms: { android: device } });
+      const commands: string[] = [];
+      setExecutor(
+        makeExecutor({
+          run(cmd) {
+            if (cmd.includes('-list-avds')) return 'stim-adopted';
+            if (cmd.endsWith('adb devices') || cmd.endsWith('adb" devices'))
+              return 'List of devices attached\nemulator-5584\tdevice';
+            if (cmd.includes('emu avd name')) return 'stim-adopted\nOK';
+            throw new Error(`Unexpected run: ${cmd}`);
+          },
+          runQuiet: (cmd) => (cmd.includes('emu avd name') ? 'stim-adopted\nOK' : null),
+          runFile(file, args = []) {
+            const cmd = [file, ...args].join(' ');
+            commands.push(cmd);
+            if (args.includes('list')) return 'package:com.example.app\npackage:com.example.other';
+            if (args.includes('clear')) return mode === 'cleanup-failed' ? 'Failed' : 'Success';
+            if (args.includes('uninstall')) return 'Success';
+            if (args.includes('path')) return 'package:/data/app/base.apk';
+            if (args.includes('sha256sum'))
+              return `${mode === 'different' ? '0'.repeat(64) : hashFile(apkPath)}  /data/app/base.apk`;
+            if (args.includes('install')) return 'Success';
+            throw new Error(`Unexpected runFile: ${cmd}`);
+          },
+        }),
+      );
+      const h = harness({ ensureDevice: async () => device, resolveCached: () => apkPath, install: installAndroidApp });
+      const result = await h.run();
+      expect(result.ok).toBe(mode !== 'cleanup-failed');
+      expect(result.error?.message?.includes('Could not clean com.example.app')).toBe(
+        mode === 'cleanup-failed' ? true : undefined,
+      );
+      expect(h.calls.launch.length).toBe(mode === 'cleanup-failed' ? 0 : 1);
+      const clear = commands.indexOf('adb -s emulator-5584 shell pm clear com.example.app');
+      const hash = commands.indexOf('adb -s emulator-5584 shell pm path com.example.app');
+      expect(clear).toBeGreaterThanOrEqual(0);
+      expect(hash > clear).toBe(mode !== 'cleanup-failed');
+      expect(commands.some((command) => command.includes(' install -r '))).toBe(mode === 'different');
+      expect(h.stderr.some((line) => line.includes('already has this build'))).toBe(mode === 'same');
+      expect(loadConfig()?.projects[root]?.platforms?.android?.adoptionPending).toBe(
+        mode === 'cleanup-failed' ? true : undefined,
+      );
+    },
+  );
+});
 
 const labelled = (lines: string[], label: string) => lines.filter((l) => l.startsWith(`  ${label}`));
 const readState = () => JSON.parse(readFileSync(workspaceStateFile(root), 'utf-8'));

--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -1,0 +1,271 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getProject, loadConfig, setDevice, upsertProject } from '../config.ts';
+import { ensureOwnedDevice } from '../engine/device.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
+import { adoptParked, parkSim, readParked, removeParkedAfter } from '../sim-pool.ts';
+import { avdPoolConfiguration, hostSystemImageArch, resetAdoptedAvd } from '../sim/android.ts';
+import { teardownOwnedAvd, teardownParkedAvd } from '../teardown.ts';
+import { collectParkedAvds, deleteParkedAvds, findOrphanedDevices } from '../commands/gc/devices.ts';
+
+let home: string;
+let saved: Record<string, string | undefined>;
+let avds: Set<string>;
+let running: string | null;
+let calls: string[];
+let failDelete: boolean;
+let packageOutput: string;
+let cleanupResult: string;
+const image = `system-images;android-36;google_apis;${hostSystemImageArch()}`;
+const configuration = avdPoolConfiguration(8, {});
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-android-pool-'));
+  saved = Object.fromEntries(
+    ['STIM_HOME', 'STIM_POOL_ANDROID_PARKED_MAX', 'ANDROID_HOME', 'ANDROID_AVD_HOME', 'DISPLAY'].map((key) => [
+      key,
+      process.env[key],
+    ]),
+  );
+  process.env.STIM_HOME = home;
+  process.env.STIM_POOL_ANDROID_PARKED_MAX = '1';
+  process.env.ANDROID_HOME = join(home, 'sdk');
+  process.env.ANDROID_AVD_HOME = join(home, 'avd');
+  process.env.DISPLAY = ':0';
+  mkdirSync(join(home, 'sdk', ...image.split(';')), { recursive: true });
+  avds = new Set();
+  running = null;
+  calls = [];
+  failDelete = false;
+  packageOutput = 'package:com.example.app\npackage:com.example.other';
+  cleanupResult = 'Success';
+  const run = (cmd: string): string => {
+    calls.push(cmd);
+    if (cmd === 'emulator -list-avds') return [...avds].join('\n');
+    if (cmd === 'adb devices') return `List of devices attached\n${running ? 'emulator-5554\tdevice\n' : ''}`;
+    if (cmd.includes('emu avd name')) return `${running}\nOK`;
+    if (cmd.includes('getprop sys.boot_completed')) return '1';
+    if (cmd.includes('shell sync')) return '';
+    if (cmd.includes('emu kill')) {
+      running = null;
+      return '';
+    }
+    if (cmd.includes('delete avd')) {
+      if (failDelete) throw new Error('AVD deletion failed');
+      avds.delete(/-n "([^"]+)"/.exec(cmd)![1]!);
+      return '';
+    }
+    if (cmd.includes('create avd')) {
+      makeAvd(/-n "([^"]+)"/.exec(cmd)![1]!);
+      return '';
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  };
+  setExecutor({
+    run,
+    runQuiet: run,
+    runFile(file, args = []) {
+      calls.push([file, ...args].join(' '));
+      if (args.includes('list')) return packageOutput;
+      if (args.includes('clear') || args.includes('uninstall')) return cleanupResult;
+      throw new Error(`Unexpected file command: ${file} ${args.join(' ')}`);
+    },
+    spawn(_file, args = []) {
+      running = args[args.indexOf('-avd') + 1]!;
+      return { pid: 9999, unref() {} };
+    },
+  });
+});
+
+afterEach(() => {
+  resetExecutor();
+  rmSync(home, { recursive: true, force: true });
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function makeAvd(name: string): void {
+  avds.add(name);
+  const directory = join(home, 'avd', `${name}.avd`);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(home, 'avd', `${name}.ini`), `path=${directory}\n`);
+  writeFileSync(
+    join(directory, 'config.ini'),
+    `image.sysdir.1=${image.split(';').join('/')}\ndisk.dataPartition.size=8589934592\n`,
+  );
+}
+
+function park(name = 'stim-source', overrides = {}) {
+  makeAvd(name);
+  upsertProject('/source', { platforms: { android: { avdName: name, owned: true } } });
+  return parkSim({
+    platform: 'android',
+    projectPath: '/source',
+    max: 1,
+    record: { udid: name, name, systemImage: image, configuration, parkedAt: new Date().toISOString(), ...overrides },
+  });
+}
+
+test('a new workspace adopts a compatible stopped AVD and retains cleanup state across a retry', async () => {
+  park();
+  upsertProject('/adopter', {});
+  const options = { platform: 'android', projectPath: '/adopter', label: 'adopter', settings: {} };
+  const adopted = await ensureOwnedDevice(options);
+  expect(adopted).toMatchObject({
+    avdName: 'stim-source',
+    adopted: true,
+    adoptionPending: true,
+    poolConfiguration: configuration,
+  });
+  expect(readParked('android')).toEqual([]);
+  expect(calls.some((call) => call.includes('create avd'))).toBe(false);
+  running = null;
+  const retried = await ensureOwnedDevice({ ...options, project: getProject('/adopter') });
+  expect(retried.adoptionPending).toBe(true);
+  expect(getProject('/adopter')?.platforms?.android?.adoptionPending).toBe(true);
+});
+
+test.each([
+  { systemImage: image.replace('android-36', 'android-35') },
+  { configuration: avdPoolConfiguration(10, {}) },
+  { configuration: avdPoolConfiguration(8, { 'hw.ramSize': '4096' }) },
+])('an incompatible parked AVD stays parked and its name cannot be recovered by creation: %j', async (overrides) => {
+  park('stim-source', overrides);
+  upsertProject('/adopter', {});
+  const result = await ensureOwnedDevice({
+    platform: 'android',
+    projectPath: '/adopter',
+    label: 'source',
+    settings: {},
+  });
+  expect(result.created).toBe(true);
+  expect(result.avdName).not.toBe('stim-source');
+  expect(readParked('android').map((record) => record.name)).toEqual(['stim-source']);
+});
+
+test('a missing parked AVD loses only its pool record before a fresh device is created', async () => {
+  park();
+  avds.clear();
+  upsertProject('/adopter', {});
+  const result = await ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', label: 'new', settings: {} });
+  expect(result.created).toBe(true);
+  expect(readParked('android')).toEqual([]);
+  expect(calls.some((call) => call.includes('delete avd'))).toBe(false);
+});
+
+test('an emulator with a live process but no adb connection stays parked', async () => {
+  park();
+  writeFileSync(join(home, 'avd', 'stim-source.avd', 'hardware-qemu.ini.lock'), String(process.pid));
+  upsertProject('/adopter', {});
+  const result = await ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', label: 'new', settings: {} });
+  expect(result.created).toBe(true);
+  expect(readParked('android').map((record) => record.name)).toEqual(['stim-source']);
+  expect(calls.some((call) => call.includes('delete avd'))).toBe(false);
+});
+
+test('a concurrent adoption cannot be overwritten by a new AVD creation using an older workspace record', async () => {
+  park();
+  upsertProject('/adopter', {});
+  const previous = getProject('/adopter');
+  expect(
+    adoptParked({
+      platform: 'android',
+      projectPath: '/adopter',
+      udid: 'stim-source',
+      device: { avdName: 'stim-source', owned: true, adoptionPending: true },
+    }),
+  ).not.toBeNull();
+  await expect(
+    ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', project: previous, label: 'new', settings: {} }),
+  ).rejects.toThrow('Another Stim run assigned AVD');
+  expect(getProject('/adopter')?.platforms?.android?.avdName).toBe('stim-source');
+  expect(calls.some((call) => call.includes('create avd'))).toBe(false);
+});
+
+test('parking shuts down an owned AVD and overflow deletion failures keep both ownership records', () => {
+  park('stim-old');
+  makeAvd('stim-new');
+  setDevice('/source', 'android', { avdName: 'stim-new', owned: true });
+  running = 'stim-new';
+  failDelete = true;
+  const result = teardownOwnedAvd('stim-new', {
+    del: true,
+    park: { projectPath: '/source', max: 1, configuration },
+    waitForShutdown: (_name, shutdown) => shutdown(1000),
+  });
+  expect(result.parked?.name).toBe('stim-new');
+  expect(result.evictionFailures).toEqual([expect.stringContaining('AVD deletion failed')]);
+  expect(getProject('/source')?.platforms?.android).toBeUndefined();
+  expect(readParked('android')).toHaveLength(2);
+  expect(running).toBeNull();
+  failDelete = false;
+  expect(teardownParkedAvd('stim-old').status).toBe('torn-down');
+  expect(readParked('android').map((record) => record.name)).toEqual(['stim-new']);
+});
+
+test('pool deletion excludes adoption and an adopted emulator cannot be deleted by a stale GC report', () => {
+  park();
+  upsertProject('/adopter', {});
+  const request = {
+    platform: 'android' as const,
+    projectPath: '/adopter',
+    udid: 'stim-source',
+    device: { avdName: 'stim-source', owned: true },
+  };
+  expect(() =>
+    removeParkedAfter('android', 'stim-source', () => {
+      expect(adoptParked(request)).toBeNull();
+      throw new Error('retain for retry');
+    }),
+  ).toThrow('retain for retry');
+  const report = collectParkedAvds({ directorySize: () => 1024 });
+  expect(adoptParked(request)?.name).toBe('stim-source');
+  expect(deleteParkedAvds(report)).toBe(0);
+  expect(avds.has('stim-source')).toBe(true);
+});
+
+test('GC protects parked emulators from the orphan sweep and keeps an unverifiable listing', () => {
+  park();
+  expect(findOrphanedDevices({ config: loadConfig(), avds: ['stim-source'] })).toMatchObject({
+    orphaned: [],
+    kept: [{ reason: 'referenced by the emulator pool' }],
+  });
+  const report = collectParkedAvds({
+    listAvds: () => {
+      throw new Error('SDK unavailable');
+    },
+    directorySize: () => 1024,
+  });
+  expect(report[0]?.listed).toBeNull();
+  expect(deleteParkedAvds(report)).toBe(1);
+  expect(readParked('android')).toHaveLength(1);
+});
+
+test('adoption clears the retained app and uninstalls other third-party apps, with a failed clear refusing reuse', () => {
+  makeAvd('stim-source');
+  running = 'stim-source';
+  resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+  expect(calls).toContain('adb -s emulator-5554 shell pm clear com.example.app');
+  expect(calls).toContain('adb -s emulator-5554 uninstall com.example.other');
+  expect(calls).not.toContain('adb -s emulator-5554 uninstall com.example.app');
+  cleanupResult = 'Failed';
+  expect(() => resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).toThrow('Could not clean');
+  packageOutput = 'Error: package manager unavailable';
+  expect(() => resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).toThrow(
+    'Could not read installed apps',
+  );
+});
+
+test('an AVD whose configured disk size changed is evicted rather than adopted', async () => {
+  park();
+  const config = join(home, 'avd', 'stim-source.avd', 'config.ini');
+  writeFileSync(config, readFileSync(config, 'utf8').replace('8589934592', '10737418240'));
+  upsertProject('/adopter', {});
+  const result = await ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', label: 'new', settings: {} });
+  expect(result.created).toBe(true);
+  expect(avds.has('stim-source')).toBe(false);
+  expect(readParked('android')).toEqual([]);
+});

--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getProject, loadConfig, setDevice, upsertProject } from '../config.ts';
 import { ensureOwnedDevice } from '../engine/device.ts';
-import { resetExecutor, setExecutor } from '../exec.ts';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import { adoptParked, parkSim, readParked, removeParkedAfter } from '../sim-pool.ts';
 import { avdPoolConfiguration, hostSystemImageArch, resetAdoptedAvd } from '../sim/android.ts';
 import { teardownOwnedAvd, teardownParkedAvd } from '../teardown.ts';
@@ -183,6 +183,32 @@ test('a concurrent adoption cannot be overwritten by a new AVD creation using an
   ).rejects.toThrow('Another Stim run assigned AVD');
   expect(getProject('/adopter')?.platforms?.android?.avdName).toBe('stim-source');
   expect(calls.some((call) => call.includes('create avd'))).toBe(false);
+});
+
+test('an AVD parked between failed creation and recovery cannot bypass adoption', async () => {
+  upsertProject('/adopter', {});
+  const previous = getExecutor();
+  let creationFailed = false;
+  setExecutor({
+    ...previous,
+    run(cmd) {
+      if (cmd.includes('create avd')) {
+        creationFailed = true;
+        throw new Error('AVD stim-source already exists');
+      }
+      if (cmd === 'emulator -list-avds' && creationFailed) {
+        creationFailed = false;
+        park();
+      }
+      return previous.run(cmd);
+    },
+  });
+  await expect(
+    ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', label: 'source', settings: {} }),
+  ).rejects.toThrow('was parked by another Stim run');
+  expect(getProject('/adopter')?.platforms?.android).toBeUndefined();
+  expect(readParked('android').map((record) => record.name)).toEqual(['stim-source']);
+  expect(running).toBeNull();
 });
 
 test('parking shuts down an owned AVD and overflow deletion failures keep both ownership records', () => {

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -1280,7 +1280,10 @@ test('runDoctor keeps shared checks and filters native checks and remote backend
         android: { remote: 'eas' },
       }),
     );
-    writeFileSync(join(home, 'config.json'), JSON.stringify({ pool: { iosParkedMax: 'bad' } }));
+    writeFileSync(
+      join(home, 'config.json'),
+      JSON.stringify({ pool: { iosParkedMax: 'bad', androidParkedMax: 'bad' } }),
+    );
     const options = {
       concurrency: { maxBuilds: 0, maxDevices: 0 },
       remoteEnv: {
@@ -1308,6 +1311,8 @@ test('runDoctor keeps shared checks and filters native checks and remote backend
     expect(android.some((finding) => finding.title.includes('SimSlim'))).toBe(false);
     expect(android.some((finding) => finding.title === 'This project uses a remote proxy')).toBe(false);
     expect(android.some((finding) => finding.title.includes('simulator pool bound'))).toBe(false);
+    expect(android.some((finding) => finding.title.includes('emulator pool bound'))).toBe(true);
+    expect(ios.some((finding) => finding.title.includes('emulator pool bound'))).toBe(false);
     expect(android.some((finding) => finding.title.includes('no eas-cli'))).toBe(true);
   } finally {
     delete process.env.STIM_HOME;

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -167,33 +167,44 @@ test('status still warns about a recorded sim missing from a readable listing', 
   expect(logs.some((l) => /recorded sim UDID-GONE no longer exists/.test(l))).toBeTruthy();
 });
 
-test('status reports a parked simulator when no projects remain', async () => {
-  process.env.STIM_POOL_IOS_PARKED_MAX = '3';
-  saveConfig(
-    makeConfig({
-      parked: {
-        ios: [
-          {
-            udid: 'PARKED-1',
-            name: 'stim-parked (iPhone 17 26.5) park',
-            deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
-            runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
-            parkedAt: '2026-09-03T00:00:00.000Z',
-            simslimManaged: false,
-          },
-        ],
-        android: [],
-      },
-    }),
-  );
+test.each(['ios', 'android'] as const)(
+  'status reports a parked %s device when no projects remain',
+  async (platform) => {
+    const env = platform === 'ios' ? 'STIM_POOL_IOS_PARKED_MAX' : 'STIM_POOL_ANDROID_PARKED_MAX';
+    process.env[env] = '3';
+    saveConfig(
+      makeConfig({
+        parked: {
+          [platform]: [
+            platform === 'android'
+              ? {
+                  udid: 'stim-parked',
+                  name: 'stim-parked',
+                  systemImage: 'system-images;android-36;google_apis;arm64-v8a',
+                  configuration: '[]',
+                  parkedAt: '2026-09-03T00:00:00.000Z',
+                }
+              : {
+                  udid: 'PARKED-1',
+                  name: 'stim-parked (iPhone 17 26.5) park',
+                  deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-17',
+                  runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+                  parkedAt: '2026-09-03T00:00:00.000Z',
+                  simslimManaged: false,
+                },
+          ],
+        },
+      }),
+    );
 
-  try {
-    const logs = await runStatus();
-    expect(logs).toContain('pool: 1 parked iOS simulator (max 3)');
-  } finally {
-    delete process.env.STIM_POOL_IOS_PARKED_MAX;
-  }
-});
+    try {
+      const logs = await runStatus();
+      expect(logs).toContain(`pool: 1 parked ${platform === 'ios' ? 'iOS simulator' : 'Android emulator'} (max 3)`);
+    } finally {
+      delete process.env[env];
+    }
+  },
+);
 
 async function runStatusJson() {
   const program = new Command();

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1,3 +1,4 @@
+import { parkedMaxSetting } from '../sim-pool.ts';
 import {
   resolveOptimizations,
   artifactCachePolicy,
@@ -719,7 +720,9 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let estimatesRead: RunEstimates | null = null;
   const estimates = (): RunEstimates => (estimatesRead ??= readEstimates({ projectKey, platform: PLATFORM }));
   const settings = resolveSettingsFor(settingsContext);
-  const [shapeError, ...moreShapeErrors] = settingShapeErrors(settings);
+  const [shapeError, ...moreShapeErrors] = [parkedMaxSetting('android').error, ...settingShapeErrors(settings)].filter(
+    (error): error is string => Boolean(error),
+  );
   if (shapeError) {
     return fail('STIM_BAD_ARG', shapeError, SETTING_SHAPE_REMEDY, { lines: moreShapeErrors });
   }

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -378,7 +378,8 @@ export async function finishAndroidRun({
   }
   androidPackage = packageFromApk || androidPackage || detectAndroidPackage(root);
 
-  if (!physical && !remoteDevice && device.adoptionPending) {
+  const adopting = !physical && !remoteDevice && Boolean(device.adoptionPending);
+  if (adopting) {
     if (!androidPackage || !device.avdName)
       return fail(
         LAUNCH_FAILED,
@@ -387,14 +388,6 @@ export async function finishAndroidRun({
       );
     try {
       resetAdoptedAvd(device.avdName, serial, androidPackage);
-      withConfigLock(() => {
-        const config = loadConfig();
-        const current = config?.projects[root]?.platforms?.android;
-        if (!config || !current || current.avdName !== device.avdName)
-          throw new Error('The adopted emulator assignment changed during cleanup.');
-        delete current.adoptionPending;
-        saveConfig(config);
-      });
     } catch (error) {
       return fail(
         LAUNCH_FAILED,
@@ -411,7 +404,7 @@ export async function finishAndroidRun({
     serial,
     apkPath: apkPath!,
     packageName: androidPackage,
-    allowUninstall: release,
+    allowUninstall: release || adopting,
   });
   if (installed.failed) {
     const conflict = installConflictKind(installed.reason);
@@ -425,6 +418,24 @@ export async function finishAndroidRun({
         rerun
       : `Check that ${serial} is still connected (\`adb devices\`) and has room for the APK.`;
     return fail(installed.code || INSTALL_FAILED, installed.reason, installRemedy, { lastBuildStatus: true });
+  }
+  if (adopting) {
+    try {
+      withConfigLock(() => {
+        const config = loadConfig();
+        const current = config?.projects[root]?.platforms?.android;
+        if (!config || !current || current.avdName !== device.avdName)
+          throw new Error('The adopted emulator assignment changed during installation.');
+        delete current.adoptionPending;
+        saveConfig(config);
+      });
+    } catch (error) {
+      return fail(
+        LAUNCH_FAILED,
+        `Could not finish adopting emulator ${device.avdName}: ${String((error as Error)?.message || error)}`,
+        'Retry to reconcile the emulator assignment; the app was not launched.',
+      );
+    }
   }
   const installSkipped = Boolean(installed.skipped);
   phase(

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -1,3 +1,4 @@
+import { resetAdoptedAvd } from '../../sim/android.ts';
 import type { ChildProcess } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { basename } from 'node:path';
@@ -50,7 +51,7 @@ import { remoteAndroidDeps } from '../../engine/device-remote.ts';
 import { type RunLease, DEBUG_VERIFY_STEP_MS, lostLine, lostRefusal } from '../../engine/device-lease-run.ts';
 import { type LoadProjectProviderResult, exitAfterFlush } from '../../engine/remote-cache.ts';
 import { type ReportAndroidResultArgs, finishAndroidUpload, reportAndroidResult, persistLastBuild } from './result.ts';
-import { upsertProject } from '../../config.ts';
+import { loadConfig, saveConfig, withConfigLock, upsertProject } from '../../config.ts';
 import { providerUploadOutcome } from '../../build-cache.ts';
 import { detectAndroidPackage } from '../../project.ts';
 import { launchOutcomeRecord } from '../native-runtime.ts';
@@ -368,7 +369,7 @@ export async function finishAndroidRun({
     'device',
     physical
       ? `${device.deviceName || serial} (${serial}) connected, not owned by Stim`
-      : `${device.avdName || serial} (${serial}) booted ${bootDuration()}`,
+      : `${device.avdName || serial} (${serial}) ${device.adopted || device.adoptionPending ? 'adopted' : 'booted'} ${bootDuration()}`,
   );
 
   const packageFromApk = readApkPackage(apkPath);
@@ -376,6 +377,32 @@ export async function finishAndroidRun({
     phase('install', chalk.dim(`applicationId ${packageFromApk} (from the APK; project files say ${androidPackage})`));
   }
   androidPackage = packageFromApk || androidPackage || detectAndroidPackage(root);
+
+  if (!physical && !remoteDevice && device.adoptionPending) {
+    if (!androidPackage || !device.avdName)
+      return fail(
+        LAUNCH_FAILED,
+        'Cannot clean an adopted emulator without its app package and AVD name.',
+        'Retry once the APK applicationId can be read.',
+      );
+    try {
+      resetAdoptedAvd(device.avdName, serial, androidPackage);
+      withConfigLock(() => {
+        const config = loadConfig();
+        const current = config?.projects[root]?.platforms?.android;
+        if (!config || !current || current.avdName !== device.avdName)
+          throw new Error('The adopted emulator assignment changed during cleanup.');
+        delete current.adoptionPending;
+        saveConfig(config);
+      });
+    } catch (error) {
+      return fail(
+        LAUNCH_FAILED,
+        `Could not clean adopted emulator ${device.avdName}: ${String((error as Error)?.message || error)}`,
+        'Fix the device cleanup error and retry; adoption remains pending and the app was not launched.',
+      );
+    }
+  }
 
   const lostBeforeInstall = physical ? raiseLeaseFor(ADB_INSTALL_TIMEOUT_MS, true) : null;
   if (lostBeforeInstall) return lostBeforeInstall;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -21,6 +21,8 @@ import { emptyCaches, planCacheEmptying, selectCaches, trimCaches } from './gc/c
 import {
   collectDeviceLeases,
   collectParkedSims,
+  collectParkedAvds,
+  deleteParkedAvds,
   deleteParkedSims,
   deleteProjectDevices,
   describeUnverifiableDevices,
@@ -119,6 +121,7 @@ export async function collectGcReport(
       deviceSweepNotices: [],
       easSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
       parkedSims: [],
+      parkedAvds: [],
       caches,
       cacheScope: scope,
       olderThan,
@@ -142,6 +145,7 @@ export async function collectGcReport(
     }
   }
   const parkedSims = collectParkedSims(deps);
+  const parkedAvds = collectParkedAvds(deps);
   const deadProjects: string[] = [];
   const invalidProjects: string[] = [];
   const skipped: GcSkip[] = [];
@@ -257,6 +261,7 @@ export async function collectGcReport(
     deadProjects,
     invalidProjects,
     parkedSims,
+    parkedAvds,
     orphanedDevices,
     staleDevices,
     staleDeviceRecords,
@@ -279,7 +284,7 @@ export async function collectGcReport(
 }
 
 export async function runGc(opts: RunGcOptions = {}, deps: GcDependencies = {}): Promise<void> {
-  const poolError = parkedMaxSetting('ios').error;
+  const poolError = parkedMaxSetting('ios').error || parkedMaxSetting('android').error;
   if (poolError) {
     console.error(chalk.yellow(`${poolError} ${POOL_SETTING_REMEDY}`));
   }
@@ -397,6 +402,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
   const actionable =
     deadProjects.length + invalidProjects.length > 0 ||
     report.parkedSims.length > 0 ||
+    report.parkedAvds.length > 0 ||
     orphanedDevices.length > 0 ||
     staleDevices.length > 0 ||
     staleDeviceRecords.length > 0 ||
@@ -419,7 +425,7 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     return;
   }
 
-  let deleteFailures = deleteParkedSims(report.parkedSims, deps);
+  let deleteFailures = deleteParkedSims(report.parkedSims, deps) + deleteParkedAvds(report.parkedAvds);
 
   removeInvalidProjectEntries(invalidProjects);
 

--- a/packages/stim-cli/src/commands/gc/devices.ts
+++ b/packages/stim-cli/src/commands/gc/devices.ts
@@ -6,9 +6,9 @@ import { plural } from '../../command-output.ts';
 import { directorySize } from '../../fs-util.ts';
 import { leaseIsExpired, listLeaseFiles, type LeaseFileEntry } from '../../engine/device-lease.ts';
 import { listAllIosSims, listIosDeviceTypes, parseRuntimeVersion, type IosSimRecord } from '../../sim/ios.ts';
-import { ownedAvdDirectory } from '../../sim/android.ts';
+import { listAvds, ownedAvdDirectory } from '../../sim/android.ts';
 import { dropParked, readParked, type ParkedSim } from '../../sim-pool.ts';
-import { teardownOwnedIosSim, teardownOwnedAvd, teardownParkedIosSim } from '../../teardown.ts';
+import { teardownOwnedIosSim, teardownOwnedAvd, teardownParkedIosSim, teardownParkedAvd } from '../../teardown.ts';
 import type { Config, OrphanedDevice } from '../../types.ts';
 
 export interface StaleProjectDevice {
@@ -56,6 +56,7 @@ export interface ParkedSimReport {
 }
 
 export interface GcDeviceDependencies {
+  listAvds?: typeof listAvds;
   avdDirectory?: typeof ownedAvdDirectory;
   directorySize?: typeof directorySize;
   listAllIosSims?: typeof listAllIosSims;
@@ -105,6 +106,9 @@ export function findOrphanedDevices({
   }
   for (const sim of readParked('ios', { config })) {
     referenced.set(sim.udid, { path: 'the simulator pool', mounted: true });
+  }
+  for (const avd of readParked('android', { config })) {
+    referenced.set(avd.name, { path: 'the emulator pool', mounted: true });
   }
 
   const orphaned: OrphanedDevice[] = [];
@@ -287,6 +291,58 @@ export function collectParkedSims(deps: GcDeviceDependencies): ParkedSimReport[]
     deviceTypes = (deps.listIosDeviceTypes ?? listIosDeviceTypes)();
   } catch {}
   return describeParkedSims(records, sims, deviceTypes);
+}
+
+export interface ParkedAvdReport {
+  name: string;
+  systemImage: string;
+  parkedAt: string;
+  bytes: number | null;
+  listed: boolean | null;
+}
+
+export function collectParkedAvds(deps: GcDeviceDependencies): ParkedAvdReport[] {
+  const records = readParked('android');
+  if (!records.length) return [];
+  let avds: string[] | null = null;
+  try {
+    avds = (deps.listAvds ?? listAvds)();
+  } catch {}
+  return records.map((record) => {
+    let bytes: number | null = null;
+    try {
+      const directory = (deps.avdDirectory ?? ownedAvdDirectory)(record.name);
+      if (directory) bytes = (deps.directorySize ?? directorySize)(directory, { timeoutMs: AVD_SIZE_TIMEOUT_MS });
+    } catch {}
+    return {
+      name: record.name,
+      systemImage: record.systemImage,
+      parkedAt: record.parkedAt,
+      bytes,
+      listed: avds === null ? null : avds.includes(record.name),
+    };
+  });
+}
+
+export function deleteParkedAvds(avds: readonly ParkedAvdReport[]): number {
+  let failures = 0;
+  for (const avd of avds) {
+    if (avd.listed === null) {
+      failures++;
+      console.log(chalk.red(`Could not verify parked android emulator ${avd.name}; its pool record was kept.`));
+      continue;
+    }
+    const result = teardownParkedAvd(avd.name);
+    if (result.status === 'failed') {
+      failures++;
+      console.log(chalk.red(`Failed to delete parked android emulator ${avd.name}: ${result.reason}`));
+    } else if (result.status === 'torn-down') {
+      console.log(chalk.green(`Deleted parked android emulator ${avd.name}`));
+    } else {
+      console.log(chalk.dim(`Skipped ${avd.name}; it is no longer parked.`));
+    }
+  }
+  return failures;
 }
 
 export function deleteParkedSims(parkedSims: readonly ParkedSimReport[], deps: GcDeviceDependencies = {}): number {

--- a/packages/stim-cli/src/commands/gc/report.ts
+++ b/packages/stim-cli/src/commands/gc/report.ts
@@ -2,7 +2,13 @@ import { formatLongDuration, shortUdid } from '../../command-output.ts';
 import { formatBytes } from '../../fs-util.ts';
 import type { BuildLockInfo, BuildSlotInfo, GcSkip, OrphanedDevice } from '../../types.ts';
 import type { GcCache } from './caches.ts';
-import type { DeviceLeaseGarbage, ParkedSimReport, StaleDeviceRecord, StaleProjectDevice } from './devices.ts';
+import type {
+  DeviceLeaseGarbage,
+  ParkedAvdReport,
+  ParkedSimReport,
+  StaleDeviceRecord,
+  StaleProjectDevice,
+} from './devices.ts';
 import type { EasSessionSweep } from './eas-sessions.ts';
 
 export interface GcReport {
@@ -10,6 +16,7 @@ export interface GcReport {
   deadProjects: string[];
   invalidProjects: string[];
   parkedSims: ParkedSimReport[];
+  parkedAvds: ParkedAvdReport[];
   orphanedDevices: OrphanedDevice[];
   staleDevices: StaleProjectDevice[];
   staleDeviceRecords: StaleDeviceRecord[];
@@ -53,6 +60,21 @@ function formatParkedSimReport(parkedSims: readonly ParkedSimReport[], now: numb
   return lines;
 }
 
+function formatParkedAvdReport(parkedAvds: readonly ParkedAvdReport[], now: number): string[] {
+  if (!parkedAvds.length) return [];
+  const lines: string[] = [];
+  lines.push(`Parked emulators (${parkedAvds.length}):`);
+  for (const avd of parkedAvds) {
+    const listed =
+      avd.listed === false ? ' - not on this machine' : avd.listed === null ? ' - listing unavailable; kept' : '';
+    lines.push(
+      `  android ${avd.name} ${avd.systemImage} ${parkedAge(avd.parkedAt, now)}${avd.bytes === null ? '' : ` ${formatBytes(avd.bytes)}`}${listed}`,
+    );
+  }
+  lines.push('              --delete attempts verified deletions and keeps failures.');
+  return lines;
+}
+
 function projectEntryLines(header: string, paths: string[]): string[] {
   return paths.length ? [header, ...paths.map((path) => `  ${path}`)] : [];
 }
@@ -63,6 +85,7 @@ export function formatGcReport(
     deadProjects = [],
     invalidProjects = [],
     parkedSims = [],
+    parkedAvds = [],
     orphanedDevices = [],
     staleDevices = [],
     staleDeviceRecords = [],
@@ -89,6 +112,7 @@ export function formatGcReport(
     deadProjects.length === 0 &&
     invalidProjects.length === 0 &&
     parkedSims.length === 0 &&
+    parkedAvds.length === 0 &&
     orphanedDevices.length === 0 &&
     staleDevices.length === 0 &&
     staleDeviceRecords.length === 0 &&
@@ -123,6 +147,7 @@ export function formatGcReport(
   );
 
   lines.push(...formatParkedSimReport(parkedSims, now));
+  lines.push(...formatParkedAvdReport(parkedAvds, now));
 
   if (orphanedDevices.length) {
     lines.push(`Orphaned devices (${orphanedDevices.length}):`);

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -103,8 +103,10 @@ export default function statusCommand(program: Command): void {
         worktrees as unknown as WorktreeFacts[],
         projects.map(([p]) => p),
       );
-      const poolMax = parkedMaxSetting('ios');
-      const pool = poolLine({ platform: 'ios', parked: readParked('ios').length, max: poolMax.max });
+      const pools = (['ios', 'android'] as const).map((platform) => {
+        const { max, error } = parkedMaxSetting(platform);
+        return { error, line: poolLine({ platform, parked: readParked(platform).length, max }) };
+      });
 
       if (opts.json) {
         console.log(
@@ -121,8 +123,10 @@ export default function statusCommand(program: Command): void {
 
       if (projects.length === 0 && orphanWorktrees.length === 0) {
         console.log(chalk.dim('No projects registered.'));
-        if (poolMax.error) console.log(chalk.yellow(`${poolMax.error} ${POOL_SETTING_REMEDY}`));
-        if (pool) console.log(chalk.dim(pool));
+        for (const pool of pools) {
+          if (pool.error) console.log(chalk.yellow(`${pool.error} ${POOL_SETTING_REMEDY}`));
+          if (pool.line) console.log(chalk.dim(pool.line));
+        }
         for (const line of deviceLeaseLines(leases, leaseNow)) console.log(line);
         return;
       }
@@ -175,8 +179,10 @@ export default function statusCommand(program: Command): void {
         for (const w of state.warnings) console.log(chalk.yellow(`  ! ${w}`));
       }
 
-      if (poolMax.error) console.log(chalk.yellow(`\n${poolMax.error} ${POOL_SETTING_REMEDY}`));
-      if (pool) console.log(chalk.dim(`\n${pool}`));
+      for (const pool of pools) {
+        if (pool.error) console.log(chalk.yellow(`\n${pool.error} ${POOL_SETTING_REMEDY}`));
+        if (pool.line) console.log(chalk.dim(`\n${pool.line}`));
+      }
 
       const leaseLines = deviceLeaseLines(leases, leaseNow);
       if (leaseLines.length) {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -244,7 +244,7 @@ interface ReclaimAllResult {
   parkedDevices: ParkedDevice[];
   evictedDevices: ParkedDevice[];
   poolNotes: string[];
-  parkedMax: number;
+  parkedMax: Record<'ios' | 'android', number>;
   skippedDevices: SkippedDevice[];
   keptEntries: string[];
   retainedResources: RetainedResource[];
@@ -347,7 +347,7 @@ async function reclaimAll(
     parkedDevices,
     evictedDevices,
     poolNotes,
-    parkedMax: parkedMaxSetting('ios').max,
+    parkedMax: { ios: parkedMaxSetting('ios').max, android: parkedMaxSetting('android').max },
     skippedDevices,
     keptEntries,
     retainedResources,
@@ -363,10 +363,21 @@ async function reclaimAll(
 function poolLines(result: ReclaimAllResult): string[] {
   const lines: string[] = [];
   for (const device of result.parkedDevices) {
-    lines.push(chalk.dim(phaseLine('device', `parked ${device.name} (${shortUdid(device.udid)})`)));
+    lines.push(
+      chalk.dim(
+        phaseLine(
+          'device',
+          `parked ${device.name}${device.platform === 'android' ? '' : ` (${shortUdid(device.udid)})`}`,
+        ),
+      ),
+    );
   }
   for (const device of result.evictedDevices) {
-    lines.push(chalk.dim(phaseLine('device', `deleted ${device.name} (pool over ${result.parkedMax})`)));
+    lines.push(
+      chalk.dim(
+        phaseLine('device', `deleted ${device.name} (pool over ${result.parkedMax[device.platform ?? 'ios']})`),
+      ),
+    );
   }
   for (const note of result.poolNotes) lines.push(chalk.yellow(phaseLine('device', note)));
   return lines;
@@ -532,7 +543,7 @@ function printRemovalCleanup(result: ReclaimAllResult, failed: boolean): void {
 }
 
 async function runRemove(target: string | undefined, opts: RemoveOptions = {}): Promise<void> {
-  const poolError = parkedMaxSetting('ios').error;
+  const poolError = parkedMaxSetting('ios').error || parkedMaxSetting('android').error;
   if (poolError) {
     console.error(chalk.red(poolError));
     console.error(chalk.dim(POOL_SETTING_REMEDY));

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -712,11 +712,17 @@ export function runDoctor(
     remoteBuildCache && provider === 'eas'
       ? checkEasAuth({ provider, owner, auth: easAuth({ projectRoot, owner }) })
       : null;
-  if (platform !== 'android') {
-    const poolSettingError = parkedMaxSetting('ios').error;
+  for (const poolPlatform of ['ios', 'android'] as const) {
+    if (platform && platform !== poolPlatform) continue;
+    const poolSettingError = parkedMaxSetting(poolPlatform).error;
     if (poolSettingError) {
       settingShapeFindings.push(
-        finding('cost', 'The simulator pool bound is not a number', poolSettingError, POOL_SETTING_REMEDY),
+        finding(
+          'cost',
+          `The ${poolPlatform === 'ios' ? 'simulator' : 'emulator'} pool bound is not a number`,
+          poolSettingError,
+          POOL_SETTING_REMEDY,
+        ),
       );
     }
   }

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { randomUUID } from 'node:crypto';
 import { phaseLine } from '../command-output.ts';
 import {
   allConsolePortsAndSerials,
@@ -32,6 +33,11 @@ import {
 } from '../sim/ios.ts';
 import { adoptParked, dropParked, parkedMaxSetting, readParked, selectParked } from '../sim-pool.ts';
 import {
+  assertOwnedAvdStopped,
+  avdPoolConfiguration,
+  ownedAvdMatchesConfiguration,
+  pickDefaultSystemImage,
+  listInstalledSystemImages,
   bootAndroidEmulator,
   configureNewOwnedAvd,
   createOwnedAvd,
@@ -46,7 +52,7 @@ import {
   type SystemImage,
 } from '../sim/android.ts';
 import { androidAvdConfigSetting, androidDataPartitionSizeGbSetting, iosSimSlimProfileSetting } from '../settings.ts';
-import { teardownOwnedAvd, teardownParkedIosSim } from '../teardown.ts';
+import { teardownOwnedAvd, teardownParkedAvd, teardownParkedIosSim } from '../teardown.ts';
 import { reconcileSimSlim } from './simslim.ts';
 
 export interface OwnedDeviceRecord {
@@ -65,6 +71,7 @@ export interface OwnedDeviceRecord {
   adopted?: boolean;
   adoptionPending?: boolean;
   parkedCacheKey?: string;
+  poolConfiguration?: string;
   /**
    * The boot this call started, and the promise that finishes it: the wait on
    * `simctl bootstatus -b` and the SimSlim reconcile that follows it.
@@ -500,6 +507,7 @@ async function ensureOwnedAndroidDevice({
   teardownAvd: typeof teardownOwnedAvd;
 } & EmulatorLogging): Promise<OwnedDeviceRecord> {
   const avdConfig = androidAvdConfigSetting(settings, settingsRoot);
+  const configuration = avdPoolConfiguration(androidDataPartitionSizeGbSetting(settings), avdConfig);
   if (record?.setupIncomplete && record.avdName) {
     const cleanup = teardownAvd(record.avdName, { del: true });
     if (cleanup.status === 'failed' || cleanup.status === 'skipped') {
@@ -522,6 +530,7 @@ async function ensureOwnedAndroidDevice({
       } else if (resolved.serial) {
         const consolePort = Number(resolved.serial.replace(/^emulator-/, ''));
         const updated = {
+          ...record,
           avdName: record.avdName,
           consolePort,
           owned: true,
@@ -538,6 +547,7 @@ async function ensureOwnedAndroidDevice({
         return {
           ...(await bootOwnedAvdOnFreshPort({
             avdName: record.avdName,
+            metadata: record,
             projectPath,
             deviceName: record.deviceName,
             out,
@@ -576,10 +586,78 @@ async function ensureOwnedAndroidDevice({
     note(chalk.dim('Creating an owned emulator instead. Pass `--device` to build for a connected device.'));
   }
 
+  if (parkedMaxSetting('android').max > 0) {
+    const systemImage = pickDefaultSystemImage(listInstalledSystemImages(), {
+      systemImage: flags.systemImage || settings.android?.systemImage,
+    })?.pkg;
+    const candidates = readParked('android')
+      .filter((entry) => entry.systemImage === systemImage && entry.configuration === configuration)
+      .toSorted((a, b) => a.parkedAt.localeCompare(b.parkedAt));
+    for (const parked of candidates) {
+      if (parked.deletionClaim !== undefined) continue;
+      const resolved = resolveOwnedAvdSerial(parked.name);
+      if (resolved.missing) {
+        dropParked('android', parked.udid);
+        continue;
+      }
+      if (resolved.notOwned || resolved.serial) continue;
+      try {
+        assertOwnedAvdStopped(parked.name);
+      } catch (error) {
+        out(phaseLine('device', `kept parked ${parked.name}: ${String((error as Error)?.message || error)}`));
+        continue;
+      }
+      if (
+        ownedAvdSystemImage(parked.name) !== systemImage ||
+        !ownedAvdMatchesConfiguration(parked.name, configuration)
+      ) {
+        const result = teardownParkedAvd(parked.name);
+        if (result.status === 'failed') out(phaseLine('device', `kept ${parked.name}: ${result.reason}`));
+        continue;
+      }
+      const adopted = {
+        avdName: parked.name,
+        deviceName: parked.name,
+        owned: true,
+        poolConfiguration: configuration,
+        adoptionPending: true,
+      };
+      if (!adoptParked({ platform: 'android', projectPath, udid: parked.udid, device: adopted })) continue;
+      return {
+        ...(await bootOwnedAvdOnFreshPort({
+          avdName: parked.name,
+          projectPath,
+          metadata: adopted,
+          out,
+          logFile,
+          alive,
+        })),
+        adopted: true,
+        systemImage,
+      };
+    }
+  }
+  const reservedNames = readParked('android').map((entry) => entry.name);
+  if (reservedNames.includes(ownedAvdName(label))) label = `${label}-${randomUUID().slice(0, 8)}`;
+
   let created: { avdName: string; systemImage: string | null };
   let fresh = false;
   try {
-    created = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
+    created = withConfigLock(() => {
+      const current = loadConfig()?.projects[projectPath]?.platforms?.android;
+      if (current?.avdName && current.avdName !== record?.avdName) {
+        throw new Error(`Another Stim run assigned AVD ${current.avdName} to this workspace. Retry to use it.`);
+      }
+      const result = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
+      setDevice(projectPath, 'android', {
+        avdName: result.avdName,
+        owned: true,
+        deviceName: result.avdName,
+        setupIncomplete: true,
+        poolConfiguration: configuration,
+      });
+      return result;
+    });
     fresh = true;
   } catch (e) {
     const message = String((e as Error)?.message || e);
@@ -607,12 +685,6 @@ async function ensureOwnedAndroidDevice({
     }
   }
   if (fresh) {
-    setDevice(projectPath, 'android', {
-      avdName: created.avdName,
-      owned: true,
-      deviceName: created.avdName,
-      setupIncomplete: true,
-    });
     try {
       configureAvd(created.avdName, {
         dataPartitionSizeGb: androidDataPartitionSizeGbSetting(settings),
@@ -634,6 +706,7 @@ async function ensureOwnedAndroidDevice({
   return {
     ...(await bootOwnedAvdOnFreshPort({
       avdName: created.avdName,
+      metadata: fresh ? { poolConfiguration: configuration } : undefined,
       projectPath,
       deviceName: created.avdName,
       out,
@@ -659,7 +732,8 @@ export function claimAndroidConsolePort(
     avdName,
     deviceName,
     livePorts = [],
-  }: { projectPath: string; avdName: string; deviceName?: string; livePorts?: number[] },
+    metadata,
+  }: { projectPath: string; avdName: string; deviceName?: string; livePorts?: number[]; metadata?: OwnedDeviceRecord },
   {
     lock = withConfigLock,
     recordedPorts = () => allConsolePortsAndSerials().androidConsolePorts,
@@ -673,6 +747,8 @@ export function claimAndroidConsolePort(
   return lock(() => {
     const consolePort = nextConsolePort([...recordedPorts(), ...livePorts]);
     const claim: AndroidConsolePortClaim = {
+      ...(metadata?.poolConfiguration ? { poolConfiguration: metadata.poolConfiguration } : {}),
+      ...(metadata?.adoptionPending ? { adoptionPending: true } : {}),
       avdName,
       consolePort,
       owned: true,
@@ -693,6 +769,7 @@ function liveAndroidConsolePorts(): number[] {
 
 async function bootOwnedAvdOnFreshPort({
   avdName,
+  metadata,
   projectPath,
   deviceName,
   out,
@@ -700,6 +777,7 @@ async function bootOwnedAvdOnFreshPort({
   alive = isPidAlive,
 }: {
   avdName: string;
+  metadata?: OwnedDeviceRecord;
   projectPath: string;
   deviceName?: string;
   out: Notify;
@@ -709,6 +787,7 @@ async function bootOwnedAvdOnFreshPort({
     avdName,
     deviceName,
     livePorts: liveAndroidConsolePorts(),
+    metadata,
   });
   const serial = `emulator-${claim.consolePort}`;
   try {

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -637,9 +637,6 @@ async function ensureOwnedAndroidDevice({
       };
     }
   }
-  const reservedNames = readParked('android').map((entry) => entry.name);
-  if (reservedNames.includes(ownedAvdName(label))) label = `${label}-${randomUUID().slice(0, 8)}`;
-
   let created: { avdName: string; systemImage: string | null };
   let fresh = false;
   try {
@@ -648,6 +645,8 @@ async function ensureOwnedAndroidDevice({
       if (current?.avdName && current.avdName !== record?.avdName) {
         throw new Error(`Another Stim run assigned AVD ${current.avdName} to this workspace. Retry to use it.`);
       }
+      if (readParked('android').some((entry) => entry.name === ownedAvdName(label)))
+        label = `${label}-${randomUUID().slice(0, 8)}`;
       const result = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
       setDevice(projectPath, 'android', {
         avdName: result.avdName,
@@ -663,22 +662,29 @@ async function ensureOwnedAndroidDevice({
     const message = String((e as Error)?.message || e);
     const avdName = ownedAvdName(label);
     if (message.includes('already exists') && listAvds().includes(avdName)) {
-      const owner = findOtherProjectOwningAvd(avdName, projectPath);
-      if (owner) {
-        throw new Error(
-          `AVD ${avdName} already exists and is owned by another project (${owner}). Pass a distinct --label to avoid the collision instead of hijacking it.`,
-          { cause: e },
-        );
-      }
-      const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
-      if (current?.avdName === avdName) {
-        const state = current.setupIncomplete ? 'has incomplete setup' : 'was registered';
-        throw new Error(
-          `AVD ${avdName} ${state} by another concurrent Stim run. Retry after that run finishes so the recorded device is resolved safely.`,
-          { cause: e },
-        );
-      }
-      created = { avdName, systemImage: ownedAvdSystemImage(avdName) };
+      created = withConfigLock(() => {
+        if (readParked('android').some((entry) => entry.name === avdName)) {
+          throw new Error(`AVD ${avdName} was parked by another Stim run. Retry to adopt it safely.`, { cause: e });
+        }
+        const owner = findOtherProjectOwningAvd(avdName, projectPath);
+        if (owner) {
+          throw new Error(
+            `AVD ${avdName} already exists and is owned by another project (${owner}). Pass a distinct --label to avoid the collision instead of hijacking it.`,
+            { cause: e },
+          );
+        }
+        const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
+        if (current?.avdName) {
+          const state = current.setupIncomplete ? 'has incomplete setup' : 'was registered';
+          throw new Error(
+            `AVD ${current.avdName} ${state} by another concurrent Stim run. Retry after that run finishes so the recorded device is resolved safely.`,
+            { cause: e },
+          );
+        }
+        const result = { avdName, systemImage: ownedAvdSystemImage(avdName) };
+        setDevice(projectPath, 'android', { avdName, owned: true, deviceName: avdName });
+        return result;
+      });
       out(chalk.dim(phaseLine('device', `recovered ${avdName} (unrecorded from a prior run)`)));
     } else {
       throw e;

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -114,8 +114,8 @@ Stim creates, boots, and deletes only devices it created. Owned simulators use
 the stim-<label> (<model> <runtime>) name. Never point Stim at a user-created
 emulator or simulator.
 
-worktree remove parks the workspace's simulator for later adoption. A parked
-simulator is Stim-owned: never delete one by hand. gc --delete clears verified
+worktree remove parks the workspace's simulator or emulator for later adoption.
+A parked device is Stim-owned: never delete one by hand. gc --delete clears verified
 entries and keeps failures; see guide lifecycle pool. First launch on a
 physical iPhone can need the one-time taps named by the remedy.
 

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -5,11 +5,11 @@ const cleanup: GuideTopic = {
   preamble: () => `CLEANUP AND DISK
 
 WHAT RECLAIMS AN OWNED DEVICE
-  stim worktree remove    parks the owned simulator
-                            (\`guide lifecycle pool\`) and deletes every other
-                            owned device under the worktree
+  stim worktree remove    parks eligible owned simulators and emulators
+                            (\`guide lifecycle pool\`); deletes them when
+                            parking is disabled or their setup cannot be verified
   stim gc --delete        sweeps stim-* devices no project references, and
-                            clears verified parked simulators
+                            clears verified parked simulators and emulators
   stim gc --delete --older-than <days>
                             also reaps the device of a project nothing has
                             touched in that long, even though the project is
@@ -40,7 +40,7 @@ to stats.json.corrupt-<unix ms> and starts a new one.`,
 ON THE MAIN CHECKOUT
   git cannot remove the main working tree, and deleting the source tree is not
   what anyone meant -- so there, and only there, \`worktree remove\` reclaims
-  the ENVIRONMENT and nothing else: the owned devices are deleted, the Metro
+  the ENVIRONMENT and nothing else: the owned devices are parked or deleted, the Metro
   port freed, the registry entries (including nested monorepo app dirs)
   dropped, and the global workspace directory deleted. The tree itself is never touched, which
   is also why the dirty-tree and unpushed guards do not apply on that path.

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -365,7 +365,34 @@ result as proof instead of requiring an unrelated screenshot.`,
   for unlisted \`stim-\` devices stays refused: a parked record in THIS config
   proves that simulator is Stim's and parked by this home. \`stop\` never
   parks -- it shuts the owned simulator down and keeps it assigned. Neither
-  does \`gc --delete\`, which is deleting what it finds.`,
+  does \`gc --delete\`, which is deleting what it finds.
+
+  ANDROID EMULATOR POOL
+  Android uses the same bounded park/adopt lifecycle, with
+  \`pool.androidParkedMax\` (default 3) or STIM_POOL_ANDROID_PARKED_MAX.
+  A redirected STIM_HOME disables parking unless that environment override
+  is set. Zero disables parking and adoption. \`stop\` keeps the assignment;
+  \`worktree remove\` parks eligible AVDs, and \`gc --delete\` empties the pool.
+
+  Adoption matches the system image, data partition size, and the creation
+  settings from android.avdConfig / android.avdConfigFile. The AVD keeps its
+  original stim-<label> name so its Quick Boot snapshot can survive reuse.
+  Normal desktop boots allow Quick Boot; headless Linux disables snapshots.
+  Incompatible AVDs stay parked until eviction or GC. AVDs created by older
+  versions without a recorded creation configuration are deleted at removal.
+
+  Android cleanup happens AFTER boot, before install or launch: \`adb shell
+  pm clear\` clears the adopting app's data while retaining its APK, and
+  other third-party apps are uninstalled. Failed cleanup blocks launch and
+  remains pending for a retry. The installed APK's SHA-256 must match the
+  requested artifact before Stim skips installation; a package name or cache
+  key alone is insufficient, including for release builds with swapped JS.
+
+  Parked AVDs retain app data until adoption. System apps, shared storage,
+  accounts and device settings also remain: this is not a factory reset.
+  Set the Android bound to 0 when a project needs a fresh device. Status lists
+  parked Android emulators; GC reports their system image, age and disk size.
+`,
     },
     builds: {
       summary:

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -387,6 +387,8 @@ result as proof instead of requiring an unrelated screenshot.`,
   remains pending for a retry. The installed APK's SHA-256 must match the
   requested artifact before Stim skips installation; a package name or cache
   key alone is insufficient, including for release builds with swapped JS.
+  If the retained APK has a conflicting signer or version, adoption uninstalls
+  it and retries installation. Adoption stays pending until installation succeeds.
 
   Parked AVDs retain app data until adoption. System apps, shared storage,
   accounts and device settings also remain: this is not a factory reset.

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -230,7 +230,7 @@ Unset, 0, or any non-positive value means NO enforcement -- the default, where
 Stim limits nothing. See \`guide lifecycle concurrency\` for what each cap
 does.
 
-THE SIMULATOR POOL BOUND IS MACHINE-LEVEL TOO
+THE DEVICE POOL BOUNDS ARE MACHINE-LEVEL TOO
 \`pool.iosParkedMax\` caps how many parked simulators \`worktree remove\` may
 leave behind for a later workspace to adopt. It is machine-level for the same
 reason: the disk they sit on is the whole machine's, about 2.5 GB each.
@@ -246,8 +246,16 @@ that already exists stays where it is until \`gc --delete\`. A value that is
 not a whole number 0 or more is refused by name on \`worktree remove\` and
 \`ios\`, and warned about by \`status\`, \`gc\` and \`doctor\`.
 
+Android uses \`pool.androidParkedMax\` or STIM_POOL_ANDROID_PARKED_MAX with
+these same defaults and validation rules. \`android\` validates that bound;
+\`worktree remove\`, \`status\`, \`gc\` and \`doctor\` check the applicable
+platform bounds. Android adoption matches the system image and AVD creation
+settings, preserves the APK, and clears app data before launch. See
+\`guide lifecycle pool\` for cleanup and the system state that remains.
+
 When STIM_HOME is set, parking and adoption are OFF unless
-STIM_POOL_IOS_PARKED_MAX is set too. A redirected home is a scoped config --
+the corresponding STIM_POOL_IOS_PARKED_MAX or STIM_POOL_ANDROID_PARKED_MAX
+is set too. A redirected home is a scoped config --
 test suites and the end-to-end harness use one -- and a scoped config must not
 leave simulators on the machine it cannot account for. A redirected home that
 wants a pool says so with the variable.

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -236,8 +236,25 @@ function reclaimOwnedDevices(
 
   const android = project?.platforms?.android;
   if (android?.owned && android.avdName) {
-    const r = teardownOwnedAvd(android.avdName, { del: true });
-    if (r.status === 'torn-down') deletedDevices.push(android.avdName);
+    const bound = parkedMaxSetting('android');
+    const r = teardownOwnedAvd(android.avdName, {
+      del: true,
+      ...(park && !bound.error && bound.max > 0
+        ? {
+            park: {
+              projectPath,
+              max: bound.max,
+              configuration: typeof android.poolConfiguration === 'string' ? android.poolConfiguration : undefined,
+            },
+          }
+        : {}),
+    });
+    if (r.parkFallback) poolNotes.push(`could not park ${android.avdName}: ${r.parkFallback} -- deleted it instead`);
+    for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
+    if (r.parked) {
+      parkedDevices.push(r.parked);
+      evictedDevices.push(...(r.evicted ?? []));
+    } else if (r.status === 'torn-down') deletedDevices.push(android.avdName);
     else if (r.status === 'skipped') {
       skippedDevices.push({ platform: 'android', name: android.avdName, reason: `${r.reason} -- not touched` });
     } else if (r.status === 'failed') {

--- a/packages/stim-cli/src/sim-pool.ts
+++ b/packages/stim-cli/src/sim-pool.ts
@@ -4,22 +4,32 @@ import type { Config, DeviceRecord } from './types.ts';
 
 export type PoolPlatform = 'ios' | 'android';
 
-export interface ParkedSim {
+interface ParkedRecord {
   udid: string;
   name: string;
+  parkedAt: string;
+  deletionClaim?: unknown;
+}
+
+export interface ParkedSim extends ParkedRecord {
   deviceTypeIdentifier: string;
   runtimeIdentifier: string;
-  parkedAt: string;
   simslimManaged: boolean;
   bundleId?: string;
   cacheKey?: string;
-  deletionClaim?: unknown;
 }
+
+export interface ParkedAvd extends ParkedRecord {
+  systemImage: string;
+  configuration: string;
+}
+
+type PoolRecords = { ios: ParkedSim; android: ParkedAvd };
 
 export const DEFAULT_PARKED_MAX = 3;
 
 export const POOL_SETTING_REMEDY: string =
-  'Run `stim guide settings` for the simulator pool bound and where it can be set.';
+  'Run `stim guide settings` for the device pool bounds and where it can be set.';
 
 const MAX_SETTING: Record<PoolPlatform, { key: string; env: string }> = {
   ios: { key: 'iosParkedMax', env: 'STIM_POOL_IOS_PARKED_MAX' },
@@ -65,43 +75,52 @@ export function parkedMaxSetting(
   return { max: explicit ? parsed : env.STIM_HOME ? 0 : parsed, error: null };
 }
 
-function isParkedSim(value: unknown): value is ParkedSim {
+function isParkedRecord(value: unknown, platform: PoolPlatform): value is PoolRecords[PoolPlatform] {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return (
     typeof record.udid === 'string' &&
     typeof record.name === 'string' &&
     record.name.startsWith('stim-') &&
-    typeof record.deviceTypeIdentifier === 'string' &&
-    typeof record.runtimeIdentifier === 'string' &&
     typeof record.parkedAt === 'string' &&
-    typeof record.simslimManaged === 'boolean' &&
-    (record.bundleId === undefined || typeof record.bundleId === 'string') &&
-    (record.cacheKey === undefined || typeof record.cacheKey === 'string')
+    (platform === 'android'
+      ? record.udid === record.name &&
+        /^stim-[A-Za-z0-9._-]+$/.test(record.name) &&
+        typeof record.systemImage === 'string' &&
+        typeof record.configuration === 'string'
+      : typeof record.deviceTypeIdentifier === 'string' &&
+        typeof record.runtimeIdentifier === 'string' &&
+        typeof record.simslimManaged === 'boolean' &&
+        (record.bundleId === undefined || typeof record.bundleId === 'string') &&
+        (record.cacheKey === undefined || typeof record.cacheKey === 'string'))
   );
 }
 
-function poolBlock(config: Config | null): Record<PoolPlatform, ParkedSim[]> {
+function poolBlock(config: Config | null): { [P in PoolPlatform]: PoolRecords[P][] } {
   const raw = config?.parked;
   const block = raw !== null && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
-  const read = (platform: PoolPlatform): ParkedSim[] => {
+  const read = <P extends PoolPlatform>(platform: P): PoolRecords[P][] => {
     const list = block[platform];
-    return Array.isArray(list) ? list.filter(isParkedSim) : [];
+    return Array.isArray(list)
+      ? list.filter((record): record is PoolRecords[P] => isParkedRecord(record, platform))
+      : [];
   };
   return { ios: read('ios'), android: read('android') };
 }
 
-export function readParked(platform: PoolPlatform, { config }: { config?: Config | null } = {}): ParkedSim[] {
+export function readParked<P extends PoolPlatform>(
+  platform: P,
+  { config }: { config?: Config | null } = {},
+): PoolRecords[P][] {
   return poolBlock(config === undefined ? loadConfig() : config)[platform];
 }
 
-function writeParked(config: Config, platform: PoolPlatform, records: ParkedSim[]): void {
+function writeParked<P extends PoolPlatform>(config: Config, platform: P, records: PoolRecords[P][]): void {
   const block = poolBlock(config);
-  block[platform] = records;
-  config.parked = { ios: block.ios, android: block.android };
+  config.parked = { ...block, [platform]: records };
 }
 
-function oldestFirst(records: readonly ParkedSim[]): ParkedSim[] {
+function oldestFirst<T extends ParkedRecord>(records: readonly T[]): T[] {
   return records.toSorted((a, b) => String(a.parkedAt).localeCompare(String(b.parkedAt)));
 }
 
@@ -119,7 +138,7 @@ export function selectParked(
   );
 }
 
-export function evictOverflow(records: readonly ParkedSim[], max: number): { keep: ParkedSim[]; evicted: ParkedSim[] } {
+export function evictOverflow<T extends ParkedRecord>(records: readonly T[], max: number): { keep: T[]; evicted: T[] } {
   if (records.length <= max) return { keep: [...records], evicted: [] };
   const ordered = oldestFirst(records);
   const evicted = ordered.slice(0, ordered.length - max);
@@ -127,19 +146,24 @@ export function evictOverflow(records: readonly ParkedSim[], max: number): { kee
   return { keep: records.filter((r) => !dropped.has(r.udid)), evicted };
 }
 
-export function parkSim({
+export function parkSim<P extends PoolPlatform>({
   platform,
   projectPath,
   record,
   max,
 }: {
-  platform: PoolPlatform;
+  platform: P;
   projectPath: string;
-  record: ParkedSim;
+  record: PoolRecords[P];
   max: number;
-}): ParkedSim[] {
+}): PoolRecords[P][] {
   return withConfigLock(() => {
     const cfg = ensureConfig();
+    if (platform === 'android') {
+      const current = cfg.projects[projectPath]?.platforms?.android;
+      if (!current?.owned || current.avdName !== record.udid)
+        throw new Error('The emulator assignment changed before parking.');
+    }
     const kept = readParked(platform, { config: cfg }).filter((r) => r.udid !== record.udid);
     const { keep, evicted } = evictOverflow([...kept, record], max);
     writeParked(cfg, platform, [...keep, ...evicted]);
@@ -150,22 +174,23 @@ export function parkSim({
   });
 }
 
-export function adoptParked({
+export function adoptParked<P extends PoolPlatform>({
   platform,
   projectPath,
   udid,
   device,
 }: {
-  platform: PoolPlatform;
+  platform: P;
   projectPath: string;
   udid: string;
   device: DeviceRecord;
-}): ParkedSim | null {
+}): PoolRecords[P] | null {
   return withConfigLock(() => {
     const cfg = ensureConfig();
     const records = readParked(platform, { config: cfg });
     const taken = records.find((r) => r.udid === udid);
     if (!taken || taken.deletionClaim !== undefined) return null;
+    if (platform === 'android' && cfg.projects[projectPath]?.platforms?.android) return null;
     writeParked(
       cfg,
       platform,
@@ -197,7 +222,10 @@ function parseDeletionClaim(value: unknown): { pid: number; token: string } | nu
   return { pid: claim.pid as number, token: claim.token };
 }
 
-function claimParkedRemoval(platform: PoolPlatform, udid: string): { record: ParkedSim; token: string } | null {
+function claimParkedRemoval<P extends PoolPlatform>(
+  platform: P,
+  udid: string,
+): { record: PoolRecords[P]; token: string } | null {
   return withConfigLock(() => {
     const cfg = loadConfig();
     if (!cfg) return null;
@@ -238,11 +266,11 @@ function clearParkedRemovalClaim(platform: PoolPlatform, udid: string, token: st
   });
 }
 
-export function removeParkedAfter(
-  platform: PoolPlatform,
+export function removeParkedAfter<P extends PoolPlatform>(
+  platform: P,
   udid: string,
-  beforeRemove: (record: ParkedSim) => void,
-): ParkedSim | null {
+  beforeRemove: (record: PoolRecords[P]) => void,
+): PoolRecords[P] | null {
   const claim = claimParkedRemoval(platform, udid);
   if (!claim) return null;
   try {

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -618,6 +618,58 @@ export function configureNewOwnedAvd(
   return configPath;
 }
 
+export function avdPoolConfiguration(dataPartitionSizeGb: number, avdConfig: Record<string, string>): string {
+  return JSON.stringify(
+    Object.entries({
+      ...avdConfig,
+      'disk.dataPartition.size': String(androidDataPartitionSizeBytes(dataPartitionSizeGb)),
+    }).toSorted(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+export function ownedAvdMatchesConfiguration(avdName: string, configuration: string): boolean {
+  const directory = ownedAvdDirectory(avdName);
+  if (!directory) return false;
+  const contents = readFileSync(join(directory, 'config.ini'), 'utf8');
+  const expected: unknown = JSON.parse(configuration);
+  return (
+    Array.isArray(expected) &&
+    expected.length > 0 &&
+    expected.every(
+      (entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        entry.every((value) => typeof value === 'string') &&
+        contents.split(/\r?\n/).some((line) => line.trim() === `${entry[0]}=${entry[1]}`),
+    )
+  );
+}
+
+export function resetAdoptedAvd(avdName: string, serial: string, keepPackage: string): void {
+  const assertTarget = () => {
+    const resolved = resolveOwnedAvdSerial(avdName);
+    if (resolved.serial !== serial) throw new Error(`AVD ${avdName} is no longer running on ${serial}.`);
+  };
+  assertTarget();
+  const exec = getExecutor();
+  const output = exec.runFile('adb', ['-s', serial, 'shell', 'pm', 'list', 'packages', '-3'], { timeoutMs: 30000 });
+  const packages = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^package:([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)$/.exec(line);
+      if (!match) throw new Error(`Could not read installed apps on ${avdName}: ${line}`);
+      return match[1]!;
+    });
+  for (const packageName of packages) {
+    assertTarget();
+    const args = packageName === keepPackage ? ['shell', 'pm', 'clear', packageName] : ['uninstall', packageName];
+    const result = exec.runFile('adb', ['-s', serial, ...args], { timeoutMs: 120000 });
+    if (result.trim() !== 'Success') throw new Error(`Could not clean ${packageName} on ${avdName}: ${result.trim()}`);
+  }
+}
+
 export function bootAndroidEmulator(
   avdName: string,
   consolePort: number,

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -17,12 +17,15 @@ import {
   shutdownAndroidEmulator,
   waitForAndroidEmulatorShutdown,
   deleteAvd,
+  ownedAvdMatchesConfiguration,
+  ownedAvdSystemImage,
 } from './sim/android.ts';
 import { parkSim, removeParkedAfter, type ParkedSim } from './sim-pool.ts';
 
 export interface ParkedDevice {
   udid: string;
   name: string;
+  platform?: 'ios' | 'android';
 }
 
 export interface TeardownOutcome {
@@ -44,6 +47,21 @@ export interface ParkRequest {
   bundleId?: string | null;
   cacheKey?: string | null;
   simslimManaged?: boolean;
+  configuration?: string;
+}
+
+export function teardownParkedAvd(avdName: string): TeardownOutcome {
+  try {
+    const removed = removeParkedAfter('android', avdName, () => {
+      const result = teardownOwnedAvd(avdName, { del: true });
+      if (result.status !== 'torn-down' && result.status !== 'missing') throw new Error(result.reason);
+    });
+    return removed
+      ? { status: 'torn-down', label: avdName }
+      : { status: 'skipped', kind: 'not-parked', reason: 'emulator is no longer parked' };
+  } catch (error) {
+    return { status: 'failed', reason: String((error as Error)?.message || error) };
+  }
 }
 
 export function teardownParkedIosSim(
@@ -144,16 +162,19 @@ export function teardownOwnedAvd(
   avdName: string,
   {
     del = false,
+    park,
     waitForShutdown = waitForAndroidEmulatorShutdown,
     assertStopped = assertOwnedAvdStopped,
     resolveAvd = resolveOwnedAvdSerial,
   }: {
     del?: boolean;
+    park?: ParkRequest;
     waitForShutdown?: typeof waitForAndroidEmulatorShutdown;
     assertStopped?: typeof assertOwnedAvdStopped;
     resolveAvd?: typeof resolveOwnedAvdSerial;
   } = {},
 ): TeardownOutcome {
+  let parkFallback: string | undefined;
   try {
     const resolved = resolveAvd(avdName);
     if (resolved.notOwned) {
@@ -174,9 +195,52 @@ export function teardownOwnedAvd(
       if (current.missing) return { status: 'missing' };
       if (current.serial) throw new Error(`Owned AVD ${avdName} started again before deletion.`);
       assertStopped(avdName);
+      if (park && park.max > 0) {
+        try {
+          const systemImage = ownedAvdSystemImage(avdName);
+          if (!systemImage || !park.configuration || !ownedAvdMatchesConfiguration(avdName, park.configuration)) {
+            throw new Error('the AVD has no verified creation configuration');
+          }
+          const evicted = parkSim({
+            platform: 'android',
+            projectPath: park.projectPath,
+            max: park.max,
+            record: {
+              udid: avdName,
+              name: avdName,
+              systemImage,
+              configuration: park.configuration,
+              parkedAt: new Date().toISOString(),
+            },
+          });
+          const removed: ParkedDevice[] = [];
+          const failures: string[] = [];
+          for (const entry of evicted) {
+            const result = teardownParkedAvd(entry.name);
+            if (result.status === 'torn-down')
+              removed.push({ udid: entry.name, name: entry.name, platform: 'android' });
+            else if (result.status === 'failed')
+              failures.push(`could not delete evicted ${entry.name}: ${result.reason}`);
+          }
+          return {
+            status: 'torn-down',
+            label: avdName,
+            parked: { udid: avdName, name: avdName, platform: 'android' },
+            evicted: removed,
+            ...(failures.length ? { evictionFailures: failures } : {}),
+          };
+        } catch (error) {
+          parkFallback = String((error as Error)?.message || error);
+        }
+      }
       deleteAvd(avdName);
     }
-    return { status: 'torn-down', label: avdName, serial: resolved.serial ?? null };
+    return {
+      status: 'torn-down',
+      label: avdName,
+      serial: resolved.serial ?? null,
+      ...(parkFallback ? { parkFallback } : {}),
+    };
   } catch (e) {
     return { status: 'failed', reason: String((e as Error)?.message || e) };
   }

--- a/test/e2e/native/run-android-pool-e2e.mjs
+++ b/test/e2e/native/run-android-pool-e2e.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getExecutor } from '../../../packages/stim-cli/src/exec.ts';
+import { upsertProject } from '../../../packages/stim-cli/src/config.ts';
+import { ensureOwnedDevice } from '../../../packages/stim-cli/src/engine/device.ts';
+import { installAndroidApp } from '../../../packages/stim-cli/src/engine/app-install.ts';
+import { apkPackage, dumpApkManifest } from '../../../packages/stim-cli/src/commands/android.ts';
+import { reclaimProject } from '../../../packages/stim-cli/src/reclaim.ts';
+import { readParked } from '../../../packages/stim-cli/src/sim-pool.ts';
+import { listAvds, resetAdoptedAvd } from '../../../packages/stim-cli/src/sim/android.ts';
+import { teardownParkedAvd } from '../../../packages/stim-cli/src/teardown.ts';
+import { collectParkedAvds, deleteParkedAvds } from '../../../packages/stim-cli/src/commands/gc/devices.ts';
+
+if (process.argv[2] === '--device-worker') {
+  const projectPath = process.argv[3];
+  const device = await ensureOwnedDevice({
+    platform: 'android',
+    projectPath,
+    label: process.argv[4],
+    settings: {},
+    logFile: join(projectPath, 'emulator.log'),
+    out: (line) => process.stderr.write(`${line}\n`),
+  });
+  console.log(JSON.stringify(device));
+  process.exit(0);
+}
+
+const apkPath = process.argv[2] && resolve(process.argv[2]);
+assert(apkPath, 'Usage: node --experimental-strip-types test/e2e/native/run-android-pool-e2e.mjs <debug.apk>');
+const work = realpathSync(mkdtempSync(join(tmpdir(), 'stim-android-pool-e2e-')));
+process.env.STIM_HOME = join(work, 'home');
+process.env.STIM_POOL_ANDROID_PARKED_MAX = '1';
+const manifest = dumpApkManifest(apkPath);
+const packageName = apkPackage(manifest);
+const permission = ['android.permission.ACCESS_COARSE_LOCATION', 'android.permission.CAMERA'].find((name) =>
+  manifest?.includes(name),
+);
+assert(packageName, 'The APK must expose its applicationId');
+const exec = getExecutor();
+const roots = [];
+const owned = new Set();
+const timings = [];
+const out = (line) => process.stderr.write(`${line}\n`);
+out(`Evidence: ${work}`);
+
+async function deviceFor(index) {
+  const projectPath = join(work, `project-${index}`);
+  mkdirSync(projectPath);
+  roots.push(projectPath);
+  upsertProject(projectPath, { androidPackage: packageName });
+  const started = performance.now();
+  out(`Preparing emulator for workspace ${index}`);
+  const device = JSON.parse(
+    exec.runFile(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        fileURLToPath(import.meta.url),
+        '--device-worker',
+        projectPath,
+        `pool-e2e-${process.pid}-${index}`,
+      ],
+      { timeoutMs: 180000 },
+    ),
+  );
+  assert(device.avdName);
+  owned.add(device.avdName);
+  const ready = performance.now();
+  const serial = `emulator-${device.consolePort}`;
+  if (device.adopted) resetAdoptedAvd(device.avdName, serial, packageName);
+  const cleaned = performance.now();
+  const installed = installAndroidApp({ serial, apkPath, packageName });
+  assert(installed.ok, JSON.stringify(installed));
+  const finished = performance.now();
+  timings.push({
+    name: device.avdName,
+    systemImage: device.systemImage,
+    adopted: Boolean(device.adopted),
+    prepareMs: Math.round(ready - started),
+    cleanupMs: Math.round(cleaned - ready),
+    installMs: Math.round(finished - cleaned),
+    totalMs: Math.round(finished - started),
+    skipped: Boolean(installed.skipped),
+  });
+  out(JSON.stringify(timings.at(-1)));
+  return { projectPath, device, serial };
+}
+
+try {
+  const first = await deviceFor(1);
+  assert.equal(first.device.adopted, undefined);
+  exec.runFile('adb', ['-s', first.serial, 'shell', 'run-as', packageName, 'mkdir', '-p', 'files']);
+  exec.runFile('adb', ['-s', first.serial, 'shell', 'run-as', packageName, 'touch', 'files/stim-pool-proof']);
+  exec.runFile('adb', ['-s', first.serial, 'shell', 'run-as', packageName, 'test', '-e', 'files/stim-pool-proof']);
+  if (permission) {
+    exec.runFile('adb', ['-s', first.serial, 'shell', 'pm', 'grant', packageName, permission]);
+    const permissions = exec.runFile('adb', ['-s', first.serial, 'shell', 'dumpsys', 'package', packageName]);
+    assert(permissions.includes(`${permission}: granted=true`));
+  }
+  const removed = await reclaimProject(first.projectPath, { deleteOwnedDevices: true, parkOwnedDevices: true });
+  assert.equal(removed.parkedDevices[0]?.name, first.device.avdName, JSON.stringify(removed));
+  assert.equal(readParked('android').length, 1);
+  const second = await deviceFor(2);
+  assert.equal(second.device.avdName, first.device.avdName);
+  assert.equal(second.device.adopted, true);
+  assert.equal(timings.at(-1).skipped, true);
+  exec.runFile('adb', [
+    '-s',
+    second.serial,
+    'shell',
+    'run-as',
+    packageName,
+    'test',
+    '!',
+    '-e',
+    'files/stim-pool-proof',
+  ]);
+  if (permission) {
+    const permissions = exec.runFile('adb', ['-s', second.serial, 'shell', 'dumpsys', 'package', packageName]);
+    assert(!permissions.includes(`${permission}: granted=true`), 'Adoption must clear the runtime permission grant');
+  }
+  const parkedAgain = await reclaimProject(second.projectPath, { deleteOwnedDevices: true, parkOwnedDevices: true });
+  assert.equal(parkedAgain.parkedDevices[0]?.name, first.device.avdName, JSON.stringify(parkedAgain));
+  const report = collectParkedAvds({});
+  assert.equal(report.length, 1);
+  assert.equal(report[0].listed, true);
+  assert.equal(deleteParkedAvds(report), 0);
+  assert.equal(readParked('android').length, 0);
+  assert(!listAvds().includes(first.device.avdName));
+  writeFileSync(
+    join(work, 'result.json'),
+    JSON.stringify(
+      { packageName, timings, appDataCleared: true, permissionReset: permission ?? null, gcDeleted: true },
+      null,
+      2,
+    ),
+  );
+  out('PASS Android park/adopt, app-data cleanup, retained APK and GC');
+} finally {
+  for (const projectPath of roots) {
+    const result = await reclaimProject(projectPath, { deleteOwnedDevices: true });
+    if (result.failedDevices.length) out(JSON.stringify(result.failedDevices));
+  }
+  for (const parked of readParked('android')) {
+    const result = teardownParkedAvd(parked.name);
+    assert.equal(result.status, 'torn-down', JSON.stringify(result));
+  }
+  const remaining = listAvds().filter((name) => owned.has(name));
+  assert.deepEqual(remaining, [], `Run-owned AVDs remain: ${remaining.join(', ')}`);
+}

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -46,16 +46,25 @@ Metro route required by the remote device. Remote EAS sessions can incur cost.
 - `stim stop` releases the live environment and device leases. It ends an owned
   remote session. On a physical iPhone, stopping the log collector also closes
   the app; it does not shut down the phone or uninstall anything.
-- `stim worktree remove` releases leases, parks the owned iOS simulator for
-  another workspace, and deletes owned Android emulators. The iOS pool keeps up
-  to three simulators by default and deletes the oldest when full. Disabling
-  parking makes removal delete the simulator; see [settings](/docs/settings).
+- `stim worktree remove` releases leases, parks eligible owned iOS simulators and
+  Android emulators for another workspace. Each platform keeps up to three
+  parked devices by default and deletes the oldest when full. Disabling
+  parking makes removal delete the device; see [settings](/docs/settings).
 - `stim gc` reports stale and orphaned resources.
 - `stim gc --delete` removes verified resources from the report, including
-  parked simulators and expired device lease files.
+  parked simulators, emulators, and expired device lease files.
 
 If deletion fails, Stim keeps the ownership record and exits with an error. A
 later cleanup can then retry without losing track of the resource.
 
 Runtime state lives under `$STIM_HOME`, which defaults to `~/.stim`. Each
 workspace stores state and logs in a directory derived from its absolute path.
+
+Android adoption requires the same system image, disk size and AVD creation
+settings. It keeps the AVD name and installed APK, clears the adopting app's
+data, and uninstalls other third-party apps before launch. Installation is
+skipped only when the installed APK matches the requested file by SHA-256.
+App data remains on disk while parked; system apps, shared storage, accounts
+and device settings persist across reuse. Set `pool.androidParkedMax` to `0`
+when a fresh device is required. AVDs created before Stim recorded their
+creation configuration are deleted when removed.

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -93,7 +93,7 @@ Run `stim guide settings` for the complete key and value list.
 ```json
 {
   "concurrency": { "maxBuilds": 2, "maxDevices": 3 },
-  "pool": { "iosParkedMax": 3 },
+  "pool": { "iosParkedMax": 3, "androidParkedMax": 3 },
   "caches": {
     "buildCache": "/Volumes/Cache/stim/build-cache",
     "metroCache": "/Volumes/Cache/stim/metro-cache"
@@ -104,6 +104,8 @@ Run `stim guide settings` for the complete key and value list.
 `pool.iosParkedMax` bounds the simulators `worktree remove` parks for a later
 workspace to adopt. Absent means 3; `0` turns parking and adoption off. When
 `STIM_HOME` is set, parking is off unless `STIM_POOL_IOS_PARKED_MAX` is set too.
+`pool.androidParkedMax` and `STIM_POOL_ANDROID_PARKED_MAX` apply the same rules
+to Android emulators. See [owned devices](/docs/owned-devices) for adoption cleanup.
 
 The committed `.stim.json` `caches` key and this machine-file `caches` key are
 different shapes: the committed key is an array of extra paths for `gc` to
@@ -114,16 +116,17 @@ control build optimizations on this machine without changing project files.
 
 ## Environment variables
 
-| Variable                     | Purpose                                                                                                  |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `STIM_HOME`                  | Runtime state root. Default: `~/.stim`                                                                   |
-| `STIM_BUILD_CACHE`           | Native artifact cache root                                                                               |
-| `STIM_METRO_CACHE`           | Metro transform cache root                                                                               |
-| `STIM_MAX_BUILDS`            | Maximum concurrent native builds                                                                         |
-| `STIM_MAX_DEVICES`           | Maximum booted owned devices                                                                             |
-| `STIM_POOL_IOS_PARKED_MAX`   | Maximum parked simulators                                                                                |
-| `STIM_METRO_PUBLIC_URL`      | Public Metro URL for remote use                                                                          |
-| `STIM_ANDROID_CAS_TOOLCHAIN` | Absolute path to the [Android CAS toolchain manifest](./build-optimizations.md#experimental-android-cas) |
+| Variable                       | Purpose                                                                                                  |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `STIM_HOME`                    | Runtime state root. Default: `~/.stim`                                                                   |
+| `STIM_BUILD_CACHE`             | Native artifact cache root                                                                               |
+| `STIM_METRO_CACHE`             | Metro transform cache root                                                                               |
+| `STIM_MAX_BUILDS`              | Maximum concurrent native builds                                                                         |
+| `STIM_MAX_DEVICES`             | Maximum booted owned devices                                                                             |
+| `STIM_POOL_ANDROID_PARKED_MAX` | Maximum parked Android emulators; 0 disables parking and adoption                                        |
+| `STIM_POOL_IOS_PARKED_MAX`     | Maximum parked simulators                                                                                |
+| `STIM_METRO_PUBLIC_URL`        | Public Metro URL for remote use                                                                          |
+| `STIM_ANDROID_CAS_TOOLCHAIN`   | Absolute path to the [Android CAS toolchain manifest](./build-optimizations.md#experimental-android-cas) |
 
 Proxy remote devices also use `AGENT_DEVICE_DAEMON_BASE_URL` and
 `AGENT_DEVICE_DAEMON_AUTH_TOKEN`. Those variables belong to the optional proxy


### PR DESCRIPTION
## Description

Removing an Android worktree currently deletes its emulator, making the next workspace pay for a fresh boot and app installation. Android now recycles compatible emulators and skips installation when the retained APK matches the requested artifact.

## Solution

Extends the [iOS-only pool](https://github.com/appandflow/stim/commit/9136251258f0bafcc538f8a0645b22418d61390b) to Android: keep up to three parked emulators, match the system image and creation settings, and evict through centralized teardown. Stable AVD names preserve Quick Boot snapshots.

Adoption clears the target app's data and uninstalls other third-party apps before launch. The existing APK SHA-256 check decides whether installation can be skipped; signer or version conflicts trigger uninstall and retry. Adoption stays pending until installation succeeds, and failed deletion retains ownership for GC.

Parked app data remains until adoption; **system apps, shared storage, accounts and device settings persist across reuse**. Set `pool.androidParkedMax` to `0` for fresh devices. Older AVDs without recorded creation settings still get deleted.

## Test plan

- Regression coverage for compatibility matching, concurrent adoption/creation/deletion, cleanup failures, retained-APK verification and GC ownership.
- Real macOS / Android 36 Google Play ARM64 check: app data and a granted location permission were cleared, the same AVD was reused, installation was skipped, and GC deleted it.
- Three local runs: preparation plus cleanup and install/verification fell from 27–31s to 5–9s. The final commit measured 27.0s fresh and 4.9s recycled. Headless Linux was not measured; its existing snapshot-disabled boot is unchanged.
- Reproduce with a debuggable APK:

  ```sh
  node --experimental-strip-types test/e2e/native/run-android-pool-e2e.mjs /absolute/path/app-debug.apk
  ```

Fixes #547.
