### PR TITLE
test: stub react-native config in the fingerprint fixture

### DIFF
--- a/scripts/agent-benchmark/cache-key.test.mjs
+++ b/scripts/agent-benchmark/cache-key.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -23,9 +23,17 @@ it('hashes native inputs with the pinned CLI dependency despite a conflicting fi
       join(root, 'node_modules/@expo/fingerprint/index.js'),
       'throw new Error("Fixture fingerprint must not be loaded");',
     );
+    // @expo/fingerprint runs `npx react-native config`; without this local bin, npx installs react-native from the registry.
+    mkdirSync(join(root, 'node_modules/.bin'));
+    writeFileSync(
+      join(root, 'node_modules/.bin/react-native'),
+      '#!/bin/sh\n: > "$PWD/react-native-config.ran"\nprintf \'{"root":"%s","dependencies":{}}\' "$PWD"\n',
+      { mode: 0o755 },
+    );
     writeFileSync(join(root, 'android/build.gradle'), 'version = "one"');
     writeFileSync(join(root, 'ios/native.m'), 'one');
     const initial = benchmarkFingerprint(root, stimPackage, 'android');
+    expect(existsSync(join(root, 'react-native-config.ran'))).toBe(true);
     expect(initial).toMatch(/^[a-f0-9]{40}$/);
     writeFileSync(join(root, 'android/local.properties'), 'sdk.dir=/machine-specific-sdk');
     writeFileSync(join(root, 'ios/native.m'), 'two');


### PR DESCRIPTION
## Description

`scripts/agent-benchmark/cache-key.test.mjs` downloads `react-native` from the npm registry on every cold run, which is what pushed it past its 60 s timeout in #491. The pinned `@expo/fingerprint` (0.20.10) collects React Native core autolinking sources for a project without `expo-modules-autolinking` by spawning `npx react-native config` in the project root ([Bare.ts](https://github.com/expo/expo/blob/52fc013ec8c75e89ba8f83c167e4b6b0416e6bf7/packages/@expo/fingerprint/src/sourcer/Bare.ts#L94)). The fixture has no `react-native`, so npx installs it into its cache ([libnpmexec](https://github.com/npm/cli/blob/58c302d73123cd5a841568d17e896d52aacc8755/workspaces/libnpmexec/lib/index.js#L148-L160)), and even a warm cache revalidates the manifest against the registry on every call.

## Solution

Give the fixture an executable `node_modules/.bin/react-native` that prints an empty autolinking config. npx checks the local bin directory before it considers installing anything, so it runs the stub and never contacts the registry, while the pinned fingerprint code still runs end to end, including the guard against loading the fixture's conflicting `@expo/fingerprint` package. The timeout, the fingerprint options, and `cache-key.mjs` are unchanged. The stub also writes a marker file that the test asserts after the first fingerprint, so a silent fallback to the registry fails the test instead of only slowing it down.

`npm_config_yes=false` for this test was the other option; it stops the install, but npx still resolves the manifest from the registry first, so the test would keep making network requests. The stub is a `/bin/sh` script, which covers the ubuntu and macos CI runners and the platforms Stim supports.

## Test plan

`env -u NODE_USE_SYSTEM_CA pnpm exec vitest run scripts/agent-benchmark/cache-key.test.mjs` with an empty npm cache (`npm_config_cache=<empty dir>`, `npm_config_offline` unset):

- `origin/main`: 4 passed in 9.82 s on a fast network. npm logs `warn exec The following package was not found and will be installed: react-native@0.87.1`, fetches `react-native` and its dependency manifests from `registry.npmjs.org`, and the cache gains 163 MB under `_npx`.
- This branch: 4 passed in 0.83 s. The cache ends with no `_npx` directory and no `http fetch` line in the npm logs, and a `ps` poll during the run shows `npm exec react-native config` executing the fixture's `node_modules/.bin/react-native` stub.

**`pnpm test`**: 3701 passed, 1 skipped, 3 failed, none related to this diff: two in `engine-ios-device.test.ts` assert the OS tmpdir has no `stim-devicectl-*` entries and three stale ones exist on this machine, and one `gc.test.ts` timeout under load that passes alone (142/142). `format:check`, `lint`, `build`, `typecheck`, and `knip` pass.

Fixes #491

