### PR TITLE
fix: bundle nested dynamic imports in the bare Metro server

### DIFF
--- a/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
@@ -171,14 +171,35 @@ describe('config adjustments', () => {
     expect(ensureNativePlatform({})).toBe(false);
   });
 
-  test('normalizes a project-local Metro transformer path across worktrees', () => {
+  test('rewrites the metro-runtime asyncRequire path to the specifier Metro resolves from any module (#476)', () => {
     const config = {
       transformer: {
         asyncRequireModulePath: join(root, 'node_modules', 'metro-runtime', 'src', 'modules', 'asyncRequire.js'),
       },
     };
     expect(normalizeMetroTransformerPaths(config, root)).toBe(true);
-    expect(config.transformer.asyncRequireModulePath).toBe('./node_modules/metro-runtime/src/modules/asyncRequire.js');
+    expect(config.transformer.asyncRequireModulePath).toBe('metro-runtime/src/modules/asyncRequire');
+  });
+
+  test('keeps an asyncRequire path that is not the hoisted metro-runtime module', () => {
+    for (const path of [
+      join(
+        root,
+        'node_modules',
+        '.pnpm',
+        'metro-runtime@0.84.5',
+        'node_modules',
+        'metro-runtime',
+        'src',
+        'modules',
+        'asyncRequire.js',
+      ),
+      join(root, 'src', 'asyncRequire.js'),
+    ]) {
+      const config = { transformer: { asyncRequireModulePath: path } };
+      expect(normalizeMetroTransformerPaths(config, root)).toBe(false);
+      expect(config.transformer.asyncRequireModulePath).toBe(path);
+    }
   });
 
   test('keeps a Metro transformer path outside the project root', () => {

--- a/packages/stim-cli/src/supervisor/server-bare.ts
+++ b/packages/stim-cli/src/supervisor/server-bare.ts
@@ -180,12 +180,18 @@ function installSharedCacheStore({
   return true;
 }
 
+// Metro's collectDependencies emits this value verbatim as a dependency of every
+// module with an import(), so a project-relative path only resolves from the project root.
+// Metro's default bare specifier resolves from any directory, but only to the copy
+// hoisted to node_modules.
+const ASYNC_REQUIRE_MODULE = 'metro-runtime/src/modules/asyncRequire';
+
 export function normalizeMetroTransformerPaths(config: BareModule, root: string): boolean {
   const current = config?.transformer?.asyncRequireModulePath;
   if (typeof current !== 'string' || !isAbsolute(current)) return false;
-  const local = relative(root, current);
-  if (local === '' || local === '..' || local.startsWith(`..${sep}`) || isAbsolute(local)) return false;
-  config.transformer.asyncRequireModulePath = `./${local.split(sep).join('/')}`;
+  const local = relative(root, current).split(sep).join('/');
+  if (local !== `node_modules/${ASYNC_REQUIRE_MODULE}.js`) return false;
+  config.transformer.asyncRequireModulePath = ASYNC_REQUIRE_MODULE;
   return true;
 }
 


### PR DESCRIPTION
## Description

`stim start` on a bare React Native project cannot bundle a file below the project root that contains a dynamic `import()`. Metro answers the bundle request with HTTP 500:

```
Unable to resolve module ./node_modules/metro-runtime/src/modules/asyncRequire.js from src/example/handleExample.ts
```

Stim rewrites `transformer.asyncRequireModulePath` to the project-relative `./node_modules/...` string ([bc28b54e](https://github.com/appandflow/stim/commit/bc28b54e18d4b03a01f250ce1dad4ff69198bb33), for a worktree-independent transform key). Metro emits that string verbatim as a dependency of every module with an `import()` ([collectDependencies.js#L276](https://github.com/react/metro/blob/4ac5f345c9964db6110eda9250f1a657d0f11cfd/packages/metro/src/ModuleGraph/worker/collectDependencies.js#L276-L277)) and resolves it relative to the importing file ([resolve.js#L468](https://github.com/react/metro/blob/4ac5f345c9964db6110eda9250f1a657d0f11cfd/packages/metro-resolver/src/resolve.js#L468)), so only a root-level file finds it. Plain `react-native start` keeps the absolute path and is unaffected.

## Solution

Rewrite the path to Metro's own default, the bare specifier `metro-runtime/src/modules/asyncRequire` ([defaults/index.js#L93](https://github.com/react/metro/blob/4ac5f345c9964db6110eda9250f1a657d0f11cfd/packages/metro-config/src/defaults/index.js#L93)): node_modules lookup resolves it from any directory, and the transform key stays root-independent because it hashes the config value ([metro-transform-worker/src/index.js#L778](https://github.com/react/metro/blob/4ac5f345c9964db6110eda9250f1a657d0f11cfd/packages/metro-transform-worker/src/index.js#L778)).

**Scope:** the rewrite only fires for the hoisted `<root>/node_modules/metro-runtime/src/modules/asyncRequire.js`. A pnpm `.pnpm/...` path or a custom module stays absolute: it bundles, but keeps a per-worktree transform key as before bc28b54e.

**Alternative:** resolving the relative form against the project root in a `resolveRequest` wrapper would intercept every resolution, including the project's own resolver, for the same result.

## Test plan

Real Metro runs (invariant 9) on a fresh `@react-native-community/cli init` app (RN 0.87.1, metro 0.87.0, npm) where `src/example/handleExample.ts` does `await import('@features/example/useExampleHook')` through a `resolveRequest` path alias plus a nested relative `import()`; `STIM_HOME` in a scratch directory, CLI built from this branch:

- Unfixed (aefe6ece): `stim start --json`, then `curl "http://localhost:8082/index.bundle?platform=android&dev=true&minify=false"` returns 500 with the error above; `stim logs --errors --json` shows `bundling_error`.
- This branch: the same request returns 200 (4.1 MB) with `metro-runtime/src/modules/asyncRequire`, `src/example/handleExample` and `src/features/example/useExampleHook` in the bundle; `stim logs --errors --json` prints nothing; `stim stop` frees the port.
- Cross-worktree key: Metro's `getTransformCacheKey` on two copies of the app at different paths differs with the absolute path (`e6348d74...` vs `d5cfbe4d...`) and matches with the rewrite (`33783d9e...`).
- Not run: `stim android` on the fixture (no cached build or emulator for it), and a pnpm-installed project.

`pnpm run format:check`, `lint`, `build`, `typecheck`, `knip` and `test:e2e` pass.

**Known failing:** `pnpm test` has two pre-existing `engine-ios-device.test.ts` failures that expect no `stim-devicectl-*` directories in the machine tmpdir; three stale ones from Sep 5 sit there, unrelated to this change.

Fixes #476


