### PR TITLE
fix: symbolicate launch errors and capture native crashes

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2459,8 +2459,8 @@ describe('Contract 1: the launch marker', () => {
     expect(marker).toBeTruthy();
     assert(marker);
     expect(marker.src).toBe('build');
-    expect(marker.event).toBe('app_launched');
-    expect(marker.msg).toMatch(/com\.example\.app on emulator-5584 against Metro port 8082/);
+    expect(marker.event).toBe('launch_attempt');
+    expect(marker.msg).toMatch(/launching com\.example\.app on emulator-5584/);
   });
 });
 
@@ -2728,7 +2728,7 @@ describe('launch verification', () => {
           {
             src: 'client',
             msg: 'a redbox from the app',
-            stack: Array.from({ length: 7 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
+            stack: Array.from({ length: 12 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
           },
         ],
       }),
@@ -2740,8 +2740,8 @@ describe('launch verification', () => {
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
     expect(text).toContain('Error stack:');
-    expect(text).toContain('at frame4 (app.tsx:5)');
-    expect(text).not.toContain('at frame5');
+    expect(text).toContain('at frame9 (app.tsx:10)');
+    expect(text).not.toContain('at frame10');
     expect(text).toContain('... 2 more frames');
     expect(text).toContain('stim logs --source all');
     expect(text).not.toMatch(/a native framework error/);
@@ -2759,7 +2759,8 @@ describe('launch verification', () => {
     });
     const result = await h.run();
     expect(result.ok).toBe(false);
-    expect(h.stderr.join('\n')).toMatch(/run `stim android` again.*Metro reload cannot restart an exited app/);
+    expect(h.stderr.join('\n')).toContain("adb -s 'emulator-5584' shell am force-stop 'com.example.app'");
+    expect(h.stderr.join('\n')).toMatch(/run `stim android` again.*Metro reload cannot recover/);
   });
 
   test.each([

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2735,10 +2735,13 @@ describe('launch verification', () => {
         ],
       }),
     });
-    await h.run();
+    const result = await h.run();
+    expect(result.facts?.launched).toBe(true);
+    expect(h.stdout[0]).toMatch(/^WARNING: .*app errors detected/);
+    expect(h.stdout.join('\n')).not.toContain('OK:');
     const text = h.stderr.join('\n');
     expect(text).toMatch(
-      /^  launch {6}1 error-level record in the device log during launch \(logs --errors --source device\)$/m,
+      /^  launch {6}1 general device error-level record \(not confirmed app errors\); inspect with stim logs --errors --source device$/m,
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
     expect(text).toContain('Error stack:');

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1,4 +1,6 @@
 import { hashFile } from '../engine/installed-artifact.ts';
+import { vi } from 'vitest';
+import * as crashDiagnostics from '../native-crash.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
@@ -3291,7 +3293,7 @@ describe('release skips Metro entirely', () => {
     const result = await h.run();
     expect(result.ok).toBe(false);
     expect(result.error?.code).toBe('STIM_LAUNCH_FAILED');
-    expect(h.stderr.join('\n')).toMatch(/UNVERIFIED: no com\.example\.app process/);
+    expect(h.stderr.join('\n')).toMatch(/FATAL: no com\.example\.app process/);
     expect(h.stderr.join('\n')).toMatch(/stim logs --errors/);
   });
 
@@ -3305,6 +3307,29 @@ describe('release skips Metro entirely', () => {
     expect(result.facts?.launched).toBe('unverified');
     expect(h.stderr.join('\n')).toMatch(/UNVERIFIED: the app process check failed/);
     expect(h.stderr.join('\n')).not.toMatch(/no com\.example\.app process/);
+  });
+
+  test('a release native crash overrides a still-live PID behind Android crash UI', async () => {
+    const read = vi.spyOn(crashDiagnostics, 'captureNativeCrashes').mockReturnValue([
+      {
+        src: 'device',
+        level: 'fatal',
+        event: 'native_crash',
+        msg: 'Native crash: java.lang.IllegalStateException: release failed',
+      },
+    ]);
+    try {
+      const h = harness({
+        variant: 'productionRelease',
+        verifyReleaseLaunched: async () => ({ verified: true, waitedMs: 3000, pid: 44 }),
+      });
+      const result = await h.run();
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe('STIM_LAUNCH_FAILED');
+      expect(h.stderr.join('\n')).toContain('FATAL: the app reported a native crash');
+    } finally {
+      read.mockRestore();
+    }
   });
 
   test('the android.variant setting is the repo default, and the flag overrides it back to debug', async () => {
@@ -4361,6 +4386,11 @@ describe('--device refusals found in review', () => {
     const state = JSON.stringify(readState());
     expect(state).not.toContain('RFCR7081Q9L');
     expect(loadConfig()?.projects?.[root]?.platforms?.android).toBeUndefined();
+    const records = parseNdjsonText(readFileSync(join(workspaceLogsDir(root), 'build-android.ndjson'), 'utf8'));
+    expect(records.find((record) => record.event === 'launch_attempt')).toMatchObject({
+      physical: true,
+      deviceId: 'RFCR7081Q9L',
+    });
   });
 });
 

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -108,7 +108,9 @@ test("a verified launch counts the device log and still prints the app's own err
     { src: 'metro', msg: 'a bundler error' },
   ];
   const report = launchErrorReport(records);
-  expect(report.summary).toBe('3 error-level records in the device log during launch (logs --errors --source device)');
+  expect(report.summary).toBe(
+    '3 general device error-level records (not confirmed app errors); inspect with stim logs --errors --source device',
+  );
   expect(report.lines).toEqual(['a redbox', 'a bundler error']);
 });
 
@@ -116,7 +118,9 @@ test('the count never depends on the process a record names', () => {
   const named = launchErrorReport([{ src: 'device', proc: 'Trailhead', msg: 'x' }]);
   const unnamed = launchErrorReport([{ src: 'device', msg: 'x' }]);
   expect(named.summary).toBe(unnamed.summary);
-  expect(named.summary).toBe('1 error-level record in the device log during launch (logs --errors --source device)');
+  expect(named.summary).toBe(
+    '1 general device error-level record (not confirmed app errors); inspect with stim logs --errors --source device',
+  );
   expect(named.lines).toEqual([]);
 });
 
@@ -158,9 +162,11 @@ test('launch previews cap a JavaScript stack split across Android log records wi
     'Error: second failure',
     'Error stack:',
     '  at retry (retry.ts:4:2)',
-    'Full captured stacks: stim logs --source all (add --json for raw records)',
+    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    'Full captured logs: stim logs --source all (without --errors)',
+    'Raw records: stim logs --source all --json',
   ]);
-  expect(report.summary).toContain('17 error-level records');
+  expect(report.summary).toBeNull();
   expect(records.map((record) => record.msg)).toEqual(messages);
 });
 
@@ -177,7 +183,9 @@ test('launch previews unescape and bound serialized React component stacks while
     'Component stack:',
     ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
     '  ... 4 more frames',
-    'Full captured stacks: stim logs --source all (add --json for raw records)',
+    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    'Full captured logs: stim logs --source all (without --errors)',
+    'Raw records: stim logs --source all --json',
   ]);
 });
 
@@ -196,11 +204,13 @@ test('launch previews preserve structured error and component stacks separately 
   expect(lines).toContain('  at fn9 (app.tsx:10:3)');
   expect(lines).not.toContain('  at fn10 (app.tsx:11:3)');
   expect(lines).toContain('  ... 3 more frames');
-  expect(lines.slice(-4)).toEqual([
+  expect(lines.slice(-6)).toEqual([
     'Component stack:',
     '  at Screen (screen.tsx:10:3)',
     '  at Root (root.tsx:4:2)',
-    'Full captured stacks: stim logs --source all (add --json for raw records)',
+    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    'Full captured logs: stim logs --source all (without --errors)',
+    'Raw records: stim logs --source all --json',
   ]);
   expect(JSON.stringify(records)).toBe(original);
 });
@@ -250,8 +260,10 @@ test('launch previews still bound a component stack whose serialized log record 
     'Component stack:',
     ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
     '  ... 3 more frames',
-    '[captured stack text is incomplete]',
-    'Full captured stacks: stim logs --source all (add --json for raw records)',
+    '[captured stack text is incomplete: the runtime truncated it; saved logs cannot restore missing text]',
+    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    'Full captured logs: stim logs --source all (without --errors)',
+    'Raw records: stim logs --source all --json',
   ]);
 });
 
@@ -269,6 +281,8 @@ test('launch previews retain Expo and Hermes frame order and reset depth between
     'Error stack:',
     '  render@app.tsx:4:3',
     '  parent@root.tsx:5:4',
-    'Full captured stacks: stim logs --source all (add --json for raw records)',
+    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    'Full captured logs: stim logs --source all (without --errors)',
+    'Raw records: stim logs --source all --json',
   ]);
 });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -162,9 +162,7 @@ test('launch previews cap a JavaScript stack split across Android log records wi
     'Error: second failure',
     'Error stack:',
     '  at retry (retry.ts:4:2)',
-    'Stack preview: up to 10 frames per stack; app frames preferred.',
     'Full captured logs: stim logs --source all',
-    'Raw records: stim logs --source all --json',
   ]);
   expect(report.summary).toBeNull();
   expect(records.map((record) => record.msg)).toEqual(messages);
@@ -183,9 +181,7 @@ test('launch previews unescape and bound serialized React component stacks while
     'Component stack:',
     ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
     '  ... 4 more frames',
-    'Stack preview: up to 10 frames per stack; app frames preferred.',
     'Full captured logs: stim logs --source all',
-    'Raw records: stim logs --source all --json',
   ]);
 });
 
@@ -204,13 +200,11 @@ test('launch previews preserve structured error and component stacks separately 
   expect(lines).toContain('  at fn9 (app.tsx:10:3)');
   expect(lines).not.toContain('  at fn10 (app.tsx:11:3)');
   expect(lines).toContain('  ... 3 more frames');
-  expect(lines.slice(-6)).toEqual([
+  expect(lines.slice(-4)).toEqual([
     'Component stack:',
     '  at Screen (screen.tsx:10:3)',
     '  at Root (root.tsx:4:2)',
-    'Stack preview: up to 10 frames per stack; app frames preferred.',
     'Full captured logs: stim logs --source all',
-    'Raw records: stim logs --source all --json',
   ]);
   expect(JSON.stringify(records)).toBe(original);
 });
@@ -259,11 +253,8 @@ test('launch previews still bound a component stack whose serialized log record 
   expect(lines).toEqual([
     'Component stack:',
     ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
-    '  ... 3 more frames',
-    '[captured stack text is incomplete: the runtime truncated it; saved logs cannot restore missing text]',
-    'Stack preview: up to 10 frames per stack; app frames preferred.',
+    '  ... 2 more frames',
     'Full captured logs: stim logs --source all',
-    'Raw records: stim logs --source all --json',
   ]);
 });
 
@@ -281,8 +272,6 @@ test('launch previews retain Expo and Hermes frame order and reset depth between
     'Error stack:',
     '  render@app.tsx:4:3',
     '  parent@root.tsx:5:4',
-    'Stack preview: up to 10 frames per stack; app frames preferred.',
     'Full captured logs: stim logs --source all',
-    'Raw records: stim logs --source all --json',
   ]);
 });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -163,7 +163,7 @@ test('launch previews cap a JavaScript stack split across Android log records wi
     'Error stack:',
     '  at retry (retry.ts:4:2)',
     'Stack preview: up to 10 frames per stack; app frames preferred.',
-    'Full captured logs: stim logs --source all (without --errors)',
+    'Full captured logs: stim logs --source all',
     'Raw records: stim logs --source all --json',
   ]);
   expect(report.summary).toBeNull();
@@ -184,7 +184,7 @@ test('launch previews unescape and bound serialized React component stacks while
     ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
     '  ... 4 more frames',
     'Stack preview: up to 10 frames per stack; app frames preferred.',
-    'Full captured logs: stim logs --source all (without --errors)',
+    'Full captured logs: stim logs --source all',
     'Raw records: stim logs --source all --json',
   ]);
 });
@@ -209,7 +209,7 @@ test('launch previews preserve structured error and component stacks separately 
     '  at Screen (screen.tsx:10:3)',
     '  at Root (root.tsx:4:2)',
     'Stack preview: up to 10 frames per stack; app frames preferred.',
-    'Full captured logs: stim logs --source all (without --errors)',
+    'Full captured logs: stim logs --source all',
     'Raw records: stim logs --source all --json',
   ]);
   expect(JSON.stringify(records)).toBe(original);
@@ -262,7 +262,7 @@ test('launch previews still bound a component stack whose serialized log record 
     '  ... 3 more frames',
     '[captured stack text is incomplete: the runtime truncated it; saved logs cannot restore missing text]',
     'Stack preview: up to 10 frames per stack; app frames preferred.',
-    'Full captured logs: stim logs --source all (without --errors)',
+    'Full captured logs: stim logs --source all',
     'Raw records: stim logs --source all --json',
   ]);
 });
@@ -282,7 +282,7 @@ test('launch previews retain Expo and Hermes frame order and reset depth between
     '  render@app.tsx:4:3',
     '  parent@root.tsx:5:4',
     'Stack preview: up to 10 frames per stack; app frames preferred.',
-    'Full captured logs: stim logs --source all (without --errors)',
+    'Full captured logs: stim logs --source all',
     'Raw records: stim logs --source all --json',
   ]);
 });

