### PR TITLE
feat: publish the CLI as stim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
               if (bad) console.log(`${manifest.name} is ${manifest.version} but the tag is ${tag}`);
               for (const group of groups) {
                 for (const [name, range] of Object.entries(manifest[group] ?? {})) {
-                  if (name !== "stim-cli" && !name.startsWith("@stim-cli/")) continue;
+                  if (name !== "stim" && !name.startsWith("@stim-cli/")) continue;
                   const ok = accepted.has(range);
                   console.log(`${manifest.name} ${group}.${name} ${range} ${ok ? "ok" : "MISMATCH"}`);
                   if (!ok) bad += 1;
@@ -146,11 +146,11 @@ jobs:
           else
             npm publish "$RUNNER_TEMP/tarballs/expo-build-cache.tgz" --provenance --access public --tag "$DIST_TAG"
           fi
-      - name: Publish stim-cli
+      - name: Publish stim
         run: |
           version=$(node -p "require('$RUNNER_TEMP/tarballs/stim-cli.package.json').version")
-          if npm view "stim-cli@$version" version >/dev/null 2>&1; then
-            echo "stim-cli@$version is already published"
+          if npm view "stim@$version" version >/dev/null 2>&1; then
+            echo "stim@$version is already published"
           else
             npm publish "$RUNNER_TEMP/tarballs/stim-cli.tgz" --provenance --access public --tag "$DIST_TAG"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,11 +173,11 @@ skill changes only when its activation description or single routing command
 changes.
 
 Document command invocation once in each human-facing installation entry
-point. Show the no-install form, `npx stim-cli <command>`, and the global
-install, `npm install --global stim-cli`. The static skill is only a router and
+point. Show the no-install form, `npx stim <command>`, and the global
+install, `npm install --global stim`. The static skill is only a router and
 does not repeat installation instructions. Use `stim` alone in later examples.
 In a document that does not explain installation, add one short note that tells
-readers to replace `stim` with `npx stim-cli` when it is not installed globally.
+readers to replace `stim` with `npx stim` when it is not installed globally.
 On the website, use synchronized Global and npx tabs with Global as the default.
 Keep the full `npx` form in runnable hooks, release checks, and registry
 remedies, which cannot assume a global install.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ or configured remote devices.
 
 ## Install
 
-The npm package is named `stim-cli`. It installs the `stim` command.
+The `stim` npm package installs the `stim` command. If you previously installed
+`stim-cli` globally, run `npm uninstall --global stim-cli` first.
 
 ```bash
-npm install --global stim-cli
+npm install --global stim
 npx skills add appandflow/stim
 ```
 
 Run without a global install when needed:
 
 ```bash
-npx stim-cli <command>
+npx stim <command>
 ```
 
 Then ask your coding agent to build and run the app. The normal loop is:
@@ -77,7 +78,7 @@ stim guide settings
 
 ## Packages
 
-- [`stim-cli`](./packages/stim-cli) provides the `stim` command.
+- [`stim`](./packages/stim-cli) provides the `stim` command.
 - [`@stim-cli/metro`](./packages/metro) shares Metro transforms and records logs.
 - [`@stim-cli/expo-build-cache`](./packages/expo-build-cache) lets direct Expo
   builds share native artifacts with Stim.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process
 
-How to cut a new version of `stim-cli` to npm and GitHub. Keep this in sync with
+How to cut a new version of `stim` to npm and GitHub. Keep this in sync with
 what we actually do — when something changes, update both this file and the
 real workflow at the same time.
 
@@ -8,7 +8,7 @@ real workflow at the same time.
 
 ```
 packages/core                @stim-cli/core                shared primitives (cache roots, cache key, registration)
-packages/stim-cli              stim-cli                      the CLI
+packages/stim-cli            stim                          the CLI
 packages/cache               @stim-cli/cache               cache provider contract and tier coordination
 packages/expo-build-cache    @stim-cli/expo-build-cache    Expo build cache provider
 packages/metro               @stim-cli/metro               shared Metro transform cache + log reporter
@@ -32,7 +32,7 @@ the semver-higher one. Pull it and list commits since the matching tag:
 
 ```bash
 git fetch --tags
-if last=$(npm view stim-cli dist-tags --json 2>/dev/null | node -e '
+if last=$(npm view stim dist-tags --json 2>/dev/null | node -e '
   const { latest, next } = JSON.parse(require("fs").readFileSync(0, "utf8"));
   const parse = (v) => {
     const [core, pre] = v.split("-");
@@ -60,7 +60,7 @@ if last=$(npm view stim-cli dist-tags --json 2>/dev/null | node -e '
   echo "Last published: v$last"
   git log "v$last..HEAD" --oneline
 else
-  echo "No published stim-cli version"
+  echo "No published stim version"
   git log --oneline
 fi
 ```
@@ -72,7 +72,7 @@ first-publication bootstrap in
 Use `X.Y.Z-rc.N` for a release candidate. The workflow computes the publish
 dist-tag itself from the tag and the registry: it reads `npm view
 @stim-cli/core version` -- the first package every run publishes, not
-`stim-cli`, the last -- as its stable-or-not signal, and a candidate
+`stim`, the last -- as its stable-or-not signal, and a candidate
 publishes to `next` instead of `latest` only when that signal is already a
 stable version, so a plain `npm install` never regresses to a candidate.
 Every other publish -- a stable version, or a candidate published while no
@@ -220,7 +220,7 @@ The manual rows and report format are in
 [`docs/field-test-protocol.md`](./docs/field-test-protocol.md). Do not repeat
 the cache suite by hand: attach its machine-readable summary. Attach the loop
 suite result and log for each loop row. Run manual rows with the built candidate
-CLI as described by the protocol, never `stim-cli@latest`. Every claim in the
+CLI as described by the protocol, never `stim@latest`. Every claim in the
 draft release notes needs a matching automated check or manual observation.
 Missing evidence is not a pass.
 
@@ -373,9 +373,9 @@ repeat the affected gate rather than waiving it.
 8. **Smoke-test the published versions** from a scratch directory:
    ```bash
    version=X.Y.Z
-   cd /tmp && npx "stim-cli@$version" --version
-   cd /tmp && npx "stim-cli@$version" guide agent >/dev/null
-   npm view "stim-cli@$version" readme | head -c 200        # NOT "No README data found!"
+   cd /tmp && npx "stim@$version" --version
+   cd /tmp && npx "stim@$version" guide agent >/dev/null
+   npm view "stim@$version" readme | head -c 200        # NOT "No README data found!"
    npm view "@stim-cli/core@$version" version
    npm view "@stim-cli/cache@$version" version
    npm view "@stim-cli/expo-build-cache@$version" version

--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -25,7 +25,7 @@ pins remain separate. Never pool iOS and Android timings into one number.
 
 ## Pins and preparation
 
-Pin the exact published `stim-cli` version and package integrity, fixture
+Pin the exact published `stim` version and package integrity, fixture
 commit, runner version, model, reasoning effort, service tier, `agent-device`
 version and executable hash, Node.js, host machine, and platform toolchain
 before preparing the block. iOS also pins CocoaPods, Xcode, iPhone model, and

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -29,8 +29,8 @@ change into an app or worktree.
 For a standalone field pass of the published release:
 
 ```bash
-published_version=$(npm view stim-cli version)
-stim() { npx "stim-cli@$published_version" "$@"; }
+published_version=$(npm view stim version)
+stim() { npx "stim@$published_version" "$@"; }
 test "$(stim --version)" = "$published_version"
 npx skills add appandflow/stim
 stim guide agent

--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -9,7 +9,7 @@ The npm registry is the source of truth for "what was last released" -- a
 publish can fail after the tag is pushed, leaving the tag ahead of the
 registry. Post-stable, the last-published version can sit on either the
 `latest` or the `next` dist-tag; RELEASE.md section 1 shows the
-`npm view stim-cli dist-tags --json` invocation that checks both and picks
+`npm view stim dist-tags --json` invocation that checks both and picks
 the semver-higher one. If `git describe --tags --abbrev=0` is higher than
 that, a previous release got tagged but never landed. **Retry that publish
 at the existing version** (RELEASE.md section 4 step 7, or the manual
@@ -42,7 +42,7 @@ pnpm --filter @stim-cli/core publish --access public --tag <dist-tag> --otp <cod
 pnpm --filter @stim-cli/cache publish --access public --tag <dist-tag> --otp <code>
 pnpm --filter @stim-cli/metro publish --access public --tag <dist-tag> --otp <code>
 pnpm --filter @stim-cli/expo-build-cache publish --access public --tag <dist-tag> --otp <code>
-pnpm --filter stim-cli publish --access public --tag <dist-tag> --otp <code>
+pnpm --filter stim publish --access public --tag <dist-tag> --otp <code>
 ```
 
 ## First publication of a NEW package
@@ -53,6 +53,13 @@ published by hand (OTP) before the workflow can cover it. Then configure the
 package's trusted publisher for `appandflow/stim`, workflow `release.yml`,
 environment `release`. The workflow's already-exists skip makes the next
 tagged release pick it up cleanly.
+
+When an acquired package name already has a placeholder version, publish the
+CLI at the version the four scoped packages already share. Verify that version
+exists for every dependency before packing. The rename goes through a reviewed
+PR and required CI; inspect and smoke-test its pnpm tarball before the manual
+publish. Preserve existing version tags and publish only the new package name.
+Future releases resume the normal five-package workflow.
 
 For a from-scratch bootstrap (first release ever): confirm all the package
 names are available, use the intended first version, review the full release

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -9,7 +9,7 @@ second tier by pointing `cache.provider` at a module that implements this
 contract. Stim ships no network provider; writing one is an addition, not a
 change to Stim.
 
-If Stim is not installed globally, replace `stim` with `npx stim-cli`.
+If Stim is not installed globally, replace `stim` with `npx stim`.
 
 ## Selecting a provider
 

--- a/packages/expo-build-cache/README.md
+++ b/packages/expo-build-cache/README.md
@@ -8,7 +8,7 @@ Stim ignores two machine-local Android paths (`android/local.properties`,
 two hashes differ and each side fills its own entry. List them in the project's
 `.fingerprintignore` to bring the hashes back together.
 
-If Stim is not installed globally, replace `stim` with `npx stim-cli`.
+If Stim is not installed globally, replace `stim` with `npx stim`.
 
 ```bash
 npm install --save-dev @stim-cli/expo-build-cache
@@ -28,7 +28,7 @@ For current Expo SDK versions:
 
 Expo SDK 53 reads this value under `expo.experiments.buildCacheProvider`.
 
-The provider works without the `stim-cli` npm package. When Stim is available,
+The provider works without the `stim` npm package. When Stim is available,
 the provider registers its cache so `stim gc` can report and trim it.
 
 Set `STIM_BUILD_CACHE` to override the cache location.

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -3,7 +3,7 @@
 Optional Metro integration for Stim. It exports a transform cache shared across
 worktrees and an NDJSON reporter for structured Metro and client logs.
 
-If Stim is not installed globally, replace `stim` with `npx stim-cli`.
+If Stim is not installed globally, replace `stim` with `npx stim`.
 
 ```bash
 npm install --save-dev @stim-cli/metro

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -1,6 +1,6 @@
 # Stim
 
-The `stim-cli` npm package installs the `stim` command.
+The `stim` npm package installs the `stim` command.
 
 Stim gives coding agents fast, isolated React Native and Expo environments. Each
 project or git worktree gets its own Metro port and owned device. Shared caches
@@ -8,15 +8,18 @@ keep native and JavaScript builds warm across worktrees.
 
 ## Install
 
+If you previously installed `stim-cli` globally, follow the
+[migration instructions](#migrating-from-stim-cli) first.
+
 ```bash
-npm install --global stim-cli
+npm install --global stim
 npx skills add appandflow/stim
 ```
 
 Run without a global install when needed:
 
 ```bash
-npx stim-cli <command>
+npx stim <command>
 ```
 
 Node 20.19.4 or later on Node 20, or Node 22.12.0 or later, is required.
@@ -113,9 +116,17 @@ Runtime state defaults to `~/.stim`. Set `STIM_HOME` to move it. Stim manages
 owned simulators and emulators, leases connected physical devices, and supports
 configured remote devices.
 
-## Package name
+## Migrating from stim-cli
 
-The product and command are named Stim. The npm package remains `stim-cli` until
-the unscoped `stim` package name is available.
+Remove the old global package before installing `stim`, since both provide the
+same command:
+
+```bash
+npm uninstall --global stim-cli
+npm install --global stim
+```
+
+Update programmatic imports from `stim-cli/cache-manifest` to
+`stim/cache-manifest`. The `@stim-cli/*` packages keep their names.
 
 MIT License.

--- a/packages/stim-cli/package.json
+++ b/packages/stim-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stim-cli",
+  "name": "stim",
   "version": "1.0.0-rc.23",
   "description": "Stim: fast, isolated React Native environments for coding agents",
   "keywords": [

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -288,10 +288,10 @@ test('the static skill is only the agent guide router', () => {
 
 test('every guide topic explains the npx fallback for short stim commands', () => {
   for (const body of allBodies()) {
-    expect(body).toMatch(/not installed globally[^.]*npx stim-cli/i);
+    expect(body).toMatch(/not installed globally[^.]*npx stim`/i);
   }
   expect(renderIndex('9.9.9')).toContain('stim guide <topic>');
-  expect(renderIndex('9.9.9')).toMatch(/not installed globally[^.]*npx stim-cli/i);
+  expect(renderIndex('9.9.9')).toMatch(/not installed globally[^.]*npx stim`/i);
 });
 
 test('the agent workflow checks errors before and after edits, before cleanup', () => {

--- a/packages/stim-cli/src/commands/guide.ts
+++ b/packages/stim-cli/src/commands/guide.ts
@@ -29,7 +29,7 @@ export function sectionNames(name: string): string[] {
   return Object.keys(topicByName(name)?.sections ?? {});
 }
 
-const COMMAND_NOTATION = 'Commands use `stim`. If it is not installed globally, replace `stim` with `npx stim-cli`.';
+const COMMAND_NOTATION = 'Commands use `stim`. If it is not installed globally, replace `stim` with `npx stim`.';
 
 function wordCount(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -830,11 +830,11 @@ not on any remote"  (worktree remove)
     environment: {
       summary: 'npx registry E401/E404, the Node floor, no free Metro port, the reservation race',
       separator: '--- ENVIRONMENT ---',
-      body: () => `"npm error code E401 / E404" while \`npx\` resolves the stim-cli package
+      body: () => `"npm error code E401 / E404" while \`npx\` resolves the stim package
   The repo probably pins a private registry in \`.npmrc\`, so \`npx\` looked for
   the package there instead of on npm. Use the public registry for this command:
 
-    npx --registry=https://registry.npmjs.org stim-cli <command>
+    npx --registry=https://registry.npmjs.org stim <command>
 
   A line such as \`npm warn exec ... will be installed\` is normal when using
   the no-install form.

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -440,7 +440,7 @@ PREFER SELF-REGISTRATION OVER THE 'caches' SETTING
 There is no 'cache' command. A cache registers itself from code instead, once,
 and every 'gc' report shows it from then on, tagged (registered):
 
-  import { register } from 'stim-cli/cache-manifest';
+  import { register } from 'stim/cache-manifest';
   register({ dir: '<dir>', name: '<what to call it>', entriesDepth: 2 });
 
 entriesDepth is how far below dir one entry sits (default 1, a flat store).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ linkWorkspacePackages: true
 #   exempt so a release does not lock the repo out of itself
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - stim-cli
+  - stim
   - '@stim-cli/*'
   - unique-pid@0.1.1
 allowBuilds:

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -19,12 +19,12 @@ benchmark-root/
   golden/
   pins.env
   targets.json
-  runtime/node_modules/stim-cli/
+  runtime/node_modules/stim/
   results/
   state/
 ```
 
-`bin/stim` is an executable shim for the pinned `stim-cli` in `runtime`.
+`bin/stim` is an executable shim for the pinned `stim` in `runtime`.
 `pins.env` contains the exact fixture, CLI, agent-device, OS, Xcode, Node, and
 CocoaPods values checked by `preflight`; use the keys read by `versionChecks`
 in `driver.mjs`. `targets.json` defines this machine's timing expectations for
@@ -81,7 +81,7 @@ Set the machine-local paths explicitly:
 export STIM_BENCH_ROOT=/path/to/benchmark-root
 export STIM_BENCH_FIXTURE=/path/to/clean-trailhead-checkout
 export STIM_BENCH_WORKTREE_PARENT=/path/to/benchmark-worktrees
-export STIM_BENCH_STIM_PACKAGE="$STIM_BENCH_ROOT/runtime/node_modules/stim-cli"
+export STIM_BENCH_STIM_PACKAGE="$STIM_BENCH_ROOT/runtime/node_modules/stim"
 export STIM_BENCH_CODEX_AUTH=/path/to/codex-auth.json
 export STIM_BENCH_SKILLS_ROOT=/path/to/skills
 ```

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -73,7 +73,7 @@ const allowedBin = join(root, 'allowed-bin');
 const stimBin = join(root, 'bin');
 const golden = join(root, 'golden');
 const worktreeParent = resolve(process.env.STIM_BENCH_WORKTREE_PARENT ?? join(root, '../trailhead-worktrees'));
-const stimPackage = resolve(process.env.STIM_BENCH_STIM_PACKAGE ?? join(root, 'runtime', 'node_modules', 'stim-cli'));
+const stimPackage = resolve(process.env.STIM_BENCH_STIM_PACKAGE ?? join(root, 'runtime', 'node_modules', 'stim'));
 const stimCli = join(stimPackage, 'dist', 'cli.mjs');
 const agentDeviceBin = process.env.STIM_BENCH_AGENT_DEVICE_BIN ?? 'agent-device';
 const nativeCompatManifest = process.env.STIM_BENCH_NATIVE_COMPAT_MANIFEST;
@@ -498,6 +498,7 @@ function git(...args) {
 }
 
 function versionChecks() {
+  const stimManifest = JSON.parse(readFileSync(join(stimPackage, 'package.json'), 'utf8'));
   const macVersion = run('sw_vers', ['-productVersion']);
   const macBuild = run('sw_vers', ['-buildVersion']);
   const xcode = run('xcodebuild', ['-version']).split('\n');
@@ -507,9 +508,9 @@ function versionChecks() {
     CLAUDE_VERSION: run(claudeBin, ['--version']).split(/\s+/)[0],
     NODE_VERSION: run('node', ['--version']).replace(/^v/, ''),
     COCOAPODS_VERSION: run('pod', ['--version']),
-    STIM_VERSION: JSON.parse(readFileSync(join(stimPackage, 'package.json'), 'utf8')).version,
+    STIM_VERSION: stimManifest.version,
     STIM_INTEGRITY: JSON.parse(readFileSync(join(root, 'runtime', 'package-lock.json'), 'utf8')).packages[
-      'node_modules/stim-cli'
+      `node_modules/${stimManifest.name}`
     ].integrity,
     AGENT_DEVICE_VERSION: run(agentDeviceBin, ['--version']).split(/\s+/).at(-1),
     AGENT_DEVICE_SHA256: sha256(executablePath(agentDeviceBin)),

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -39,7 +39,7 @@ const internalRanges = (manifest) => {
   const found = [];
   for (const group of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
     for (const [name, range] of Object.entries(manifest[group] ?? {})) {
-      if (name === 'stim-cli' || name.startsWith('@stim-cli/')) found.push({ group, name, range });
+      if (name === 'stim' || name.startsWith('@stim-cli/')) found.push({ group, name, range });
     }
   }
   return found;

--- a/test/e2e/release-prep.e2e.js
+++ b/test/e2e/release-prep.e2e.js
@@ -65,11 +65,23 @@ test('the five packages share one version and only bare workspace: ranges', () =
     const pkg = readManifest(REPO, dir);
     for (const group of ['dependencies', 'devDependencies', 'peerDependencies']) {
       for (const [name, range] of Object.entries(pkg[group] ?? {})) {
-        if (name !== 'stim-cli' && !name.startsWith('@stim-cli/')) continue;
+        if (name !== 'stim' && !name.startsWith('@stim-cli/')) continue;
         assert.equal(ACCEPTED_RANGES.has(range), true, `packages/${dir} ${group}.${name} is "${range}"`);
       }
     }
   }
+});
+
+test('--check refuses a versioned dependency on the renamed CLI', () => {
+  withWorkspace((root) => {
+    const core = readManifest(root, 'core');
+    core.devDependencies = { ...core.devDependencies, stim: '^1.0.0' };
+    writeFileSync(manifestIn(root, 'core'), `${JSON.stringify(core, null, 2)}\n`);
+
+    const result = runPrep(root, '--check');
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stderr, /devDependencies\.stim is "\^1\.0\.0", not one of workspace:/);
+  });
 });
 
 test('a bump rewrites all five versions and leaves the lockfile alone', () => {
@@ -110,7 +122,7 @@ test('a malformed, non-increasing, or missing version is refused without touchin
 test('a manifest the bump cannot rewrite leaves every version where it was', () => {
   withWorkspace((root) => {
     const before = versionsIn(root);
-    writeFileSync(manifestIn(root, 'stim-cli'), '{ "name": "stim-cli" }\n');
+    writeFileSync(manifestIn(root, 'stim-cli'), '{ "name": "stim" }\n');
 
     const result = runPrep(root, '99.0.0');
     assert.equal(result.status, 1, result.stdout);
@@ -135,6 +147,7 @@ test('pnpm pack substitutes the workspace ranges the CLI ships with', () => {
     const shipped = JSON.parse(execFileSync('tar', ['-xzOf', packed, 'package/package.json'], { encoding: 'utf8' }));
     const version = readManifest(REPO, 'stim-cli').version;
 
+    assert.equal(shipped.name, 'stim');
     assert.equal(shipped.version, version);
     for (const name of ['@stim-cli/cache', '@stim-cli/core', '@stim-cli/metro']) {
       assert.equal(shipped.dependencies[name], `^${version}`);

--- a/test/runtime-floor.mjs
+++ b/test/runtime-floor.mjs
@@ -28,7 +28,7 @@ const entrypoints = [
   ['@stim-cli/cache', 'loadCacheProvider'],
   ['@stim-cli/expo-build-cache', 'cacheRoot'],
   ['@stim-cli/metro', 'sharedCacheStores'],
-  ['stim-cli/cache-manifest', 'readManifest'],
+  ['stim/cache-manifest', 'readManifest'],
 ];
 
 for (const [specifier, exportName] of entrypoints) {

--- a/website/docs/agent-skills.md
+++ b/website/docs/agent-skills.md
@@ -5,7 +5,7 @@ description: 'Install the small Stim workflow skill for coding agents'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Install the bundled skill from the repository:
 

--- a/website/docs/android-cas.md
+++ b/website/docs/android-cas.md
@@ -102,7 +102,7 @@ assertion failures stop the script. All fixture data remains available.
 
 After building the Stim checkout, use its CLI with a disposable React Native/Expo
 worktree and a private `STIM_HOME`. Commands use `stim`; replace it with
-`npx stim-cli` if it is not installed globally.
+`npx stim` if it is not installed globally.
 
 For persistent selection, merge this into `$STIM_HOME/config.json` (default
 `~/.stim/config.json`). The same `optimizations` object in `.stim.json` can

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -7,7 +7,7 @@ description: 'How Stim keeps worktree builds warm'
 import StimTabs from '@site/src/components/StimTabs';
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Stim shares four types of work across projects and git worktrees:
 

--- a/website/docs/build-optimizations.md
+++ b/website/docs/build-optimizations.md
@@ -6,7 +6,7 @@ description: 'Control native artifact reuse, compiler caches, PCH, and Metro cac
 import StimTabs from '@site/src/components/StimTabs';
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Stim enables build optimizations by default. Use the `optimizations` settings to
 disable individual layers when debugging or to opt into experimental compiler

--- a/website/docs/cache-packages.md
+++ b/website/docs/cache-packages.md
@@ -5,7 +5,7 @@ description: 'Optional npm packages for builds that run outside Stim'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Stim supplies its own cache arguments when it runs Metro and native builds. A
 project does not need these packages for `stim start`, `stim ios`, or
@@ -58,6 +58,6 @@ For current Expo SDK versions:
 Expo SDK 53 reads the provider under `expo.experiments.buildCacheProvider`.
 Confirm the key for the project's SDK before adding it.
 
-Both packages work without the `stim-cli` npm package. They register their cache
+Both packages work without the `stim` npm package. They register their cache
 directories in Stim's cache manifest when available, so `stim gc` can report and
 trim them.

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -7,7 +7,7 @@ description: 'Every Stim command and option'
 import StimTabs from '@site/src/components/StimTabs';
 
 Commands use `stim`. If Stim is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Run `stim <command> --help` for parser help. Run `stim guide` for the full
 reference that ships with the installed version.

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -7,7 +7,7 @@ description: 'A supervised Metro server and a queryable launch timeline'
 import StimTabs from '@site/src/components/StimTabs';
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 `stim start` reserves a port for the workspace and starts its React Native or
 Expo dev server under a detached supervisor. The command exits only after the
@@ -172,7 +172,7 @@ Copy this prompt into your coding agent:
 ```text
 Add optional Stim app-readiness logs to this app. Read `stim guide agent`,
 then follow `stim guide lifecycle readiness` from the installed CLI. If Stim
-is not installed globally, use `npx stim-cli` instead of `stim`.
+is not installed globally, use `npx stim` instead of `stim`.
 
 Use the app's existing initialization and splash-screen lifecycle without
 adding a package or monitoring SDK. Cover its real startup destinations,

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,8 +9,10 @@ import PromptBox, { PromptGrid } from '@site/src/components/PromptBox';
 
 ## Install Stim
 
-Install the CLI globally or run it with npx. The package is `stim-cli`; the
-installed command is `stim`.
+Install the CLI globally or run it with npx. The package and command are both
+`stim`. If you previously installed `stim-cli` globally, run
+`npm uninstall --global stim-cli` first. The `@stim-cli/*` packages keep their
+names.
 
 <StimInstallTabs />
 

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -5,7 +5,7 @@ description: 'Owned devices, physical-device leases, and cleanup'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Stim creates and records its local simulators and emulators. Their names start
 with `stim-`. It never creates, boots, or deletes a simulator or emulator that

--- a/website/docs/requirements.md
+++ b/website/docs/requirements.md
@@ -5,7 +5,7 @@ description: 'Local and optional remote requirements'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 ## All projects
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -5,7 +5,7 @@ description: 'Project, repository, machine, and environment settings'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Most projects need no settings. Use `stim guide settings` for descriptions that
 match the installed version.

--- a/website/docs/why.md
+++ b/website/docs/why.md
@@ -5,7 +5,7 @@ description: 'Fast, isolated React Native environments for coding agents'
 ---
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 Stim gives each coding agent a complete React Native environment. Each project
 or git worktree gets a reserved Metro port and an owned simulator or emulator.

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -7,7 +7,7 @@ description: 'Parallel worktrees that share expensive build caches'
 import StimTabs from '@site/src/components/StimTabs';
 
 Commands use `stim`. If it is not installed globally, replace `stim` with
-`npx stim-cli`.
+`npx stim`.
 
 ## Create with Git
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -69,7 +69,7 @@ const config: Config = {
         { to: '/benchmarks', label: 'Benchmarks', position: 'left' },
         { to: '/docs/changelog', label: 'Changelog', position: 'left' },
         {
-          href: 'https://www.npmjs.com/package/stim-cli',
+          href: 'https://www.npmjs.com/package/stim',
           label: 'npm',
           position: 'right',
         },
@@ -94,7 +94,7 @@ const config: Config = {
         {
           title: 'Packages',
           items: [
-            { label: 'stim-cli', href: 'https://www.npmjs.com/package/stim-cli' },
+            { label: 'stim', href: 'https://www.npmjs.com/package/stim' },
             { label: '@stim-cli/metro', href: 'https://www.npmjs.com/package/@stim-cli/metro' },
             {
               label: '@stim-cli/expo-build-cache',

--- a/website/src/components/StimTabs.tsx
+++ b/website/src/components/StimTabs.tsx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
 const groupId = 'stim-invocation';
-const npxPrefix = 'npx stim-cli';
+const npxPrefix = 'npx stim';
 
 function normalize(code: string): string {
   return code.trim();
@@ -33,7 +33,7 @@ export function StimInstallTabs(): ReactNode {
   return (
     <Tabs groupId={groupId} defaultValue="global">
       <TabItem value="global" label="Global">
-        <CodeBlock language="bash">{`npm install --global stim-cli
+        <CodeBlock language="bash">{`npm install --global stim
 stim <command>`}</CodeBlock>
       </TabItem>
       <TabItem value="npx" label="npx">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -197,7 +197,7 @@ export default function Home(): ReactNode {
           <nav aria-label="Footer navigation">
             <Link to="/docs/why">Why Stim</Link>
             <Link to="/docs/changelog">Changelog</Link>
-            <a href="https://www.npmjs.com/package/stim-cli">npm</a>
+            <a href="https://www.npmjs.com/package/stim">npm</a>
           </nav>
           <p>
             MIT License. Built by <a href="https://appandflow.com">AppAndFlow</a>.


### PR DESCRIPTION
## Description

The project now owns the `stim` npm package. The `stim-cli` name was retained deliberately [while it was unavailable](https://github.com/appandflow/stim/commit/cc9276bfc338debe6aae9042b44a0bf0d34f989d).

## Solution

Publish the CLI as `stim` and update installation guidance, programmatic imports, and release automation. The four `@stim-cli/*` packages keep their names. Existing global users remove `stim-cli` before installing `stim` because both provide the same command.

The first manual 2FA publish uses `1.0.0-rc.23`, matching the already-published scoped packages. Trusted publishing for `stim` is configured separately afterward; existing release tags stay unchanged.

## Test plan

- Install the inspected pnpm tarball in a scratch directory: `stim --version`, npm command resolution, guide output, and both import/require of `stim/cache-manifest` pass.
- Exercise release preparation and packing: reject a versioned internal `stim` dependency, verify the shipped name and resolved workspace ranges, and load the renamed export at the supported runtime floor.
- Build the website and verify its global/npx commands, migration instructions, and npm package link.

Fixes #568
