### PR TITLE
perf: copy warm worktrees directly

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -93,6 +93,10 @@ there. Warm copies missing ignored state from main, including eligible `.env`
 and local configuration files. Existing entries are preserved; existing
 ignored directories such as `node_modules` are skipped whole.
 
+Wait for warm to finish before editing, installing dependencies, starting
+Metro/builds, or running another warm in that worktree. Concurrent writes are
+unsafe: entries created after the initial check can be overwritten or removed.
+
 After the work is preserved, `stim worktree remove` removes any linked
 worktree, warmed or not. Git-created branches stay. See the
 [worktree guide](https://appandflow.github.io/stim/docs/worktrees) for exclusions

--- a/packages/stim-cli/src/__tests__/doctor-storage.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-storage.test.ts
@@ -50,7 +50,7 @@ test('doctor detects iOS output/cache and configured staging mismatches separate
   expect(findings[1]?.detail).toContain(output);
 });
 
-test('an explicit override on another volume warns for warm and artifact preparation', () => {
+test('an explicit override on another volume warns for artifact preparation but not direct warming', () => {
   const staging = join(base, 'override');
   const findings = checkStorageLayout(project, {
     platform: 'ios',
@@ -58,7 +58,6 @@ test('an explicit override on another volume warns for warm and artifact prepara
     stagingRoot: () => staging,
   });
   expect(findings.map((finding) => finding.title)).toEqual([
-    'Worktree staging crosses filesystems',
     'Cached app/APK staging crosses filesystems',
     'iOS device app staging crosses filesystems',
   ]);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -227,6 +227,7 @@ test('current guides require completed warming and leave worktree creation to Gi
   expect(body).toContain('stim worktree remove');
   for (const guide of [renderTopic('agent'), renderSection('lifecycle', 'options')]) {
     expect(guide).toContain('Wait for warm to exit successfully (exit code 0)');
+    expect(guide).toMatch(/Concurrent\s+writes to the destination are unsafe/);
   }
   expect(body).not.toMatch(/worktree create|--carry-ignored|STIM_WORKTREE_BRANCH_EXISTS/);
   expect(body).not.toMatch(/worktreeDir|worktree\.baseRef|worktree\.include|\.worktreeinclude/);

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -19,40 +19,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import { cloneIgnoredEntries, warmWorktreePaths } from '../worktree.ts';
-import { temporaryRoot } from '../temporary.ts';
 import { Command } from 'commander';
 import { registerWarm } from '../commands/worktree.ts';
-
-const publication = vi.hoisted(() => ({
-  beforePublish: null as ((path: string) => void) | null,
-  beforeLink: null as ((from: string, to: string) => void) | null,
-  beforeMkdir: null as ((path: string) => void) | null,
-  stagingPaths: [] as string[],
-}));
-vi.mock('fs', async (importOriginal) => {
-  const fs = await importOriginal<typeof import('fs')>();
-  return {
-    ...fs,
-    mkdtempSync: (prefix: string) => {
-      const path = fs.mkdtempSync(prefix);
-      if (prefix.endsWith('.stim-warm-')) publication.stagingPaths.push(path);
-      return path;
-    },
-    mkdirSync: (path: string, options?: import('fs').MakeDirectoryOptions) => {
-      publication.beforeMkdir?.(path);
-      return fs.mkdirSync(path, options);
-    },
-    copyFileSync: (from: string, to: string, mode?: number) => {
-      publication.beforePublish?.(to);
-      return fs.copyFileSync(from, to, mode);
-    },
-    linkSync: (from: string, to: string) => {
-      publication.beforePublish?.(to);
-      publication.beforeLink?.(from, to);
-      return fs.linkSync(from, to);
-    },
-  };
-});
 
 let base: string;
 let root: string;
@@ -68,7 +36,6 @@ function write(dir: string, rel: string, value: string): void {
 }
 
 beforeEach(() => {
-  publication.stagingPaths = [];
   base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-test-warm-')));
   root = join(base, 'main');
   target = join(base, 'linked');
@@ -89,13 +56,9 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   resetExecutor();
-  publication.beforePublish = null;
-  publication.beforeLink = null;
-  publication.beforeMkdir = null;
   process.exitCode = 0;
   delete process.env.STIM_HOME;
   rmSync(base, { recursive: true, force: true });
-  for (const path of publication.stagingPaths) rmSync(path, { recursive: true, force: true });
 });
 
 function warm() {
@@ -163,41 +126,9 @@ test('missing-only copy discards partial clone output before byte-copy fallback'
   expect(result.copied).toEqual(['node_modules']);
   expect(readdirSync(join(target, 'node_modules'))).toEqual(['pkg']);
   expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
 });
 
-test.each(['file', 'empty directory', 'dangling symlink'])(
-  'missing-only copy preserves a concurrently created %s',
-  (kind) => {
-    write(root, 'node_modules/pkg/index.js', 'source package');
-    const real = getExecutor();
-    setExecutor({
-      ...real,
-      runFile(file, args, opts) {
-        const result = real.runFile(file, args, opts);
-        if (file === 'cp') {
-          if (kind === 'file') writeFileSync(join(target, 'node_modules'), 'concurrent file');
-          else if (kind === 'empty directory') mkdirSync(join(target, 'node_modules'));
-          else symlinkSync('missing-packages', join(target, 'node_modules'));
-        }
-        return result;
-      },
-    });
-    const result = warm();
-    expect(result.copied).toEqual([]);
-    expect(result.skipped).toEqual([{ file: 'node_modules', reason: 'exists' }]);
-    const actual =
-      kind === 'file'
-        ? readFileSync(join(target, 'node_modules'), 'utf-8')
-        : kind === 'empty directory'
-          ? readdirSync(join(target, 'node_modules'))
-          : readlinkSync(join(target, 'node_modules'));
-    const expected = kind === 'file' ? 'concurrent file' : kind === 'empty directory' ? [] : 'missing-packages';
-    expect(actual).toEqual(expected);
-  },
-);
-
-test('failed missing-only copies leave no partial destination and retain their error', () => {
+test('failed direct copies report partial output and keep existing files on retry', () => {
   write(root, 'node_modules/pkg/index.js', 'source package');
   const real = getExecutor();
   setExecutor({
@@ -213,8 +144,8 @@ test('failed missing-only copies leave no partial destination and retain their e
   const result = warm();
   expect(result.copied).toEqual([]);
   expect(result.failed).toEqual([{ file: 'node_modules', error: 'copy failed' }]);
-  expect(existsSync(join(target, 'node_modules'))).toBe(false);
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+  expect(readFileSync(join(target, 'node_modules/partial'), 'utf-8')).toBe('incomplete');
+  expect(warm().skipped).toEqual([{ file: 'node_modules', reason: 'exists' }]);
 });
 
 test('missing-only copy preserves relative symlinks without linking files back to the source', () => {
@@ -223,14 +154,19 @@ test('missing-only copy preserves relative symlinks without linking files back t
   const destination = join(target, 'node_modules/pkg/index.js');
   linkSync(source, join(root, 'node_modules/pkg/sibling.js'));
   symlinkSync('pkg', join(root, 'node_modules/alias'));
+  write(base, 'outside/.DerivedData/keep', 'outside data');
+  symlinkSync('../../outside', join(root, 'node_modules/outside'));
+  symlinkSync('../../../outside', join(root, 'node_modules/pkg/.DerivedData'));
   const result = warm();
   expect(result.failed).toEqual([]);
   expect(readlinkSync(join(target, 'node_modules/alias'))).toBe('pkg');
+  expect(readlinkSync(join(target, 'node_modules/outside'))).toBe('../../outside');
+  expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
+  expect(readFileSync(join(base, 'outside/.DerivedData/keep'), 'utf-8')).toBe('outside data');
   const published = lstatSync(destination);
   expect(published.ino).not.toBe(lstatSync(source).ino);
   expect(published.nlink).toBe(1);
   expect(lstatSync(join(target, 'node_modules/pkg/sibling.js')).ino).not.toBe(published.ino);
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   write(target, 'node_modules/pkg/index.js', 'edited destination');
   expect(readFileSync(source, 'utf-8')).toBe('source package');
   expect(readFileSync(join(target, 'node_modules/pkg/sibling.js'), 'utf-8')).toBe('source package');
@@ -238,61 +174,18 @@ test('missing-only copy preserves relative symlinks without linking files back t
   expect(readFileSync(destination, 'utf-8')).toBe('edited destination');
 });
 
-test.skipIf(process.platform !== 'darwin')(
-  'publication reuses the private staged inode and preserves timestamps',
-  () => {
-    write(root, '.env', 'source config');
-    const source = join(root, '.env');
-    utimesSync(source, new Date('2020-01-01'), new Date('2021-01-01'));
-    let staged: ReturnType<typeof lstatSync> | undefined;
-    let stagedPath: string | undefined;
-    publication.beforeLink = (from) => {
-      stagedPath = from;
-      staged = lstatSync(from);
-    };
-    const result = warm();
-    expect(result.failed).toEqual([]);
-    const published = lstatSync(join(target, '.env'));
-    expect(staged).toBeDefined();
-    expect(stagedPath).toBe(join(publication.stagingPaths[0]!, 'entry'));
-    expect(staged?.ino).not.toBe(lstatSync(source).ino);
-    expect(published.ino).toBe(staged?.ino);
-    expect(published.atimeMs).toBe(staged?.atimeMs);
-    expect(published.mtimeMs).toBe(staged?.mtimeMs);
-    expect(published.nlink).toBe(1);
-    expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
-  },
-);
-
-test.each(['EXDEV', 'ENOTSUP', 'EPERM'])('publication copies independently when linking fails with %s', (code) => {
-  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
-  write(root, 'node_modules/pkg/index.js', 'source package');
-  let links = 0;
-  publication.beforeLink = () => {
-    links++;
-    throw Object.assign(new Error('link unavailable'), { code });
-  };
-  const result = warm();
-  expect(links).toBe(1);
-  expect(result.failed).toEqual([]);
-  expect(result.copied).toEqual(['node_modules']);
-  expect(result.cloned).toBe(false);
-  write(target, 'node_modules/pkg/index.js', 'edited destination');
-  expect(readFileSync(join(root, 'node_modules/pkg/index.js'), 'utf-8')).toBe('source package');
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
-});
-
-test('publication refuses EEXIST without attempting to copy', () => {
-  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+test.skipIf(process.platform !== 'darwin')('direct cloning preserves source timestamps', () => {
   write(root, '.env', 'source config');
-  publication.beforeLink = () => {
-    throw Object.assign(new Error('link destination exists'), { code: 'EEXIST' });
-  };
+  const source = join(root, '.env');
+  utimesSync(source, new Date('2020-01-01'), new Date('2021-01-01'));
+  const before = lstatSync(source);
   const result = warm();
-  expect(result.copied).toEqual([]);
-  expect(result.failed).toEqual([{ file: '.env', error: 'link destination exists' }]);
-  expect(existsSync(join(target, '.env'))).toBe(false);
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
+  expect(result.failed).toEqual([]);
+  expect(result.cloned).toBe(true);
+  const copied = lstatSync(join(target, '.env'));
+  expect(copied.ino).not.toBe(before.ino);
+  expect(copied.atimeMs).toBe(before.atimeMs);
+  expect(copied.mtimeMs).toBe(before.mtimeMs);
 });
 
 async function runWarm(cwd: string) {
@@ -313,40 +206,6 @@ async function runWarm(cwd: string) {
     error.mockRestore();
   }
 }
-
-test.each([
-  ['file', false],
-  ['dangling symlink', false],
-  ['file', true],
-  ['dangling symlink', true],
-])('publication preserves a late %s and earlier files (copy fallback: %s)', (kind, fallback) => {
-  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
-  write(root, 'node_modules/a.js', 'source a');
-  write(root, 'node_modules/b.js', 'source b');
-  if (fallback) {
-    publication.beforeLink = () => {
-      throw Object.assign(new Error('link unavailable'), { code: 'ENOTSUP' });
-    };
-  }
-  publication.beforePublish = (path) => {
-    if (path === join(target, 'node_modules/b.js')) {
-      publication.beforePublish = null;
-      if (kind === 'file') writeFileSync(path, 'concurrent b');
-      else symlinkSync('missing-b', path);
-    }
-  };
-  const result = warm();
-  expect(result.copied).toEqual([]);
-  expect(result.failed).toHaveLength(1);
-  expect(result.failed[0]?.error).toMatch(/EEXIST/);
-  expect(readFileSync(join(target, 'node_modules/a.js'), 'utf-8')).toBe('source a');
-  const actual =
-    kind === 'file'
-      ? readFileSync(join(target, 'node_modules/b.js'), 'utf-8')
-      : readlinkSync(join(target, 'node_modules/b.js'));
-  expect(actual).toBe(kind === 'file' ? 'concurrent b' : 'missing-b');
-  expect(existsSync(join(target, 'node_modules/missing-b'))).toBe(false);
-});
 
 test('warm identifies canonical main and linked roots from a symlinked subdirectory', () => {
   const alias = join(base, 'alias');
@@ -509,20 +368,6 @@ test.each(['android/build/', 'apps/mobile/'])('warm excludes generated autolinki
   );
 });
 
-test('exclusive directory publication preserves an empty directory created after the final precheck', () => {
-  write(root, 'node_modules/pkg/index.js', 'source package');
-  publication.beforeMkdir = (path) => {
-    if (path === join(target, 'node_modules')) {
-      publication.beforeMkdir = null;
-      mkdirSync(path);
-    }
-  };
-  const result = warm();
-  expect(result.copied).toEqual([]);
-  expect(result.failed[0]?.error).toMatch(/EEXIST/);
-  expect(readdirSync(join(target, 'node_modules'))).toEqual([]);
-});
-
 test('missing-only copy preserves executable file modes', () => {
   write(root, 'node_modules/pkg/bin', '#!/bin/sh\nexit 0\n');
   chmodSync(join(root, 'node_modules/pkg/bin'), 0o755);
@@ -531,7 +376,7 @@ test('missing-only copy preserves executable file modes', () => {
   expect(lstatSync(join(target, 'node_modules/pkg/bin')).mode & 0o777).toBe(0o755);
 });
 
-test('warm copies read-only directories, preserves their modes, and removes staging', async () => {
+test('warm removes excluded copies from read-only directories and restores their modes', async () => {
   write(root, 'node_modules/pkg/index.js', 'read-only package');
   write(root, 'node_modules/pkg/.DerivedData/large', 'excluded');
   chmodSync(join(root, 'node_modules/pkg'), 0o555);
@@ -541,16 +386,10 @@ test('warm copies read-only directories, preserves their modes, and removes stag
     expect(readFileSync(join(target, 'node_modules/pkg/index.js'), 'utf-8')).toBe('read-only package');
     expect(lstatSync(join(target, 'node_modules/pkg')).mode & 0o777).toBe(0o555);
     expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
-    expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   } finally {
     chmodSync(join(root, 'node_modules/pkg'), 0o755);
-    for (const entry of [
-      join(target, 'node_modules'),
-      ...publication.stagingPaths.map((path) => join(path, 'entry')),
-    ]) {
-      const pkg = join(entry, 'pkg');
-      if (existsSync(pkg)) chmodSync(pkg, 0o755);
-    }
+    const pkg = join(target, 'node_modules/pkg');
+    if (existsSync(pkg)) chmodSync(pkg, 0o755);
   }
 });
 
@@ -577,7 +416,7 @@ test('warm copies project-owned .stim directories unless the main exclusion file
   expect(readFileSync(join(target, 'apps/mobile/.stim/project.json'), 'utf-8')).toBe('nested project data');
 });
 
-test('staging ignored files never exposes their contents to Git status or git add', async () => {
+test('directly copied ignored files stay invisible to Git status and git add', async () => {
   write(root, '.env', 'source secret');
   const observations: { status: string; add: string; staged: string }[] = [];
   const real = getExecutor();
@@ -598,8 +437,6 @@ test('staging ignored files never exposes their contents to Git status or git ad
   const result = await runWarm(target);
   expect(result.code).toBe(0);
   expect(observations).toEqual([{ status: '', add: '', staged: 'source secret' }]);
-  expect(publication.stagingPaths.map((path) => realpathSync(dirname(path)))).toEqual([temporaryRoot(target)]);
-  expect(publication.stagingPaths.every((path) => !existsSync(path))).toBe(true);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('source secret');
 });
 

--- a/packages/stim-cli/src/doctor-storage.ts
+++ b/packages/stim-cli/src/doctor-storage.ts
@@ -36,7 +36,11 @@ export function checkStorageLayout(
   try {
     const target = repoRoot(projectRoot) ?? projectRoot;
     const source = listWorktrees(target)[0]?.path ?? target;
-    check('Worktree staging', [source, stagingRoot(target), target], temporaryFix);
+    check(
+      'Worktree copy',
+      [source, target],
+      'Keep the main checkout and linked worktree on the same volume to share file blocks when warming.',
+    );
     const cache = sharedBuildCache();
     check('Cached app/APK staging', [cache, stagingRoot(join(cache, 'artifact.app'))], temporaryFix);
     const cacheFix =

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -21,7 +21,10 @@ Read guide lifecycle options for exclusions and incomplete-copy remedies.
 Wait for warm to exit successfully (exit code 0) before running stim start,
 stim ios, stim android, or a dependency install in that worktree. If the shell
 tool returns a running session or job ID, poll or wait for that job to finish;
-the ID is not completion. Do not install dependencies while warm is copying.
+the ID is not completion. Concurrent writes to the destination are unsafe:
+warm checks for existing entries before copying, not during the copy. Do not
+edit files, install dependencies, or run another warm in that worktree until
+it finishes; concurrent files can be overwritten or removed.
 If warm fails or reports incomplete, resolve the reported failure first.
 
 Before native worktree work, run doctor for the platform in scope. It checks

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -726,7 +726,11 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   Wait for warm to exit successfully (exit code 0) before running start,
   ios, android, or a dependency install in that worktree. If a shell tool
   yields a running session or job ID, poll or wait for completion; empty
-  stdout or a returned job ID does not mean the copy has finished.
+  stdout or a returned job ID does not mean the copy has finished. Concurrent
+  writes to the destination are unsafe: existing entries are checked before
+  copying, not during it. Do not edit files, run another warm, or start any
+  other writer in that worktree until warm finishes. Concurrent files can be
+  overwritten or removed.
 
   Warm copies installed dependencies, Pods, native output, and other ignored
   paths eligible under the main checkout's Git ignore rules, including .env
@@ -737,20 +741,18 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   for the destination checkout on its next build. Warm also skips paths
   overlapping a nested destination worktree or below a symlink ancestor.
 
-  Large copies stage privately outside Git working trees on the destination
-  volume. STIM_TMPDIR or machine tempDir overrides that placement; doctor warns
-  when the source, staging, and destination cross volumes and require full
-  copies. Read guide settings for temporary storage configuration. If no safe
-  writable staging location exists, warm refuses instead of using another
-  volume automatically.
+  Warm copies directly into the destination, without intermediate staging.
+  Keep main and the linked worktree on the same volume to retain copy-on-write
+  cloning where supported. Cross-volume copies require full file data; doctor
+  reports that cost. STIM_TMPDIR and machine tempDir do not affect warming.
 
   Existing entries, including dangling symlinks, stay untouched. An existing
   ignored directory such as node_modules is skipped WHOLE; missing children are not
   filled in. Warm does not copy tracked changes, switch branches, install
   dependencies, or build. stdout stays empty; stderr reports copied, kept,
   and failed entry counts. A copy failure exits 1 and reports incomplete;
-  files published before a failure remain. Inspect the named failed entry
-  before retrying: a partially published directory will be kept on the retry.
+  files copied before a failure remain. Inspect the named failed entry
+  before retrying: a partially copied directory will be kept on the retry.
   A completed copy is not proof that dependencies match this branch. Follow
   any lockfile remedies before building, and install missing dependencies
   with the project's package manager when the source has none to copy.

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -385,10 +385,11 @@ second one means transforms are being shared. A bare project writes
 \`cache_store_added\` directly, because there Stim adds the store itself.
 
 TEMPORARY STORAGE
-Large temporary copies for worktree warm, iOS app preparation, release JS/APK
+Large temporary copies for iOS app preparation, release JS/APK
 swaps, and the doctor fingerprint checkout select a writable directory on the
-relevant filesystem. Warm uses the destination worktree volume; app/APK
-preparation uses the artifact volume. A system temporary directory on that
+relevant filesystem. App/APK preparation uses the artifact volume. Worktree
+warm copies directly to the destination and does not use temporary storage.
+A system temporary directory on that
 volume is preferred, then a writable ancestor of the relevant path. Staging
 is private and outside Git working trees, so ignored secrets cannot enter
 Git status or git add. If no safe location exists, the operation refuses.

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -1,21 +1,7 @@
-import {
-  chmodSync,
-  constants,
-  copyFileSync,
-  existsSync,
-  lstatSync,
-  linkSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  readlinkSync,
-  realpathSync,
-  symlinkSync,
-  utimesSync,
-} from 'fs';
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, utimesSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
-import { makeTemporaryDirectory, removeTemporaryEntry } from './temporary.ts';
+import { removeTemporaryEntry } from './temporary.ts';
 
 const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
 
@@ -229,39 +215,23 @@ function missingDestinationReason(target: string, rel: string): string | null {
   return lstatSync(join(target, rel), { throwIfNoEntry: false }) ? 'exists' : null;
 }
 
-function publishMissingEntry(from: string, to: string, rel: string): boolean {
-  let cloned = true;
-  const stat = lstatSync(from);
-  if (stat.isSymbolicLink()) {
-    symlinkSync(readlinkSync(from), to);
-  } else if (stat.isFile()) {
-    if (process.platform === 'darwin') {
-      // libuv has no macOS clonefile backend: https://github.com/libuv/libuv/pull/3987.
-      try {
-        linkSync(from, to);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw error;
-        cloned = false;
-      }
+function removeCopiedExclusions(path: string, rel: string): void {
+  const entries = readdirSync(path, { withFileTypes: true });
+  const excluded = entries.filter((entry) => isCarrySkipped(`${rel}/${entry.name}`));
+  if (excluded.length > 0) {
+    const stat = lstatSync(path);
+    chmodSync(path, stat.mode | 0o700);
+    try {
+      for (const entry of excluded) removeTemporaryEntry(join(path, entry.name));
+    } finally {
+      utimesSync(path, stat.atime, stat.mtime);
+      chmodSync(path, stat.mode);
     }
-    if (process.platform !== 'darwin' || !cloned) {
-      copyFileSync(from, to, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE);
-    }
-    utimesSync(to, stat.atime, stat.mtime);
-  } else if (stat.isDirectory()) {
-    mkdirSync(to, { mode: stat.mode | 0o700 });
-    for (const name of readdirSync(from)) {
-      const child = `${rel}/${name}`;
-      if (!isCarrySkipped(child) && !publishMissingEntry(join(from, name), join(to, name), child)) {
-        cloned = false;
-      }
-    }
-    utimesSync(to, stat.atime, stat.mtime);
-    chmodSync(to, stat.mode);
-  } else {
-    throw new Error(`Unsupported ignored entry: ${from}`);
   }
-  return cloned;
+  for (const entry of entries) {
+    const child = `${rel}/${entry.name}`;
+    if (entry.isDirectory() && !isCarrySkipped(child)) removeCopiedExclusions(join(path, entry.name), child);
+  }
 }
 
 export function cloneIgnoredEntries({
@@ -283,7 +253,6 @@ export function cloneIgnoredEntries({
   for (const rel of listCarryableIgnoredEntries(root, patterns)) {
     const from = join(root, rel);
     const to = join(target, rel);
-    let staging: string | undefined;
     try {
       const reason = guard.covers(rel)
         ? 'tracked'
@@ -294,27 +263,18 @@ export function cloneIgnoredEntries({
         skipped.push({ file: rel, reason });
         continue;
       }
-      staging = makeTemporaryDirectory(target, '.stim-warm-');
-      const destination = join(staging, 'entry');
+      mkdirSync(dirname(to), { recursive: true });
       try {
-        getExecutor().runFile('cp', ['-Rc', from, destination]);
+        getExecutor().runFile('cp', ['-Rc', from, to]);
       } catch {
-        removeTemporaryEntry(destination);
-        getExecutor().runFile('cp', ['-R', from, destination]);
+        removeTemporaryEntry(to);
+        getExecutor().runFile('cp', ['-R', from, to]);
         cloned = false;
       }
-      const changed = missingDestinationReason(target, rel);
-      if (changed) {
-        skipped.push({ file: rel, reason: changed });
-        continue;
-      }
-      mkdirSync(dirname(to), { recursive: true });
-      if (!publishMissingEntry(destination, to, rel)) cloned = false;
+      if (lstatSync(to).isDirectory()) removeCopiedExclusions(to, rel);
       copied.push(rel);
     } catch (e) {
       failed.push({ file: rel, error: String((e as Error)?.message || e) });
-    } finally {
-      if (staging) removeTemporaryEntry(staging);
     }
   }
   return { copied, skipped, failed, cloned };

--- a/test/e2e/storage-volumes.e2e.js
+++ b/test/e2e/storage-volumes.e2e.js
@@ -8,7 +8,7 @@ import { cloneIgnoredEntries } from '../../packages/stim-cli/src/worktree.ts';
 import { checkStorageLayout } from '../../packages/stim-cli/src/doctor-storage.ts';
 
 test(
-  'warm stages on the destination APFS volume even when cloning falls back',
+  'warm copies directly on the destination APFS volume despite a temporary override and clone fallback',
   { skip: process.platform !== 'darwin' },
   () => {
     const base = realpathSync(mkdtempSync(join(tmpdir(), 'stim-volumes-e2e-')));
@@ -41,7 +41,7 @@ test(
       process.env.STIM_HOME = join(base, 'home');
       process.env.STIM_BUILD_CACHE = join(volume, 'cache');
       process.env.TMPDIR = base;
-      delete process.env.STIM_TMPDIR;
+      process.env.STIM_TMPDIR = base;
       mkdirSync(source);
       git(['init', '-q', '-b', 'main']);
       writeFileSync(join(source, '.gitignore'), 'node_modules/\n');
@@ -63,14 +63,12 @@ test(
       for (const fallback of [false, true]) {
         const target = join(volume, `linked-${fallback}`);
         git(['worktree', 'add', '-qb', `linked-${fallback}`, target]);
-        const staged = [];
         setExecutor({
           ...real,
           runFile(file, args, opts) {
             if (file !== 'cp') return real.runFile(file, args, opts);
-            const staging = dirname(args.at(-1));
-            assert.equal(statSync(staging).dev, statSync(target).dev);
-            staged.push(staging);
+            assert.equal(args.at(-1), join(target, 'node_modules'));
+            assert.equal(statSync(dirname(args.at(-1))).dev, statSync(source).dev);
             if (fallback && args[0] === '-Rc') throw new Error('force clone fallback');
             return real.runFile(file, args, opts);
           },
@@ -80,15 +78,22 @@ test(
         assert.deepEqual(result.copied, ['node_modules']);
         assert.equal(result.cloned, !fallback);
         assert.equal(readFileSync(join(target, 'node_modules', 'pkg', 'index.js'), 'utf8'), 'source package');
-        for (const path of staged) assert.throws(() => statSync(path), { code: 'ENOENT' });
       }
       resetExecutor();
+      delete process.env.STIM_TMPDIR;
       assert.deepEqual(checkStorageLayout(source, { platform: 'android' }), []);
       process.env.STIM_TMPDIR = base;
       assert.deepEqual(
         checkStorageLayout(source, { platform: 'android' }).map((finding) => finding.title),
-        ['Worktree staging crosses filesystems', 'Cached app/APK staging crosses filesystems'],
+        ['Cached app/APK staging crosses filesystems'],
       );
+      const crossVolume = join(base, 'linked-other-volume');
+      git(['worktree', 'add', '-qb', 'linked-other-volume', crossVolume]);
+      const findings = checkStorageLayout(crossVolume, { platform: 'android' });
+      const warmFinding = findings.find((finding) => finding.title === 'Worktree copy crosses filesystems');
+      assert.ok(warmFinding);
+      assert.match(warmFinding.detail, /cannot share file blocks across volumes/);
+      assert.match(warmFinding.fix, /main checkout and linked worktree on the same volume/);
     } finally {
       resetExecutor();
       for (const [key, value] of Object.entries(previous)) {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -311,8 +311,13 @@ ignored `.env` and local configuration files are included. The main checkout's
 nonempty `.worktreeexclude` replaces its resolved `worktree.exclude` setting.
 See [worktree isolation](./worktrees.md) for exclusions.
 
+Wait for warm to finish before any other process writes to the destination.
+Concurrent writes are unsafe: files created after the initial existence check
+can be overwritten or removed. This includes edits, installs, builds, Metro,
+and another warm invocation.
+
 stdout stays empty. stderr reports copied, kept, and failed entries. Failures
-exit 1; inspect failed paths before retrying, since partially published
+exit 1; inspect failed paths before retrying, since partially copied
 entries remain and existing directories are skipped. Warm does not install
 dependencies or build.
 

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -31,24 +31,34 @@ branch's `HEAD`. The main checkout must still be available. It copies missing
 ignored entries, including installed dependencies, Pods, native build output,
 `.env`, and local configuration files. APFS clones keep copies space-efficient
 where supported; a normal byte copy is used when cloning is unavailable.
+Copies go directly to the destination with no intermediate staging. Keep main
+and the linked worktree on the same volume to benefit from CoW; `STIM_TMPDIR`
+and `tempDir` do not affect warming.
 
 Warm preserves the current branch, tracked files, and every existing
 destination entry, including dangling symlinks. An existing ignored directory
 such as `node_modules` is skipped whole; warm does not fill missing children.
 Untracked files that Git does not ignore are not copied.
 
+Wait for warm to exit successfully before editing, installing dependencies,
+starting Metro/builds, or running another warm in that worktree. **Concurrent
+writes to the destination are unsafe:** existing entries are checked before
+copying, not during it. Concurrent files can be overwritten or removed.
+
 Stim excludes:
 
 - Nested registered Git worktrees, including ignored parents containing them.
 - Any `.DerivedData` directory.
+- `android/build/generated/autolinking`, including in nested apps, so Gradle
+  regenerates paths for the new checkout.
 - Paths matched by main's nonempty `.worktreeexclude`, or its resolved
   `worktree.exclude` setting when that file is absent or empty.
 - Destination paths that overlap a registered nested worktree or have symlink
   ancestors.
 
 Warm writes only to stderr: copied, kept, and failed entry counts, plus any
-lockfile remedies. A failure exits 1; files already published remain. Inspect
-the named failure before retrying, because a partially published directory is
+lockfile remedies. A failure exits 1; files already copied remain. Inspect
+the named failure before retrying, because a partially copied directory is
 kept on retry. A completed copy does not prove dependencies are installed or
 match the current branch. Install missing dependencies with the project's
 package manager when main has none to copy.


### PR DESCRIPTION
## Description

Warming Trailhead's ignored files took 69s despite same-volume APFS cloning. The copier now takes 27s with destination checks and exclusions retained. These are copy timings, not full mobile-build benchmarks; most of the removed time was per-file publication and staging cleanup.

## Solution

Copy directly into missing destinations. Keep the up-front tracked-file, existing-entry, symlink-ancestor, and nested-worktree checks; remove excluded generated output from the copy. Doctor checks the actual source/destination volumes instead of a staging path warm no longer uses.

This deliberately relaxes [the concurrent-writer protection introduced in #420](https://github.com/appandflow/stim/commit/64121692796dacd0b24e90fe2115346f49d42a46). **Other processes must not write to the destination until warm finishes:** late files can be overwritten or removed. The agent guide and user docs state this constraint. Copy failures remain nonzero and can leave partial output to inspect before retrying.

## Test plan

- Real Git/filesystem regressions cover existing entries, source isolation, symlinks, read-only directories, generated-cache exclusions, and partial-copy fallback.
- A disposable APFS-volume test exercises direct copying and forced clone fallback with system temp and `STIM_TMPDIR` on another volume, then checks doctor's cross-volume finding for an actual cross-volume worktree.
- Trailhead fixture `45c134e86833523737da87df17c55bb9fa7a2547`, external APFS SSD, macOS 26.5 / Node 26.7.0: 27.06s and 27.05s. All nine entries copied without fallback; sampled files matched and had independent inodes.

Fixes #571.
