### PR TITLE
fix: keep benchmark endpoint circles visible

### DIFF
--- a/website/src/components/BenchmarkTimeline.module.css
+++ b/website/src/components/BenchmarkTimeline.module.css
@@ -251,9 +251,16 @@
   padding: 0.5rem 0;
 }
 
+.axis,
+.dotTrack,
+.shellTracks,
+.backgroundTracks {
+  margin-inline: 1rem;
+}
+
 .backgroundTrack {
   position: relative;
-  min-width: 44rem;
+  min-width: 0;
 }
 
 .backgroundBar {
@@ -389,7 +396,7 @@
 
 .shellTrack {
   position: relative;
-  min-width: 44rem;
+  min-width: 0;
 }
 
 .commandBar {


### PR DESCRIPTION
## Description

The time-zero circle sits half behind the sticky Agent label. The same overlap affects event markers.

## Solution

Inset the axis and all tracks equally, leaving room for endpoint circles and their halos without moving timestamps relative to commands. Shell and background rows shrink with the inset instead of overflowing their time scale. This is CSS-only; benchmark data and timing are unchanged.

## Test plan

Compared old and new styles in 390px browser frames at 1x and 2x zoom, scrolled to both ends. The first circles are fully visible after the fix, with commands and axis positions aligned; the final markers and halos also fit.

![Before and after at time zero, 2x zoom](https://github.com/user-attachments/assets/8f47d553-cb34-4565-8728-02c517f32e71)

Fixes #560
