### PR TITLE
fix: shorten launch stack previews

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2725,7 +2725,11 @@ describe('launch verification', () => {
         waitedMs: 2500,
         errors: [
           { src: 'device', proc: 'ReactNativeJS(1234)', msg: 'a native framework error' },
-          { src: 'client', msg: 'a redbox from the app' },
+          {
+            src: 'client',
+            msg: 'a redbox from the app',
+            stack: Array.from({ length: 7 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
+          },
         ],
       }),
     });
@@ -2735,6 +2739,11 @@ describe('launch verification', () => {
       /^  launch {6}1 error-level record in the device log during launch \(logs --errors --source device\)$/m,
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
+    expect(text).toContain('Error stack:');
+    expect(text).toContain('at frame4 (app.tsx:5)');
+    expect(text).not.toContain('at frame5');
+    expect(text).toContain('... 2 more frames');
+    expect(text).toContain('stim logs --source all');
     expect(text).not.toMatch(/a native framework error/);
     expect(text).toContain('stim reload android');
     expect(text).toMatch(/Do not run `stim android` unless native inputs changed or the app process exits/);

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -208,6 +208,29 @@ test('launch previews preserve structured error and component stacks separately 
   expect(JSON.stringify(records)).toBe(original);
 });
 
+test('launch previews bound JSON-serialized object fields from the Metro client reporter', () => {
+  const stack = Array.from(
+    { length: 8 },
+    (_, i) => `    at error${i} (http://localhost:8082/index.bundle?platform=android:${i + 1}:2)`,
+  ).join('\n');
+  const componentStack = Array.from(
+    { length: 8 },
+    (_, i) => `    at component${i} (http://localhost:8082/index.bundle?platform=android:${i + 1}:3)`,
+  ).join('\n');
+  const record = { src: 'client', msg: JSON.stringify({ message: 'render failed', stack, componentStack }) };
+  const original = JSON.stringify(record);
+  const lines = launchErrorReport([record]).lines;
+  expect(lines).toContain('Error stack:');
+  expect(lines).toContain('  at error4 (index.bundle:5:2 [unsymbolicated])');
+  expect(lines).toContain('  ... 3 more frames');
+  expect(lines).toContain('Component stack:');
+  expect(lines).toContain('  at component2 (index.bundle:3:3 [unsymbolicated])');
+  expect(lines).toContain('  ... 5 more frames');
+  expect(lines.join('\n')).toContain('render failed');
+  expect(lines.join('\n')).not.toMatch(/error5|component3|platform=android|\\n/);
+  expect(JSON.stringify(record)).toBe(original);
+});
+
 test('launch previews do not interpret escaped newlines in ordinary error messages or discard malformed stack text', () => {
   const msg = 'Error: expected literal \\n in input';
   const malformed = "componentStack: 'unterminated text";

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -140,3 +140,117 @@ test('no device record means no count line at all', () => {
   expect(quiet.summary).toBe(null);
   expect(quiet.lines).toEqual(['x']);
 });
+
+test('launch previews cap a JavaScript stack split across Android log records without hiding the next error', () => {
+  const messages = [
+    'Error: first failure',
+    ...Array.from({ length: 9 }, (_, i) => `    at frame${i} (app.ts:${i + 1}:2)`),
+    'Error: second failure',
+    '    at retry (retry.ts:4:2)',
+  ];
+  const records = messages.map((msg) => ({ src: 'device', platform: 'android', proc: 'ReactNativeJS(123)', msg }));
+  const report = launchErrorReport(records);
+  expect(report.lines).toEqual([
+    'Error: first failure',
+    'Error stack:',
+    ...messages.slice(1, 6).map((line) => `  ${line.trim()}`),
+    '  ... 4 more frames',
+    'Error: second failure',
+    'Error stack:',
+    '  at retry (retry.ts:4:2)',
+    'Full captured stacks: stim logs --source all (add --json for raw records)',
+  ]);
+  expect(report.summary).toContain('12 error-level records');
+  expect(records.map((record) => record.msg)).toEqual(messages);
+});
+
+test('launch previews unescape and bound serialized React component stacks while labeling bundle coordinates honestly', () => {
+  const frames = Array.from(
+    { length: 7 },
+    (_, i) =>
+      `    at Component${i} (http://localhost:8082/index.bundle//&platform=ios&dev=true&transform.engine=hermes:${100 + i}:20)`,
+  );
+  const msg = `{ [Error: startup failed]\n  componentStack: '${frames.join('\\n')}',\n  isComponentError: true }`;
+  const report = launchErrorReport([{ src: 'client', msg }]);
+  expect(report.lines).toEqual([
+    '{ [Error: startup failed]',
+    'Component stack:',
+    '  at Component0 (index.bundle:100:20 [unsymbolicated])',
+    '  at Component1 (index.bundle:101:20 [unsymbolicated])',
+    '  at Component2 (index.bundle:102:20 [unsymbolicated])',
+    '  ... 4 more frames',
+    '  isComponentError: true }',
+    'Full captured stacks: stim logs --source all (add --json for raw records)',
+  ]);
+});
+
+test('launch previews preserve structured error and component stacks separately without mutating raw evidence', () => {
+  const records = [
+    {
+      src: 'client',
+      msg: 'Error: render failed',
+      stack: Array.from({ length: 8 }, (_, i) => ({ file: 'app.tsx', line: i + 1, column: 3, fn: `fn${i}` })),
+      componentStack: '\n    at Screen (screen.tsx:10:3)\n    at Root (root.tsx:4:2)',
+    },
+  ];
+  const original = JSON.stringify(records);
+  const lines = launchErrorReport(records).lines;
+  expect(lines).toContain('  at fn0 (app.tsx:1:3)');
+  expect(lines).toContain('  at fn4 (app.tsx:5:3)');
+  expect(lines).not.toContain('  at fn5 (app.tsx:6:3)');
+  expect(lines).toContain('  ... 3 more frames');
+  expect(lines.slice(-4)).toEqual([
+    'Component stack:',
+    '  at Screen (screen.tsx:10:3)',
+    '  at Root (root.tsx:4:2)',
+    'Full captured stacks: stim logs --source all (add --json for raw records)',
+  ]);
+  expect(JSON.stringify(records)).toBe(original);
+});
+
+test('launch previews do not interpret escaped newlines in ordinary error messages or discard malformed stack text', () => {
+  const msg = 'Error: expected literal \\n in input';
+  const malformed = "componentStack: 'unterminated text";
+  expect(
+    launchErrorReport([
+      { src: 'metro', msg },
+      { src: 'metro', msg: malformed },
+    ]).lines,
+  ).toEqual([msg, malformed]);
+});
+
+test('launch previews still bound a component stack whose serialized log record was truncated', () => {
+  const frames = Array.from(
+    { length: 12 },
+    (_, i) => `    at Component${i} (http://localhost:8082/index.bundle?platform=android&dev=true:${100 + i}:20)`,
+  );
+  const msg = `componentStack: '\\n${frames.join('\\n')}\\n    at Last (http://localhost:8082/index.bundle?plat`;
+  const lines = launchErrorReport([{ src: 'client', msg }]).lines;
+  expect(lines).toEqual([
+    'Component stack:',
+    '  at Component0 (index.bundle:100:20 [unsymbolicated])',
+    '  at Component1 (index.bundle:101:20 [unsymbolicated])',
+    '  at Component2 (index.bundle:102:20 [unsymbolicated])',
+    '  ... 10 more frames',
+    '[captured stack text is incomplete]',
+    'Full captured stacks: stim logs --source all (add --json for raw records)',
+  ]);
+});
+
+test('launch previews retain Expo and Hermes frame order and reset depth between sources', () => {
+  const records = [
+    { src: 'metro', msg: 'Error: failed\nCode: app.tsx\n> 4 | throw error\nCall Stack\n  Screen (app.tsx:4:3)' },
+    { src: 'client', msg: 'render@app.tsx:4:3\nparent@root.tsx:5:4' },
+  ];
+  expect(launchErrorReport(records).lines).toEqual([
+    'Error: failed',
+    'Code: app.tsx',
+    '> 4 | throw error',
+    'Error stack:',
+    '  Screen (app.tsx:4:3)',
+    'Error stack:',
+    '  render@app.tsx:4:3',
+    '  parent@root.tsx:5:4',
+    'Full captured stacks: stim logs --source all (add --json for raw records)',
+  ]);
+});

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -901,7 +901,11 @@ describe('launch verification', () => {
           errors: [
             { src: 'device', proc: 'Fixture', msg: 'Failed to send CA Event for app launch measurements' },
             { src: 'device', proc: 'Fixture', msg: 'NSBundle (null) initWithPath failed' },
-            { src: 'client', msg: 'a redbox from the app' },
+            {
+              src: 'client',
+              msg: 'a redbox from the app',
+              stack: Array.from({ length: 7 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
+            },
           ],
         }),
       },
@@ -911,6 +915,11 @@ describe('launch verification', () => {
       /^  launch {6}2 error-level records in the device log during launch \(logs --errors --source device\)$/m,
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
+    expect(text).toContain('Error stack:');
+    expect(text).toContain('at frame4 (app.tsx:5)');
+    expect(text).not.toContain('at frame5');
+    expect(text).toContain('... 2 more frames');
+    expect(text).toContain('stim logs --source all');
     expect(text).not.toMatch(/Failed to send CA Event/);
     expect(text).not.toMatch(/NSBundle/);
   });

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -1,3 +1,5 @@
+import { launchErrorPreview } from './launch-error-preview.ts';
+
 const LABEL_WIDTH = 11;
 
 export function formatDuration(ms: unknown): string {
@@ -127,7 +129,6 @@ export function isOutputLabel(label: unknown): boolean {
   return OUTPUT_LABELS.includes(String(label));
 }
 
-/** The two fields a launch report reads off a collector's NDJSON record. */
 export interface LaunchErrorRecord {
   src?: unknown;
   msg?: unknown;
@@ -149,10 +150,7 @@ export function isAppLaunchError(record: LaunchErrorRecord): boolean {
  */
 export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summary: string | null; lines: string[] } {
   const fromDevice = records.filter((record) => record.src === 'device');
-  const lines = records
-    .filter(isAppLaunchError)
-    .map((record) => (record.msg === undefined || record.msg === null ? '' : String(record.msg)))
-    .filter((msg) => msg !== '');
+  const lines = launchErrorPreview(records.filter(isAppLaunchError));
   const summary =
     fromDevice.length === 0
       ? null

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -22,6 +22,7 @@ import {
   installConflictKind,
 } from '../../engine/app-install.ts';
 import { appReadinessMessage, formatDuration, launchErrorReport, phaseLine, stepTimer } from '../../command-output.ts';
+import { launchErrorPreview } from '../../launch-error-preview.ts';
 import { MODE_BARE, MODE_EXPO, writeWorkspaceLaunch, writeWorkspaceState } from '../../supervisor/state.ts';
 import type {
   VerifyLaunchResultLike,
@@ -149,9 +150,7 @@ async function verifyAndroidRun({
           ? 'Metro bundle delivery failed'
           : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
-    for (const record of verification.errors ?? []) {
-      if (record.msg) phase('', chalk.red(String(record.msg)));
-    }
+    for (const line of launchErrorPreview(verification.errors ?? [])) phase('', chalk.red(line));
     if (verification.processAlive === false) {
       phase(
         'remedy',

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -23,6 +23,7 @@ import {
   stepTimer,
 } from '../../command-output.ts';
 import { localNetworkPending, DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../../engine/ios-device.ts';
+import { launchErrorPreview } from '../../launch-error-preview.ts';
 import { MODE_BARE, MODE_EXPO } from '../../supervisor/state.ts';
 import type {
   VerifyLaunchResultLike,
@@ -155,9 +156,7 @@ async function verifyIosRun({
           ? 'Metro bundle delivery failed'
           : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
-    for (const record of verification.errors ?? []) {
-      if (record.msg) note(chalk.red(phaseLine('', String(record.msg))));
-    }
+    for (const line of launchErrorPreview(verification.errors ?? [])) note(chalk.red(phaseLine('', line)));
     if (verification.processAlive === false) {
       note(
         chalk.yellow(

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -138,6 +138,22 @@ WHAT WRITES WHAT
                        readiness wait even without a client or Metro copy.
                        Client and Metro errors still print individually.
 
+                       Human ios/android output previews up to five frames per
+                       error stack and three per React component stack, in
+                       captured order, with an omitted-frame count. Escaped
+                       component stacks print one frame per line. Long bundle
+                       URLs are shortened and labeled unsymbolicated; shortening
+                       is not source-map resolution. Read full captured detail
+                       with \`stim logs --source all\`, or add \`--json\` for raw
+                       records. This preview does not alter logs or JSON.
+
+                       Symbolication is best effort: Expo's printed code frame
+                       and Call Stack are retained by the human logs query; bare
+                       Metro symbolication responses are separate context. The
+                       launch preview does not request symbolication or invent
+                       a missing error stack from a component stack. Device logs
+                       may be truncated by the platform before Stim sees them.
+
                        The connection refusal \`TCP Conn ... Failed :
                        error 0:61 [61]\` (61 is ECONNREFUSED) is not even
                        counted. The app got its bundle over this workspace's

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -9,16 +9,16 @@ function decodeStack(value: string): string {
 
 function expandStackFields(message: string): string {
   const expanded = message.replace(
-    /\b(componentStack|stack):\s*(['"])((?:\\.|(?!\2)[^\\])*)\2,?/g,
-    (_match, field: string, _quote: string, value: string) => {
-      return `${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n`;
+    /(?<!\w)(['"]?)(componentStack|stack)\1:\s*(['"])((?:\\.|(?!\3)[^\\])*)\3,?/g,
+    (_match, _keyQuote: string, field: string, _quote: string, value: string) => {
+      return `\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n`;
     },
   );
   return expanded.replace(
-    /(^|\n)[ \t]*(componentStack|stack):[ \t]*(['"])((?:\\.|[^\\\n])*)$/g,
-    (match, prefix: string, field: string, _quote: string, value: string) => {
+    /(^|\n|[,{])[ \t]*(['"]?)(componentStack|stack)\2:[ \t]*(['"])((?:\\.|[^\\\n])*)$/g,
+    (match, prefix: string, _keyQuote: string, field: string, _quote: string, value: string) => {
       if (!/\\n\s+at\s/.test(value)) return match;
-      return `${prefix}${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete]`;
+      return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete]`;
     },
   );
 }

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -1,0 +1,105 @@
+type RecordLike = { msg?: unknown; stack?: unknown; componentStack?: unknown; [key: string]: unknown };
+type StackKind = 'Error' | 'Component';
+
+function decodeStack(value: string): string {
+  return value.replace(/\\([nrt\\'"])/g, (_escape, char: string) => {
+    return ({ n: '\n', r: '\r', t: '\t' } as Record<string, string>)[char] ?? char;
+  });
+}
+
+function expandStackFields(message: string): string {
+  const expanded = message.replace(
+    /\b(componentStack|stack):\s*(['"])((?:\\.|(?!\2)[^\\])*)\2,?/g,
+    (_match, field: string, _quote: string, value: string) => {
+      return `${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n`;
+    },
+  );
+  return expanded.replace(
+    /(^|\n)[ \t]*(componentStack|stack):[ \t]*(['"])((?:\\.|[^\\\n])*)$/g,
+    (match, prefix: string, field: string, _quote: string, value: string) => {
+      if (!/\\n\s+at\s/.test(value)) return match;
+      return `${prefix}${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete]`;
+    },
+  );
+}
+
+function shortFrame(frame: string): string {
+  return frame.trim().replace(/https?:\/\/[^\s)]+/g, (location) => {
+    const match = /^(.*\.bundle)(?:[^\s]*?)(:\d+:\d+)$/.exec(location);
+    if (!match) return location;
+    return `${match[1]!.split('/').at(-1)}${match[2]} [unsymbolicated]`;
+  });
+}
+
+function structuredFrames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((frame: unknown) => {
+    if (frame === null || typeof frame !== 'object') return [];
+    const { file, line, column, fn } = frame as Record<string, unknown>;
+    const location = [typeof file === 'string' ? file : null, line, column]
+      .filter((part) => typeof part === 'string' || (typeof part === 'number' && Number.isFinite(part)))
+      .join(':');
+    const name = typeof fn === 'string' ? fn : '';
+    return name && location ? [`at ${name} (${location})`] : name || location ? [`at ${name || location}`] : [];
+  });
+}
+
+/** Formats a bounded human launch preview without changing captured records. */
+export function launchErrorPreview(records: readonly RecordLike[]): string[] {
+  const lines: string[] = [];
+  let kind: StackKind = 'Error';
+  let frames: string[] = [];
+  let hadStack = false;
+  let source = '';
+  const flush = () => {
+    if (frames.length) {
+      hadStack = true;
+      const limit = kind === 'Component' ? 3 : 5;
+      lines.push(`${kind} stack:`, ...frames.slice(0, limit).map((frame) => `  ${shortFrame(frame)}`));
+      if (frames.length > limit) lines.push(`  ... ${frames.length - limit} more frames`);
+    }
+    frames = [];
+    kind = 'Error';
+  };
+  const consume = (line: string) => {
+    const header = /^\s*(Component stack|Error stack|Call Stack):?\s*$/i.exec(line);
+    if (header) {
+      flush();
+      kind = /^component/i.test(header[1]!) ? 'Component' : 'Error';
+    } else if (
+      /^\s*at\s+\S/.test(line) ||
+      /^\s*\S[^\n]*@\S+:\d+:\d+\s*$/.test(line) ||
+      /^\s+\S[^\n]*\([^()]+:\d+:\d+\)\s*$/.test(line)
+    ) {
+      frames.push(line);
+    } else if (line.trim()) {
+      flush();
+      lines.push(line);
+    }
+  };
+  for (const record of records) {
+    const nextSource = JSON.stringify([record.src, record.platform, record.proc]);
+    if (source !== nextSource) flush();
+    source = nextSource;
+    if (record.msg != null) {
+      for (const line of expandStackFields(String(record.msg)).split(/\r?\n/)) consume(line);
+    }
+    const stack = typeof record.stack === 'string' ? record.stack.split(/\r?\n/) : structuredFrames(record.stack);
+    if (stack.length) {
+      flush();
+      for (const line of stack) consume(line);
+    }
+    const components =
+      typeof record.componentStack === 'string'
+        ? record.componentStack.split(/\r?\n/)
+        : structuredFrames(record.componentStack);
+    if (components.length) {
+      flush();
+      kind = 'Component';
+      for (const line of components) consume(line);
+    }
+  }
+  flush();
+  if (hadStack) lines.push('Full captured stacks: stim logs --source all (add --json for raw records)');
+  return lines;
+}

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -31,6 +31,20 @@ available. These checks do not prove that a screen rendered correctly.
 A nonfatal error still appears as launch evidence. The agent can read the error
 and decide whether the change caused it.
 
+The human launch summary shows up to **5 error-stack frames** and **3 React
+component-stack frames**, in captured order, followed by the omitted-frame count.
+Error stacks describe the call path; component stacks describe the React parent
+tree. They are labeled separately. Full captured detail remains available through
+`stim logs --source all`; add `--json` for raw records.
+
+Symbolication is best effort. In development, `stim logs --errors` retains Expo's
+printed source excerpt and Call Stack; bare React Native's Metro symbolication
+responses appear as separate context, not as an inferred match to an error.
+Launch previews do not request source maps themselves. Shortened bundle locations
+are explicitly labeled **unsymbolicated**, and a component stack is never used
+to invent a missing error stack. OS logging can truncate text before Stim captures
+it; “full” means the records actually captured, not a recovered original stack.
+
 ### Optional app-declared readiness
 
 No package or monitoring SDK is required. In a debug app, emit this once at


### PR DESCRIPTION
## Description

Platform launch summaries can be dominated by escaped React component stacks and bundle URLs. Truncated serialized component stacks also need readable previews.

## Solution

Show separate previews of up to five error frames and three component frames, preserving captured order and reporting omissions. Shortened bundle coordinates remain explicitly unsymbolicated. Handle split log records and incomplete component-stack text without changing raw logs, JSON, error counts, or launch decisions. The same formatter covers verified and fatal iOS/Android output.

No active symbolication is added. In this benchmark, Expo's later symbolicated error frame and source excerpt remain available through `stim logs --errors`.

## Test plan

Replayed the captured Luna Android launch text through the formatter: the giant serialized component tree becomes three lines, an omission count, and an incomplete-capture notice. Platform-command regressions verify the shared depth cap; parser cases cover split records, structured stacks, separate sources/errors, malformed fields, and preservation of raw evidence.

```text
Component stack:
  at RootLayout(./_layout.tsx) (index.bundle:322489:20 [unsymbolicated])
  at WrappedScreenComponent (index.bundle:112238:48 [unsymbolicated])
  at Suspense (<anonymous>)
  ... 15 more frames
[captured stack text is incomplete]
Full captured stacks: stim logs --source all (add --json for raw records)
```

Fixes #562