--- a/packages/stim-cli/src/__tests__/command-output.test.ts
+++ b/packages/stim-cli/src/__tests__/command-output.test.ts
@@ -144,7 +144,7 @@ test('no device record means no count line at all', () => {
 test('launch previews cap a JavaScript stack split across Android log records without hiding the next error', () => {
   const messages = [
     'Error: first failure',
-    ...Array.from({ length: 9 }, (_, i) => `    at frame${i} (app.ts:${i + 1}:2)`),
+    ...Array.from({ length: 14 }, (_, i) => `    at frame${i} (app.ts:${i + 1}:2)`),
     'Error: second failure',
     '    at retry (retry.ts:4:2)',
   ];
@@ -153,20 +153,20 @@ test('launch previews cap a JavaScript stack split across Android log records wi
   expect(report.lines).toEqual([
     'Error: first failure',
     'Error stack:',
-    ...messages.slice(1, 6).map((line) => `  ${line.trim()}`),
+    ...messages.slice(1, 11).map((line) => `  ${line.trim()}`),
     '  ... 4 more frames',
     'Error: second failure',
     'Error stack:',
     '  at retry (retry.ts:4:2)',
     'Full captured stacks: stim logs --source all (add --json for raw records)',
   ]);
-  expect(report.summary).toContain('12 error-level records');
+  expect(report.summary).toContain('17 error-level records');
   expect(records.map((record) => record.msg)).toEqual(messages);
 });
 
 test('launch previews unescape and bound serialized React component stacks while labeling bundle coordinates honestly', () => {
   const frames = Array.from(
-    { length: 7 },
+    { length: 14 },
     (_, i) =>
       `    at Component${i} (http://localhost:8082/index.bundle//&platform=ios&dev=true&transform.engine=hermes:${100 + i}:20)`,
   );
@@ -175,11 +175,8 @@ test('launch previews unescape and bound serialized React component stacks while
   expect(report.lines).toEqual([
     '{ [Error: startup failed]',
     'Component stack:',
-    '  at Component0 (index.bundle:100:20 [unsymbolicated])',
-    '  at Component1 (index.bundle:101:20 [unsymbolicated])',
-    '  at Component2 (index.bundle:102:20 [unsymbolicated])',
+    ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
     '  ... 4 more frames',
-    '  isComponentError: true }',
     'Full captured stacks: stim logs --source all (add --json for raw records)',
   ]);
 });
@@ -189,15 +186,15 @@ test('launch previews preserve structured error and component stacks separately 
     {
       src: 'client',
       msg: 'Error: render failed',
-      stack: Array.from({ length: 8 }, (_, i) => ({ file: 'app.tsx', line: i + 1, column: 3, fn: `fn${i}` })),
+      stack: Array.from({ length: 13 }, (_, i) => ({ file: 'app.tsx', line: i + 1, column: 3, fn: `fn${i}` })),
       componentStack: '\n    at Screen (screen.tsx:10:3)\n    at Root (root.tsx:4:2)',
     },
   ];
   const original = JSON.stringify(records);
   const lines = launchErrorReport(records).lines;
   expect(lines).toContain('  at fn0 (app.tsx:1:3)');
-  expect(lines).toContain('  at fn4 (app.tsx:5:3)');
-  expect(lines).not.toContain('  at fn5 (app.tsx:6:3)');
+  expect(lines).toContain('  at fn9 (app.tsx:10:3)');
+  expect(lines).not.toContain('  at fn10 (app.tsx:11:3)');
   expect(lines).toContain('  ... 3 more frames');
   expect(lines.slice(-4)).toEqual([
     'Component stack:',
@@ -210,24 +207,24 @@ test('launch previews preserve structured error and component stacks separately 
 
 test('launch previews bound JSON-serialized object fields from the Metro client reporter', () => {
   const stack = Array.from(
-    { length: 8 },
+    { length: 13 },
     (_, i) => `    at error${i} (http://localhost:8082/index.bundle?platform=android:${i + 1}:2)`,
   ).join('\n');
   const componentStack = Array.from(
-    { length: 8 },
+    { length: 13 },
     (_, i) => `    at component${i} (http://localhost:8082/index.bundle?platform=android:${i + 1}:3)`,
   ).join('\n');
   const record = { src: 'client', msg: JSON.stringify({ message: 'render failed', stack, componentStack }) };
   const original = JSON.stringify(record);
   const lines = launchErrorReport([record]).lines;
   expect(lines).toContain('Error stack:');
-  expect(lines).toContain('  at error4 (index.bundle:5:2 [unsymbolicated])');
+  expect(lines).toContain('  at error9 (index.bundle:10:2 [unsymbolicated])');
   expect(lines).toContain('  ... 3 more frames');
   expect(lines).toContain('Component stack:');
-  expect(lines).toContain('  at component2 (index.bundle:3:3 [unsymbolicated])');
-  expect(lines).toContain('  ... 5 more frames');
+  expect(lines).toContain('  at component9 (index.bundle:10:3 [unsymbolicated])');
+  expect(lines).toContain('  ... 3 more frames');
   expect(lines.join('\n')).toContain('render failed');
-  expect(lines.join('\n')).not.toMatch(/error5|component3|platform=android|\\n/);
+  expect(lines.join('\n')).not.toMatch(/error10|component10|platform=android|\\n/);
   expect(JSON.stringify(record)).toBe(original);
 });
 
@@ -251,10 +248,8 @@ test('launch previews still bound a component stack whose serialized log record 
   const lines = launchErrorReport([{ src: 'client', msg }]).lines;
   expect(lines).toEqual([
     'Component stack:',
-    '  at Component0 (index.bundle:100:20 [unsymbolicated])',
-    '  at Component1 (index.bundle:101:20 [unsymbolicated])',
-    '  at Component2 (index.bundle:102:20 [unsymbolicated])',
-    '  ... 10 more frames',
+    ...Array.from({ length: 10 }, (_, i) => `  at Component${i} (index.bundle:${100 + i}:20 [unsymbolicated])`),
+    '  ... 3 more frames',
     '[captured stack text is incomplete]',
     'Full captured stacks: stim logs --source all (add --json for raw records)',
   ]);

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, expect, test } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { symbolicateErrors } from '../error-symbolication.ts';
+import { errorDiagnostics, mergeErrorCopies } from '../error-diagnostics.ts';
+import { captureNativeCrashes, parseAndroidCrashes, parseIosCrash } from '../native-crash.ts';
+import { verifyLaunch } from '../engine/app-install.ts';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resetExecutor, setExecutor } from '../exec.ts';
+import { launchErrorPreview } from '../launch-error-preview.ts';
+import { buildCriteria, recordMatches } from '../logs-query.ts';
+
+let server: Server | undefined;
+afterEach(async () => {
+  server?.closeAllConnections();
+  await new Promise<void>((resolve) => (server ? server.close(() => resolve()) : resolve()));
+  server = undefined;
+});
+
+test('symbolication preserves stack association, normalizes text columns and leaves raw records unchanged', async () => {
+  let posted: unknown;
+  server = createServer(async (req, res) => {
+    let text = '';
+    for await (const chunk of req) text += chunk;
+    posted = JSON.parse(text);
+    res.setHeader('Content-Type', 'application/json');
+    res.end(
+      JSON.stringify({
+        stack: [
+          { file: '/app/src/crash.ts', lineNumber: 7, column: 4 },
+          { file: '/app/app/_layout.tsx', lineNumber: 12, column: 2 },
+        ],
+      }),
+    );
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as { port: number }).port;
+  const raw = [
+    {
+      src: 'device',
+      msg: 'Error: broken\n    at fail (http://10.0.2.2:8083/index.bundle?platform=android:100:8)',
+      componentStack: '    at Screen (http://10.0.2.2:8083/index.bundle?platform=android:200:3)',
+    },
+  ];
+  const original = JSON.stringify(raw);
+  const result = await symbolicateErrors(raw, { port });
+  expect(posted).toEqual({
+    stack: [
+      {
+        file: 'http://10.0.2.2:8083/index.bundle?platform=android',
+        lineNumber: 100,
+        column: 7,
+        methodName: '<unknown>',
+      },
+      {
+        file: 'http://10.0.2.2:8083/index.bundle?platform=android',
+        lineNumber: 200,
+        column: 2,
+        methodName: '<unknown>',
+      },
+    ],
+  });
+  expect(result[0]?.msg).toContain('/app/src/crash.ts:7:5');
+  expect(result[0]?.componentStack).toContain('/app/app/_layout.tsx:12:3');
+  expect(JSON.stringify(raw)).toBe(original);
+});
+
+test('a failed or mismatched symbolication response keeps the captured stack readable', async () => {
+  const raw = [{ msg: 'Error: broken\n    at fail (http://localhost:8083/index.bundle:100:8)' }];
+  server = createServer((_req, res) => res.end(JSON.stringify({ stack: [] })));
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as { port: number }).port;
+  const result = await symbolicateErrors(raw, { port });
+  expect(result[0]?.msg).toBe(raw[0]?.msg);
+  expect(result[0]?.symbolicationNote).toContain('invalid Metro response');
+  expect((await symbolicateErrors(raw, { port: null }))[0]?.symbolicationNote).toContain('no verified Metro');
+});
+
+test('app frames beyond a framework prefix survive both preview limits without reversing the call chain', () => {
+  const frames = [
+    ...Array.from({ length: 11 }, (_, i) => `    at react${i} (/app/node_modules/react/index.js:${i + 1}:2)`),
+    '    at View (/app/src/View.tsx:4:3)',
+    '    at RootLayout(./_layout.tsx) (http://localhost:8082/index.bundle:22:3)',
+  ];
+  const record = { msg: 'Error: failed', stack: frames.join('\n'), componentStack: frames.join('\n') };
+  const lines = launchErrorPreview([record], '/app');
+  expect(lines.filter((line) => line.startsWith('  at '))).toHaveLength(20);
+  expect(lines.filter((line) => line.includes('View (src/View.tsx:4:3)'))).toHaveLength(2);
+  expect(lines.filter((line) => line.includes('3 more frames (3 dependency/native)'))).toHaveLength(2);
+  expect(lines.indexOf('  at View (src/View.tsx:4:3)')).toBeGreaterThan(
+    lines.indexOf('  at react0 (node_modules/react/index.js:1:2)'),
+  );
+});
+
+test('cross-source copies collapse only with matching title, location, platform and time', () => {
+  const a = { ts: 1000, src: 'client', platform: 'ios', msg: 'Error: broken\n    at render (app.tsx:4:2)' };
+  const b = { ...a, ts: 1100, src: 'device' };
+  expect(mergeErrorCopies([a, b])).toHaveLength(1);
+  expect(mergeErrorCopies([a, b, { ...a, ts: 1200 }])).toHaveLength(2);
+  expect(mergeErrorCopies([a, b])[0]?.mirroredSources).toEqual(['client', 'device']);
+  for (const other of [
+    { ...b, platform: 'android' },
+    { ...b, ts: 2500 },
+    { ...b, src: 'client' },
+    { ...b, msg: 'Error: broken\n    at other (app.tsx:8:2)' },
+  ]) {
+    expect(mergeErrorCopies([a, other])).toHaveLength(2);
+  }
+});
+
+test('iOS reports cannot leak another simulator, app or previous launch into the crash summary', () => {
+  const body = {
+    captureTime: '2025-01-02T00:00:01Z',
+    coalitionName: 'com.apple.CoreSimulator.SimDevice.own',
+    bundleInfo: { CFBundleIdentifier: 'app.test' },
+    incident: 'incident',
+    exception: { type: 'EXC_BAD_ACCESS', signal: 'SIGSEGV' },
+    threads: [
+      {
+        triggered: true,
+        frames: [{ imageIndex: 0, symbol: 'crashHere', imageOffset: 42, sourceFile: 'App.swift', sourceLine: 17 }],
+      },
+    ],
+    usedImages: [{ name: 'TestApp' }],
+  };
+  const text = '{}\n' + JSON.stringify(body);
+  const target = {
+    platform: 'ios' as const,
+    deviceId: 'own',
+    appId: 'app.test',
+    since: Date.parse('2025-01-02T00:00:00Z'),
+  };
+  expect(parseIosCrash(text, target)?.record.stack).toEqual([{ file: 'App.swift', line: 17, fn: 'crashHere' }]);
+  expect(parseIosCrash(text, { ...target, deviceId: 'other' })).toBeNull();
+  expect(parseIosCrash(text, { ...target, appId: 'other' })).toBeNull();
+  expect(parseIosCrash(text, { ...target, since: target.since + 2000 })).toBeNull();
+});
+
+test('Android crash buffer retains the exception from a dead app but not another process or old crash', () => {
+  const text = [
+    '1000.000 E/AndroidRuntime( 44): FATAL EXCEPTION: main',
+    '1000.001 E/AndroidRuntime( 44): Process: app.test, PID: 44',
+    '1000.002 E/AndroidRuntime( 44): java.lang.IllegalStateException: native failure',
+    '1000.003 E/AndroidRuntime( 44):     at app.test.MainActivity.onCreate(MainActivity.kt:10)',
+    '1001.000 E/AndroidRuntime( 45): FATAL EXCEPTION: main',
+    '1001.001 E/AndroidRuntime( 45): Process: other.app, PID: 45',
+  ].join('\n');
+  const target = { platform: 'android' as const, deviceId: 'emulator-5554', appId: 'app.test', since: 1000000 };
+  const records = parseAndroidCrashes(text, target, 100);
+  expect(records).toHaveLength(1);
+  expect(records[0]?.msg).toContain('MainActivity.kt:10');
+  expect(records[0]?.deviceTs).toBe(1000000);
+  expect(parseAndroidCrashes(text, target, 150)[0]?.deviceTs).toBe(records[0]?.deviceTs);
+  expect(records[0]?.msg).not.toContain('other.app');
+  expect(parseAndroidCrashes(text, { ...target, since: 2000000 }, 100)).toEqual([]);
+  expect(recordMatches(records[0], buildCriteria({ errorsOnly: true }))).toBe(true);
+  expect(recordMatches({ ...records[0], event: undefined }, buildCriteria({ errorsOnly: true }))).toBe(false);
+  expect(recordMatches(records[0], buildCriteria({ errorsOnly: true, sources: ['metro'] }))).toBe(false);
+});
+
+test('a native crash before any Metro request ends verification without calling the app healthy or merely unverified', async () => {
+  let time = 1000;
+  const crash = {
+    ts: 1500,
+    src: 'device',
+    platform: 'ios',
+    level: 'fatal',
+    event: 'native_crash',
+    msg: 'App.swift:17: Fatal error: broken',
+  };
+  const result = await verifyLaunch({
+    since: 1000,
+    platform: 'ios',
+    readRecords: () => [],
+    readDeviceRecords: () => [],
+    readClientRecords: () => [],
+    readNativeCrashes: () => [crash],
+    processAlive: () => false,
+    now: () => time,
+    sleep: async (ms) => {
+      time += ms;
+    },
+  });
+  expect(result).toMatchObject({ fatal: true, verified: false, processAlive: false, errors: [crash] });
+  expect(result.waitedMs).toBeLessThan(2000);
+});
+
+test('an unavailable process probe or unrelated crash does not invent a native launch failure', async () => {
+  for (const alive of [null, false]) {
+    let time = 1000;
+    const result = await verifyLaunch({
+      since: 1000,
+      platform: 'ios',
+      timeoutMs: 2500,
+      readRecords: () => [],
+      readDeviceRecords: () => [],
+      readClientRecords: () => [],
+      readNativeCrashes: () => [{ ts: 1500, platform: 'android', event: 'native_crash', level: 'fatal' }],
+      processAlive: () => alive,
+      now: () => time,
+      sleep: async (ms) => {
+        time += ms;
+      },
+    });
+    expect(result.fatal).not.toBe(true);
+    expect(result.verified).toBe(false);
+  }
+});
+
+test('Android crash evidence is fatal even while its PID remains behind a system crash dialog', async () => {
+  let time = 1000;
+  const crash = {
+    ts: 1500,
+    src: 'device',
+    platform: 'android',
+    level: 'fatal',
+    event: 'native_crash',
+    msg: 'FATAL EXCEPTION: main',
+  };
+  const result = await verifyLaunch({
+    since: 1000,
+    platform: 'android',
+    readRecords: () => [],
+    readDeviceRecords: () => [],
+    readClientRecords: () => [],
+    readNativeCrashes: () => [crash],
+    processAlive: () => true,
+    now: () => time,
+    sleep: async (ms) => {
+      time += ms;
+    },
+  });
+  expect(result).toMatchObject({ fatal: true, verified: false, processAlive: true, errors: [crash] });
+  expect(result.waitedMs).toBeLessThan(2000);
+});
+
+test('structured Metro frames retain zero-based columns, including the first column', async () => {
+  let posted: unknown;
+  server = createServer(async (req, res) => {
+    let text = '';
+    for await (const chunk of req) text += chunk;
+    posted = JSON.parse(text);
+    res.end(JSON.stringify({ stack: [{ file: '/app/source.ts', lineNumber: 5, column: 0 }] }));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as { port: number }).port;
+  const [record] = await symbolicateErrors(
+    [{ stack: [{ file: 'http://localhost:8083/index.bundle', line: 1, column: 0, fn: 'start' }] }],
+    { port },
+  );
+  expect(posted).toMatchObject({ stack: [{ column: 0 }] });
+  expect(record?.stack).toEqual([{ file: '/app/source.ts', line: 5, column: 0, fn: 'start' }]);
+});
+
+test('a stalled symbolication server cannot hide or indefinitely delay the original error', async () => {
+  server = createServer(() => {});
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as { port: number }).port;
+  const raw = { msg: 'Error: failed\n at render (http://localhost:8083/index.bundle:1:1)' };
+  const [record] = await symbolicateErrors([raw], { port, timeoutMs: 30 });
+  expect(record?.msg).toBe(raw.msg);
+  expect(record?.symbolicationNote).toContain('timed out');
+});
+
+test('APK frames require a matching ELF build ID and repeated collection does not duplicate a crash', () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-native-diagnostics-'));
+  const priorSdk = process.env.ANDROID_HOME;
+  process.env.STIM_HOME = join(root, 'stim-home');
+  process.env.ANDROID_HOME = join(root, 'sdk');
+  const tools = join(root, 'sdk/ndk/27/toolchains/llvm/prebuilt/host/bin');
+  const libraries = join(root, 'android/app/src/main/jniLibs/arm64-v8a');
+  const logs = join(process.env.STIM_HOME, 'logs');
+  const epoch = Math.floor(Date.now() / 1000);
+  const raw = [
+    `${epoch}.000 F/DEBUG( 80): *** *** *** ***`,
+    `${epoch}.001 F/DEBUG( 80): pid: 44, tid: 44, name: app.test  >>> app.test <<<`,
+    `${epoch}.002 F/DEBUG( 80): signal 6 (SIGABRT), code -1`,
+    `${epoch}.003 F/DEBUG( 80): #00 pc 000046bc /data/app/base.apk (offset 0x8534000) (BuildId: abc123)`,
+  ].join('\n');
+  try {
+    mkdirSync(tools, { recursive: true });
+    mkdirSync(libraries, { recursive: true });
+    writeFileSync(join(tools, 'llvm-symbolizer'), '');
+    writeFileSync(join(libraries, 'libapp.so'), '');
+    let matches = true;
+    let symbolRequests = 0;
+    const requestedAddresses: string[] = [];
+    setExecutor({
+      runFile: () => String(Date.now()),
+      runFileQuiet: (file, args) => {
+        if (file === 'adb') return raw;
+        if (file.endsWith('llvm-readelf')) return `Build ID: ${matches ? 'abc123' : 'def456'}`;
+        if (file.endsWith('llvm-symbolizer')) {
+          symbolRequests++;
+          requestedAddresses.push(args.at(-1));
+          return `crashHere\n${root}/app.cpp:17:4`;
+        }
+        return null;
+      },
+    });
+    const target = {
+      root,
+      platform: 'android' as const,
+      appId: 'app.test',
+      deviceId: 'owned',
+      since: epoch * 1000 - 1000,
+    };
+    const [first] = captureNativeCrashes(target, logs);
+    expect(first?.stack).toEqual([{ fn: 'crashHere', file: `${root}/app.cpp`, line: 17, column: 4 }]);
+    expect(requestedAddresses).toEqual(['0x000046bc']);
+    captureNativeCrashes(target, logs);
+    expect(readdirSync(logs).filter((name) => name.endsWith('.ndjson'))).toHaveLength(1);
+    expect(readdirSync(logs).some((name) => name.endsWith('.tmp'))).toBe(false);
+    expect(JSON.parse(readFileSync(join(logs, readdirSync(logs)[0]!), 'utf8')).rawReport).toContain('base.apk');
+    const priorRequests = symbolRequests;
+    matches = false;
+    const [mismatch] = captureNativeCrashes(target, logs);
+    expect(symbolRequests).toBe(priorRequests);
+    expect(mismatch?.stack).toMatchObject([{ file: 'base.apk' }]);
+    expect(mismatch?.symbolicationNote).toContain('partial');
+  } finally {
+    resetExecutor();
+    if (priorSdk === undefined) delete process.env.ANDROID_HOME;
+    else process.env.ANDROID_HOME = priorSdk;
+    delete process.env.STIM_HOME;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('human error queries include correlated component context without admitting an unrelated device error', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-error-context-'));
+  process.env.STIM_HOME = root;
+  try {
+    const primary = { src: 'metro', ts: 1000, level: 'error', msg: 'Error: broken', stack: 'at render (app.tsx:4:2)' };
+    const related = {
+      src: 'device',
+      ts: 1100,
+      level: 'error',
+      msg: 'Error: broken',
+      componentStack: 'at Screen (app.tsx:4:2)',
+    };
+    const unrelated = { ...related, ts: 1150, componentStack: 'at Other (other.tsx:2:3)' };
+    writeFileSync(join(root, 'device.ndjson'), [related, unrelated].map((record) => JSON.stringify(record)).join('\n'));
+    const result = await errorDiagnostics([primary], { root, logsDir: root, port: null });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ stack: primary.stack, componentStack: related.componentStack });
+    expect(JSON.stringify(result)).not.toContain('other.tsx');
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('split Android error-object lines remain associated with their own error and are not printed twice', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-split-error-'));
+  process.env.STIM_HOME = root;
+  try {
+    const header = {
+      src: 'device',
+      ts: 1000,
+      proc: 'ReactNativeJS(44)',
+      platform: 'android',
+      level: 'error',
+      msg: '{ [Error: broken]',
+    };
+    const component = { ...header, ts: 1001, msg: "  componentStack: '\\n    at Screen (app.tsx:4:2)" };
+    const metadata = { ...header, ts: 1001, msg: '  isComponentError: true }' };
+    const other = {
+      ...component,
+      ts: 1002,
+      proc: 'ReactNativeJS(55)',
+      msg: "  componentStack: '\\n    at Wrong (other.tsx:5:2)',",
+    };
+    const records = [header, component, metadata, other];
+    writeFileSync(join(root, 'device.ndjson'), records.map((record) => JSON.stringify(record)).join('\n'));
+    const result = await errorDiagnostics(records, { root, logsDir: root, port: null });
+    expect(result).toHaveLength(2);
+    expect(result[0]?.msg).toContain('Screen (app.tsx:4:2)');
+    expect(result[0]?.msg).not.toContain('Wrong');
+    expect(result[1]?.msg).toContain('Wrong');
+    const preview = launchErrorPreview(result, root).join('\n');
+    expect(preview).toContain('Component stack:');
+    expect(preview).toContain('at Screen (app.tsx:4:2)');
+    expect(preview).not.toContain('isComponentError: true');
+    expect(preview).toContain('captured stack text is incomplete');
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -125,13 +125,18 @@ test('native previews remove metadata noise but full output preserves it and Jav
   expect(java).toContain('Caused-by stack:\n  at crash');
 });
 
-test('a runtime-truncated frame remains identifiable without a broken bundle URL', () => {
-  const preview = launchErrorPreview([
-    { msg: "componentStack: '\\n    at Route (http://localhost:8082/index.bundle?plat" },
-  ]).join('\n');
-  expect(preview).toContain('at Route (location incomplete)');
-  expect(preview).toContain('runtime truncated');
-  expect(preview).not.toContain('http://');
+test('launch omits incomplete frames and capture noise while full logs retain the evidence', () => {
+  const record = {
+    msg: "componentStack: '\\n    at Route (http://localhost:8082/index.bundle?plat",
+    symbolicationNote: 'Same error captured by metro + device; raw copies retained in logs --json.',
+  };
+  const original = JSON.stringify(record);
+  expect(launchErrorPreview([record])).toEqual([]);
+  const full = launchErrorPreview([record], undefined, { full: true }).join('\n');
+  expect(full).toContain('at Route (http://localhost:8082/index.bundle?plat');
+  expect(full).not.toContain('runtime truncated');
+  expect(full).toContain('Same error captured');
+  expect(JSON.stringify(record)).toBe(original);
   const frames = [
     'at Screen (app.tsx:1:1)',
     ...Array.from({ length: 10 }, (_, i) => `at framework${i} (node_modules/lib/index.js:${i + 1}:2)`),
@@ -434,7 +439,10 @@ test('split Android error-object lines remain associated with their own error an
     expect(preview).toContain('Component stack:');
     expect(preview).toContain('at Screen (app.tsx:4:2)');
     expect(preview).not.toContain('isComponentError: true');
-    expect(preview).toContain('captured stack text is incomplete');
+    expect(preview).not.toContain('captured stack text is incomplete');
+    const full = launchErrorPreview(result, root, { full: true }).join('\n');
+    expect(full).toContain('at Screen (app.tsx:4:2)');
+    expect(full).not.toContain('captured stack text is incomplete');
   } finally {
     delete process.env.STIM_HOME;
     rmSync(root, { recursive: true, force: true });

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -97,6 +97,43 @@ test('app frames beyond a framework prefix survive both preview limits without r
   );
 });
 
+test('native previews remove metadata noise but full output preserves it and Java causes stay distinct', () => {
+  const record = {
+    event: 'native_crash',
+    msg: 'Native crash',
+    stack: [
+      { file: 'libc.so', fn: '(abort+156) (BuildId: abc123) [captured native frame]' },
+      {
+        file: 'Trailhead.debug.dylib',
+        fn: '@objc AppDelegate.application (in Trailhead.debug.dylib) (/<compiler-generated>:0)',
+      },
+    ],
+  };
+  const preview = launchErrorPreview([record]).join('\n');
+  expect(preview).toContain('at (abort+156) (libc.so)');
+  expect(preview).toContain('at @objc AppDelegate.application (Trailhead.debug.dylib; compiler-generated)');
+  expect(preview).not.toContain('BuildId');
+  const full = launchErrorPreview([record], undefined, { full: true }).join('\n');
+  expect(full).toContain('BuildId: abc123');
+  expect(full).toContain('[captured native frame]');
+  const java = launchErrorPreview([
+    {
+      msg: 'RuntimeException: failed\n  at wrapper (Runtime.java:5)\nCaused by: IllegalStateException: broken\n  at crash (MainApplication.kt:34)',
+    },
+  ]).join('\n');
+  expect(java).toContain('Error stack:\n  at wrapper');
+  expect(java).toContain('Caused-by stack:\n  at crash');
+});
+
+test('a runtime-truncated frame remains identifiable without a broken bundle URL', () => {
+  const preview = launchErrorPreview([
+    { msg: "componentStack: '\\n    at Route (http://localhost:8082/index.bundle?plat" },
+  ]).join('\n');
+  expect(preview).toContain('at Route (location incomplete)');
+  expect(preview).toContain('runtime truncated');
+  expect(preview).not.toContain('http://');
+});
+
 test('cross-source copies collapse only with matching title, location, platform and time', () => {
   const a = { ts: 1000, src: 'client', platform: 'ios', msg: 'Error: broken\n    at render (app.tsx:4:2)' };
   const b = { ...a, ts: 1100, src: 'device' };

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { symbolicateErrors } from '../error-symbolication.ts';
 import { errorDiagnostics, mergeErrorCopies } from '../error-diagnostics.ts';
-import { captureNativeCrashes, parseAndroidCrashes, parseIosCrash } from '../native-crash.ts';
+import { captureNativeCrashes, captureWorkspaceCrashes, parseAndroidCrashes, parseIosCrash } from '../native-crash.ts';
 import { verifyLaunch } from '../engine/app-install.ts';
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,6 +10,10 @@ import { join } from 'node:path';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { launchErrorPreview } from '../launch-error-preview.ts';
 import { buildCriteria, recordMatches } from '../logs-query.ts';
+import { recordFromLine } from '../supervisor/server-expo.ts';
+import { clearWorkspaceStateKeys, writeWorkspaceState } from '../supervisor/state.ts';
+import { upsertProject } from '../config.ts';
+import { deviceLeasePath, fileLeaseIo } from '../engine/device-lease.ts';
 
 let server: Server | undefined;
 afterEach(async () => {
@@ -135,6 +139,7 @@ test('iOS reports cannot leak another simulator, app or previous launch into the
   expect(parseIosCrash(text, { ...target, deviceId: 'other' })).toBeNull();
   expect(parseIosCrash(text, { ...target, appId: 'other' })).toBeNull();
   expect(parseIosCrash(text, { ...target, since: target.since + 2000 })).toBeNull();
+  expect(parseIosCrash(text, { ...target, until: target.since + 500 })).toBeNull();
 });
 
 test('Android crash buffer retains the exception from a dead app but not another process or old crash', () => {
@@ -385,6 +390,131 @@ test('split Android error-object lines remain associated with their own error an
     expect(preview).not.toContain('isComponentError: true');
     expect(preview).toContain('captured stack text is incomplete');
   } finally {
+    delete process.env.STIM_HOME;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('historical Expo errors keep their original coordinates after bundle activity on either Expo log path', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-expo-rebuild-'));
+  process.env.STIM_HOME = root;
+  const original = {
+    ts: 1000,
+    src: 'device',
+    platform: 'android',
+    msg: 'Error: broken\n at fail (http://localhost:8083/index.bundle:10:2)',
+  };
+  try {
+    const events = [
+      { ...recordFromLine('Android Bundling 20%'), ts: 1100 },
+      { ...recordFromLine('Android Bundled 50ms', { stream: 'stderr' }), ts: 1100 },
+      recordFromLine(
+        'stim-bundle-response: ' +
+          JSON.stringify({
+            src: 'metro',
+            event: 'bundle_response_started',
+            platform: 'android',
+            requestId: 'next',
+            ts: 1100,
+          }),
+        { stream: 'stderr' },
+      ),
+    ];
+    for (const event of events) {
+      writeFileSync(join(root, 'metro.ndjson'), JSON.stringify(event) + '\n');
+      const [record] = await errorDiagnostics([original], { root, logsDir: root, port: 8083, allowRequest: true });
+      expect(record?.msg).toBe(original.msg);
+      expect(record?.symbolicationNote).toContain('Metro rebuilt after this error');
+    }
+    writeFileSync(join(root, 'metro.ndjson'), JSON.stringify({ ...events[2], platform: 'ios' }) + '\n');
+    const [otherPlatform] = await errorDiagnostics([original], { root, logsDir: root, port: null });
+    expect(otherPlatform?.symbolicationNote).toBeUndefined();
+  } finally {
+    delete process.env.STIM_HOME;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('live native collection requires the current launch and device claim, not a historical launch marker', () => {
+  const root = mkdtempSync(join(tmpdir(), 'stim-crash-claim-'));
+  process.env.STIM_HOME = join(root, 'home');
+  const logs = join(root, 'logs');
+  const since = Date.now() - 5000;
+  const launch = {
+    appId: 'app.test',
+    deviceId: 'emulator-5556',
+    metroPort: null,
+    release: true,
+    deepLinkUrl: null,
+    launchedAt: new Date(since).toISOString(),
+  };
+  let reads = 0;
+  let avd = 'stim-own';
+  const marker = {
+    event: 'launch_attempt',
+    platform: 'android',
+    ts: since,
+    appId: launch.appId,
+    deviceId: launch.deviceId,
+  };
+  const raw = [
+    `${Math.floor((since + 1000) / 1000)}.000 E/AndroidRuntime( 44): FATAL EXCEPTION: main`,
+    `${Math.floor((since + 1000) / 1000)}.001 E/AndroidRuntime( 44): Process: app.test, PID: 44`,
+    `${Math.floor((since + 1000) / 1000)}.002 E/AndroidRuntime( 44): java.lang.IllegalStateException: failed`,
+  ].join('\n');
+  try {
+    mkdirSync(logs);
+    writeFileSync(join(logs, 'launch.ndjson'), JSON.stringify(marker) + '\n');
+    writeWorkspaceState(root, { launches: { android: launch } });
+    upsertProject(root, { platforms: { android: { owned: true, avdName: 'stim-own' } } });
+    setExecutor({
+      runFile: () => String(Date.now()),
+      runFileQuiet: (_file, args) => {
+        if (args.includes('emu')) return avd + '\nOK';
+        reads++;
+        return raw;
+      },
+    });
+    captureWorkspaceCrashes(root, logs);
+    expect(reads).toBe(1);
+    expect(readdirSync(logs).filter((name) => name.startsWith('native-crash-'))).toHaveLength(1);
+    clearWorkspaceStateKeys(root, ['launches']);
+    captureWorkspaceCrashes(root, logs);
+    expect(reads).toBe(1);
+    writeWorkspaceState(root, { launches: { android: launch } });
+    avd = 'stim-other-workspace';
+    captureWorkspaceCrashes(root, logs);
+    expect(reads).toBe(1);
+    writeFileSync(join(logs, 'launch.ndjson'), JSON.stringify({ ...marker, physical: true }) + '\n');
+    clearWorkspaceStateKeys(root, ['launches']);
+    fileLeaseIo.writeHolder(root, { android: { id: launch.deviceId, token: 'own-token', kind: 'declared' } });
+    const lease = {
+      version: 1,
+      platform: 'android',
+      id: launch.deviceId,
+      holder: root,
+      token: 'own-token',
+      grantedAt: new Date(since - 1000).toISOString(),
+      expiresAt: new Date(Date.now() + 10000).toISOString(),
+    };
+    fileLeaseIo.writeLease(deviceLeasePath('android', launch.deviceId), JSON.stringify(lease));
+    captureWorkspaceCrashes(root, logs);
+    expect(reads).toBe(2);
+    fileLeaseIo.writeLease(
+      deviceLeasePath('android', launch.deviceId),
+      JSON.stringify({ ...lease, token: 'new-token', holder: root + '-other' }),
+    );
+    captureWorkspaceCrashes(root, logs);
+    expect(reads).toBe(2);
+    expect(
+      parseAndroidCrashes(
+        raw,
+        { platform: 'android', appId: launch.appId, deviceId: launch.deviceId, since, until: since + 1 },
+        0,
+      ),
+    ).toEqual([]);
+  } finally {
+    resetExecutor();
     delete process.env.STIM_HOME;
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -132,6 +132,15 @@ test('a runtime-truncated frame remains identifiable without a broken bundle URL
   expect(preview).toContain('at Route (location incomplete)');
   expect(preview).toContain('runtime truncated');
   expect(preview).not.toContain('http://');
+  const frames = [
+    'at Screen (app.tsx:1:1)',
+    ...Array.from({ length: 10 }, (_, i) => `at framework${i} (node_modules/lib/index.js:${i + 1}:2)`),
+    'at anonymous (http://localhost:8082/index.bundle?plat',
+  ];
+  const bounded = launchErrorPreview([{ stack: frames.join('\n') }]).join('\n');
+  expect(bounded).toContain('at framework8');
+  expect(bounded).not.toContain('at anonymous');
+  expect(bounded).not.toContain('app frames prioritized');
 });
 
 test('cross-source copies collapse only with matching title, location, platform and time', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -373,6 +373,33 @@ describe('ios', () => {
     expect(exec.calls.length).toBe(1);
   });
 
+  test('a cold Expo launch attaches console capture and passes its project URL without launching two React hosts', () => {
+    const exec = recordingExec({ outputs: { 'simctl launch': 'com.example.app: 4242' } });
+    const result = launchIosApp(
+      {
+        udid: 'U1',
+        bundleId: 'com.example.app',
+        metroPort: 8082,
+        devClientScheme: 'myapp',
+        consolePaths: { stdout: '/container/trace.out', stderr: '/container/trace.err' },
+      },
+      { exec },
+    );
+    expect(result.pid).toBe(4242);
+    expect(exec.calls[2]).toEqual([
+      'xcrun',
+      'simctl',
+      'launch',
+      '--stdout=/container/trace.out',
+      '--stderr=/container/trace.err',
+      'U1',
+      'com.example.app',
+      '--initialUrl',
+      'http://localhost:8082/?disableOnboarding=1',
+    ]);
+    expect(exec.calls).toHaveLength(3);
+  });
+
   test('a failed launch is reported, not thrown', () => {
     const exec = recordingExec({ fail: 'simctl launch' });
     expect(launchIosApp({ udid: 'U1', bundleId: 'com.example.app', metroPort: 8082 }, { exec }).reason).toMatch(

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -904,7 +904,7 @@ describe('launch verification', () => {
             {
               src: 'client',
               msg: 'a redbox from the app',
-              stack: Array.from({ length: 7 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
+              stack: Array.from({ length: 12 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `frame${i}` })),
             },
           ],
         }),
@@ -916,8 +916,8 @@ describe('launch verification', () => {
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
     expect(text).toContain('Error stack:');
-    expect(text).toContain('at frame4 (app.tsx:5)');
-    expect(text).not.toContain('at frame5');
+    expect(text).toContain('at frame9 (app.tsx:10)');
+    expect(text).not.toContain('at frame10');
     expect(text).toContain('... 2 more frames');
     expect(text).toContain('stim logs --source all');
     expect(text).not.toMatch(/Failed to send CA Event/);
@@ -2092,7 +2092,8 @@ describe('success output', () => {
     expect(marker).toBeTruthy();
     assert(marker);
     expect(marker.src).toBe('build');
-    expect(marker.msg).toMatch(/launched com\.example\.app on BF2A.* against Metro port 8082/);
+    expect(marker.event).toBe('launch_attempt');
+    expect(marker.msg).toMatch(/launching com\.example\.app on BF2A/);
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -876,7 +876,7 @@ describe('launch verification', () => {
 
   test('an app error with a live native process recommends reload instead of another native run', async () => {
     reserve();
-    const { errs } = await run(
+    const { errs, logs } = await run(
       {},
       {
         verifyLaunch: async () => ({
@@ -890,6 +890,8 @@ describe('launch verification', () => {
     expect(text).toMatch(/native app is still running/);
     expect(text).toContain('stim reload ios');
     expect(text).toMatch(/Do not run `stim ios` unless native inputs changed or the app process exits/);
+    expect(logs[0]).toMatch(/^WARNING: .*app errors detected/);
+    expect(logs.join('\n')).not.toContain('OK:');
   });
 
   test('a verified launch counts the device log instead of printing it', async () => {
@@ -914,7 +916,7 @@ describe('launch verification', () => {
     );
     const text = errs.join('\n');
     expect(text).toMatch(
-      /^  launch {6}2 error-level records in the device log during launch \(logs --errors --source device\)$/m,
+      /^  launch {6}2 general device error-level records \(not confirmed app errors\); inspect with stim logs --errors --source device$/m,
     );
     expect(text).toMatch(/^  launch {6}a redbox from the app$/m);
     expect(text).toContain('Error stack:');

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert';
+import { vi } from 'vitest';
+import * as crashDiagnostics from '../native-crash.ts';
 import { captureProcessToken } from '../process-identity.ts';
 import { once } from 'node:events';
 import { type ChildProcess, spawn } from 'node:child_process';
@@ -3121,6 +3123,26 @@ describe('configuration resolution', () => {
 });
 
 describe('release skips Metro entirely', () => {
+  test('an attributable native crash overrides a live release process probe', async () => {
+    const read = vi
+      .spyOn(crashDiagnostics, 'captureNativeCrashes')
+      .mockReturnValue([
+        { src: 'device', level: 'fatal', event: 'native_crash', msg: 'App.swift:17: Fatal error: release failed' },
+      ]);
+    try {
+      const { logs, errs, exitCode } = await run(
+        { configuration: 'Release', json: true },
+        {
+          verifyReleaseLaunch: async () => ({ verified: true, waitedMs: 3000 }),
+        },
+      );
+      expect(exitCode).toBe(1);
+      expect(parseFirst(logs).code).toBe('STIM_LAUNCH_FAILED');
+      expect(errs.join('\n')).toContain('FATAL: the app reported a native crash');
+    } finally {
+      read.mockRestore();
+    }
+  });
   test('no gate, no reservation needed, no port wiring, plain launch', async () => {
     const { exitCode, calls, errs } = await run({ configuration: 'Release' });
     expect(exitCode).toBe(null);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -942,6 +942,8 @@ describe('launch verification', () => {
     expect(exitCode).toBe(1);
     expect(errs.join('\n')).toMatch(/attention client lost event tag/);
     expect(errs.join('\n')).toMatch(/run `stim ios` again.*Metro reload cannot restart an exited app/);
+    expect(errs.join('\n')).toContain('about a minute or longer');
+    expect(errs.join('\n')).toContain('Run `stim logs --errors` again');
   });
 
   test('a Metro build failure with a live native process recommends reload instead of another native run', async () => {
@@ -3177,6 +3179,7 @@ describe('release skips Metro entirely', () => {
     expect(parseFirst(logs).code).toBe('STIM_LAUNCH_FAILED');
     expect(errs.join('\n')).toMatch(/process exited within/);
     expect(errs.join('\n')).toMatch(/stim logs --errors/);
+    expect(errs.join('\n')).toContain('about a minute or longer');
   });
 
   test('the ios.configuration setting is the repo default, and the flag overrides it back to Debug', async () => {

--- a/packages/stim-cli/src/__tests__/logs-command.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-command.test.ts
@@ -245,32 +245,30 @@ describe('logs command', () => {
     expect(parseNdjsonLine(out[0])).toEqual(record);
   });
 
-  test('omitting --errors shows every string and structured stack frame while JSON stays raw', async () => {
-    const frames = Array.from({ length: 13 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `render${i}` }));
-    const record = {
-      ts: 1,
-      src: 'client',
-      level: 'error',
-      msg: 'x'.repeat(1100),
-      stack: frames,
-      componentStack: frames.map((f) => `at ${f.fn} (${f.file}:${f.line}:1)`).join('\n'),
-    };
-    writeLog('client.ndjson', [record]);
-    await run({ errors: true });
-    expect(out[0]).not.toContain('render12');
-    expect(out[0]).toContain('3 more frames');
-    expect(out[0]).toContain('without --errors');
-    out.length = 0;
-    await run({ source: ['all'] });
-    expect(out[0]).toContain(record.msg);
-    expect(out[0]?.match(/render12/g)).toHaveLength(2);
-    expect(out[0]).toContain('Component stack:');
-    expect(out[0]).not.toContain('more frames');
-    expect(out[0]).not.toContain('Stack preview:');
-    out.length = 0;
-    await run({ errors: true, json: true });
-    expect(parseNdjsonLine(out[0])).toEqual(record);
-  });
+  test.each([{}, { errors: true }, { errors: true, tail: '1' }])(
+    'logs %j shows every string and structured stack frame while JSON stays raw',
+    async (options) => {
+      const frames = Array.from({ length: 13 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `render${i}` }));
+      const record = {
+        ts: 1,
+        src: 'client',
+        level: 'error',
+        msg: 'x'.repeat(1100),
+        stack: frames,
+        componentStack: frames.map((f) => `at ${f.fn} (${f.file}:${f.line}:1)`).join('\n'),
+      };
+      writeLog('client.ndjson', [record]);
+      await run(options);
+      expect(out[0]).toContain(record.msg);
+      expect(out[0]?.match(/render12/g)).toHaveLength(2);
+      expect(out[0]).toContain('Component stack:');
+      expect(out[0]).not.toContain('more frames');
+      expect(out[0]).not.toContain('Stack preview:');
+      out.length = 0;
+      await run({ errors: true, json: true });
+      expect(parseNdjsonLine(out[0])).toEqual(record);
+    },
+  );
 
   test('exits 0 and prints nothing to stdout when nothing matches', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'info', msg: 'fine' }]);
@@ -330,7 +328,7 @@ describe('logs command', () => {
     expect(parseNdjsonLine(out[0])).toEqual(error);
   });
 
-  test('--errors groups split Android frames before capping errors and prioritizing app frames', async () => {
+  test('--errors groups split Android frames into one complete stack before limiting error records', async () => {
     const base = { ts: 1000, src: 'device', level: 'error', platform: 'android', proc: 'ReactNativeJS(42)' };
     const records = [
       { ...base, msg: 'Error: broken' },
@@ -346,9 +344,9 @@ describe('logs command', () => {
     await run({ errors: true, source: 'device' });
     expect(out).toHaveLength(2);
     expect(out[0]).toContain('app/Screen.tsx:5:2');
-    expect(out[0]?.match(/  at /g)).toHaveLength(10);
+    expect(out[0]?.match(/  at /g)).toHaveLength(26);
     expect(out[0]?.match(/Error stack/g)).toHaveLength(1);
-    expect(out[0]).toContain('16 more frames');
+    expect(out[0]).not.toContain('more frames');
     expect(out[1]).toContain('another failure');
     out.length = 0;
     await run({ errors: true, source: 'device', json: true });

--- a/packages/stim-cli/src/__tests__/logs-command.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-command.test.ts
@@ -303,6 +303,31 @@ describe('logs command', () => {
     expect(parseNdjsonLine(out[0])).toEqual(error);
   });
 
+  test('--errors groups split Android frames before capping errors and prioritizing app frames', async () => {
+    const base = { ts: 1000, src: 'device', level: 'error', platform: 'android', proc: 'ReactNativeJS(42)' };
+    const records = [
+      { ...base, msg: 'Error: broken' },
+      ...Array.from({ length: 25 }, (_, i) => ({
+        ...base,
+        ts: 1001 + i,
+        msg: `    at react${i} (node_modules/react/index.js:${i + 1}:2)`,
+      })),
+      { ...base, ts: 1030, msg: '    at Screen (app/Screen.tsx:5:2)' },
+      { ...base, ts: 1031, msg: 'Error: another failure' },
+    ];
+    writeLog('device.ndjson', records);
+    await run({ errors: true, source: 'device' });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('app/Screen.tsx:5:2');
+    expect(out[0]?.match(/  at /g)).toHaveLength(10);
+    expect(out[0]?.match(/Error stack/g)).toHaveLength(1);
+    expect(out[0]).toContain('16 more frames');
+    expect(out[1]).toContain('another failure');
+    out.length = 0;
+    await run({ errors: true, source: 'device', json: true });
+    expect(out).toHaveLength(records.length);
+  });
+
   test('--errors keeps bare React Native symbolication with its error in human output', async () => {
     const error = { ts: 1, src: 'client', level: 'error', msg: '[Error: STIM_BARE_LAUNCH_CRASH]' };
     writeLog('client.ndjson', [

--- a/packages/stim-cli/src/__tests__/logs-command.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-command.test.ts
@@ -57,7 +57,7 @@ function captureAction(register: (program: Command) => void) {
 }
 
 describe('formatting', () => {
-  test('formatTime renders local wall clock to the millisecond', () => {
+  test('formatTime renders local wall clock to the millisecond', async () => {
     const ts = Date.UTC(2026, 7, 25, 12, 34, 56, 789);
     const d = new Date(ts);
     const pad = (n: number, w = 2) => String(n).padStart(w, '0');
@@ -66,35 +66,35 @@ describe('formatting', () => {
     expect(formatTime(ts)).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3}$/);
   });
 
-  test('formatTime renders a record with no usable ts without crashing', () => {
+  test('formatTime renders a record with no usable ts without crashing', async () => {
     expect(formatTime(undefined)).toBe('--:--:--.---');
     expect(formatTime('nope')).toBe('--:--:--.---');
   });
 
-  test('formatRecord is "HH:MM:SS.mmm level src msg" with aligned columns', () => {
+  test('formatRecord is "HH:MM:SS.mmm level src msg" with aligned columns', async () => {
     const line = formatRecord({ ts: 0, src: 'metro', level: 'error', msg: 'Unable to resolve module' });
     expect(line).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3} error metro  Unable to resolve module$/);
   });
 
-  test('the level and src columns are padded so messages line up', () => {
+  test('the level and src columns are padded so messages line up', async () => {
     const a = formatRecord({ ts: 0, src: 'metro', level: 'info', msg: 'x' });
     const b = formatRecord({ ts: 0, src: 'client', level: 'error', msg: 'x' });
     expect(a.indexOf('x')).toBe(b.indexOf('x'));
   });
 
-  test('formatStackFrame renders fn, file, line and column', () => {
+  test('formatStackFrame renders fn, file, line and column', async () => {
     expect(formatStackFrame({ file: 'src/App.js', line: 12, column: 3, fn: 'render' })).toBe(
       'at render (src/App.js:12:3)',
     );
   });
 
-  test('formatStackFrame degrades when fields are missing', () => {
+  test('formatStackFrame degrades when fields are missing', async () => {
     expect(formatStackFrame({ file: 'src/App.js', line: 12 })).toBe('at src/App.js:12');
     expect(formatStackFrame({ fn: 'render' })).toBe('at render');
     expect(formatStackFrame({})).toBe(null);
   });
 
-  test('stack frames follow the message, indented', () => {
+  test('stack frames follow the message, indented', async () => {
     const line = formatRecord({
       ts: 0,
       src: 'client',
@@ -112,19 +112,19 @@ describe('formatting', () => {
     expect(lines[2]).toBe('    at src/index.js:1:1');
   });
 
-  test('a multi-line message keeps its own lines, indented under the first', () => {
+  test('a multi-line message keeps its own lines, indented under the first', async () => {
     const line = formatRecord({ ts: 0, src: 'metro', level: 'error', msg: 'first\nsecond' });
     const lines = line.split('\n');
     expect(lines[0]).toMatch(/first$/);
     expect(lines[1]).toBe('    second');
   });
 
-  test('a record missing src or msg still renders', () => {
+  test('a record missing src or msg still renders', async () => {
     const line = formatRecord({ ts: 0, level: 'info' });
     expect(line).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3} info /);
   });
 
-  test('formatRecord paints only the level, and defaults to no colour', () => {
+  test('formatRecord paints only the level, and defaults to no colour', async () => {
     const line = formatRecord({ ts: 0, src: 'metro', level: 'warn', msg: 'hm' }, { paint: (t) => `<${t}>` });
     expect(line).toMatch(/<warn >/);
     expect(formatRecord({ ts: 0, src: 'metro', level: 'warn', msg: 'hm' }).includes('<')).toBe(false);
@@ -132,12 +132,12 @@ describe('formatting', () => {
 });
 
 describe('option validation', () => {
-  test('parseTail accepts a non-negative integer', () => {
+  test('parseTail accepts a non-negative integer', async () => {
     expect(parseTail('50')).toEqual({ n: 50 });
     expect(parseTail('0')).toEqual({ n: 0 });
   });
 
-  test('parseTail rejects garbage with a message instead of NaN', () => {
+  test('parseTail rejects garbage with a message instead of NaN', async () => {
     for (const bad of ['abc', '-1', '1.5', '', ' ']) {
       const r = parseTail(bad);
       expect(r.n).toBe(undefined);
@@ -145,7 +145,7 @@ describe('option validation', () => {
     }
   });
 
-  test('validateSources accepts the Contract-1 sources and rejects a typo', () => {
+  test('validateSources accepts the Contract-1 sources and rejects a typo', async () => {
     expect(validateSources(['metro', 'client'])).toEqual({ sources: ['metro', 'client'] });
     expect(validateSources(undefined)).toEqual({ sources: undefined });
     const r = validateSources(['metrro']);
@@ -154,13 +154,13 @@ describe('option validation', () => {
     expect(r.error).toMatch(/metro, client, device, build/);
   });
 
-  test('validateSources expands all to every Contract-1 source', () => {
+  test('validateSources expands all to every Contract-1 source', async () => {
     expect(validateSources(['all'])).toEqual({ sources: ['metro', 'client', 'device', 'build'] });
     expect(validateSources(['client', 'all'])).toEqual({ sources: ['metro', 'client', 'device', 'build'] });
     expect(validateSources(['metrro']).error).toMatch(/or all/);
   });
 
-  test('validateLevel accepts the Contract-1 levels and names the valid set otherwise', () => {
+  test('validateLevel accepts the Contract-1 levels and names the valid set otherwise', async () => {
     expect(validateLevel('warn')).toEqual({ level: 'warn' });
     const r = validateLevel('loud');
     expect(r.level).toBe(undefined);
@@ -219,57 +219,57 @@ describe('logs command', () => {
     writeFileSync(join(logsDir, name), records.map((r) => `${JSON.stringify(r)}\n`).join(''));
   }
 
-  function run(opts: Record<string, unknown>) {
+  async function run(opts: Record<string, unknown>) {
     try {
-      captureAction(logsCommand)(opts);
+      await captureAction(logsCommand)(opts);
     } catch (err) {
       if ((err as Error).message !== 'exit') throw err;
     }
   }
 
-  test('prints the merged timeline, one line per record', () => {
+  test('prints the merged timeline, one line per record', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'info', msg: 'bundling' }]);
     writeLog('client.ndjson', [{ ts: 2, src: 'client', level: 'warn', msg: 'deprecated' }]);
-    run({});
+    await run({});
     expect(exitCode).toBe(null);
     expect(out.length).toBe(2);
     expect(out[0]).toMatch(/ info  metro  bundling$/);
     expect(out[1]).toMatch(/ warn  client deprecated$/);
   });
 
-  test('--json emits the raw records, one valid NDJSON object per line', () => {
+  test('--json emits the raw records, one valid NDJSON object per line', async () => {
     const record = { ts: 1, src: 'metro', level: 'error', msg: 'boom', event: 'bundling_error' };
     writeLog('metro.ndjson', [record]);
-    run({ json: true });
+    await run({ json: true });
     expect(out.length).toBe(1);
     expect(parseNdjsonLine(out[0])).toEqual(record);
   });
 
-  test('exits 0 and prints nothing to stdout when nothing matches', () => {
+  test('exits 0 and prints nothing to stdout when nothing matches', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'info', msg: 'fine' }]);
-    run({ errors: true });
+    await run({ errors: true });
     expect(exitCode).toBe(null);
     expect(out).toEqual([]);
   });
 
-  test('exits 0 when the workspace has no log directory at all', () => {
+  test('exits 0 when the workspace has no log directory at all', async () => {
     rmSync(workspaceDir(project), { recursive: true, force: true });
-    run({});
+    await run({});
     expect(exitCode).toBe(null);
     expect(out).toEqual([]);
   });
 
-  test('--errors applies the marker window across sources', () => {
+  test('--errors applies the marker window across sources', async () => {
     writeLog('client.ndjson', [
       { ts: 10, src: 'client', level: 'error', msg: 'stale' },
       { ts: 30, src: 'client', level: 'error', msg: 'fresh' },
     ]);
     writeLog('build-ios.ndjson', [{ ts: 20, src: 'build', level: 'info', msg: 'launched', marker: true }]);
-    run({ errors: true, json: true });
+    await run({ errors: true, json: true });
     expect(parsedMsgs(out)).toEqual(['fresh']);
   });
 
-  test('--errors keeps Expo code and call-stack lines with their error in human output', () => {
+  test('--errors keeps Expo code and call-stack lines with their error in human output', async () => {
     const event = 'expo_stdout';
     const error = {
       ts: 1,
@@ -290,7 +290,7 @@ describe('logs command', () => {
       { ts: 8, src: 'metro', level: 'info', raw: true, event, msg: 'iOS Bundled 50ms' },
     ]);
 
-    run({ errors: true });
+    await run({ errors: true });
     expect(out).toHaveLength(1);
     expect(out[0]).toContain('Code: _layout.tsx');
     expect(out[0]).toContain('RootLayout (app/_layout.tsx:27:18)');
@@ -298,12 +298,12 @@ describe('logs command', () => {
     expect(out[0]).not.toContain('iOS Bundled');
 
     out.length = 0;
-    run({ errors: true, json: true });
+    await run({ errors: true, json: true });
     expect(out).toHaveLength(1);
     expect(parseNdjsonLine(out[0])).toEqual(error);
   });
 
-  test('--errors keeps bare React Native symbolication with its error in human output', () => {
+  test('--errors keeps bare React Native symbolication with its error in human output', async () => {
     const error = { ts: 1, src: 'client', level: 'error', msg: '[Error: STIM_BARE_LAUNCH_CRASH]' };
     writeLog('client.ndjson', [
       error,
@@ -328,7 +328,7 @@ describe('logs command', () => {
       },
     ]);
 
-    run({ errors: true });
+    await run({ errors: true });
     expect(out).toHaveLength(3);
     expect(out[0]).toContain('[Error: STIM_BARE_LAUNCH_CRASH]');
     expect(out[1]).toContain('Metro symbolication context (not correlated to a specific client error)');
@@ -337,12 +337,12 @@ describe('logs command', () => {
     expect(out[2]).toContain('Code: /app/App.tsx:16:35');
 
     out.length = 0;
-    run({ errors: true, json: true });
+    await run({ errors: true, json: true });
     expect(out).toHaveLength(1);
     expect(parseNdjsonLine(out[0])).toEqual(error);
   });
 
-  test('--errors reports reordered bare symbolication separately from client errors', () => {
+  test('--errors reports reordered bare symbolication separately from client errors', async () => {
     writeLog('client.ndjson', [
       {
         ts: 1,
@@ -355,7 +355,7 @@ describe('logs command', () => {
       { ts: 3, src: 'client', level: 'error', msg: '[Error: second]' },
     ]);
 
-    run({ errors: true });
+    await run({ errors: true });
     expect(out).toHaveLength(3);
     expect(out[0]).toContain('not correlated to a specific client error');
     expect(out[0]).toContain('First.tsx');
@@ -363,7 +363,7 @@ describe('logs command', () => {
     expect(out[2]).not.toContain('First.tsx');
   });
 
-  test('--since also bounds bare context when a launch marker exists', () => {
+  test('--since also bounds bare context when a launch marker exists', async () => {
     const now = Date.now();
     writeLog('build-ios.ndjson', [
       { ts: now - 60 * 60 * 1000, src: 'build', level: 'info', msg: 'launched', marker: true },
@@ -386,62 +386,62 @@ describe('logs command', () => {
       { ts: now, src: 'client', level: 'error', msg: '[Error: recent]' },
     ]);
 
-    run({ errors: true, since: '5m' });
+    await run({ errors: true, since: '5m' });
     expect(out.join('\n')).toContain('recent context');
     expect(out.join('\n')).not.toContain('old context');
   });
 
-  test('--source, --level, --grep and --tail reach the query', () => {
+  test('--source, --level, --grep and --tail reach the query', async () => {
     writeLog('metro.ndjson', [
       { ts: 1, src: 'metro', level: 'debug', msg: 'noise' },
       { ts: 2, src: 'metro', level: 'error', msg: 'Unable to resolve module a' },
       { ts: 3, src: 'metro', level: 'error', msg: 'Unable to resolve module b' },
     ]);
     writeLog('client.ndjson', [{ ts: 4, src: 'client', level: 'error', msg: 'Unable to resolve module c' }]);
-    run({ source: ['metro'], level: 'error', grep: 'resolve module', tail: '1', json: true });
+    await run({ source: ['metro'], level: 'error', grep: 'resolve module', tail: '1', json: true });
     expect(parsedMsgs(out)).toEqual(['Unable to resolve module b']);
   });
 
-  test('a bad --since exits 1 with a message naming the accepted forms', () => {
+  test('a bad --since exits 1 with a message naming the accepted forms', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'info', msg: 'x' }]);
-    run({ since: 'soon' });
+    await run({ since: 'soon' });
     expect(exitCode).toBe(1);
     expect(errOut.join('\n')).toMatch(/soon/);
     expect(errOut.join('\n')).toMatch(/30s|5m|2h/);
     expect(out).toEqual([]);
   });
 
-  test('a typo in --source exits 1 rather than reporting an empty pass', () => {
+  test('a typo in --source exits 1 rather than reporting an empty pass', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'error', msg: 'boom' }]);
-    run({ source: ['metrro'], errors: true });
+    await run({ source: ['metrro'], errors: true });
     expect(exitCode).toBe(1);
     expect(errOut.join('\n')).toMatch(/metrro/);
     expect(out).toEqual([]);
   });
 
-  test('a bad --level exits 1', () => {
-    run({ level: 'loud' });
+  test('a bad --level exits 1', async () => {
+    await run({ level: 'loud' });
     expect(exitCode).toBe(1);
     expect(errOut.join('\n')).toMatch(/loud/);
   });
 
-  test('a bad --tail exits 1', () => {
-    run({ tail: 'lots' });
+  test('a bad --tail exits 1', async () => {
+    await run({ tail: 'lots' });
     expect(exitCode).toBe(1);
     expect(errOut.join('\n')).toMatch(/--tail/);
   });
 
-  test('a bad --grep exits 1 rather than throwing a RegExp stack', () => {
-    run({ grep: '[unterminated' });
+  test('a bad --grep exits 1 rather than throwing a RegExp stack', async () => {
+    await run({ grep: '[unterminated' });
     expect(exitCode).toBe(1);
     expect(errOut.join('\n')).toMatch(/grep/);
   });
 
-  test('outside a project it exits 1 and says so', () => {
+  test('outside a project it exits 1 and says so', async () => {
     const bare = mkdtempSync(join(tmpdir(), 'stim-logscmd-bare-'));
     process.chdir(bare);
     try {
-      run({});
+      await run({});
     } finally {
       process.chdir(project);
       rmSync(bare, { recursive: true, force: true });
@@ -450,53 +450,53 @@ describe('logs command', () => {
     expect(errOut.join('\n')).toMatch(/project/i);
   });
 
-  test('--since is honoured against real timestamps', () => {
+  test('--since is honoured against real timestamps', async () => {
     const now = Date.now();
     writeLog('metro.ndjson', [
       { ts: now - 3600000, src: 'metro', level: 'info', msg: 'an hour ago' },
       { ts: now - 1000, src: 'metro', level: 'info', msg: 'a second ago' },
     ]);
-    run({ since: '30s', json: true });
+    await run({ since: '30s', json: true });
     expect(parsedMsgs(out)).toEqual(['a second ago']);
   });
 
   describe('--errors, after the field test', () => {
-    test('the device stream is out of scope by default', () => {
+    test('the device stream is out of scope by default', async () => {
       writeLog('device.ndjson', [
         { ts: 1, src: 'device', level: 'error', msg: 'nw_socket_handle_socket_event [C1:2] Socket SO_ERROR [54]' },
         { ts: 2, src: 'device', level: 'fatal', msg: 'UIScene lifecycle will soon be required' },
       ]);
-      run({ errors: true });
+      await run({ errors: true });
       expect(exitCode).toBe(null);
       expect(out).toEqual([]);
     });
 
-    test('--source device puts it back, and so does --source all', () => {
+    test('--source device puts it back, and so does --source all', async () => {
       writeLog('device.ndjson', [{ ts: 1, src: 'device', level: 'error', msg: 'native crash' }]);
       writeLog('client.ndjson', [{ ts: 2, src: 'client', level: 'error', msg: 'js crash' }]);
 
-      run({ errors: true, source: ['device'], json: true });
+      await run({ errors: true, source: ['device'], json: true });
       expect(parsedMsgs(out)).toEqual(['native crash']);
 
       out.length = 0;
-      run({ errors: true, source: ['all'], json: true });
+      await run({ errors: true, source: ['all'], json: true });
       expect(parsedMsgs(out)).toEqual(['native crash', 'js crash']);
     });
 
-    test('a plain logs (no --errors) still prints the device stream', () => {
+    test('a plain logs (no --errors) still prints the device stream', async () => {
       writeLog('device.ndjson', [{ ts: 1, src: 'device', level: 'error', msg: 'device line' }]);
-      run({});
+      await run({});
       expect(out.length).toBe(1);
       expect(out[0]).toMatch(/device line$/);
     });
 
-    test(`--errors prints at most ${ERRORS_PRINT_CAP} errors plus context and says how many are left`, () => {
+    test(`--errors prints at most ${ERRORS_PRINT_CAP} errors plus context and says how many are left`, async () => {
       const many = [];
       for (let i = 0; i < 3004; i += 1) {
         many.push({ ts: 1000 + i, src: 'client', level: 'error', msg: `boom ${i}` });
       }
       writeLog('client.ndjson', many);
-      run({ errors: true });
+      await run({ errors: true });
       expect(out.length).toBe(ERRORS_PRINT_CAP + 1);
       expect(out[0]).toMatch(/boom 0$/);
       expect(out[ERRORS_PRINT_CAP - 1]).toMatch(/boom 19$/);
@@ -506,7 +506,7 @@ describe('logs command', () => {
       expect(out[ERRORS_PRINT_CAP]).toMatch(/--json/);
     });
 
-    test('the error cap includes context around visible errors without counting it as an error', () => {
+    test('the error cap includes context around visible errors without counting it as an error', async () => {
       const symbolication = (ts: number, msg: string) => ({
         ts,
         src: 'client',
@@ -523,37 +523,37 @@ describe('logs command', () => {
       records.push(symbolication(24, 'after hidden error'));
       writeLog('client.ndjson', records);
 
-      run({ errors: true });
+      await run({ errors: true });
       expect(out.join('\n')).toContain('before visible errors');
       expect(out.join('\n')).toContain('after visible errors');
       expect(out.join('\n')).not.toContain('after hidden error');
       expect(out.at(-1)).toMatch(/and 1 more/);
     });
 
-    test('the cap does not apply to --json, or to an explicit --tail', () => {
+    test('the cap does not apply to --json, or to an explicit --tail', async () => {
       const many = [];
       for (let i = 0; i < 25; i += 1) many.push({ ts: 1000 + i, src: 'client', level: 'error', msg: `boom ${i}` });
       writeLog('client.ndjson', many);
 
-      run({ errors: true, json: true });
+      await run({ errors: true, json: true });
       expect(out.length).toBe(25);
 
       out.length = 0;
-      run({ errors: true, tail: '25' });
+      await run({ errors: true, tail: '25' });
       expect(out.length).toBe(25);
     });
 
-    test('a result at the cap prints no trailer', () => {
+    test('a result at the cap prints no trailer', async () => {
       const many = [];
       for (let i = 0; i < ERRORS_PRINT_CAP; i += 1)
         many.push({ ts: 1000 + i, src: 'client', level: 'error', msg: `boom ${i}` });
       writeLog('client.ndjson', many);
-      run({ errors: true });
+      await run({ errors: true });
       expect(out.length).toBe(ERRORS_PRINT_CAP);
       expect(!out.join('\n').includes('more')).toBeTruthy();
     });
 
-    test('a bundle marker one second after a startup crash does not hide it', () => {
+    test('a bundle marker one second after a startup crash does not hide it', async () => {
       const at = (sec: number) => Date.parse(`2026-08-24T16:03:${sec}Z`);
       writeLog('build-ios.ndjson', [{ ts: at(50), src: 'build', level: 'info', msg: 'launched', marker: true }]);
       writeLog('client.ndjson', [
@@ -562,7 +562,7 @@ describe('logs command', () => {
       writeLog('metro.ndjson', [
         { ts: at(55), src: 'metro', level: 'info', msg: 'bundle build done (1)', marker: true },
       ]);
-      run({ errors: true, json: true });
+      await run({ errors: true, json: true });
       expect(parsedMsgs(out)).toEqual(['[Error: Exception in HostFunction]']);
     });
   });

--- a/packages/stim-cli/src/__tests__/logs-command.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-command.test.ts
@@ -245,6 +245,33 @@ describe('logs command', () => {
     expect(parseNdjsonLine(out[0])).toEqual(record);
   });
 
+  test('omitting --errors shows every string and structured stack frame while JSON stays raw', async () => {
+    const frames = Array.from({ length: 13 }, (_, i) => ({ file: 'app.tsx', line: i + 1, fn: `render${i}` }));
+    const record = {
+      ts: 1,
+      src: 'client',
+      level: 'error',
+      msg: 'x'.repeat(1100),
+      stack: frames,
+      componentStack: frames.map((f) => `at ${f.fn} (${f.file}:${f.line}:1)`).join('\n'),
+    };
+    writeLog('client.ndjson', [record]);
+    await run({ errors: true });
+    expect(out[0]).not.toContain('render12');
+    expect(out[0]).toContain('3 more frames');
+    expect(out[0]).toContain('without --errors');
+    out.length = 0;
+    await run({ source: ['all'] });
+    expect(out[0]).toContain(record.msg);
+    expect(out[0]?.match(/render12/g)).toHaveLength(2);
+    expect(out[0]).toContain('Component stack:');
+    expect(out[0]).not.toContain('more frames');
+    expect(out[0]).not.toContain('Stack preview:');
+    out.length = 0;
+    await run({ errors: true, json: true });
+    expect(parseNdjsonLine(out[0])).toEqual(record);
+  });
+
   test('exits 0 and prints nothing to stdout when nothing matches', async () => {
     writeLog('metro.ndjson', [{ ts: 1, src: 'metro', level: 'info', msg: 'fine' }]);
     await run({ errors: true });
@@ -526,8 +553,8 @@ describe('logs command', () => {
       expect(out[0]).toMatch(/boom 0$/);
       expect(out[ERRORS_PRINT_CAP - 1]).toMatch(/boom 19$/);
       const hidden = 3004 - ERRORS_PRINT_CAP;
-      expect(out[ERRORS_PRINT_CAP]).toMatch(new RegExp(`and ${hidden} more`));
-      expect(out[ERRORS_PRINT_CAP]).toMatch(new RegExp(`--tail ${hidden}`));
+      expect(out[ERRORS_PRINT_CAP]).toContain(`${hidden} not shown`);
+      expect(out[ERRORS_PRINT_CAP]).toContain('--tail 3004');
       expect(out[ERRORS_PRINT_CAP]).toMatch(/--json/);
     });
 
@@ -552,7 +579,31 @@ describe('logs command', () => {
       expect(out.join('\n')).toContain('before visible errors');
       expect(out.join('\n')).toContain('after visible errors');
       expect(out.join('\n')).not.toContain('after hidden error');
-      expect(out.at(-1)).toMatch(/and 1 more/);
+      expect(out.at(-1)).toContain('1 not shown');
+    });
+
+    test('the cap remedy includes raw copies so grouping cannot hide errors from the suggested tail', async () => {
+      const records = Array.from({ length: 21 }, (_, i) => ({
+        ts: i * 2000,
+        level: 'error',
+        platform: 'ios',
+        msg: `Error: boom ${i}\n  at render (app.tsx:${i + 1}:2)`,
+      }));
+      writeLog(
+        'client.ndjson',
+        records.map((r) => ({ ...r, src: 'client' })),
+      );
+      writeLog(
+        'metro.ndjson',
+        records.map((r) => ({ src: 'metro', ts: r.ts + 100, level: r.level, platform: r.platform, msg: r.msg })),
+      );
+      await run({ errors: true });
+      expect(out.at(-1)).toContain('20 of 21 matching error records');
+      expect(out.at(-1)).toContain('--tail 42');
+      out.length = 0;
+      await run({ errors: true, tail: '42' });
+      expect(out).toHaveLength(21);
+      expect(out.at(-1)).toContain('boom 20');
     });
 
     test('the cap does not apply to --json, or to an explicit --tail', async () => {

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -148,9 +148,12 @@ export function isAppLaunchError(record: LaunchErrorRecord): boolean {
  * Splits the error-level records a verified launch collected into the device
  * log the run counts and the records it still prints one by one.
  */
-export function launchErrorReport(records: readonly LaunchErrorRecord[]): { summary: string | null; lines: string[] } {
+export function launchErrorReport(
+  records: readonly LaunchErrorRecord[],
+  root?: string,
+): { summary: string | null; lines: string[] } {
   const fromDevice = records.filter((record) => record.src === 'device');
-  const lines = launchErrorPreview(records.filter(isAppLaunchError));
+  const lines = launchErrorPreview(records.filter(isAppLaunchError), root);
   const summary =
     fromDevice.length === 0
       ? null

--- a/packages/stim-cli/src/command-output.ts
+++ b/packages/stim-cli/src/command-output.ts
@@ -152,12 +152,12 @@ export function launchErrorReport(
   records: readonly LaunchErrorRecord[],
   root?: string,
 ): { summary: string | null; lines: string[] } {
-  const fromDevice = records.filter((record) => record.src === 'device');
+  const fromDevice = records.filter((record) => record.src === 'device' && !isAppLaunchError(record));
   const lines = launchErrorPreview(records.filter(isAppLaunchError), root);
   const summary =
     fromDevice.length === 0
       ? null
-      : `${plural(fromDevice.length, 'error-level record')} in the device log during launch (logs --errors --source device)`;
+      : `${plural(fromDevice.length, 'general device error-level record')} (not confirmed app errors); inspect with stim logs --errors --source device`;
   return { summary, lines };
 }
 

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -99,7 +99,7 @@ async function verifyAndroidRun({
   physical,
   scheme,
   phase,
-}: VerifyAndroidRunArgs): Promise<boolean | string> {
+}: VerifyAndroidRunArgs): Promise<{ state: boolean | string; warning?: string }> {
   const readNativeCrashes = () =>
     remoteDevice
       ? []
@@ -109,7 +109,7 @@ async function verifyAndroidRun({
         );
   if (remoteRelease) {
     phase('verify', chalk.yellow('UNVERIFIED: remote adapter launch accepted; process verification is unavailable'));
-    return LAUNCH_UNVERIFIED;
+    return { state: LAUNCH_UNVERIFIED };
   }
   if (release) {
     const processCheck = await verifyReleaseLaunched({ serial, packageName: androidPackage });
@@ -119,11 +119,11 @@ async function verifyAndroidRun({
         'verify',
         `process alive ${formatDuration(processCheck.waitedMs ?? 0)} after launch (${variant}: no bundle fetch to observe)`,
       );
-      return true;
+      return { state: true };
     }
     if (processCheck?.reason === 'probe-failed' && !crashes.length) {
       phase('verify', chalk.yellow('UNVERIFIED: the app process check failed'));
-      return LAUNCH_UNVERIFIED;
+      return { state: LAUNCH_UNVERIFIED };
     }
     for (const line of launchErrorPreview(crashes, root)) phase('launch', chalk.red(line));
     if (!crashes.length)
@@ -145,7 +145,7 @@ async function verifyAndroidRun({
         'A release process exited before readiness. Run `stim logs --errors` for captured crash reports, or `stim logs --source device` for the full device output.',
       ),
     );
-    return LAUNCH_FATAL;
+    return { state: LAUNCH_FATAL };
   }
 
   const verification: VerifyLaunchResultLike = metroCheck
@@ -212,7 +212,7 @@ async function verifyAndroidRun({
         ),
       );
     }
-    return LAUNCH_FATAL;
+    return { state: LAUNCH_FATAL };
   }
   if (verification?.verified) {
     phase(
@@ -236,11 +236,19 @@ async function verifyAndroidRun({
         ),
       );
     }
-    return true;
+    return {
+      state: true,
+      warning:
+        report.lines.length > 0
+          ? 'app errors detected; inspect the error above'
+          : verification.readiness === 'timed-out' || verification.readiness === 'error'
+            ? 'app readiness not confirmed; inspect the UI and logs'
+            : undefined,
+    };
   }
   if (verification?.skipped) {
     phase('verify', 'skipped (--no-metro-check): the launch is reported as unverified');
-    return LAUNCH_UNVERIFIED;
+    return { state: LAUNCH_UNVERIFIED };
   }
   if (verification?.requested) {
     phase(
@@ -252,7 +260,7 @@ async function verifyAndroidRun({
       '',
       chalk.dim('Nothing to do: `stim logs --source metro` shows the build finishing, usually within a minute.'),
     );
-    return LAUNCH_BUNDLING;
+    return { state: LAUNCH_BUNDLING };
   }
 
   phase('verify', chalk.yellow("UNVERIFIED: no bundle request reached this workspace's Metro"));
@@ -266,7 +274,7 @@ async function verifyAndroidRun({
     mode: isExpo ? MODE_EXPO : MODE_BARE,
   }))
     phase('', chalk.yellow(line));
-  return LAUNCH_UNVERIFIED;
+  return { state: LAUNCH_UNVERIFIED };
 }
 
 interface FinishAndroidRunArgs {
@@ -620,7 +628,7 @@ export async function finishAndroidRun({
   }
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
-  const launchState = await verifyAndroidRun({
+  const { state: launchState, warning: launchWarning } = await verifyAndroidRun({
     root,
     release,
     remoteRelease,
@@ -671,6 +679,7 @@ export async function finishAndroidRun({
     remote,
     providerName,
     launchState,
+    launchWarning,
     launched,
     ccache,
     durationMs: now() - started,

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -113,21 +113,18 @@ async function verifyAndroidRun({
   }
   if (release) {
     const processCheck = await verifyReleaseLaunched({ serial, packageName: androidPackage });
-    if (processCheck?.verified) {
+    const crashes = readNativeCrashes();
+    if (processCheck?.verified && !crashes.length) {
       phase(
         'verify',
         `process alive ${formatDuration(processCheck.waitedMs ?? 0)} after launch (${variant}: no bundle fetch to observe)`,
       );
       return true;
     }
-    if (processCheck?.reason === 'probe-failed') {
+    if (processCheck?.reason === 'probe-failed' && !crashes.length) {
       phase('verify', chalk.yellow('UNVERIFIED: the app process check failed'));
       return LAUNCH_UNVERIFIED;
     }
-    const crashes = captureNativeCrashes(
-      { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
-      logsDir,
-    );
     for (const line of launchErrorPreview(crashes, root)) phase('launch', chalk.red(line));
     if (!crashes.length)
       phase(
@@ -137,7 +134,9 @@ async function verifyAndroidRun({
     phase(
       'verify',
       chalk.yellow(
-        `UNVERIFIED: no ${androidPackage} process on ${serial} ${formatDuration(processCheck?.waitedMs ?? 0)} after launch`,
+        crashes.length
+          ? 'FATAL: the app reported a native crash'
+          : `FATAL: no ${androidPackage} process on ${serial} ${formatDuration(processCheck?.waitedMs ?? 0)} after launch`,
       ),
     );
     phase(
@@ -524,6 +523,7 @@ export async function finishAndroidRun({
     appId: androidPackage,
     deviceId: serial,
     remote: Boolean(remoteDevice),
+    physical,
     msg: `launching ${androidPackage} on ${serial}`,
   });
   const launched: LaunchResultLike = release

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -20,6 +20,7 @@ import {
   ADB_INSTALL_TIMEOUT_MS,
   RELEASE_VERIFY_WAIT_MS,
   installConflictKind,
+  deviceShellArg,
 } from '../../engine/app-install.ts';
 import { appReadinessMessage, formatDuration, launchErrorReport, phaseLine, stepTimer } from '../../command-output.ts';
 import { launchErrorPreview } from '../../launch-error-preview.ts';
@@ -57,10 +58,14 @@ import { providerUploadOutcome } from '../../build-cache.ts';
 import { detectAndroidPackage } from '../../project.ts';
 import { launchOutcomeRecord } from '../native-runtime.ts';
 import { startCollector } from './collector.ts';
+import { captureNativeCrashes, printNativeCrashReport } from '../../native-crash.ts';
+import { errorDiagnostics } from '../../error-diagnostics.ts';
 
 interface VerifyAndroidRunArgs {
+  root: string;
   release: boolean;
   remoteRelease: boolean;
+  remoteDevice: boolean;
   verifyReleaseLaunched: typeof verifyAndroidReleaseLaunch;
   verifyLaunched: typeof verifyLaunch;
   serial: string;
@@ -77,8 +82,10 @@ interface VerifyAndroidRunArgs {
 }
 
 async function verifyAndroidRun({
+  root,
   release,
   remoteRelease,
+  remoteDevice,
   verifyReleaseLaunched,
   verifyLaunched,
   serial,
@@ -93,6 +100,13 @@ async function verifyAndroidRun({
   scheme,
   phase,
 }: VerifyAndroidRunArgs): Promise<boolean | string> {
+  const readNativeCrashes = () =>
+    remoteDevice
+      ? []
+      : captureNativeCrashes(
+          { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
+          logsDir,
+        );
   if (remoteRelease) {
     phase('verify', chalk.yellow('UNVERIFIED: remote adapter launch accepted; process verification is unavailable'));
     return LAUNCH_UNVERIFIED;
@@ -110,6 +124,16 @@ async function verifyAndroidRun({
       phase('verify', chalk.yellow('UNVERIFIED: the app process check failed'));
       return LAUNCH_UNVERIFIED;
     }
+    const crashes = captureNativeCrashes(
+      { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
+      logsDir,
+    );
+    for (const line of launchErrorPreview(crashes, root)) phase('launch', chalk.red(line));
+    if (!crashes.length)
+      phase(
+        'logs',
+        'Process missing; no attributable native crash report captured. Read `stim logs --source device` for available output.',
+      );
     phase(
       'verify',
       chalk.yellow(
@@ -119,7 +143,7 @@ async function verifyAndroidRun({
     phase(
       '',
       chalk.yellow(
-        'A release app that dies at startup usually crashed loading its embedded bundle; `stim logs --errors` has the device log that says why.',
+        'A release process exited before readiness. Run `stim logs --errors` for captured crash reports, or `stim logs --source device` for the full device output.',
       ),
     );
     return LAUNCH_FATAL;
@@ -133,28 +157,50 @@ async function verifyAndroidRun({
         metroPort,
         platform: 'android',
         mode: isExpo ? MODE_EXPO : MODE_BARE,
+        readNativeCrashes,
         processAlive: () => {
           const pid = androidAppProcess(serial, androidPackage);
           return pid === undefined ? null : pid !== null;
         },
       })
     : { verified: false, skipped: true };
+  const nativeCrashes = verification.errors?.some((record) => record.event === 'native_crash')
+    ? []
+    : readNativeCrashes();
+  if (nativeCrashes.length) {
+    verification.fatal = true;
+  }
+  verification.errors = await errorDiagnostics([...(verification.errors ?? []), ...nativeCrashes], {
+    root,
+    logsDir,
+    port: metroPort,
+    allowRequest: true,
+  });
   if (verification.readiness)
     phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
+    const nativeFatal = verification.errors?.some((record) => record.event === 'native_crash');
     const deliveryFailed = verification.record?.event === 'bundle_response_failed';
-    const reason =
-      verification.processAlive === false
+    const reason = nativeFatal
+      ? 'the app reported a native crash'
+      : verification.processAlive === false
         ? 'the app process exited'
         : deliveryFailed
           ? 'Metro bundle delivery failed'
           : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
-    for (const line of launchErrorPreview(verification.errors ?? [])) phase('', chalk.red(line));
-    if (verification.processAlive === false) {
+    for (const line of launchErrorPreview(verification.errors ?? [], root)) phase('', chalk.red(line));
+    if (verification.processAlive === false && !verification.errors?.some((record) => record.event === 'native_crash'))
+      phase(
+        'logs',
+        'No attributable native crash report captured yet. Run `stim logs --errors` again for delayed reports, or `stim logs --source device` for available output.',
+      );
+    if (nativeFatal || verification.processAlive === false) {
       phase(
         'remedy',
-        chalk.yellow('Fix the crash, then run `stim android` again. A Metro reload cannot restart an exited app.'),
+        chalk.yellow(
+          `Fix the crash, then restart the app: \`adb -s ${deviceShellArg(serial)} shell am force-stop ${deviceShellArg(androidPackage)}\`, then run \`stim android\` again. A crashed Android process can remain alive behind the system crash dialog; Metro reload cannot recover it.`,
+        ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
       const reloadRemedy = physical
@@ -177,7 +223,7 @@ async function verifyAndroidRun({
         (verification.readiness ? '' : ', stable for 3s -- the first screen may still be rendering') +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    const report = launchErrorReport(verification.errors ?? []);
+    const report = launchErrorReport(verification.errors ?? [], root);
     if (report.summary) phase('launch', chalk.dim(report.summary));
     for (const line of report.lines) phase('launch', chalk.yellow(line));
     if (report.lines.length > 0 && verification.processAlive === true && metroPort !== null) {
@@ -468,6 +514,18 @@ export async function finishAndroidRun({
   const scheme = release ? undefined : resolveDevClientScheme(root, apkPath);
   const launchTimer = stepTimer(now);
   const launchedAt = now();
+  writer.write({
+    src: 'build',
+    level: 'info',
+    marker: true,
+    event: 'launch_attempt',
+    ts: launchedAt,
+    platform: 'android',
+    appId: androidPackage,
+    deviceId: serial,
+    remote: Boolean(remoteDevice),
+    msg: `launching ${androidPackage} on ${serial}`,
+  });
   const launched: LaunchResultLike = release
     ? remoteDevice
       ? remoteDevice.launch({ serial, packageName: androidPackage, metroPort: null })
@@ -480,6 +538,12 @@ export async function finishAndroidRun({
         physical,
       });
   if (launched.failed) {
+    printNativeCrashReport(
+      { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
+      logsDir,
+      (line) => phase('launch', chalk.red(line)),
+      Boolean(remoteDevice),
+    );
     return fail(
       launched.code || LAUNCH_FAILED,
       launched.reason,
@@ -491,7 +555,6 @@ export async function finishAndroidRun({
     src: 'build',
     level: 'info',
     event: 'app_launched',
-    marker: true,
     msg: release
       ? `launched ${androidPackage} on ${serial} (${variant}, embedded JS bundle, no Metro)`
       : `launched ${androidPackage} on ${serial} against Metro port ${metroPort}`,
@@ -558,8 +621,10 @@ export async function finishAndroidRun({
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const launchState = await verifyAndroidRun({
+    root,
     release,
     remoteRelease,
+    remoteDevice: Boolean(remoteDevice),
     verifyReleaseLaunched,
     verifyLaunched,
     serial,

--- a/packages/stim-cli/src/commands/android/result.ts
+++ b/packages/stim-cli/src/commands/android/result.ts
@@ -177,6 +177,7 @@ export interface ReportAndroidResultArgs {
   remote: LoadProjectProviderResult | null;
   providerName: string | null;
   launchState: boolean | string;
+  launchWarning?: string;
   launched: LaunchResultLike;
   ccache: CcacheActivity;
   durationMs: number;
@@ -202,6 +203,7 @@ export function reportAndroidResult({
   remote,
   providerName,
   launchState,
+  launchWarning,
   launched,
   ccache,
   durationMs,
@@ -241,11 +243,12 @@ export function reportAndroidResult({
     emit(JSON.stringify(facts));
   } else {
     const summary =
-      `OK: ${androidPackage} launched on ${serial}, ` +
+      `${launchWarning ? 'WARNING' : 'OK'}: ${androidPackage} launched on ${serial}, ` +
       `${release ? `${variant} (embedded JS, no Metro)` : `Metro port ${metroPort}`} ` +
       `(${cacheOutcome(record.cacheHit, remote?.name ?? providerName)})`;
-    const outcome =
-      launchState === LAUNCH_UNVERIFIED
+    const outcome = launchWarning
+      ? chalk.yellow(`${summary} -- ${launchWarning}`)
+      : launchState === LAUNCH_UNVERIFIED
         ? chalk.yellow(`${summary} -- launch UNVERIFIED`)
         : launchState === LAUNCH_BUNDLING
           ? chalk.green(`${summary} -- bundle requested, still building`)

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -43,7 +43,12 @@ import { type ReportIosResultArgs, finishIosUpload, reportIosResult } from './re
 import { providerUploadOutcome } from '../../build-cache.ts';
 import { launchOutcomeRecord } from '../native-runtime.ts';
 import { COLLECTOR_EXIT_WAIT_MS } from './collector.ts';
-import { captureNativeCrashes, printNativeCrashReport, simulatorConsolePaths } from '../../native-crash.ts';
+import {
+  captureNativeCrashes,
+  IOS_CRASH_REPORT_RETRY,
+  printNativeCrashReport,
+  simulatorConsolePaths,
+} from '../../native-crash.ts';
 import { errorDiagnostics } from '../../error-diagnostics.ts';
 
 interface VerifyIosRunArgs {
@@ -69,6 +74,20 @@ interface VerifyIosRunArgs {
   lanOrigin: string | null;
   remoteDevice: boolean;
   metroOrigin: string | null;
+}
+
+function missingCrashReportHint({
+  physical,
+  remote,
+  crashed,
+}: {
+  physical: boolean;
+  remote: boolean;
+  crashed: boolean;
+}): string {
+  return crashed && !physical && !remote
+    ? `No attributable native crash report captured yet. ${IOS_CRASH_REPORT_RETRY}`
+    : 'No attributable native crash report captured. Read `stim logs --source device` for available output.';
 }
 
 async function verifyIosRun({
@@ -124,7 +143,11 @@ async function verifyIosRun({
       note(
         phaseLine(
           'logs',
-          'No attributable native crash report captured. Read `stim logs --source device` for available output.',
+          missingCrashReportHint({
+            physical,
+            remote: Boolean(remoteDevice),
+            crashed: processCheck?.reason === 'exited',
+          }),
         ),
       );
     phase(
@@ -197,12 +220,7 @@ async function verifyIosRun({
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
     for (const line of launchErrorPreview(verification.errors ?? [], root)) note(chalk.red(phaseLine('', line)));
     if (verification.processAlive === false && !verification.errors?.some((record) => record.event === 'native_crash'))
-      note(
-        phaseLine(
-          'logs',
-          'No attributable native crash report captured yet. Run `stim logs --errors` again for delayed reports, or `stim logs --source device` for available output.',
-        ),
-      );
+      note(phaseLine('logs', missingCrashReportHint({ physical, remote: Boolean(remoteDevice), crashed: true })));
     if (nativeFatal || verification.processAlive === false) {
       note(
         chalk.yellow(

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -113,7 +113,7 @@ async function verifyIosRun({
   lanOrigin,
   remoteDevice,
   metroOrigin,
-}: VerifyIosRunArgs): Promise<boolean | string> {
+}: VerifyIosRunArgs): Promise<{ state: boolean | string; warning?: string }> {
   const readNativeCrashes = () =>
     remoteDevice
       ? []
@@ -136,7 +136,7 @@ async function verifyIosRun({
         'verify',
         `process alive ${formatDuration(processCheck.waitedMs ?? 0)} after launch (${configuration}: no bundle fetch to observe)`,
       );
-      return true;
+      return { state: true };
     }
     for (const line of launchErrorPreview(crashes, root)) note(chalk.red(phaseLine('launch', line)));
     if (!crashes.length)
@@ -170,7 +170,7 @@ async function verifyIosRun({
         ),
       ),
     );
-    return crashes.length || processCheck?.reason === 'exited' ? LAUNCH_FATAL : LAUNCH_UNVERIFIED;
+    return { state: crashes.length || processCheck?.reason === 'exited' ? LAUNCH_FATAL : LAUNCH_UNVERIFIED };
   }
 
   const verification: VerifyLaunchResultLike = metroCheck
@@ -241,7 +241,7 @@ async function verifyIosRun({
         ),
       );
     }
-    return LAUNCH_FATAL;
+    return { state: LAUNCH_FATAL };
   }
   if (verification?.verified) {
     phase(
@@ -266,11 +266,18 @@ async function verifyIosRun({
         ),
       );
     }
-    return true;
+    return {
+      state: true,
+      warning: hasAppErrors
+        ? 'app errors detected; inspect the error above'
+        : verification.readiness === 'timed-out' || verification.readiness === 'error'
+          ? 'app readiness not confirmed; inspect the UI and logs'
+          : undefined,
+    };
   }
   if (verification?.skipped) {
     phase('verify', 'skipped (--no-metro-check): the launch is reported as unverified');
-    return LAUNCH_UNVERIFIED;
+    return { state: LAUNCH_UNVERIFIED };
   }
   if (verification?.requested) {
     phase(
@@ -283,7 +290,7 @@ async function verifyIosRun({
         phaseLine('', 'Nothing to do: `stim logs --source metro` shows the build finishing, usually within a minute.'),
       ),
     );
-    return LAUNCH_BUNDLING;
+    return { state: LAUNCH_BUNDLING };
   }
 
   phase('verify', chalk.yellow("UNVERIFIED: no bundle request reached this workspace's Metro"));
@@ -309,7 +316,7 @@ async function verifyIosRun({
       }),
   }))
     note(chalk.yellow(phaseLine('', line)));
-  return LAUNCH_UNVERIFIED;
+  return { state: LAUNCH_UNVERIFIED };
 }
 
 function reportLaunchErrors(errors: LaunchErrorRecord[], note: (line: string) => void, root: string): boolean {
@@ -753,7 +760,7 @@ export async function finishIosRun({
   if (remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
-  const launchState = await verifyIosRun({
+  const { state: launchState, warning: launchWarning } = await verifyIosRun({
     root,
     appPath,
     d,
@@ -820,6 +827,7 @@ export async function finishIosRun({
     useBuildCache,
     waitedForBuild,
     launchState,
+    launchWarning,
     remote,
     providerName,
     closeWriter,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -43,8 +43,12 @@ import { type ReportIosResultArgs, finishIosUpload, reportIosResult } from './re
 import { providerUploadOutcome } from '../../build-cache.ts';
 import { launchOutcomeRecord } from '../native-runtime.ts';
 import { COLLECTOR_EXIT_WAIT_MS } from './collector.ts';
+import { captureNativeCrashes, printNativeCrashReport, simulatorConsolePaths } from '../../native-crash.ts';
+import { errorDiagnostics } from '../../error-diagnostics.ts';
 
 interface VerifyIosRunArgs {
+  root: string;
+  appPath: string | null;
   d: IosDeps;
   release: boolean;
   launched: ReturnType<IosDeps['launchIosApp']>;
@@ -68,6 +72,8 @@ interface VerifyIosRunArgs {
 }
 
 async function verifyIosRun({
+  root,
+  appPath,
   d,
   release,
   launched,
@@ -89,6 +95,13 @@ async function verifyIosRun({
   remoteDevice,
   metroOrigin,
 }: VerifyIosRunArgs): Promise<boolean | string> {
+  const readNativeCrashes = () =>
+    remoteDevice
+      ? []
+      : captureNativeCrashes(
+          { root, platform: 'ios', deviceId: udid, appId: bundleId, since: launchedAt, appPath, physical },
+          logsDir,
+        );
   const deviceProcess = (): boolean | null => {
     const pid = d.iosDeviceProcess({ udid, appName: appName ?? bundleId });
     return pid === undefined ? null : pid !== null;
@@ -105,6 +118,20 @@ async function verifyIosRun({
       );
       return true;
     }
+    const crashes = remoteDevice
+      ? []
+      : captureNativeCrashes(
+          { platform: 'ios', deviceId: udid, appId: bundleId, since: launchedAt, appPath, physical },
+          logsDir,
+        );
+    for (const line of launchErrorPreview(crashes, root)) note(chalk.red(phaseLine('launch', line)));
+    if (!crashes.length)
+      note(
+        phaseLine(
+          'logs',
+          'No attributable native crash report captured. Read `stim logs --source device` for available output.',
+        ),
+      );
     phase(
       'verify',
       chalk.yellow(
@@ -119,7 +146,7 @@ async function verifyIosRun({
       chalk.yellow(
         phaseLine(
           '',
-          'A release app that dies at startup usually crashed loading its embedded bundle; `stim logs --errors` has the device log that says why.',
+          'A release process exited before readiness. Run `stim logs --errors` for captured crash reports, or `stim logs --source device` for the full device output.',
         ),
       ),
     );
@@ -134,6 +161,7 @@ async function verifyIosRun({
         metroPort,
         platform: 'ios',
         mode: isExpo ? MODE_EXPO : MODE_BARE,
+        readNativeCrashes,
         processAlive: remoteDevice
           ? null
           : physical
@@ -145,19 +173,40 @@ async function verifyIosRun({
               },
       })
     : { verified: false, skipped: true };
+  const nativeCrashes = verification.errors?.some((record) => record.event === 'native_crash')
+    ? []
+    : readNativeCrashes();
+  if (nativeCrashes.length) {
+    verification.fatal = true;
+  }
+  verification.errors = await errorDiagnostics([...(verification.errors ?? []), ...nativeCrashes], {
+    root,
+    logsDir,
+    port: metroPort,
+    allowRequest: true,
+  });
   if (verification.readiness)
     phase('readiness', appReadinessMessage(verification.readiness, verification.waitedMs ?? 0));
   if (verification?.fatal) {
+    const nativeFatal = verification.errors?.some((record) => record.event === 'native_crash');
     const deliveryFailed = verification.record?.event === 'bundle_response_failed';
-    const reason =
-      verification.processAlive === false
+    const reason = nativeFatal
+      ? 'the app reported a native crash'
+      : verification.processAlive === false
         ? 'the app process exited'
         : deliveryFailed
           ? 'Metro bundle delivery failed'
           : 'Metro could not build the bundle';
     phase('verify', chalk.red(`FATAL after ${formatDuration(verification.waitedMs ?? 0)}: ${reason}`));
-    for (const line of launchErrorPreview(verification.errors ?? [])) note(chalk.red(phaseLine('', line)));
-    if (verification.processAlive === false) {
+    for (const line of launchErrorPreview(verification.errors ?? [], root)) note(chalk.red(phaseLine('', line)));
+    if (verification.processAlive === false && !verification.errors?.some((record) => record.event === 'native_crash'))
+      note(
+        phaseLine(
+          'logs',
+          'No attributable native crash report captured yet. Run `stim logs --errors` again for delayed reports, or `stim logs --source device` for available output.',
+        ),
+      );
+    if (nativeFatal || verification.processAlive === false) {
       note(
         chalk.yellow(
           phaseLine('remedy', 'Fix the crash, then run `stim ios` again. A Metro reload cannot restart an exited app.'),
@@ -187,7 +236,7 @@ async function verifyIosRun({
         (verification.readiness ? '' : ', stable for 3s -- the first screen may still be rendering') +
         ` (${formatDuration(verification.waitedMs ?? 0)} total)`,
     );
-    const hasAppErrors = reportLaunchErrors(verification.errors ?? [], note);
+    const hasAppErrors = reportLaunchErrors(verification.errors ?? [], note, root);
     if (hasAppErrors && verification.processAlive === true && metroPort !== null) {
       const reloadRemedy =
         physical || remoteDevice
@@ -248,8 +297,8 @@ async function verifyIosRun({
   return LAUNCH_UNVERIFIED;
 }
 
-function reportLaunchErrors(errors: LaunchErrorRecord[], note: (line: string) => void): boolean {
-  const report = launchErrorReport(errors);
+function reportLaunchErrors(errors: LaunchErrorRecord[], note: (line: string) => void, root: string): boolean {
+  const report = launchErrorReport(errors, root);
   if (report.summary) note(chalk.dim(phaseLine('launch', report.summary)));
   for (const line of report.lines) note(chalk.yellow(phaseLine('launch', line)));
   return report.lines.length > 0;
@@ -514,6 +563,19 @@ export async function finishIosRun({
     const payloadUrl = scheme && metroPort !== null && lanAddress ? devClientUrl(scheme, metroPort, lanAddress) : null;
     const launchTimer = stepTimer(d.now);
     launchedAt = d.now();
+    logWriter().write({
+      src: 'build',
+      level: 'info',
+      marker: true,
+      event: 'launch_attempt',
+      ts: launchedAt,
+      platform: 'ios',
+      appId: bundleId,
+      deviceId: udid,
+      appPath,
+      physical: true,
+      msg: `launching ${bundleId} on ${udid}`,
+    });
     const collector = await d.replaceCollector({
       root,
       udid,
@@ -608,8 +670,37 @@ export async function finishIosRun({
     if (!remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
     const launchTimer = stepTimer(d.now);
     launchedAt = d.now();
-    launched = d.launchIosApp({ udid, bundleId: bundleId!, metroPort, devClientScheme: scheme });
+    logWriter().write({
+      src: 'build',
+      level: 'info',
+      marker: true,
+      event: 'launch_attempt',
+      ts: launchedAt,
+      platform: 'ios',
+      appId: bundleId,
+      deviceId: udid,
+      appPath,
+      remote: Boolean(remoteDevice),
+      msg: `launching ${bundleId} on ${udid}`,
+    });
+    launched = d.launchIosApp({
+      udid,
+      bundleId: bundleId!,
+      metroPort,
+      devClientScheme: scheme,
+      consolePaths: simulatorConsolePaths(
+        { deviceId: udid, appId: bundleId!, since: launchedAt },
+        true,
+        Boolean(remoteDevice),
+      ),
+    });
     if (launched?.failed) {
+      printNativeCrashReport(
+        { root, platform: 'ios', deviceId: udid, appId: bundleId!, since: launchedAt, appPath },
+        logsDir,
+        (line) => note(chalk.red(phaseLine('launch', line))),
+        Boolean(remoteDevice),
+      );
       return fail({
         code: launched.code || 'STIM_LAUNCH_FAILED',
         message: launched.reason,
@@ -637,7 +728,6 @@ export async function finishIosRun({
   logWriter().write({
     src: 'build',
     level: 'info',
-    marker: true,
     event: 'launch',
     msg: release
       ? `launched ${bundleId} on ${udid} (${configuration}, embedded JS bundle, no Metro)`
@@ -649,6 +739,8 @@ export async function finishIosRun({
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const launchState = await verifyIosRun({
+    root,
+    appPath,
     d,
     release,
     launched,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -111,19 +111,14 @@ async function verifyIosRun({
     const processCheck = physical
       ? await d.verifyIosDeviceReleaseLaunch({ udid, appName: appName ?? bundleId })
       : await d.verifyReleaseLaunch({ pid: launched?.pid ?? null });
-    if (processCheck?.verified) {
+    const crashes = readNativeCrashes();
+    if (processCheck?.verified && !crashes.length) {
       phase(
         'verify',
         `process alive ${formatDuration(processCheck.waitedMs ?? 0)} after launch (${configuration}: no bundle fetch to observe)`,
       );
       return true;
     }
-    const crashes = remoteDevice
-      ? []
-      : captureNativeCrashes(
-          { platform: 'ios', deviceId: udid, appId: bundleId, since: launchedAt, appPath, physical },
-          logsDir,
-        );
     for (const line of launchErrorPreview(crashes, root)) note(chalk.red(phaseLine('launch', line)));
     if (!crashes.length)
       note(
@@ -135,22 +130,24 @@ async function verifyIosRun({
     phase(
       'verify',
       chalk.yellow(
-        processCheck?.reason === 'exited'
-          ? `UNVERIFIED: the app process exited within ${formatDuration(processCheck.waitedMs ?? 0)} of launch`
-          : physical
-            ? `UNVERIFIED: devicectl could not read ${udid}'s process list`
-            : 'UNVERIFIED: simctl launch reported no process id to check',
+        crashes.length
+          ? 'FATAL: the app reported a native crash'
+          : processCheck?.reason === 'exited'
+            ? `FATAL: the app process exited within ${formatDuration(processCheck.waitedMs ?? 0)} of launch`
+            : physical
+              ? `UNVERIFIED: devicectl could not read ${udid}'s process list`
+              : 'UNVERIFIED: simctl launch reported no process id to check',
       ),
     );
     note(
       chalk.yellow(
         phaseLine(
           '',
-          'A release process exited before readiness. Run `stim logs --errors` for captured crash reports, or `stim logs --source device` for the full device output.',
+          'Release readiness was not established. Run `stim logs --errors` for captured crash reports, or `stim logs --source device` for the full device output.',
         ),
       ),
     );
-    return processCheck?.reason === 'exited' ? LAUNCH_FATAL : LAUNCH_UNVERIFIED;
+    return crashes.length || processCheck?.reason === 'exited' ? LAUNCH_FATAL : LAUNCH_UNVERIFIED;
   }
 
   const verification: VerifyLaunchResultLike = metroCheck

--- a/packages/stim-cli/src/commands/ios/result.ts
+++ b/packages/stim-cli/src/commands/ios/result.ts
@@ -187,6 +187,7 @@ export interface ReportIosResultArgs {
   useBuildCache: boolean;
   waitedForBuild: WaitedForBuild | null;
   launchState: boolean | string;
+  launchWarning?: string;
   remote: LoadProjectProviderResult | null;
   providerName: string | null;
   closeWriter: () => void;
@@ -218,6 +219,7 @@ export function reportIosResult({
   useBuildCache,
   waitedForBuild,
   launchState,
+  launchWarning,
   remote,
   providerName,
   closeWriter,
@@ -270,11 +272,12 @@ export function reportIosResult({
     console.log(JSON.stringify(facts));
   } else {
     const summary =
-      `OK: ${bundleId} on ${deviceLabel(device, udid)}, ` +
+      `${launchWarning ? 'WARNING' : 'OK'}: ${bundleId} on ${deviceLabel(device, udid)}, ` +
       (release ? `${configuration} (embedded JS, no Metro)` : `Metro port ${metroPort}`) +
       ` (${cacheDescription(cacheHit, remote?.name ?? providerName)}, ${formatDuration(durationMs)})`;
-    const outcome =
-      launchState === LAUNCH_UNVERIFIED
+    const outcome = launchWarning
+      ? chalk.yellow(`${summary} -- ${launchWarning}`)
+      : launchState === LAUNCH_UNVERIFIED
         ? chalk.yellow(`${summary} -- launch UNVERIFIED`)
         : launchState === LAUNCH_BUNDLING
           ? chalk.green(`${summary} -- bundle requested, still building`)

--- a/packages/stim-cli/src/commands/logs.ts
+++ b/packages/stim-cli/src/commands/logs.ts
@@ -190,9 +190,11 @@ export default function logsCommand(program: Command): void {
           console.log(JSON.stringify(record));
           return;
         }
-        const rendered = opts.errors
-          ? { ...record, msg: launchErrorPreview([record], root).join('\n'), stack: undefined }
-          : record;
+        const rendered = {
+          ...record,
+          msg: launchErrorPreview([record], root, { full: !opts.errors }).join('\n'),
+          stack: undefined,
+        };
         console.log(formatRecord(rendered, { paint: record?.level ? LEVEL_COLOURS[record.level] : undefined }));
       };
 
@@ -222,7 +224,11 @@ export default function logsCommand(program: Command): void {
       for (const record of capped) emit(record);
       const hidden = errorCount - capped.filter((record) => record.errorContext !== true).length;
       if (hidden > 0) {
-        console.log(chalk.dim(`... and ${hidden} more (rerun with --tail ${hidden} or --json)`));
+        console.log(
+          chalk.dim(
+            `Showing ${ERRORS_PRINT_CAP} of ${errorCount} matching error records; ${hidden} not shown. Add --tail ${rawRecords.length} to include all captured records before grouping (stacks still previewed), or --json for raw records.`,
+          ),
+        );
       }
 
       if (!opts.follow) {

--- a/packages/stim-cli/src/commands/logs.ts
+++ b/packages/stim-cli/src/commands/logs.ts
@@ -6,6 +6,10 @@ import { workspaceLogsDir } from '../paths.ts';
 import { LEVELS, SOURCES } from '../ndjson.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
 import { buildCriteria, compileGrep, fileSizes, followLogs, parseSince, queryLogs } from '../logs-query.ts';
+import { errorDiagnostics } from '../error-diagnostics.ts';
+import { launchErrorPreview } from '../launch-error-preview.ts';
+import { readWorkspaceState } from '../supervisor/state.ts';
+import { captureWorkspaceCrashes } from '../native-crash.ts';
 
 const LEVEL_WIDTH = 5;
 const SRC_WIDTH = 6;
@@ -127,11 +131,11 @@ export default function logsCommand(program: Command): void {
     .option('--tail <n>', 'Only the last n matching records')
     .option(
       '--errors',
-      "Only errors and fatals since the last marker, from metro, client and build (the agent-loop query). Device errors are the OS talking, not the app -- the app's own crashes reach the client and metro streams -- so add --source device or --source all to include them.",
+      'Errors and fatals since the last marker, from metro, client and build, plus confirmed native app-crash reports. Add --source device or --source all for general device errors.',
     )
     .option('--follow', 'Keep streaming new records until interrupted')
     .option('--json', 'Emit the raw records, one per line (valid NDJSON; zero matches is zero bytes, exit 0)')
-    .action((opts: LogsOptions) => {
+    .action(async (opts: LogsOptions) => {
       const root = findProjectRoot(process.cwd());
       if (!root) {
         console.error(chalk.red('Not in a React Native project (no package.json found).'));
@@ -186,12 +190,25 @@ export default function logsCommand(program: Command): void {
           console.log(JSON.stringify(record));
           return;
         }
-        console.log(formatRecord(record, { paint: record?.level ? LEVEL_COLOURS[record.level] : undefined }));
+        const rendered = opts.errors
+          ? { ...record, msg: launchErrorPreview([record], root).join('\n'), stack: undefined }
+          : record;
+        console.log(formatRecord(rendered, { paint: record?.level ? LEVEL_COLOURS[record.level] : undefined }));
       };
 
       const offsets = opts.follow ? fileSizes(dir) : null;
 
-      const records = queryLogs(query);
+      captureWorkspaceCrashes(root, dir);
+      const rawRecords = queryLogs(query);
+      const supervisorPort = readWorkspaceState(root)?.supervisor?.port;
+      const records = opts.json
+        ? rawRecords
+        : await errorDiagnostics(rawRecords, {
+            root,
+            logsDir: dir,
+            port: typeof supervisorPort === 'number' ? supervisorPort : null,
+            allowRequest: true,
+          });
       const errorCount = records.filter((record) => record.errorContext !== true).length;
       let seenErrors = 0;
       const capped =

--- a/packages/stim-cli/src/commands/logs.ts
+++ b/packages/stim-cli/src/commands/logs.ts
@@ -192,7 +192,7 @@ export default function logsCommand(program: Command): void {
         }
         const rendered = {
           ...record,
-          msg: launchErrorPreview([record], root, { full: !opts.errors }).join('\n'),
+          msg: launchErrorPreview([record], root, { full: true }).join('\n'),
           stack: undefined,
         };
         console.log(formatRecord(rendered, { paint: record?.level ? LEVEL_COLOURS[record.level] : undefined }));
@@ -226,7 +226,7 @@ export default function logsCommand(program: Command): void {
       if (hidden > 0) {
         console.log(
           chalk.dim(
-            `Showing ${ERRORS_PRINT_CAP} of ${errorCount} matching error records; ${hidden} not shown. Add --tail ${rawRecords.length} to include all captured records before grouping (stacks still previewed), or --json for raw records.`,
+            `Showing ${ERRORS_PRINT_CAP} of ${errorCount} matching error records; ${hidden} not shown. Add --tail ${rawRecords.length} to include all captured records before grouping, or --json for raw records. Stacks are shown in full.`,
           ),
         );
       }

--- a/packages/stim-cli/src/diagnostic-store.ts
+++ b/packages/stim-cli/src/diagnostic-store.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { withDirLock } from './dir-lock.ts';
+
+/** Publishes an immutable diagnostic snapshot atomically; existing evidence wins. */
+export function writeDiagnosticOnce(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  withDirLock(
+    `${path}.lock`,
+    () => {
+      if (existsSync(path)) return;
+      const temporary = `${path}.${randomUUID()}.tmp`;
+      try {
+        writeFileSync(temporary, content, { flag: 'wx' });
+        renameSync(temporary, path);
+      } finally {
+        try {
+          unlinkSync(temporary);
+        } catch {}
+      }
+    },
+    { waitMs: 100, pollMs: 10 },
+  );
+}

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -206,7 +206,7 @@ export function iosAppProcess(
   const e = exec || getExecutor();
   let out = '';
   try {
-    out = e.runFile('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'list']);
+    out = e.runFile('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'list'], { timeoutMs: 2000 });
   } catch {
     return undefined;
   }
@@ -225,10 +225,24 @@ export function launchIosApp(
     bundleId,
     metroPort,
     devClientScheme = null,
-  }: { udid: string; bundleId: string; metroPort: number | string | null; devClientScheme?: string | null },
+    consolePaths,
+  }: {
+    udid: string;
+    bundleId: string;
+    metroPort: number | string | null;
+    devClientScheme?: string | null;
+    consolePaths?: { stdout: string; stderr: string };
+  },
   { exec = null }: ExecOpt = {},
 ): IosLaunchResult {
   const e = exec || getExecutor();
+  const launchArgs = [
+    'simctl',
+    'launch',
+    ...(consolePaths ? [`--stdout=${consolePaths.stdout}`, `--stderr=${consolePaths.stderr}`] : []),
+    udid,
+    bundleId,
+  ];
   if (metroPort !== null) {
     try {
       e.runFile('xcrun', [
@@ -252,6 +266,15 @@ export function launchIosApp(
     if (devClientScheme) {
       const url = devClientUrl(devClientScheme, metroPort);
       try {
+        if (consolePaths && iosAppProcess(udid, bundleId, { exec: e }) === null) {
+          // Expo's EXDevLauncherController.initialUrlFromProcessInfo loads this
+          // project directly; launch-then-openurl can create two React hosts.
+          const initialUrl = new URL(url).searchParams.get('url')!;
+          const pid = parseLaunchedPid(
+            e.runFile('xcrun', [...launchArgs, '--initialUrl', initialUrl], { timeoutMs: 10000 }),
+          );
+          return { ok: true, mode: 'launch', url, jsLocation: jsLocationValue(metroPort), pid };
+        }
         e.runFile('xcrun', ['simctl', 'openurl', udid, url]);
         return { ok: true, mode: 'openurl', url, jsLocation: jsLocationValue(metroPort) };
       } catch (err) {
@@ -261,7 +284,7 @@ export function launchIosApp(
   }
 
   try {
-    const out = e.runFile('xcrun', ['simctl', 'launch', udid, bundleId]);
+    const out = e.runFile('xcrun', launchArgs, { timeoutMs: 10000 });
     const result: IosLaunchResult = { ok: true, mode: 'launch', pid: parseLaunchedPid(out) };
     if (metroPort !== null) result.jsLocation = jsLocationValue(metroPort);
     return result;
@@ -772,6 +795,31 @@ function expoBundleLine(msg: string) {
   return /\bBundl(?:ing|ed)\b/.test(msg);
 }
 
+function nativeLaunchFailure({
+  readCrashes,
+  since,
+  platform,
+  processAlive,
+  mode,
+  waitedMs,
+}: {
+  readCrashes: (() => NdjsonRecord[]) | null;
+  since: number | string | undefined;
+  platform: 'ios' | 'android' | null;
+  processAlive: (() => boolean | null) | null;
+  mode: string | null;
+  waitedMs: number;
+}): VerifyLaunchResult | null {
+  if (!readCrashes) return null;
+  const crashes = readCrashes().filter(
+    (record) =>
+      record.event === 'native_crash' && after(record, since) && recordCouldBelongToPlatform(record, platform),
+  );
+  return crashes.length
+    ? { verified: false, fatal: true, errors: crashes, processAlive: processAlive?.() ?? null, mode, waitedMs }
+    : null;
+}
+
 export async function verifyLaunch({
   logsDir,
   since,
@@ -784,6 +832,7 @@ export async function verifyLaunch({
   readRecords = null,
   readDeviceRecords = null,
   readClientRecords = null,
+  readNativeCrashes = null,
   processAlive = null,
   onReadinessPending = null,
   now = Date.now,
@@ -800,6 +849,7 @@ export async function verifyLaunch({
   readRecords?: (() => NdjsonRecord[]) | null;
   readDeviceRecords?: (() => NdjsonRecord[]) | null;
   readClientRecords?: (() => NdjsonRecord[]) | null;
+  readNativeCrashes?: (() => NdjsonRecord[]) | null;
   processAlive?: (() => boolean | null) | null;
   onReadinessPending?: (() => void) | null;
   now?: () => number;
@@ -817,10 +867,23 @@ export async function verifyLaunch({
   let deliveryId: string | null = null;
   let runtimeLoadingAt: number | null = null;
   let runtimeStartedAt: number | null = null;
+  let nextCrashCheck = startedAt + 1000;
   while (true) {
     const metroRecords = read().filter((record) => after(record, since));
     const deviceRecords = readDevice().filter((record) => after(record, since));
     const clientRecords = readClient().filter((record) => after(record, since));
+    if (now() >= nextCrashCheck) {
+      nextCrashCheck = now() + 2000;
+      const crash = nativeLaunchFailure({
+        readCrashes: readNativeCrashes,
+        since,
+        platform,
+        processAlive,
+        mode,
+        waitedMs: now() - startedAt,
+      });
+      if (crash) return crash;
+    }
     if (deliveryId === null) {
       const request = metroRecords.find(
         (record) =>

--- a/packages/stim-cli/src/error-diagnostics.ts
+++ b/packages/stim-cli/src/error-diagnostics.ts
@@ -27,14 +27,15 @@ function identity(record: NdjsonRecord): string {
 function attachDeviceErrorContext(timeline: NdjsonRecord[], selected: NdjsonRecord[]): NdjsonRecord[] {
   const consumed = new Set<string>();
   const rendered = selected.map((record) => {
-    if (record.src !== 'device' || !errorTitle(record) || !record.proc) return record;
+    if (record.src !== 'device' || !record.proc) return record;
+    if (!errorTitle(record) && !/^\s+at\s+\S/.test(record.msg ?? '')) return record;
     const index = timeline.findIndex((entry) => identity(entry) === identity(record));
     if (index < 0) return record;
     const context: string[] = [];
     for (const next of timeline.slice(index + 1)) {
-      if (Number(next.ts) - Number(record.ts) > 1000 || context.length >= 10) break;
+      if (Number(next.ts) - Number(record.ts) > 1000 || context.length >= 200) break;
       if (next.src !== 'device' || next.proc !== record.proc || next.platform !== record.platform) continue;
-      if (!/^\s*(?:(?:componentStack|stack):\s*['"]|isComponentError:|[{}],?$)/.test(next.msg ?? '')) break;
+      if (!/^\s*(?:(?:componentStack|stack):\s*['"]|isComponentError:|[{}],?$|at\s+\S)/.test(next.msg ?? '')) break;
       context.push(String(next.msg));
       consumed.add(identity(next));
     }
@@ -183,25 +184,36 @@ export async function errorDiagnostics(
       return record;
     }
   });
-  if (allowRequest && port && (await resolveProjectMetro(port, root)).metro) {
-    const pending = records.flatMap((record, index) => {
-      if (rendered[index] !== record) return [];
-      const rebuilt = timeline.some(
-        (event) =>
-          ['bundle_build_started', 'server_started', 'supervisor_started'].includes(String(event.event)) &&
-          Number(event.ts) > Number(record.ts) &&
-          (!event.platform || !record.platform || event.platform === record.platform),
-      );
-      if (rebuilt && bundleLocations(record).length) {
-        rendered[index] = {
-          ...record,
-          symbolicationNote:
-            'Metro rebuilt after this error; captured coordinates retained rather than mapping against a different bundle.',
-        };
-        return [];
-      }
-      return [{ record, index }];
-    });
+  const pending = records.flatMap((record, index) => {
+    if (rendered[index] !== record || !bundleLocations(record).length) return [];
+    const rebuilt = timeline.some(
+      (event) =>
+        ([
+          'bundle_build_started',
+          'bundle_build_done',
+          'bundle_build_failed',
+          'server_started',
+          'supervisor_started',
+          'bundle_response_started',
+          'bundle_response_finished',
+          'bundle_response_failed',
+        ].includes(String(event.event)) ||
+          (['expo_stdout', 'expo_stderr'].includes(String(event.event)) &&
+            /\bBundl(?:ing|ed)\b/.test(event.msg ?? ''))) &&
+        Number(event.ts) > Number(record.ts) &&
+        (!event.platform || !record.platform || event.platform === record.platform),
+    );
+    if (rebuilt) {
+      rendered[index] = {
+        ...record,
+        symbolicationNote:
+          'Metro rebuilt after this error; captured coordinates retained rather than mapping against a different bundle.',
+      };
+      return [];
+    }
+    return [{ record, index }];
+  });
+  if (pending.length && allowRequest && port && (await resolveProjectMetro(port, root)).metro) {
     const resolved = await symbolicateErrors(
       pending.map(({ record }) => record),
       { port },

--- a/packages/stim-cli/src/error-diagnostics.ts
+++ b/packages/stim-cli/src/error-diagnostics.ts
@@ -1,0 +1,228 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { NdjsonRecord } from './ndjson.ts';
+import { bundleLocations, symbolicateErrors } from './error-symbolication.ts';
+import { resolveProjectMetro } from './metro.ts';
+import { attachExpoErrorContext, readLogRecords } from './logs-query.ts';
+import { writeDiagnosticOnce } from './diagnostic-store.ts';
+
+function key(record: NdjsonRecord): string {
+  return createHash('sha256').update(JSON.stringify(record)).digest('hex');
+}
+
+function errorTitle(record: NdjsonRecord): string | null {
+  const line = String(record.msg ?? '')
+    .split('\n')[0]!
+    .trim()
+    .replace(/^ERROR\s+/, '');
+  const match = /^(?:\{\s*)?\[?((?:\w*Error|\w*Exception): .+?)\]?$/.exec(line);
+  return match?.[1] ?? null;
+}
+
+function identity(record: NdjsonRecord): string {
+  return JSON.stringify([record.src, record.ts, record.proc, record.msg]);
+}
+
+function attachDeviceErrorContext(timeline: NdjsonRecord[], selected: NdjsonRecord[]): NdjsonRecord[] {
+  const consumed = new Set<string>();
+  const rendered = selected.map((record) => {
+    if (record.src !== 'device' || !errorTitle(record) || !record.proc) return record;
+    const index = timeline.findIndex((entry) => identity(entry) === identity(record));
+    if (index < 0) return record;
+    const context: string[] = [];
+    for (const next of timeline.slice(index + 1)) {
+      if (Number(next.ts) - Number(record.ts) > 1000 || context.length >= 10) break;
+      if (next.src !== 'device' || next.proc !== record.proc || next.platform !== record.platform) continue;
+      if (!/^\s*(?:(?:componentStack|stack):\s*['"]|isComponentError:|[{}],?$)/.test(next.msg ?? '')) break;
+      context.push(String(next.msg));
+      consumed.add(identity(next));
+    }
+    return context.length ? { ...record, msg: [record.msg, ...context].join('\n') } : record;
+  });
+  return rendered.filter((_record, index) => !consumed.has(identity(selected[index]!)));
+}
+
+/** Collapses only cross-source copies with the same error title and a shared stack location. */
+export function mergeErrorCopies(records: readonly NdjsonRecord[], root?: string): NdjsonRecord[] {
+  const result: NdjsonRecord[] = [];
+  for (const record of records) {
+    if (record.event === 'native_crash' && record.pid) {
+      const duplicate = result.findIndex(
+        (other) =>
+          other.event === 'native_crash' &&
+          other.pid === record.pid &&
+          other.deviceId === record.deviceId &&
+          other.appId === record.appId &&
+          Math.abs(Number(other.ts) - Number(record.ts)) < 5000,
+      );
+      if (duplicate >= 0) {
+        const prior = result[duplicate]!;
+        const full = Array.isArray(record.stack) ? record : prior;
+        const consoleRecord = full === record ? prior : record;
+        result[duplicate] = {
+          ...full,
+          msg: full.msg === consoleRecord.msg ? full.msg : `${consoleRecord.msg}\n${full.msg}`,
+        };
+        continue;
+      }
+    }
+    const title = errorTitle(record);
+    const locations = new Set(
+      [
+        ...JSON.stringify([record.msg, record.stack, record.componentStack])
+          .replaceAll(root ? `${root}/` : '\u0000', '')
+          .matchAll(/[^\s()"\\]+:\d+:\d+/g),
+      ].map(([location]) => location),
+    );
+    const existing =
+      title && locations.size
+        ? result.findIndex(
+            (other) =>
+              !(Array.isArray(other.mirroredSources) ? other.mirroredSources : [other.src]).includes(record.src) &&
+              (!other.platform || !record.platform || other.platform === record.platform) &&
+              errorTitle(other) === title &&
+              typeof other.ts === 'number' &&
+              typeof record.ts === 'number' &&
+              Math.abs(other.ts - record.ts) < 1000 &&
+              [
+                ...JSON.stringify([other.msg, other.stack, other.componentStack])
+                  .replaceAll(root ? `${root}/` : '\u0000', '')
+                  .matchAll(/[^\s()"\\]+:\d+:\d+/g),
+              ].some(([location]) => locations.has(location)),
+          )
+        : -1;
+    if (existing < 0) result.push(record);
+    else {
+      const prior = result[existing]!;
+      const richer = JSON.stringify(record).length > JSON.stringify(prior).length ? record : prior;
+      const other = richer === record ? prior : record;
+      const sources = [
+        ...new Set([...(Array.isArray(prior.mirroredSources) ? prior.mirroredSources : [prior.src]), record.src]),
+      ];
+      result[existing] = {
+        ...richer,
+        src: prior.src,
+        ts: prior.ts,
+        platform: prior.platform ?? record.platform,
+        ...(richer.stack || other.stack ? { stack: richer.stack ?? other.stack } : {}),
+        ...(richer.componentStack || other.componentStack
+          ? { componentStack: richer.componentStack ?? other.componentStack }
+          : {}),
+        msg:
+          /\bCall Stack\b/.test(String(other.msg)) && /componentStack/.test(String(richer.msg))
+            ? `${other.msg}\n${String(richer.msg).replace(/^[^\n]*\n/, '')}`
+            : richer.msg,
+        mirroredSources: sources,
+        symbolicationNote: [
+          richer.symbolicationNote,
+          `Same error captured by ${sources.join(' + ')}; raw copies retained in logs --json.`,
+        ]
+          .filter(Boolean)
+          .join(' '),
+      };
+    }
+  }
+  return result;
+}
+
+/** Keeps symbolicated launch evidence stable when Metro later rebuilds or stops. */
+export async function errorDiagnostics(
+  input: readonly Record<string, unknown>[],
+  {
+    root,
+    logsDir,
+    port,
+    allowRequest = false,
+  }: { root: string; logsDir: string; port: number | null; allowRequest?: boolean },
+): Promise<NdjsonRecord[]> {
+  const timeline = readLogRecords(logsDir);
+  const records = attachDeviceErrorContext(
+    timeline,
+    attachExpoErrorContext(
+      timeline,
+      input.map((record) => ({
+        ...record,
+        src: typeof record.src === 'string' ? record.src : undefined,
+        msg: record.msg == null ? undefined : String(record.msg),
+        level: typeof record.level === 'string' ? record.level : undefined,
+        ts: typeof record.ts === 'number' ? record.ts : undefined,
+      })),
+    ),
+  );
+  const requestedCount = records.length;
+  const related = timeline
+    .filter(
+      (candidate) =>
+        candidate.src === 'device' &&
+        records.some(
+          (record) =>
+            record.src !== 'device' &&
+            errorTitle(record) &&
+            errorTitle(record) === errorTitle(candidate) &&
+            Math.abs(Number(record.ts) - Number(candidate.ts)) < 1000 &&
+            (!record.platform || !candidate.platform || record.platform === candidate.platform),
+        ) &&
+        !records.some(
+          (record) => record.src === candidate.src && record.ts === candidate.ts && record.msg === candidate.msg,
+        ),
+    )
+    .slice(-100);
+  records.push(...attachDeviceErrorContext(timeline, related));
+  const directory = join(logsDir, 'error-context');
+  const rendered = records.map((record) => {
+    try {
+      const saved = JSON.parse(readFileSync(join(directory, `${key(record)}.json`), 'utf8')) as {
+        original?: string;
+        rendered?: NdjsonRecord;
+      };
+      return saved.original === key(record) && saved.rendered && typeof saved.rendered === 'object'
+        ? saved.rendered
+        : record;
+    } catch {
+      return record;
+    }
+  });
+  if (allowRequest && port && (await resolveProjectMetro(port, root)).metro) {
+    const pending = records.flatMap((record, index) => {
+      if (rendered[index] !== record) return [];
+      const rebuilt = timeline.some(
+        (event) =>
+          ['bundle_build_started', 'server_started', 'supervisor_started'].includes(String(event.event)) &&
+          Number(event.ts) > Number(record.ts) &&
+          (!event.platform || !record.platform || event.platform === record.platform),
+      );
+      if (rebuilt && bundleLocations(record).length) {
+        rendered[index] = {
+          ...record,
+          symbolicationNote:
+            'Metro rebuilt after this error; captured coordinates retained rather than mapping against a different bundle.',
+        };
+        return [];
+      }
+      return [{ record, index }];
+    });
+    const resolved = await symbolicateErrors(
+      pending.map(({ record }) => record),
+      { port },
+    );
+    for (let index = 0; index < pending.length; index++) {
+      const entry = pending[index]!;
+      const value = resolved[index]!;
+      rendered[entry.index] = value;
+      if (bundleLocations(value).length === bundleLocations(entry.record).length) continue;
+      try {
+        writeDiagnosticOnce(
+          join(directory, `${key(entry.record)}.json`),
+          JSON.stringify({ original: key(entry.record), rendered: value }),
+        );
+      } catch {}
+    }
+  }
+  let merged = mergeErrorCopies(rendered.slice(0, requestedCount), root);
+  for (const candidate of rendered.slice(requestedCount)) {
+    const combined = mergeErrorCopies([...merged, candidate], root);
+    if (combined.length === merged.length) merged = combined;
+  }
+  return merged;
+}

--- a/packages/stim-cli/src/error-symbolication.ts
+++ b/packages/stim-cli/src/error-symbolication.ts
@@ -1,0 +1,113 @@
+import type { NdjsonRecord } from './ndjson.ts';
+
+interface Frame {
+  file: string;
+  lineNumber: number;
+  column: number;
+  methodName: string;
+}
+
+const LOCATION = /https?:\/\/[^\s)'"\\]+?:\d+:\d+/g;
+
+function frameFromLocation(location: string): Frame | null {
+  const match = /^(https?:\/\/.+):(\d+):(\d+)$/.exec(location);
+  if (!match) return null;
+  const file = match[1]!;
+  if (!/\.bundle(?:[/?]|$)/.test(file)) return null;
+  const lineNumber = Number(match[2]);
+  const column = Number(match[3]) - 1;
+  if (!Number.isSafeInteger(lineNumber) || lineNumber < 1 || !Number.isSafeInteger(column) || column < 0) return null;
+  return { file, lineNumber, column, methodName: '<unknown>' };
+}
+
+export function bundleLocations(record: NdjsonRecord): string[] {
+  const text = [record.msg, record.stack, record.componentStack]
+    .filter((value) => typeof value === 'string')
+    .join('\n');
+  const found = [...text.matchAll(LOCATION)].map(([location]) => location);
+  for (const value of [record.stack, record.componentStack]) {
+    if (!Array.isArray(value)) continue;
+    for (const frame of value) {
+      if (
+        frame &&
+        typeof frame.file === 'string' &&
+        typeof frame.line === 'number' &&
+        typeof frame.column === 'number'
+      ) {
+        found.push(`${frame.file}:${frame.line}:${frame.column + 1}`);
+      }
+    }
+  }
+  return [...new Set(found)].filter((location) => frameFromLocation(location) !== null);
+}
+
+/** Resolves captured bundle coordinates against the already-verified workspace Metro. */
+export async function symbolicateErrors(
+  records: readonly NdjsonRecord[],
+  { port, timeoutMs = 2000, request = fetch }: { port: number | null; timeoutMs?: number; request?: typeof fetch },
+): Promise<NdjsonRecord[]> {
+  const candidates = [...new Set(records.flatMap(bundleLocations))].slice(0, 200);
+  if (!candidates.length) return [...records];
+  const fallback = (reason: string) =>
+    records.map((record) =>
+      bundleLocations(record).length
+        ? { ...record, symbolicationNote: `JS symbolication unavailable (${reason}); captured coordinates retained.` }
+        : record,
+    );
+  if (!Number.isInteger(port) || !port || port < 1 || port > 65535) return fallback('no verified Metro');
+  try {
+    const response = await request(`http://127.0.0.1:${port}/symbolicate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stack: candidates.map(frameFromLocation) }),
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: 'error',
+    });
+    if (!response.ok) return fallback(`HTTP ${response.status}`);
+    const body = (await response.json()) as { stack?: unknown };
+    if (!Array.isArray(body.stack) || body.stack.length !== candidates.length)
+      return fallback('invalid Metro response');
+    const resolved = new Map<string, string>();
+    for (let index = 0; index < candidates.length; index++) {
+      const frame: unknown = body.stack[index];
+      if (!frame || typeof frame !== 'object') continue;
+      const { file, lineNumber, column } = frame as Partial<Frame>;
+      if (
+        typeof file !== 'string' ||
+        /[\r\n]/.test(file) ||
+        /^https?:/.test(file) ||
+        !Number.isSafeInteger(lineNumber) ||
+        lineNumber! < 1 ||
+        !Number.isSafeInteger(column) ||
+        column! < 0
+      )
+        continue;
+      resolved.set(candidates[index]!, `${file}:${lineNumber}:${column! + 1}`);
+    }
+    return records.map((record) => {
+      const matches = bundleLocations(record);
+      if (!matches.length) return record;
+      const replace = (value: unknown): unknown => {
+        if (typeof value === 'string') return value.replace(LOCATION, (location) => resolved.get(location) ?? location);
+        if (!Array.isArray(value)) return value;
+        return value.map((frame) => {
+          if (!frame || typeof frame !== 'object') return frame;
+          const mapped = resolved.get(`${frame.file}:${frame.line}:${frame.column + 1}`);
+          const match = mapped && /^(.*):(\d+):(\d+)$/.exec(mapped);
+          return match ? { ...frame, file: match[1], line: Number(match[2]), column: Number(match[3]) - 1 } : frame;
+        });
+      };
+      return {
+        ...record,
+        ...(record.msg !== undefined ? { msg: replace(record.msg) as string } : {}),
+        ...(record.stack !== undefined ? { stack: replace(record.stack) } : {}),
+        ...(record.componentStack !== undefined ? { componentStack: replace(record.componentStack) } : {}),
+        ...(matches.some((location) => !resolved.has(location))
+          ? { symbolicationNote: 'Some JS frames remain unsymbolicated; captured coordinates retained.' }
+          : {}),
+      };
+    });
+  } catch {
+    return fallback('request failed or timed out');
+  }
+}

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -102,6 +102,8 @@ RULES DURING THE LOOP
   still building" means Metro has not finished; wait and query the logs. For
   launch UNVERIFIED, follow the printed remedy before claiming success. JSON
   reports these as true, "bundling", and "unverified" in launched.
+  WARNING means the native launch completed with app errors, or an app readiness
+  signal was expected but not confirmed; inspect the output before claiming a healthy UI.
 - A clean logs --errors check requires exit code 0 AND no matching errors in
   captured logs. Exit code 0 alone means the query succeeded, even when errors
   were printed. Human output shows "No matching log records" on stderr for

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -51,6 +51,10 @@ them. It preserves source, custom launcher settings, and the shared ccache.
   # Reproduce the affected behavior and capture the baseline errors.
   stim logs --errors
 
+  # If a native process exits with no report, inspect the captured device output.
+  # An empty query is not proof that a crashed app was healthy.
+  # See guide logs for JS/native symbolication and capture limits.
+
   # Edit JavaScript or TypeScript; Fast Refresh applies the change.
   # For UI work, wait for the expected UI and repeat the affected interaction
   # on the reported device. Keep using the existing automation session, if any.

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -28,7 +28,8 @@ FLAGS
   --tail <n>       only the last n MATCHING records (applied after filtering,
                    so --level error --tail 5 is the last five ERRORS)
   --errors         errors and fatals since the last marker, from metro, client
-                   and build -- the agent query. Capped at 20 printed records.
+                   and build, plus confirmed native app-crash reports.
+                   Capped at 20 printed records.
   --follow         keep streaming until interrupted (Ctrl+C is exit 0)
   --json           the raw records, one per line, so stdout is valid NDJSON.
                    ZERO matches is ZERO bytes on stdout (an empty NDJSON
@@ -37,12 +38,13 @@ FLAGS
                    mode only, on stderr.
 
 --ERRORS, PRECISELY
-  Level error or fatal, from metro, client and build, timestamped after the
+  Level error or fatal, from metro, client and build, plus device records with
+  event native_crash (app/device/time-correlated OS reports or fatal app console output), timestamped after the
   marker that closes their window. Three rules, and a field test
   caught all three wrong at once -- it returned 3,004 iOS syslog lines on a
   healthy app while hiding a real startup crash.
 
-  SCOPE. device is NOT in the default scope. A device log is the OS talking:
+  SCOPE. General device logs are NOT in the default scope. A device log is the OS talking:
   \`simctl log stream\` is predicated on the app's PROCESS, and inside that
   process Apple's frameworks log thousands of Error-typed lines (nw_socket,
   SecTrust, WebKit, CoreUI) that have nothing to do with your app. The proven
@@ -54,7 +56,8 @@ FLAGS
   There is no such screen and there is not meant to be, so that one record is
   recorded at info -- it made every healthy cold launch report 1 error. A real
   unhandled NAVIGATE names a route your app has, and is still an error.
-  The app's own crashes reach client and metro either way. Opt back in with
+  A native crash can happen before JS or Metro exists. Confirmed native_crash
+  records are included without admitting the rest of the device noise. Opt back in with
   \`--source device\` or \`--source all\`; a plain \`logs\` with no --errors
   has always shown everything. ON A PHYSICAL IPHONE opting back in buys less
   than it does on a simulator: the device console carries no severity, so
@@ -70,8 +73,9 @@ FLAGS
       history, and when bundles fail back to back only the newest attempt's
       errors are reported -- and nothing else. A failed attempt's own summary
       and details land at or after its marker, so they stay reported.
-    a LAUNCH marker (src build, written by \`ios\` / \`android\`) resets
-      EVERYTHING: a new run of the app starts there.
+    a LAUNCH marker (src build, written before \`ios\` / \`android\` attempts
+      launch) resets EVERYTHING. It precedes the tool call so an immediate
+      native crash is not hidden by a marker written after the process died.
   A finished bundle is not evidence that the app which loaded it is fine.
   In the field case the app threw at 16:03:54 and Metro wrote its marker at
   16:03:55, one second later, because the bundler finishes accounting for a
@@ -138,21 +142,55 @@ WHAT WRITES WHAT
                        readiness wait even without a client or Metro copy.
                        Client and Metro errors still print individually.
 
-                       Human ios/android output previews up to five frames per
-                       error stack and three per React component stack, in
-                       captured order, with an omitted-frame count. Escaped
+                       Human ios/android and logs --errors output previews up to
+                       ten frames per error, component or native stack. App-source
+                       frames take priority; selected frames retain captured
+                       order, with an omitted-frame count. Escaped
                        component stacks print one frame per line. Long bundle
                        URLs are shortened and labeled unsymbolicated; shortening
                        is not source-map resolution. Read full captured detail
                        with \`stim logs --source all\`, or add \`--json\` for raw
                        records. This preview does not alter logs or JSON.
 
-                       Symbolication is best effort: Expo's printed code frame
-                       and Call Stack are retained by the human logs query; bare
-                       Metro symbolication responses are separate context. The
-                       launch preview does not request symbolication or invent
-                       a missing error stack from a component stack. Device logs
-                       may be truncated by the platform before Stim sees them.
+                       Symbolication is best effort. Human launch and non-follow
+                       logs queries ask the verified workspace Metro's /symbolicate
+                       endpoint to resolve captured JS coordinates, with a 2s
+                       request deadline and raw-coordinate fallback. Successful
+                       launch context is retained separately under logs/error-context
+                       so stopping Metro does not discard resolved evidence.
+                       Expo code frames are attached; uncorrelated bare Metro
+                       symbolication events remain separate. A component stack
+                       never substitutes for a missing error stack. Historical
+                       stacks need matching sources/maps, not a rebuilt bundle.
+
+                       Cross-source copies combine only with matching error
+                       title, stack location, compatible platform and timing.
+                       Same-source repeats and raw JSON records stay intact.
+                       Human queries may attach a correlated device component
+                       stack to a selected Metro error, but never an unrelated
+                       device error.
+
+                       iOS simulator cold launch attaches app stdout/stderr and
+                       passes Expo's initial URL directly. Fatal output is available
+                       before delayed OS reports; rerun logs --errors for those.
+                       The app cache holds console files, so external STIM_HOME
+                       paths do not violate the app sandbox. Crash evidence is
+                       retained in workspace logs. --follow does not poll for
+                       delayed OS reports.
+                       Native iOS simulator reports match app ID, simulator ID
+                       and launch time. atos resolves app addresses only after
+                       the local binary UUID matches the report. Android reads
+                       the crash buffer even when the app PID has exited. Java
+                       traces remain readable; C/C++ resolution uses NDK tools
+                       and matching local ELF build IDs. General OS noise remains
+                       excluded from --errors. Full native evidence is in
+                       logs --source device --json. Physical iPhone capture stays
+                       console-only; missing reports or symbols are not proof
+                       of a healthy app. No symbol downloads are performed.
+                       Android may keep a crashed Java PID alive behind its
+                       crash dialog. Follow the app-scoped force-stop remedy
+                       printed by android after fixing the crash, then rerun
+                       stim android. Metro reload alone cannot recover it.
 
                        The connection refusal \`TCP Conn ... Failed :
                        error 0:61 [61]\` (61 is ECONNREFUSED) is not even

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -172,7 +172,10 @@ WHAT WRITES WHAT
 
                        iOS simulator cold launch attaches app stdout/stderr and
                        passes Expo's initial URL directly. Fatal output is available
-                       before delayed OS reports; rerun logs --errors for those.
+                       before delayed OS reports; rerun logs --errors for those
+                       before stopping or releasing the device. Collection requires
+                       this workspace's current launch and device ownership or lease;
+                       afterward only already-captured reports remain available.
                        The app cache holds console files, so external STIM_HOME
                        paths do not violate the app sandbox. Crash evidence is
                        retained in workspace logs. --follow does not poll for

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -172,7 +172,8 @@ WHAT WRITES WHAT
 
                        iOS simulator cold launch attaches app stdout/stderr and
                        passes Expo's initial URL directly. Fatal output is available
-                       before delayed OS reports; rerun logs --errors for those
+                       before delayed OS reports, which can take about a minute
+                       or longer to appear; rerun logs --errors for those
                        before stopping or releasing the device. Collection requires
                        this workspace's current launch and device ownership or lease;
                        afterward only already-captured reports remain available.

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -84,10 +84,12 @@ FLAGS
   the safe direction: a client redbox that Fast Refresh already fixed keeps
   being reported until the next launch.
 
-  OUTPUT. --errors previews up to 10 frames per stack and the first 20 matching
-  error records, plus stack context. A footer reports any hidden record count;
-  use the printed --tail value to include all captured records before grouping,
-  still with previewed stacks. To remove both preview limits, omit --errors:
+  OUTPUT. Every logs command, including --errors and --follow, shows full captured
+  error, component and native stacks, with no frame or message-length limit.
+  --errors shows the first 20 matching error records, plus stack context.
+  This record-count limit never truncates a stack. A footer reports hidden
+  records; use its printed --tail value to include all records before grouping.
+  To read the complete timeline without the default error-record limit:
     stim logs --source all
   This includes all sources, levels and history, not just the latest errors;
   add --since, --level or --grep to narrow it. --source all selects sources,
@@ -154,14 +156,16 @@ WHAT WRITES WHAT
                        launch JSON or exit code: launched describes bundle/process
                        evidence, not a healthy UI. Inspect the errors and readiness.
 
-                       Human ios/android and logs --errors output previews up to
+                       Only human ios/android launch output previews up to
                        ten frames per error, component or native stack. App-source
                        frames take priority; selected frames retain captured
                        order, with an omitted-frame count. Escaped
                        component stacks print one frame per line. Long bundle
                        URLs are shortened and labeled unsymbolicated; shortening
-                       is not source-map resolution. Read full captured detail
-                       with \`stim logs --source all\`, or add \`--json\` for raw
+                       is not source-map resolution. All logs commands show full
+                       captured stacks, including \`stim logs --errors\`.
+                       Use \`stim logs --source all\` for all sources/history,
+                       or add \`--json\` for raw
                        records. This preview does not alter logs or JSON.
 
                        Symbolication is best effort. Human launch and non-follow

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -84,9 +84,17 @@ FLAGS
   the safe direction: a client redbox that Fast Refresh already fixed keeps
   being reported until the next launch.
 
-  OUTPUT. --errors prints at most 20 error records, plus any stack context, and
-  then a "... and N more" line. N is exactly what \`--tail N\` prints, because
-  what was held back IS the tail. In non-follow human output, an Expo error includes its immediately
+  OUTPUT. --errors previews up to 10 frames per stack and the first 20 matching
+  error records, plus stack context. A footer reports any hidden record count;
+  use the printed --tail value to include all captured records before grouping,
+  still with previewed stacks. To remove both preview limits, omit --errors:
+    stim logs --source all
+  This includes all sources, levels and history, not just the latest errors;
+  add --since, --level or --grep to narrow it. --source all selects sources,
+  not stack depth. For untouched captured records use:
+    stim logs --source all --json
+  Neither form can restore text the runtime truncated before capture.
+  In non-follow human output, an Expo error includes its immediately
   following code frame and Call Stack lines. Bare React Native symbolication is
   shown as separate context because Metro does not provide an error correlation
   identifier. Context does not change the error count or the raw error records
@@ -131,9 +139,9 @@ WHAT WRITES WHAT
                        --errors leaves this source out unless asked. A VERIFIED
                        LAUNCH counts these records and prints one line:
 
-                         launch      9 error-level records in the device log
-                                     during launch
-                                     (logs --errors --source device)
+                         launch      9 general device error-level records
+                                     (not confirmed app errors); inspect with
+                                     stim logs --errors --source device
 
                        The count does not attribute unknown OS errors to the app.
                        Known JavaScript errors also print individually: Android
@@ -141,6 +149,10 @@ WHAT WRITES WHAT
                        javascript records. These can interrupt an optional
                        readiness wait even without a client or Metro copy.
                        Client and Metro errors still print individually.
+                       A native app that loaded its bundle but reported app errors
+                       ends with WARNING rather than OK. This does not change the
+                       launch JSON or exit code: launched describes bundle/process
+                       evidence, not a healthy UI. Inspect the errors and readiness.
 
                        Human ios/android and logs --errors output previews up to
                        ten frames per error, component or native stack. App-source

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -1,5 +1,5 @@
 type RecordLike = { msg?: unknown; stack?: unknown; componentStack?: unknown; [key: string]: unknown };
-type StackKind = 'Error' | 'Component' | 'Native';
+type StackKind = 'Error' | 'Component' | 'Native' | 'Caused-by';
 
 function framePriority(frame: string, root?: string): number {
   const normalized = frame.replaceAll('\\', '/');
@@ -37,21 +37,29 @@ function expandStackFields(message: string): string {
     /(^|\n|[,{])[ \t]*(['"]?)(componentStack|stack)\2:[ \t]*(['"])((?:\\.|[^\\\n])*)$/gm,
     (match, prefix: string, _keyQuote: string, field: string, _quote: string, value: string) => {
       if (!/\\n\s+at\s/.test(value)) return match;
-      return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete]`;
+      return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete: the runtime truncated it; saved logs cannot restore missing text]`;
     },
   );
 }
 
 function shortFrame(frame: string, root?: string): string {
   const text = root ? frame.replaceAll(`${root}/`, '') : frame;
-  return text.trim().replace(/https?:\/\/[^\s)]+/g, (location) => {
-    const match = /^(.*\.bundle)(?:[^\s]*?)(:\d+:\d+)$/.exec(location);
-    if (!match) {
-      const bundle = /\/([^/]+\.bundle)/.exec(location)?.[1];
-      return bundle ? `${bundle} [unsymbolicated]` : location;
-    }
-    return `${match[1]!.split('/').at(-1)}${match[2]} [unsymbolicated]`;
-  });
+  const incomplete = /\(https?:\/\/[^\s)]*$/.test(text);
+  if (incomplete) return text.trim().replace(/\(https?:\/\/[^\s)]*$/, '(location incomplete)');
+  const compact = text
+    .trim()
+    .replace(/ \(BuildId: [0-9a-f]+\)/gi, '')
+    .replace(' [captured native frame]', '')
+    .replace(/ \(in ([^()]+)\) \(\/?<compiler-generated>:0\) \(\1\)$/, ' ($1; compiler-generated)')
+    .replace(/https?:\/\/[^\s)]+/g, (location) => {
+      const match = /^(.*\.bundle)(?:[^\s]*?)(:\d+:\d+)$/.exec(location);
+      if (!match) {
+        const bundle = /\/([^/]+\.bundle)/.exec(location)?.[1];
+        return bundle ? `${bundle} [unsymbolicated]` : location;
+      }
+      return `${match[1]!.split('/').at(-1)}${match[2]} [unsymbolicated]`;
+    });
+  return compact.replace(/\((\/(?:apex|system)\/[^()]+)\)/g, (_match, path: string) => `(${path.split('/').at(-1)})`);
 }
 
 function structuredFrames(value: unknown): string[] {
@@ -67,8 +75,12 @@ function structuredFrames(value: unknown): string[] {
   });
 }
 
-/** Formats a bounded human launch preview without changing captured records. */
-export function launchErrorPreview(records: readonly RecordLike[], root?: string): string[] {
+/** Formats captured stacks for humans; full mode removes preview limits and preserves frame text. */
+export function launchErrorPreview(
+  records: readonly RecordLike[],
+  root?: string,
+  { full = false }: { full?: boolean } = {},
+): string[] {
   const lines: string[] = [];
   let kind: StackKind = 'Error';
   let frames: string[] = [];
@@ -80,12 +92,12 @@ export function launchErrorPreview(records: readonly RecordLike[], root?: string
       const ranked = frames.map((frame, index) => ({ frame, index, rank: framePriority(frame, root) }));
       const selected = ranked
         .toSorted((a, b) => a.rank - b.rank || a.index - b.index)
-        .slice(0, 10)
+        .slice(0, full ? undefined : 10)
         .toSorted((a, b) => a.index - b.index);
-      const prioritized = selected.some(({ index }) => index >= 10);
+      const prioritized = !full && selected.some(({ index }) => index >= 10);
       lines.push(
         `${kind} stack${prioritized ? ' (app frames prioritized)' : ''}:`,
-        ...selected.map(({ frame }) => `  ${shortFrame(frame, root)}`),
+        ...selected.map(({ frame }) => `  ${full ? frame.trim() : shortFrame(frame, root)}`),
       );
       if (frames.length > selected.length) {
         const frameworkCount = ranked.filter((entry) => entry.rank === 2 && !selected.includes(entry)).length;
@@ -111,7 +123,12 @@ export function launchErrorPreview(records: readonly RecordLike[], root?: string
       frames.push(line);
     } else if (line.trim()) {
       flush();
-      lines.push(line.length > 1000 ? `${line.slice(0, 1000)} ... [truncated; full text in logs --json]` : line);
+      if (/^\s*Caused by:/.test(line)) kind = 'Caused-by';
+      lines.push(
+        !full && line.length > 1000
+          ? `${line.slice(0, 1000)} ... [preview shortened; full text in logs without --errors]`
+          : line,
+      );
     }
   };
   for (const record of records) {
@@ -146,6 +163,11 @@ export function launchErrorPreview(records: readonly RecordLike[], root?: string
     }
   }
   flush();
-  if (hadStack) lines.push('Full captured stacks: stim logs --source all (add --json for raw records)');
+  if (hadStack && !full)
+    lines.push(
+      'Stack preview: up to 10 frames per stack; app frames preferred.',
+      'Full captured logs: stim logs --source all (without --errors)',
+      'Raw records: stim logs --source all --json',
+    );
   return lines;
 }

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -1,5 +1,24 @@
 type RecordLike = { msg?: unknown; stack?: unknown; componentStack?: unknown; [key: string]: unknown };
-type StackKind = 'Error' | 'Component';
+type StackKind = 'Error' | 'Component' | 'Native';
+
+function framePriority(frame: string, root?: string): number {
+  const normalized = frame.replaceAll('\\', '/');
+  if (/^\s*at (?:android\.|java\.|com\.android\.|dalvik\.)/.test(normalized)) return 2;
+  if (/(?:^|\/)node_modules\//.test(normalized) || /\bnode:internal\//.test(normalized)) return 2;
+  const paths = [
+    ...normalized.matchAll(
+      /(?:\(|@|\bat )([^()]+?\.(?:[cm]?[jt]sx?|swift|kt|java|mm?|cpp|cc|c|h))(?::\d+(?::\d+)?)?(?:\)|$)/g,
+    ),
+  ];
+  for (const [, file] of paths) {
+    if (!file || /^https?:/.test(file)) continue;
+    const absolute = file.startsWith('/') || /^[A-Za-z]:\//.test(file);
+    if (!absolute && !file.startsWith('../')) return 0;
+    if (root && file.startsWith(`${root.replaceAll('\\', '/').replace(/\/$/, '')}/`)) return 0;
+  }
+  if (/^\s*at (?:RCT\w+|View|Text|ScrollView|Suspense) \(<anonymous>\)\s*$/.test(frame)) return 2;
+  return 1;
+}
 
 function decodeStack(value: string): string {
   return value.replace(/\\([nrt\\'"])/g, (_escape, char: string) => {
@@ -15,7 +34,7 @@ function expandStackFields(message: string): string {
     },
   );
   return expanded.replace(
-    /(^|\n|[,{])[ \t]*(['"]?)(componentStack|stack)\2:[ \t]*(['"])((?:\\.|[^\\\n])*)$/g,
+    /(^|\n|[,{])[ \t]*(['"]?)(componentStack|stack)\2:[ \t]*(['"])((?:\\.|[^\\\n])*)$/gm,
     (match, prefix: string, _keyQuote: string, field: string, _quote: string, value: string) => {
       if (!/\\n\s+at\s/.test(value)) return match;
       return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete]`;
@@ -23,10 +42,14 @@ function expandStackFields(message: string): string {
   );
 }
 
-function shortFrame(frame: string): string {
-  return frame.trim().replace(/https?:\/\/[^\s)]+/g, (location) => {
+function shortFrame(frame: string, root?: string): string {
+  const text = root ? frame.replaceAll(`${root}/`, '') : frame;
+  return text.trim().replace(/https?:\/\/[^\s)]+/g, (location) => {
     const match = /^(.*\.bundle)(?:[^\s]*?)(:\d+:\d+)$/.exec(location);
-    if (!match) return location;
+    if (!match) {
+      const bundle = /\/([^/]+\.bundle)/.exec(location)?.[1];
+      return bundle ? `${bundle} [unsymbolicated]` : location;
+    }
     return `${match[1]!.split('/').at(-1)}${match[2]} [unsymbolicated]`;
   });
 }
@@ -45,7 +68,7 @@ function structuredFrames(value: unknown): string[] {
 }
 
 /** Formats a bounded human launch preview without changing captured records. */
-export function launchErrorPreview(records: readonly RecordLike[]): string[] {
+export function launchErrorPreview(records: readonly RecordLike[], root?: string): string[] {
   const lines: string[] = [];
   let kind: StackKind = 'Error';
   let frames: string[] = [];
@@ -54,14 +77,28 @@ export function launchErrorPreview(records: readonly RecordLike[]): string[] {
   const flush = () => {
     if (frames.length) {
       hadStack = true;
-      const limit = kind === 'Component' ? 3 : 5;
-      lines.push(`${kind} stack:`, ...frames.slice(0, limit).map((frame) => `  ${shortFrame(frame)}`));
-      if (frames.length > limit) lines.push(`  ... ${frames.length - limit} more frames`);
+      const ranked = frames.map((frame, index) => ({ frame, index, rank: framePriority(frame, root) }));
+      const selected = ranked
+        .toSorted((a, b) => a.rank - b.rank || a.index - b.index)
+        .slice(0, 10)
+        .toSorted((a, b) => a.index - b.index);
+      const prioritized = selected.some(({ index }) => index >= 10);
+      lines.push(
+        `${kind} stack${prioritized ? ' (app frames prioritized)' : ''}:`,
+        ...selected.map(({ frame }) => `  ${shortFrame(frame, root)}`),
+      );
+      if (frames.length > selected.length) {
+        const frameworkCount = ranked.filter((entry) => entry.rank === 2 && !selected.includes(entry)).length;
+        lines.push(
+          `  ... ${frames.length - selected.length} more frames${frameworkCount ? ` (${frameworkCount} dependency/native)` : ''}`,
+        );
+      }
     }
     frames = [];
     kind = 'Error';
   };
   const consume = (line: string) => {
+    if ((hadStack || frames.length > 0) && /^\s*isComponentError:\s*(?:true|false)\s*}?,?\s*$/.test(line)) return;
     const header = /^\s*(Component stack|Error stack|Call Stack):?\s*$/i.exec(line);
     if (header) {
       flush();
@@ -74,7 +111,7 @@ export function launchErrorPreview(records: readonly RecordLike[]): string[] {
       frames.push(line);
     } else if (line.trim()) {
       flush();
-      lines.push(line);
+      lines.push(line.length > 1000 ? `${line.slice(0, 1000)} ... [truncated; full text in logs --json]` : line);
     }
   };
   for (const record of records) {
@@ -87,6 +124,7 @@ export function launchErrorPreview(records: readonly RecordLike[]): string[] {
     const stack = typeof record.stack === 'string' ? record.stack.split(/\r?\n/) : structuredFrames(record.stack);
     if (stack.length) {
       flush();
+      if (record.event === 'native_crash') kind = 'Native';
       for (const line of stack) consume(line);
     }
     const components =
@@ -97,6 +135,14 @@ export function launchErrorPreview(records: readonly RecordLike[]): string[] {
       flush();
       kind = 'Component';
       for (const line of components) consume(line);
+    }
+    if (typeof record.codeFrame === 'string') {
+      flush();
+      lines.push(record.codeFrame);
+    }
+    if (typeof record.symbolicationNote === 'string') {
+      flush();
+      lines.push(record.symbolicationNote);
     }
   }
   flush();

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -3,6 +3,7 @@ type StackKind = 'Error' | 'Component' | 'Native' | 'Caused-by';
 
 function framePriority(frame: string, root?: string): number {
   const normalized = frame.replaceAll('\\', '/');
+  if (/\(https?:\/\/[^\s)]*$/.test(normalized)) return 3;
   if (/^\s*at (?:android\.|java\.|com\.android\.|dalvik\.)/.test(normalized)) return 2;
   if (/(?:^|[/(\s])node_modules\//.test(normalized) || /\bnode:internal\//.test(normalized)) return 2;
   const paths = [
@@ -16,7 +17,7 @@ function framePriority(frame: string, root?: string): number {
     if (!absolute && !file.startsWith('../')) return 0;
     if (root && file.startsWith(`${root.replaceAll('\\', '/').replace(/\/$/, '')}/`)) return 0;
   }
-  if (/^\s*at (?:RCT\w+|View|Text|ScrollView|Suspense) \(<anonymous>\)\s*$/.test(frame)) return 2;
+  if (/\(<anonymous>\)\s*$/.test(frame)) return 2;
   return 1;
 }
 
@@ -94,7 +95,7 @@ export function launchErrorPreview(
         .toSorted((a, b) => a.rank - b.rank || a.index - b.index)
         .slice(0, full ? undefined : 10)
         .toSorted((a, b) => a.index - b.index);
-      const prioritized = !full && selected.some(({ index }) => index >= 10);
+      const prioritized = !full && selected.some(({ index, rank }) => index >= 10 && rank === 0);
       lines.push(
         `${kind} stack${prioritized ? ' (app frames prioritized)' : ''}:`,
         ...selected.map(({ frame }) => `  ${full ? frame.trim() : shortFrame(frame, root)}`),

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -3,7 +3,6 @@ type StackKind = 'Error' | 'Component' | 'Native' | 'Caused-by';
 
 function framePriority(frame: string, root?: string): number {
   const normalized = frame.replaceAll('\\', '/');
-  if (/\(https?:\/\/[^\s)]*$/.test(normalized)) return 3;
   if (/^\s*at (?:android\.|java\.|com\.android\.|dalvik\.)/.test(normalized)) return 2;
   if (/(?:^|[/(\s])node_modules\//.test(normalized) || /\bnode:internal\//.test(normalized)) return 2;
   const paths = [
@@ -38,15 +37,13 @@ function expandStackFields(message: string): string {
     /(^|\n|[,{])[ \t]*(['"]?)(componentStack|stack)\2:[ \t]*(['"])((?:\\.|[^\\\n])*)$/gm,
     (match, prefix: string, _keyQuote: string, field: string, _quote: string, value: string) => {
       if (!/\\n\s+at\s/.test(value)) return match;
-      return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}\n[captured stack text is incomplete: the runtime truncated it; saved logs cannot restore missing text]`;
+      return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}`;
     },
   );
 }
 
 function shortFrame(frame: string, root?: string): string {
   const text = root ? frame.replaceAll(`${root}/`, '') : frame;
-  const incomplete = /\(https?:\/\/[^\s)]*$/.test(text);
-  if (incomplete) return text.trim().replace(/\(https?:\/\/[^\s)]*$/, '(location incomplete)');
   const compact = text
     .trim()
     .replace(/ \(BuildId: [0-9a-f]+\)/gi, '')
@@ -121,6 +118,7 @@ export function launchErrorPreview(
       /^\s*\S[^\n]*@\S+:\d+:\d+\s*$/.test(line) ||
       /^\s+\S[^\n]*\([^()]+:\d+:\d+\)\s*$/.test(line)
     ) {
+      if (!full && /\(https?:\/\/[^\s)]*$/.test(line)) return;
       frames.push(line);
     } else if (line.trim()) {
       flush();
@@ -158,15 +156,12 @@ export function launchErrorPreview(
     }
     if (typeof record.symbolicationNote === 'string') {
       flush();
-      lines.push(record.symbolicationNote);
+      lines.push(
+        ...record.symbolicationNote.split('\n').filter((line) => full || !line.startsWith('Same error captured by ')),
+      );
     }
   }
   flush();
-  if (hadStack && !full)
-    lines.push(
-      'Stack preview: up to 10 frames per stack; app frames preferred.',
-      'Full captured logs: stim logs --source all',
-      'Raw records: stim logs --source all --json',
-    );
+  if (hadStack && !full) lines.push('Full captured logs: stim logs --source all');
   return lines;
 }

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -4,7 +4,7 @@ type StackKind = 'Error' | 'Component' | 'Native';
 function framePriority(frame: string, root?: string): number {
   const normalized = frame.replaceAll('\\', '/');
   if (/^\s*at (?:android\.|java\.|com\.android\.|dalvik\.)/.test(normalized)) return 2;
-  if (/(?:^|\/)node_modules\//.test(normalized) || /\bnode:internal\//.test(normalized)) return 2;
+  if (/(?:^|[/(\s])node_modules\//.test(normalized) || /\bnode:internal\//.test(normalized)) return 2;
   const paths = [
     ...normalized.matchAll(
       /(?:\(|@|\bat )([^()]+?\.(?:[cm]?[jt]sx?|swift|kt|java|mm?|cpp|cc|c|h))(?::\d+(?::\d+)?)?(?:\)|$)/g,

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -126,9 +126,7 @@ export function launchErrorPreview(
       flush();
       if (/^\s*Caused by:/.test(line)) kind = 'Caused-by';
       lines.push(
-        !full && line.length > 1000
-          ? `${line.slice(0, 1000)} ... [preview shortened; full text in logs without --errors]`
-          : line,
+        !full && line.length > 1000 ? `${line.slice(0, 1000)} ... [preview shortened; full text in stim logs]` : line,
       );
     }
   };
@@ -167,7 +165,7 @@ export function launchErrorPreview(
   if (hadStack && !full)
     lines.push(
       'Stack preview: up to 10 frames per stack; app frames preferred.',
-      'Full captured logs: stim logs --source all (without --errors)',
+      'Full captured logs: stim logs --source all',
       'Raw records: stim logs --source all --json',
     );
   return lines;

--- a/packages/stim-cli/src/logs-query.ts
+++ b/packages/stim-cli/src/logs-query.ts
@@ -22,6 +22,7 @@ interface MarkerWindow {
 }
 
 export interface QueryCriteria {
+  includeNativeCrashes?: boolean;
   sources?: string[];
   minLevel?: string;
   grep?: RegExp;
@@ -79,7 +80,13 @@ export function recordMatches(record: NdjsonRecord | null | undefined, criteria:
   if (!record) return false;
   const { sources, minLevel, grep, sinceTs, errorsOnly, markerTs, bundleMarkerTs } = criteria;
 
-  if (sources && sources.length > 0 && !sources.includes(record.src as string)) return false;
+  if (
+    sources &&
+    sources.length > 0 &&
+    !sources.includes(record.src as string) &&
+    !(criteria.includeNativeCrashes && record.src === 'device' && record.event === 'native_crash')
+  )
+    return false;
   if (minLevel && levelRank(record.level) < levelRank(minLevel)) return false;
 
   if (errorsOnly) {
@@ -126,7 +133,10 @@ export function buildCriteria({
   bundleMarkerTs?: number;
   now?: number;
 } = {}): QueryCriteria {
-  const criteria: QueryCriteria = { errorsOnly: Boolean(errorsOnly) };
+  const criteria: QueryCriteria = {
+    errorsOnly: Boolean(errorsOnly),
+    includeNativeCrashes: Boolean(errorsOnly && !sources?.length),
+  };
   if (sources && sources.length > 0) criteria.sources = sources;
   else if (criteria.errorsOnly) criteria.sources = ERROR_SOURCES;
   if (minLevel) criteria.minLevel = minLevel;
@@ -196,7 +206,7 @@ function isExpoErrorContext(record: NdjsonRecord, event: unknown): boolean {
   );
 }
 
-function attachExpoErrorContext(all: NdjsonRecord[], matched: NdjsonRecord[]): NdjsonRecord[] {
+export function attachExpoErrorContext(all: NdjsonRecord[], matched: NdjsonRecord[]): NdjsonRecord[] {
   return matched.map((record) => {
     if (
       record.src !== 'metro' ||
@@ -206,7 +216,10 @@ function attachExpoErrorContext(all: NdjsonRecord[], matched: NdjsonRecord[]): N
     ) {
       return record;
     }
-    const index = all.indexOf(record);
+    const index = all.findIndex(
+      (entry) =>
+        entry.ts === record.ts && entry.src === record.src && entry.msg === record.msg && entry.event === record.event,
+    );
     if (index === -1) return record;
     const context: string[] = [];
     for (let i = index + 1; i < all.length; i += 1) {

--- a/packages/stim-cli/src/native-crash.ts
+++ b/packages/stim-cli/src/native-crash.ts
@@ -1,0 +1,437 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join, resolve, sep } from 'node:path';
+import { getExecutor } from './exec.ts';
+import { androidClockOffset, parseLogcatLine } from './collector/android.ts';
+import type { NdjsonRecord } from './ndjson.ts';
+import { androidHome } from './sim/android.ts';
+import { launchErrorPreview } from './launch-error-preview.ts';
+import { deviceConsoleLevel } from './collector/ios-device.ts';
+import { writeDiagnosticOnce } from './diagnostic-store.ts';
+import { readLogRecords } from './logs-query.ts';
+import { readWorkspaceLaunches, readWorkspaceState } from './supervisor/state.ts';
+
+interface CrashTarget {
+  root?: string;
+  platform: 'ios' | 'android';
+  deviceId: string;
+  appId: string;
+  since: number;
+  appPath?: string | null;
+  physical?: boolean;
+}
+
+interface CrashFrame {
+  file: string;
+  fn: string;
+  line?: number;
+  column?: number;
+}
+interface Image {
+  path?: string;
+  name?: string;
+  uuid?: string;
+  arch?: string;
+  base?: number;
+}
+interface IosFrame {
+  sourceFile?: string;
+  sourceLine?: number;
+  symbol?: string;
+  symbolLocation?: number;
+  imageIndex?: number;
+  imageOffset?: number;
+}
+interface IosReport {
+  captureTime?: string;
+  procPath?: string;
+  coalitionName?: string;
+  incident?: string;
+  pid?: number;
+  bundleInfo?: { CFBundleIdentifier?: string };
+  exception?: { type?: string; signal?: string };
+  termination?: { namespace?: string; indicator?: string; reasons?: string[]; details?: string[] };
+  asi?: Record<string, string[]>;
+  faultingThread?: number;
+  threads?: { triggered?: boolean; frames?: IosFrame[] }[];
+  usedImages?: Image[];
+}
+
+/** Accepts only a report for this app, simulator and launch window. */
+export function parseIosCrash(text: string, target: CrashTarget): { record: NdjsonRecord; report: IosReport } | null {
+  try {
+    const newline = text.indexOf('\n');
+    const report = JSON.parse(text.slice(newline + 1)) as IosReport;
+    const ts = Date.parse(report.captureTime ?? '');
+    const simulator = `com.apple.CoreSimulator.SimDevice.${target.deviceId}`;
+    if (
+      report.bundleInfo?.CFBundleIdentifier !== target.appId ||
+      report.coalitionName !== simulator ||
+      !Number.isFinite(ts) ||
+      ts < target.since ||
+      ts > Date.now() + 1000 ||
+      !report.incident
+    )
+      return null;
+    const thread = report.threads?.find((entry) => entry.triggered) ?? report.threads?.[report.faultingThread ?? -1];
+    const stack: CrashFrame[] = (thread?.frames ?? []).map((frame) => {
+      const image = report.usedImages?.[frame.imageIndex ?? -1];
+      return {
+        file: frame.sourceFile ?? image?.name ?? '<unknown image>',
+        line: frame.sourceLine,
+        fn: frame.symbol
+          ? `${frame.symbol}${frame.symbolLocation ? ` + ${frame.symbolLocation}` : ''}`
+          : `+0x${Number(frame.imageOffset ?? 0).toString(16)} [unsymbolicated]`,
+      };
+    });
+    const details = [
+      report.exception?.type,
+      report.exception?.signal,
+      report.termination?.namespace,
+      report.termination?.indicator,
+    ]
+      .filter(Boolean)
+      .join(' / ');
+    const reasons = [
+      ...(report.termination?.reasons ?? []),
+      ...(report.termination?.details ?? []),
+      ...Object.values(report.asi ?? {}).flat(),
+    ].filter((line) => typeof line === 'string');
+    return {
+      report,
+      record: {
+        ts,
+        src: 'device',
+        platform: 'ios',
+        level: 'fatal',
+        event: 'native_crash',
+        incident: report.incident,
+        appId: target.appId,
+        deviceId: target.deviceId,
+        pid: report.pid,
+        msg: `Native crash: ${details || 'process terminated'}${reasons.length ? `\n${reasons.join('\n')}` : ''}`,
+        stack,
+        rawReport: text,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Extracts crash-buffer groups only when their own process header names the target app. */
+export function parseAndroidCrashes(text: string, target: CrashTarget, clockOffsetMs: number): NdjsonRecord[] {
+  const entries = text
+    .split('\n')
+    .map((line) => parseLogcatLine(line, { clockOffsetMs }))
+    .filter((record): record is NdjsonRecord => record !== null && Number(record.ts) >= target.since);
+  const groups: NdjsonRecord[][] = [];
+  for (const entry of entries) {
+    const last = groups.at(-1);
+    if (!last || entry.proc !== last.at(-1)?.proc || /^\s*(?:FATAL EXCEPTION:|\*\*\* \*\*\*)/.test(entry.msg ?? ''))
+      groups.push([entry]);
+    else last.push(entry);
+  }
+  return groups.flatMap((group) => {
+    const messages = group.map((record) => record.msg ?? '');
+    const process = messages
+      .map((line) => /^\s*(?:Process: (.+?), PID: \d+|pid: \d+, tid: \d+, name: .*?>>> (.*?) <<<)/.exec(line))
+      .find(Boolean);
+    const appId = process?.[1] ?? process?.[2];
+    if (appId !== target.appId) return [];
+    const msg = messages.join('\n');
+    if (!/FATAL EXCEPTION:|signal \d+ \(/.test(msg)) return [];
+    return [
+      {
+        ts: group[0]!.ts,
+        deviceTs: group[0]!.deviceTs,
+        pid: Number(/(?:PID: |pid: )(\d+)/.exec(msg)?.[1]) || undefined,
+        src: 'device',
+        platform: 'android',
+        level: 'fatal',
+        event: 'native_crash',
+        appId,
+        deviceId: target.deviceId,
+        msg: `Native crash (Android)\n${msg}`,
+        rawReport: msg,
+      },
+    ];
+  });
+}
+
+function symbolicateIos(
+  record: NdjsonRecord,
+  report: IosReport,
+  appPath: string | null | undefined,
+  deadline: number,
+): NdjsonRecord {
+  if (!appPath || !existsSync(appPath) || !Array.isArray(record.stack)) return record;
+  const thread = report.threads?.find((entry) => entry.triggered) ?? report.threads?.[report.faultingThread ?? -1];
+  const stack = [...record.stack] as CrashFrame[];
+  const verified = new Map<number, string | null>();
+  for (const [index, frame] of (thread?.frames ?? []).entries()) {
+    if (Date.now() >= deadline) break;
+    if (frame.sourceFile && frame.sourceLine) continue;
+    const imageIndex = frame.imageIndex ?? -1;
+    const image = report.usedImages?.[imageIndex];
+    if (
+      !image?.path ||
+      !image.uuid ||
+      !image.arch ||
+      !Number.isSafeInteger(image.base) ||
+      !Number.isSafeInteger(frame.imageOffset)
+    )
+      continue;
+    if (!verified.has(imageIndex)) {
+      const marker = `${basename(appPath)}/`;
+      const at = image.path.lastIndexOf(marker);
+      const relative = at < 0 ? null : image.path.slice(at + marker.length);
+      const binary = relative ? resolve(appPath, relative) : null;
+      let matched: string | null = null;
+      if (binary && binary.startsWith(resolve(appPath) + sep) && existsSync(binary)) {
+        const uuids = getExecutor().runFileQuiet('xcrun', ['dwarfdump', '--uuid', binary], { timeoutMs: 2000 });
+        if (uuids?.toLowerCase().includes(`uuid: ${image.uuid.toLowerCase()} (${image.arch.toLowerCase()})`))
+          matched = binary;
+      }
+      verified.set(imageIndex, matched);
+    }
+    const binary = verified.get(imageIndex);
+    if (!binary || Date.now() >= deadline) continue;
+    const address = image.base! + frame.imageOffset!;
+    if (!Number.isSafeInteger(address)) continue;
+    const output = getExecutor().runFileQuiet(
+      'xcrun',
+      ['atos', '-o', binary, '-arch', image.arch, '-l', `0x${image.base!.toString(16)}`, `0x${address.toString(16)}`],
+      { timeoutMs: 2000 },
+    );
+    if (output && !/^0x[0-9a-f]+$/i.test(output) && !/error:|cannot|unable/i.test(output)) {
+      stack[index] = { file: image.name ?? basename(binary), fn: output };
+    }
+  }
+  return { ...record, stack };
+}
+
+function symbolicateAndroid(record: NdjsonRecord, root: string | undefined, budget: number): NdjsonRecord {
+  if (!root || typeof record.msg !== 'string' || !/#\d+ pc /.test(record.msg)) return record;
+  const frames = [...record.msg.matchAll(/^\s*#\d+ pc ([0-9a-f]+)\s+(\S+)(.*)$/gim)];
+  const stack: CrashFrame[] = frames.map(([, address, file, suffix]) => ({
+    file: basename(file!),
+    fn: `${suffix?.trim() || `0x${address}`} [captured native frame]`,
+  }));
+  let deadline = Math.min(Date.now() + 2000, budget - 1000);
+  const ndks = join(androidHome(), 'ndk');
+  let tools: string | undefined;
+  try {
+    for (const version of readdirSync(ndks).toSorted().toReversed()) {
+      const prebuilt = join(ndks, version, 'toolchains/llvm/prebuilt');
+      for (const host of readdirSync(prebuilt)) {
+        const bin = join(prebuilt, host, 'bin');
+        if (existsSync(join(bin, 'llvm-symbolizer'))) {
+          tools = bin;
+          break;
+        }
+      }
+      if (tools) break;
+    }
+  } catch {}
+  const files: string[] = [];
+  const visit = (directory: string, depth: number) => {
+    if (depth > 10 || files.length > 500 || Date.now() >= deadline) return;
+    try {
+      for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        if (entry.isDirectory()) visit(join(directory, entry.name), depth + 1);
+        else if (entry.isFile() && entry.name.endsWith('.so')) files.push(join(directory, entry.name));
+      }
+    } catch {}
+  };
+  if (tools) {
+    for (const directory of ['android/app/src/main/jniLibs', 'android/app/build/intermediates/cxx', 'android/app/.cxx'])
+      visit(join(root, directory), 0);
+    deadline = budget;
+    const byId = new Map<string, string | null>();
+    for (const [index, [, address, file, suffix]] of frames.entries()) {
+      if (Date.now() >= deadline) break;
+      const id = /\(BuildId: ([0-9a-f]+)\)/i.exec(suffix ?? '')?.[1]?.toLowerCase();
+      if (!id) continue;
+      if (!byId.has(id)) {
+        const binary = files
+          .filter((path) => file!.endsWith('.apk') || basename(path) === basename(file!))
+          .find((path) => {
+            if (Date.now() >= deadline) return false;
+            const notes = getExecutor().runFileQuiet(join(tools!, 'llvm-readelf'), ['--notes', path], {
+              timeoutMs: 1000,
+            });
+            return /Build ID: ([0-9a-f]+)/i.exec(notes ?? '')?.[1]?.toLowerCase() === id;
+          });
+        byId.set(id, binary ?? null);
+      }
+      const binary = byId.get(id);
+      if (!binary) continue;
+      const output = getExecutor().runFileQuiet(
+        join(tools, 'llvm-symbolizer'),
+        ['--no-inlines', '--demangle', `--obj=${binary}`, `0x${address}`],
+        { timeoutMs: 1000 },
+      );
+      const [fn, location] = output?.split('\n') ?? [];
+      const match = /^(.*):(\d+):(\d+)$/.exec(location ?? '');
+      if (fn && fn !== '??' && match && match[1] !== '??' && Number(match[2]) > 0) {
+        stack[index] = { fn, file: match[1]!, line: Number(match[2]), column: Number(match[3]) };
+      }
+    }
+  }
+  const summary = record.msg
+    .split('\n')
+    .filter((line) => /Native crash|signal \d+|Abort message:|^pid:/.test(line))
+    .join('\n');
+  return {
+    ...record,
+    msg: summary,
+    stack,
+    symbolicationNote: stack.some((frame) => !frame.line)
+      ? 'Native symbols are partial: unresolved frames retain crash-buffer symbols/addresses. Full captured report: stim logs --source device --json.'
+      : undefined,
+  };
+}
+
+export function simulatorConsolePaths(
+  target: Pick<CrashTarget, 'deviceId' | 'appId' | 'since'>,
+  prepare = false,
+  remote = false,
+): { stdout: string; stderr: string } | undefined {
+  if (remote) return undefined;
+  const container = getExecutor().runFileQuiet(
+    'xcrun',
+    ['simctl', 'get_app_container', target.deviceId, target.appId, 'data'],
+    { timeoutMs: 2000 },
+  );
+  if (!container?.startsWith('/')) return undefined;
+  const directory = join(container, 'Library/Caches/Stim');
+  const key = createHash('sha256')
+    .update(JSON.stringify([target.deviceId, target.appId, target.since]))
+    .digest('hex');
+  const paths = { stdout: join(directory, `launch-${key}.stdout`), stderr: join(directory, `launch-${key}.stderr`) };
+  if (prepare) {
+    try {
+      mkdirSync(directory, { recursive: true });
+      for (const path of Object.values(paths)) writeFileSync(path, '', { flag: 'wx' });
+    } catch {
+      return undefined;
+    }
+  }
+  return paths;
+}
+
+function simulatorFatalConsole(target: CrashTarget): NdjsonRecord[] {
+  const paths = simulatorConsolePaths(target);
+  return Object.values(paths ?? {}).flatMap((path) => {
+    try {
+      if (statSync(path).size > 8 * 1024 * 1024) return [];
+      const text = readFileSync(path, 'utf8');
+      const fatal = text.split('\n').filter((line) => deviceConsoleLevel(line) === 'fatal');
+      if (!fatal.length) return [];
+      return [
+        {
+          ts: Math.max(target.since + 1, statSync(path).mtimeMs),
+          src: 'device',
+          platform: 'ios',
+          level: 'fatal',
+          event: 'native_crash',
+          appId: target.appId,
+          deviceId: target.deviceId,
+          incident: basename(path),
+          pid: Number(/\[(\d+):\d+\]/.exec(text)?.[1]) || undefined,
+          msg: fatal.join('\n'),
+          rawReport: text,
+          symbolicationNote:
+            'Captured app stderr; the operating system crash report may arrive later. Run `stim logs --errors` again for its native stack.',
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
+}
+
+/** Reads platform crash evidence without starting, stopping or modifying a device. */
+export function captureNativeCrashes(target: CrashTarget, logsDir: string): NdjsonRecord[] {
+  let records: NdjsonRecord[] = [];
+  try {
+    if (target.platform === 'ios' && !target.physical && process.platform === 'darwin') {
+      const deadline = Date.now() + 4000;
+      records = simulatorFatalConsole(target);
+      const directory = join(homedir(), 'Library/Logs/DiagnosticReports');
+      const reports = readdirSync(directory)
+        .filter((name) => name.endsWith('.ips'))
+        .map((name) => ({ path: join(directory, name), time: statSync(join(directory, name)).mtimeMs }))
+        .filter(({ time }) => time >= target.since)
+        .toSorted((a, b) => b.time - a.time)
+        .slice(0, 50);
+      const nativeReports = reports.flatMap(({ path }) => {
+        if (Date.now() >= deadline) return [];
+        if (statSync(path).size > 8 * 1024 * 1024) return [];
+        const parsed = parseIosCrash(readFileSync(path, 'utf8'), target);
+        return parsed ? [symbolicateIos(parsed.record, parsed.report, target.appPath, deadline)] : [];
+      });
+      if (nativeReports.length) records = nativeReports;
+    } else if (target.platform === 'android') {
+      const offset = androidClockOffset(target.deviceId);
+      if (offset === null) return [];
+      const text = getExecutor().runFileQuiet(
+        'adb',
+        ['-s', target.deviceId, 'logcat', '-b', 'crash', '-d', '-v', 'time,epoch', '-t', '2000'],
+        { timeoutMs: 3000 },
+      );
+      const deadline = Date.now() + 4000;
+      if (text)
+        records = parseAndroidCrashes(text, target, offset).map((record) =>
+          symbolicateAndroid(record, target.root, deadline),
+        );
+    }
+  } catch {}
+  for (const record of records) {
+    try {
+      const key = createHash('sha256')
+        .update(JSON.stringify([record.deviceId, record.incident ?? record.deviceTs, record.rawReport]))
+        .digest('hex');
+      writeDiagnosticOnce(join(logsDir, `native-crash-${key}.ndjson`), `${JSON.stringify(record)}\n`);
+    } catch {}
+  }
+  return records;
+}
+
+export function printNativeCrashReport(
+  target: CrashTarget,
+  logsDir: string,
+  emit: (line: string) => void,
+  remote: boolean,
+): void {
+  if (remote) return;
+  for (const line of launchErrorPreview(captureNativeCrashes(target, logsDir), target.root)) emit(line);
+}
+
+export function captureWorkspaceCrashes(root: string, logsDir: string): void {
+  const attempts = readLogRecords(logsDir).filter((record) => record.event === 'launch_attempt');
+  const launches = readWorkspaceLaunches(root);
+  for (const platform of ['ios', 'android'] as const) {
+    const attempt = attempts.findLast((record) => record.platform === platform);
+    if (attempt?.remote) continue;
+    const launch = launches[platform];
+    const deviceId = attempt?.deviceId ?? launch?.deviceId;
+    const appId = attempt?.appId ?? launch?.appId;
+    const since = attempt?.ts ?? Date.parse(launch?.launchedAt ?? '');
+    if (typeof deviceId !== 'string' || typeof appId !== 'string' || !Number.isFinite(since)) continue;
+    captureNativeCrashes(
+      {
+        root,
+        platform,
+        deviceId,
+        appId,
+        since: Number(since),
+        physical: attempt?.physical === true,
+        appPath: (attempt?.appPath ?? readWorkspaceState(root)?.lastBuild?.appPath) as string | undefined,
+      },
+      logsDir,
+    );
+  }
+}

--- a/packages/stim-cli/src/native-crash.ts
+++ b/packages/stim-cli/src/native-crash.ts
@@ -14,6 +14,9 @@ import { readWorkspaceLaunches, readWorkspaceState } from './supervisor/state.ts
 import { getProject } from './config.ts';
 import { deviceLeasePath, fileLeaseIo, parseLease } from './engine/device-lease.ts';
 
+export const IOS_CRASH_REPORT_RETRY =
+  'iOS crash reports can take about a minute or longer to appear. Run `stim logs --errors` again for the native stack.';
+
 interface CrashTarget {
   root?: string;
   platform: 'ios' | 'android';
@@ -350,8 +353,7 @@ function simulatorFatalConsole(target: CrashTarget): NdjsonRecord[] {
           pid: Number(/\[(\d+):\d+\]/.exec(text)?.[1]) || undefined,
           msg: fatal.join('\n'),
           rawReport: text,
-          symbolicationNote:
-            'Captured app stderr; the operating system crash report may arrive later. Run `stim logs --errors` again for its native stack.',
+          symbolicationNote: `Captured app stderr; the full operating system crash report is not available yet. ${IOS_CRASH_REPORT_RETRY}`,
         },
       ];
     } catch {

--- a/packages/stim-cli/src/native-crash.ts
+++ b/packages/stim-cli/src/native-crash.ts
@@ -11,6 +11,8 @@ import { deviceConsoleLevel } from './collector/ios-device.ts';
 import { writeDiagnosticOnce } from './diagnostic-store.ts';
 import { readLogRecords } from './logs-query.ts';
 import { readWorkspaceLaunches, readWorkspaceState } from './supervisor/state.ts';
+import { getProject } from './config.ts';
+import { deviceLeasePath, fileLeaseIo, parseLease } from './engine/device-lease.ts';
 
 interface CrashTarget {
   root?: string;
@@ -18,6 +20,7 @@ interface CrashTarget {
   deviceId: string;
   appId: string;
   since: number;
+  until?: number;
   appPath?: string | null;
   physical?: boolean;
 }
@@ -70,7 +73,7 @@ export function parseIosCrash(text: string, target: CrashTarget): { record: Ndjs
       report.coalitionName !== simulator ||
       !Number.isFinite(ts) ||
       ts < target.since ||
-      ts > Date.now() + 1000 ||
+      ts > (target.until ?? Date.now() + 1000) ||
       !report.incident
     )
       return null;
@@ -125,7 +128,10 @@ export function parseAndroidCrashes(text: string, target: CrashTarget, clockOffs
   const entries = text
     .split('\n')
     .map((line) => parseLogcatLine(line, { clockOffsetMs }))
-    .filter((record): record is NdjsonRecord => record !== null && Number(record.ts) >= target.since);
+    .filter(
+      (record): record is NdjsonRecord =>
+        record !== null && Number(record.ts) >= target.since && Number(record.ts) <= (target.until ?? Infinity),
+    );
   const groups: NdjsonRecord[][] = [];
   for (const entry of entries) {
     const last = groups.at(-1);
@@ -327,6 +333,7 @@ function simulatorFatalConsole(target: CrashTarget): NdjsonRecord[] {
   return Object.values(paths ?? {}).flatMap((path) => {
     try {
       if (statSync(path).size > 8 * 1024 * 1024) return [];
+      if (target.until !== undefined && statSync(path).mtimeMs > target.until) return [];
       const text = readFileSync(path, 'utf8');
       const fatal = text.split('\n').filter((line) => deviceConsoleLevel(line) === 'fatal');
       if (!fatal.length) return [];
@@ -414,24 +421,66 @@ export function captureWorkspaceCrashes(root: string, logsDir: string): void {
   const attempts = readLogRecords(logsDir).filter((record) => record.event === 'launch_attempt');
   const launches = readWorkspaceLaunches(root);
   for (const platform of ['ios', 'android'] as const) {
-    const attempt = attempts.findLast((record) => record.platform === platform);
-    if (attempt?.remote) continue;
-    const launch = launches[platform];
-    const deviceId = attempt?.deviceId ?? launch?.deviceId;
-    const appId = attempt?.appId ?? launch?.appId;
-    const since = attempt?.ts ?? Date.parse(launch?.launchedAt ?? '');
-    if (typeof deviceId !== 'string' || typeof appId !== 'string' || !Number.isFinite(since)) continue;
-    captureNativeCrashes(
-      {
-        root,
-        platform,
-        deviceId,
-        appId,
-        since: Number(since),
-        physical: attempt?.physical === true,
-        appPath: (attempt?.appPath ?? readWorkspaceState(root)?.lastBuild?.appPath) as string | undefined,
-      },
-      logsDir,
-    );
+    try {
+      const attempt = attempts.findLast((record) => record.platform === platform);
+      if (!attempt || attempt.remote) continue;
+      const { deviceId, appId } = attempt;
+      const since = attempt.ts;
+      const until = Date.now();
+      if (
+        typeof deviceId !== 'string' ||
+        typeof appId !== 'string' ||
+        typeof since !== 'number' ||
+        !Number.isFinite(since)
+      )
+        continue;
+      if (attempt.physical) {
+        const holder = fileLeaseIo.readHolder(root)[platform];
+        const lease = parseLease(fileLeaseIo.readLease(deviceLeasePath(platform, deviceId)));
+        if (
+          holder?.id !== deviceId ||
+          !lease ||
+          lease.platform !== platform ||
+          lease.id !== deviceId ||
+          lease.holder !== root ||
+          lease.token !== holder.token ||
+          Date.parse(lease.expiresAt) <= until ||
+          !lease.grantedAt ||
+          !Number.isFinite(Date.parse(lease.grantedAt)) ||
+          Date.parse(lease.grantedAt) > since
+        )
+          continue;
+      } else {
+        const launch = launches[platform];
+        if (
+          !launch ||
+          launch.deviceId !== deviceId ||
+          launch.appId !== appId ||
+          Date.parse(launch.launchedAt) !== since
+        )
+          continue;
+        const configured = getProject(root)?.platforms?.[platform];
+        if (!configured?.owned) continue;
+        if (platform === 'ios' && configured.deviceUdid !== deviceId) continue;
+        if (platform === 'android') {
+          if (!configured.avdName) continue;
+          const name = getExecutor().runFileQuiet('adb', ['-s', deviceId, 'emu', 'avd', 'name'], { timeoutMs: 2000 });
+          if (name?.split('\n')[0]?.trim() !== configured.avdName) continue;
+        }
+      }
+      captureNativeCrashes(
+        {
+          root,
+          platform,
+          deviceId,
+          appId,
+          since: Number(since),
+          until,
+          physical: attempt?.physical === true,
+          appPath: (attempt?.appPath ?? readWorkspaceState(root)?.lastBuild?.appPath) as string | undefined,
+        },
+        logsDir,
+      );
+    } catch {}
   }
 }

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -31,12 +31,15 @@ available. These checks do not prove that a screen rendered correctly.
 A nonfatal error still appears as launch evidence. The agent can read the error
 and decide whether the change caused it.
 
-The human launch summary and `logs --errors` show up to **10 frames per error,
+Only the human `ios` / `android` launch summary shows up to **10 frames per error,
 component, or native stack**. App-source frames take priority over dependencies;
 selected frames remain in captured order, followed by the omitted-frame count.
 Error stacks describe the call path; component stacks describe the React parent
-tree. They are labeled separately. Full captured detail remains available through
-`stim logs --source all`; add `--json` for raw records.
+tree. They are labeled separately. Every `stim logs` command, including
+`stim logs --errors`, shows full captured stacks without frame or message-length
+limits. The separate default limit of 20 error records never shortens a stack.
+Use `--source all` for all sources/history, or `--json` for raw records. Text
+truncated by the runtime before capture cannot be restored.
 
 Symbolication is best effort. In development, Stim asks the verified workspace's
 Metro `/symbolicate` endpoint to resolve captured JavaScript coordinates, with a

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -79,6 +79,11 @@ reports can be delayed, physical iPhone capture is console-only, and stripped or
 remote builds may not have matching local debug symbols. This does not download
 symbols or replace Xcode/Android Studio's full crash-analysis tooling.
 
+For delayed reports, rerun `stim logs --errors` before stopping or releasing the
+device. Collection requires the workspace's current launch and device ownership
+or lease; after release, already-captured reports remain available without
+collecting another workspace's crashes.
+
 Non-follow human queries enrich errors; `--follow` streams captured records and
 does not continuously poll OS crash reports. `--json` preserves raw evidence.
 Stim does not resymbolicate an older error after a recorded Metro rebuild.

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -38,7 +38,7 @@ Error stacks describe the call path; component stacks describe the React parent
 tree. They are labeled separately. Every `stim logs` command, including
 `stim logs --errors`, shows full captured stacks without frame or message-length
 limits. The separate default limit of 20 error records never shortens a stack.
-Use `--source all` for all sources/history, or `--json` for raw records. Text
+Use `--source all` for all log sources, or `--json` for raw records. Text
 truncated by the runtime before capture cannot be restored.
 
 Symbolication is best effort. In development, Stim asks the verified workspace's

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -31,19 +31,59 @@ available. These checks do not prove that a screen rendered correctly.
 A nonfatal error still appears as launch evidence. The agent can read the error
 and decide whether the change caused it.
 
-The human launch summary shows up to **5 error-stack frames** and **3 React
-component-stack frames**, in captured order, followed by the omitted-frame count.
+The human launch summary and `logs --errors` show up to **10 frames per error,
+component, or native stack**. App-source frames take priority over dependencies;
+selected frames remain in captured order, followed by the omitted-frame count.
 Error stacks describe the call path; component stacks describe the React parent
 tree. They are labeled separately. Full captured detail remains available through
 `stim logs --source all`; add `--json` for raw records.
 
-Symbolication is best effort. In development, `stim logs --errors` retains Expo's
-printed source excerpt and Call Stack; bare React Native's Metro symbolication
-responses appear as separate context, not as an inferred match to an error.
-Launch previews do not request source maps themselves. Shortened bundle locations
-are explicitly labeled **unsymbolicated**, and a component stack is never used
+Symbolication is best effort. In development, Stim asks the verified workspace's
+Metro `/symbolicate` endpoint to resolve captured JavaScript coordinates, with a
+short timeout and the original coordinates as fallback. Resolved launch context
+is saved separately so it remains readable after Metro stops. Expo's printed source
+excerpt and Call Stack are included when available. Uncorrelated bare React Native
+symbolication events remain explicitly separate context. Shortened bundle locations
+are labeled **unsymbolicated**, and a component stack is never used
 to invent a missing error stack. OS logging can truncate text before Stim captures
 it; “full” means the records actually captured, not a recovered original stack.
+
+Copies from different sources are combined only when their error title, stack
+location, platform compatibility, and timing match. Raw copies remain available
+with `--json`; repeated errors from the same source are not suppressed.
+Human queries can add a correlated device component stack to a selected Metro
+error; unrelated device errors are never added as context.
+
+#### Native crashes
+
+On iOS simulators, Stim attaches stdout/stderr on a cold launch and passes Expo's
+initial project URL directly, so
+an early Swift fatal error or uncaught exception can appear in the launch result.
+Console redirection uses the app's writable cache, including when `STIM_HOME` is
+on an external volume; captured crash evidence is retained in the workspace logs.
+OS crash reports can arrive later: rerunning `stim logs --errors` collects them.
+Reports are matched to the app, simulator, and launch time. Existing source locations
+and symbol names are retained, and app addresses are resolved with
+`atos` only when the local binary's UUID matches the report. Android reads the
+crash logcat buffer, including reports emitted outside the dead app's PID. Java
+exceptions retain their stack; C/C++ frames use matching local ELF build IDs and
+NDK tools where available. Unavailable symbols remain explicitly unresolved.
+Android can keep a crashed Java process alive behind its system crash dialog.
+Stim treats the crash report as failure even when the PID exists. Follow the
+printed app-scoped force-stop command after fixing the error, then rerun `stim android`.
+
+Confirmed app-crash reports are included in default `stim logs --errors` without
+including general OS error noise. Use `stim logs --source device --json` for full
+captured reports. A missing report is not proof that the app did not crash: OS
+reports can be delayed, physical iPhone capture is console-only, and stripped or
+remote builds may not have matching local debug symbols. This does not download
+symbols or replace Xcode/Android Studio's full crash-analysis tooling.
+
+Non-follow human queries enrich errors; `--follow` streams captured records and
+does not continuously poll OS crash reports. `--json` preserves raw evidence.
+Stim does not resymbolicate an older error after a recorded Metro rebuild.
+Historical unsymbolicated JS coordinates require
+the matching bundle/source maps, not an unrelated rebuilt Metro bundle.
 
 ### Optional app-declared readiness
 

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -61,7 +61,8 @@ initial project URL directly, so
 an early Swift fatal error or uncaught exception can appear in the launch result.
 Console redirection uses the app's writable cache, including when `STIM_HOME` is
 on an external volume; captured crash evidence is retained in the workspace logs.
-OS crash reports can arrive later: rerunning `stim logs --errors` collects them.
+OS crash reports can take about a minute or longer to arrive: rerunning
+`stim logs --errors` collects them before you stop or release the simulator.
 Reports are matched to the app, simulator, and launch time. Existing source locations
 and symbol names are retained, and app addresses are resolved with
 `atos` only when the local binary's UUID matches the report. Android reads the


### PR DESCRIPTION
## Description

Launch errors expose bundle coordinates instead of useful source locations, while `logs --errors` can miss native crashes entirely.

Fixes #564. Stacked on #563.

**Limits:** delayed iOS reports require another logs query before stopping or releasing the device; saved reports remain readable afterward. Physical/remote devices do not gain simulator crash reports or downloadable symbols. Live validation covers simulators/emulators, not hardware or remote devices.

## Solution

Launch output previews up to 10 frames per stack; every `logs` command, including `logs --errors`, shows full captured stacks, and `--json` preserves raw records. JS error and component stacks resolve through the workspace's verified Metro, with saved context and app frames prioritized in launch previews. Human output groups duplicate reports and preserves Java cause chains.

A live native app with a JS error ends with a warning, not a green OK; launch JSON and exit codes stay unchanged.

Capture native failures independently of Metro: app-scoped Android crash-buffer reports and iOS simulator console/OS reports, with build-ID/UUID-checked native symbols. A Java crash counts as fatal even if Android keeps its PID alive behind a crash dialog. Cold Expo launches avoid creating a second React host.

Only attributable native crashes enter default error queries; the [deliberate exclusion of OS noise](https://github.com/appandflow/stim/commit/160af9bb8d99777aeccc7adb52487c83dff7ce2d) remains. Symbolication is bounded and best-effort.

## Test plan

- Expo 58 / RN 0.87 on iOS 26.5 and Android 36 arm64; external-SSD state.
- Deliberate JS render errors: initial launch and `logs --errors` identify `app/_layout.tsx`; verify error/component labels, useful launch previews without capture warnings, and raw preservation.
- Swift `fatalError`, Java `IllegalStateException`, and JNI `abort`: verify initial failure and default error logs. Swift points to `AppDelegate.swift:17`; JNI frames resolve through the APK's ELF build ID to the C source line. Re-query iOS logs after the delayed OS report appears.
- Remove the crash triggers, cold-launch both apps, and verify app-declared readiness plus no matching default error records.
