### PR TITLE
fix: restart stuck Android apps in launch recovery

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1075,7 +1075,7 @@ describe('unverifiedLaunchLines', () => {
     expect(text).toMatch(/xcrun simctl launch --console U1 com\.x/);
   });
 
-  test('Android names its own re-launch, not simctl', () => {
+  test('Android recovery restarts the reported app before launching it again', () => {
     const text = unverifiedLaunchLines({
       platform: 'android',
       metroPort: 8082,
@@ -1083,7 +1083,9 @@ describe('unverifiedLaunchLines', () => {
       serial: 'emulator-5584',
     }).join('\n');
     expect(text).not.toMatch(/simctl/);
-    expect(text).toMatch(/adb -s emulator-5584 shell monkey -p com\.x 1/);
+    expect(text).toContain(
+      'adb -s emulator-5584 shell am force-stop com.x && adb -s emulator-5584 shell monkey -p com.x 1',
+    );
     expect(text).toMatch(/DEVELOPMENT SERVERS/);
   });
 

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -1245,7 +1245,7 @@ export function unverifiedLaunchLines({
     push(picker);
     if (serial && bundleId) {
       push(
-        `Otherwise the reverse mapping was not in place when the app started. Re-launch: adb -s ${serial} shell monkey -p ${bundleId} 1`,
+        `If the app is stuck, restart its process: adb -s ${serial} shell am force-stop ${bundleId} && adb -s ${serial} shell monkey -p ${bundleId} 1`,
       );
     }
   }

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -79,6 +79,11 @@ new JavaScript or observe the resulting UI. Verify the expected screen or
 interaction on the reported device and inspect \`stim logs --errors\` before
 claiming recovery; exit 0 alone does not prove it.
 
+For an unverified Android launch, follow the emitted device-specific remedy.
+If the app is stuck before loading its first bundle, restart its process with
+the printed force-stop and launcher commands. Foregrounding the same process
+does not restart initialization. Confirm the bundle request and expected UI.
+
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
   gc --delete --cache all empties the shared build caches every project uses


### PR DESCRIPTION
## Description

An Android app that fails its first Metro connection can remain blank. The suggested retry foregrounds the stuck process and does not restart initialization.

## Solution

The recovery command force-stops the reported package before relaunching it. Remove the unsupported assumption that adb reverse caused the failure; automatic launch behavior stays the same.

## Test plan

On an owned API 36 emulator with Expo SDK 57, the old command left the app blank. Restarting the package fetched this workspace's bundle and rendered the app. The remedy test requires both commands to target that same package and serial.

Fixes #558.
