### PR TITLE
fix: require pooled Android benchmark emulators

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -13,12 +13,12 @@ one headline number.
 
 Each model and platform contains four sequential cells:
 
-| Change     | Arm     | Device state                                                  |
-| ---------- | ------- | ------------------------------------------------------------- |
-| JavaScript | Stim    | adopt the prepared parked iOS simulator or create Android AVD |
-| JavaScript | Control | create a new simulator or AVD                                 |
-| Native     | Stim    | adopt the prepared parked iOS simulator or create Android AVD |
-| Native     | Control | create a new simulator or AVD                                 |
+| Change     | Arm     | Device state                                       |
+| ---------- | ------- | -------------------------------------------------- |
+| JavaScript | Stim    | adopt the prepared parked simulator or Android AVD |
+| JavaScript | Control | create a new simulator or AVD                      |
+| Native     | Stim    | adopt the prepared parked simulator or Android AVD |
+| Native     | Control | create a new simulator or AVD                      |
 
 Results from different platforms, change kinds, models, or deliberately changed
 pins remain separate. Never pool iOS and Android timings into one number.
@@ -39,8 +39,11 @@ Preparation runs outside the timer. On iOS it creates one Stim-owned simulator,
 warms the fixed fixture, removes its seed worktree, and verifies that cleanup
 parked the simulator. The iOS golden contains exactly one available, shut-down
 pool record whose device name starts with `stim-parked`, plus the matching build
-artifact. Android preparation warms the matching APK cache but retains no AVD;
-both Android arms create a fresh AVD during the timed run.
+artifact. Android preparation warms the matching APK cache and parks one
+Stim-owned AVD with the pinned system image and default creation settings.
+The Android Stim arm adopts that exact AVD; control creates a fresh one. Parking
+retains the APK and Quick Boot state; Stim clears app data at adoption before
+launch. Both scoped pool overrides are enabled explicitly for their platform.
 
 Before each dispatch, verify the package version and integrity, fixture commit,
 clean main checkout, golden build artifact, exact parked simulator identity and
@@ -152,7 +155,9 @@ separate PID/log monitoring.
 The Stim arm uses the inherited isolated `STIM_HOME` and invokes the pinned
 published CLI as exactly `stim`. On iOS it requests the pinned model/runtime and
 must report adoption of the prepared simulator. On Android it requests the
-pinned system image. The control must not inspect that home or use Stim; it
+pinned system image and must report adoption of the exact prepared AVD.
+Missing or incompatible parked state refuses dispatch rather than silently
+measuring a fresh boot. The control must not inspect that home or use Stim; it
 creates a new benchmark-named device with the same platform configuration.
 Android control uses the same `avdmanager` default profile, 8 GiB data
 partition, system image, and default Quick Boot policy as Stim.
@@ -331,7 +336,8 @@ or reused. If closure cannot be proven, stop and clean only the campaign-owned
 daemon. Remove the temporary screenshot and terminate only benchmark-owned
 processes. For Stim, run `stim stop` and `stim worktree remove --force`. On iOS,
 then verify that the same simulator is shut down, renamed as parked, and is the
-sole pool record. Android follows Stim's owned-emulator teardown contract. For
+sole pool record. On Android, verify that the same AVD is stopped and remains
+the sole compatible parked record, ready for the next sequential run. For
 control, remove its worktree and branch and shut down and delete only the newly
 created benchmark simulator or emulator. Do not touch unrelated physical-device
 leases or automation sessions.

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -29,7 +29,7 @@ import {
 } from '../launch-crash-benchmark.mjs';
 import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
 import { reconstructCommandEvidence } from './command-evidence.mjs';
-import { matchesGoldenPreparation } from './golden-state.mjs';
+import { matchesGoldenPreparation, preparedAndroidEmulator } from './golden-state.mjs';
 import { launchCrashSetup } from './launch-crash-setup.mjs';
 import { collectedNativeCompatibility, probeNativeCompatibility, verifyNativeCompatibility } from './native-compat.mjs';
 import {
@@ -336,6 +336,29 @@ function verifyGoldenParkedSimulator() {
   return verifyParkedSimulator(join(golden, 'stim-home'));
 }
 
+function verifyParkedAndroidEmulator(stimHome, expectedName) {
+  const activeNames = androidEmulatorTransports().map(({ serial }) =>
+    run('adb', ['-s', serial, 'emu', 'avd', 'name']).split('\n')[0].trim(),
+  );
+  return preparedAndroidEmulator({
+    config: JSON.parse(readFileSync(join(stimHome, 'config.json'), 'utf8')),
+    avds: androidAvdSnapshot().map(androidAvdDescription),
+    activeNames,
+    systemImage: pins.ANDROID_SYSTEM_IMAGE,
+    expectedName,
+  });
+}
+
+function verifyGoldenParkedAndroidEmulator() {
+  const platformGolden = goldenFor('android');
+  const readyPath = join(platformGolden, 'READY.json');
+  const expectedName = existsSync(readyPath)
+    ? JSON.parse(readFileSync(readyPath, 'utf8')).parkedEmulator?.name
+    : undefined;
+  if (existsSync(readyPath) && !expectedName) throw new Error('Android golden must be prepared with emulator pooling');
+  return verifyParkedAndroidEmulator(join(platformGolden, 'stim-home'), expectedName);
+}
+
 function ensureDirs() {
   for (const path of [results, state, allowedBin, stimBin, golden]) {
     mkdirSync(path, { recursive: true });
@@ -431,6 +454,15 @@ function androidAvdDescription(name) {
     .replaceAll('/', ';');
   return {
     name,
+    config: Object.fromEntries(
+      config
+        .split(/\r?\n/)
+        .filter((line) => line.includes('='))
+        .map((line) => {
+          const at = line.indexOf('=');
+          return [line.slice(0, at).trim(), line.slice(at + 1).trim()];
+        }),
+    ),
     deviceTypeIdentifier: config.match(/^hw\.device\.name=(.+)$/m)?.[1]?.trim(),
     runtimeIdentifier: `Android-${systemImage?.match(/android-(\d+)/)?.[1]}`,
     systemImage,
@@ -594,6 +626,7 @@ function preflight(requestedPlatform = 'ios') {
   const readyPath = join(platformGolden, 'READY.json');
   const goldenCache = existsSync(readyPath) ? verifyGoldenCache(platform, platformGolden) : null;
   const parkedSimulator = platform === 'ios' && existsSync(readyPath) ? verifyGoldenParkedSimulator() : null;
+  const parkedEmulator = platform === 'android' && existsSync(readyPath) ? verifyGoldenParkedAndroidEmulator() : null;
   const preflightRecord = {
     checkedAt: new Date().toISOString(),
     actual,
@@ -608,6 +641,7 @@ function preflight(requestedPlatform = 'ios') {
     },
     goldenCache,
     parkedSimulator,
+    parkedEmulator,
     shellProvenance,
     doctor,
     stimExecutableSha256: sha256(join(stimBin, 'stim')),
@@ -754,6 +788,7 @@ function prepareAndroid() {
   const platformGolden = goldenFor('android');
   const readyPath = join(platformGolden, 'READY.json');
   if (existsSync(readyPath)) {
+    verifyGoldenParkedAndroidEmulator();
     process.stdout.write(readFileSync(readyPath));
     return;
   }
@@ -777,7 +812,7 @@ function prepareAndroid() {
     mkdirSync(seedHome, { recursive: true });
     writeFileSync(
       join(seedHome, 'config.json'),
-      `${JSON.stringify({ version: 2, projects: {}, repos: {} }, null, 2)}\n`,
+      `${JSON.stringify({ version: 2, projects: {}, repos: {}, pool: { androidParkedMax: 1 } }, null, 2)}\n`,
     );
     writeFileSync(preparationPath, `${JSON.stringify(preparation, null, 2)}\n`);
   } else {
@@ -789,7 +824,7 @@ function prepareAndroid() {
       throw new Error(`retained Android golden provenance does not match current pins: ${finalHome}`);
     }
   }
-  const seedEnv = { ...cleanRubyEnvironment(process.env), STIM_HOME: preparingHome };
+  const seedEnv = { ...cleanRubyEnvironment(process.env), STIM_HOME: preparingHome, STIM_POOL_ANDROID_PARKED_MAX: '1' };
   let preparedDevice = null;
   const worktree = join(worktreeParent, 'bench-golden-android-seed');
   run('git', ['worktree', 'add', '--detach', worktree, 'HEAD'], {
@@ -838,6 +873,7 @@ function prepareAndroid() {
     throw new Error(`Android golden preparation failed; retained ${preparingHome}`, { cause: error });
   }
   if (preparingHome === seedHome) renameSync(seedHome, finalHome);
+  const parkedEmulator = verifyParkedAndroidEmulator(finalHome, preparedDevice?.name);
   mkdirSync(controlTmp, { recursive: true });
   const exportPath = join(platformGolden, 'control-export');
   run('npx', ['expo', 'export', '--platform', 'android', '--dev', '--output-dir', exportPath], {
@@ -858,6 +894,7 @@ function prepareAndroid() {
     agentDeviceSha256: pins.AGENT_DEVICE_SHA256,
     systemImage: pins.ANDROID_SYSTEM_IMAGE,
     deviceTypeIdentifier: preparedDevice?.deviceTypeIdentifier ?? null,
+    parkedEmulator,
     runtimeIdentifier: `Android-${pins.ANDROID_SYSTEM_IMAGE.match(/android-(\d+)/)?.[1]}`,
     buildCacheEntries: [cache.cacheKey],
   };
@@ -960,7 +997,7 @@ function platformLaunchInstructions(arm, platform, runId, startMetro) {
   if (arm === 'stim') {
     return platform === 'ios'
       ? 'Use the Stim skill and only the pinned published command available on PATH as exactly `stim` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run the iOS app on the prepared parked iPhone 17 simulator running iOS 26.5; Stim must report that it adopted the simulator. Leave Metro running until the screenshot is saved.'
-      : `Use the Stim skill and only the pinned published command available on PATH as exactly \`stim\` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run \`stim start\`, then run \`stim android --system-image ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)}\`. Leave Metro and the changed app running until the screenshot is saved.`;
+      : `Use the Stim skill and only the pinned published command available on PATH as exactly \`stim\` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run \`stim start\`, then run \`stim android --system-image ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)}\`. Use the prepared parked emulator; Stim must report that it adopted it. Leave Metro and the changed app running until the screenshot is saved.`;
   }
   if (platform === 'android') {
     return `Use only the project's local Expo and Android SDK tooling; do not use Stim. Create a new AVD named exactly ${JSON.stringify(`Trailhead_${runId}`)} from ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)} using avdmanager's default hardware profile, matching Stim; do not use an existing emulator. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim's default 8 GiB data partition. Boot it with the emulator's default Quick Boot policy, matching Stim; the fresh AVD cold-boots because no snapshot exists. Wait for Android boot completion. ${startMetro ? 'Start Metro detached. ' : ''}Build, install, and launch only the default Debug variant; do not use a Release variant. Start that native build/install/launch as a shell background process with its PID and log under /tmp, then poll it using repeated short foreground shell calls such as \`kill -0 <pid>\` and \`tail\`; do not use a long blocking shell call or end the turn while waiting. After it finishes successfully, immediately perform the agent-device proof. Leave the emulator${startMetro ? ', Metro,' : ''} and app running. `;
@@ -1299,6 +1336,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   }
   const expectedBuildCache = verifyGoldenCache(platform, platformGolden);
   const expectedParkedSimulator = platform === 'ios' ? verifyGoldenParkedSimulator() : null;
+  const expectedParkedEmulator = platform === 'android' ? verifyGoldenParkedAndroidEmulator() : null;
   const runId = `${stage}-${model.replaceAll('.', '-')}-${variant}-${arm}-${Date.now()}`;
   const expectedControlSimulator = {
     name: platform === 'ios' ? `Trailhead ${runId}` : `Trailhead_${runId}`,
@@ -1310,7 +1348,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   const expectedStimDevice =
     platform === 'android'
       ? {
-          namePrefix: 'stim-',
+          name: expectedParkedEmulator.name,
           deviceTypeIdentifier: ready.deviceTypeIdentifier,
           runtimeIdentifier: ready.runtimeIdentifier,
           systemImage: ready.systemImage,
@@ -1344,6 +1382,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   };
   const env = isolatedShellEnvironment(baseEnv, runDir);
   if (arm === 'stim' && platform === 'ios') env.STIM_POOL_IOS_PARKED_MAX = '1';
+  if (arm === 'stim' && platform === 'android') env.STIM_POOL_ANDROID_PARKED_MAX = '1';
   env.BENCH_STIM_HOME = env.STIM_HOME;
   mkdirSync(env.STIM_HOME, { recursive: true });
   if (arm === 'stim') {
@@ -1410,6 +1449,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
     profile: { ...profile, claudeGuidance, isolation, runnerEnvironment },
     expectedBuildCache,
     expectedParkedSimulator,
+    expectedParkedEmulator,
     expectedStimDevice,
     expectedControlSimulator,
     expectedControlAvdConfig:
@@ -1439,7 +1479,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
       expectedControlSimulator.deviceTypeIdentifier ?? '',
       expectedControlSimulator.runtimeIdentifier,
       platform,
-      expectedStimDevice?.namePrefix ?? '',
+      expectedStimDevice?.name ?? '',
       expectedControlSimulator.systemImage ?? '',
       `Trailhead ${runId}`,
     ],
@@ -1647,7 +1687,10 @@ function commandEvidence(meta, eventsPath, runDir, device) {
     if (isJavascriptVariant(meta.variant) && !/fingerprint\s+[0-9a-f]{6}\.\.\s+hit\b/.test(outputText)) {
       invalidReasons.push('stim-build-cache-hit-missing');
     }
-    if ((meta.platform ?? 'ios') === 'ios' && !/device\s+.+\sadopted\s+\(/.test(outputText)) {
+    if (
+      ((meta.platform ?? 'ios') === 'ios' || meta.expectedParkedEmulator) &&
+      !/device\s+.+\sadopted\s+\(/.test(outputText)
+    ) {
       invalidReasons.push('stim-parked-adoption-missing');
     }
   }
@@ -2360,7 +2403,7 @@ function cleanup(runDir) {
     const env = {
       ...cleanRubyEnvironment(process.env),
       STIM_HOME: stimHome,
-      ...(meta.platform === 'android' ? {} : { STIM_POOL_IOS_PARKED_MAX: '1' }),
+      ...(meta.platform === 'android' ? { STIM_POOL_ANDROID_PARKED_MAX: '1' } : { STIM_POOL_IOS_PARKED_MAX: '1' }),
     };
     for (const args of [['stop'], ['worktree', 'remove', '--force']]) {
       try {
@@ -2375,7 +2418,14 @@ function cleanup(runDir) {
         actions.push(`failed: stim ${args.join(' ')}: ${error}`);
       }
     }
-    if (meta.platform !== 'android') {
+    if (meta.platform === 'android') {
+      try {
+        const parked = verifyParkedAndroidEmulator(stimHome, meta.expectedParkedEmulator?.name);
+        actions.push(`verified parked emulator ${parked.name}`);
+      } catch (error) {
+        actions.push(`failed: parked emulator verification: ${error}`);
+      }
+    } else {
       try {
         const parked = verifyParkedSimulator(stimHome, meta.expectedParkedSimulator?.udid);
         actions.push(`verified parked simulator ${parked.udid}`);

--- a/scripts/agent-benchmark/golden-state.mjs
+++ b/scripts/agent-benchmark/golden-state.mjs
@@ -5,3 +5,40 @@ export function matchesGoldenPreparation(actual, expected) {
     Object.entries(expected).every(([key, value]) => actual[key] === value)
   );
 }
+
+export function preparedAndroidEmulator({ config, avds, activeNames, systemImage, expectedName }) {
+  const records = config?.parked?.android;
+  if (config?.pool?.androidParkedMax !== 1 || !Array.isArray(records) || records.length !== 1) {
+    throw new Error('golden must contain exactly one parked Android emulator with max 1');
+  }
+  const record = records[0];
+  if (
+    !record?.name?.startsWith('stim-') ||
+    record.udid !== record.name ||
+    !record.configuration ||
+    record.deletionClaim != null ||
+    (expectedName && record.name !== expectedName)
+  ) {
+    throw new Error('parked Android emulator identity or creation configuration is invalid');
+  }
+  const avd = avds.find(({ name }) => name === record.name);
+  if (!avd || record.systemImage !== systemImage || avd.systemImage !== systemImage) {
+    throw new Error('parked Android emulator is missing or has the wrong system image');
+  }
+  const configuration = JSON.parse(record.configuration);
+  if (
+    !Array.isArray(configuration) ||
+    configuration.length === 0 ||
+    !configuration.every(
+      (entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        entry.every((value) => typeof value === 'string') &&
+        avd.config?.[entry[0]] === entry[1],
+    )
+  ) {
+    throw new Error('parked Android emulator creation settings no longer match its pool record');
+  }
+  if (activeNames.includes(record.name)) throw new Error('parked Android emulator is still running');
+  return { ...record, deviceTypeIdentifier: avd.deviceTypeIdentifier, runtimeIdentifier: avd.runtimeIdentifier };
+}

--- a/scripts/agent-benchmark/golden-state.mjs
+++ b/scripts/agent-benchmark/golden-state.mjs
@@ -13,10 +13,12 @@ export function preparedAndroidEmulator({ config, avds, activeNames, systemImage
   }
   const record = records[0];
   if (
-    !record?.name?.startsWith('stim-') ||
+    typeof record?.name !== 'string' ||
+    !/^stim-[A-Za-z0-9._-]+$/.test(record.name) ||
     record.udid !== record.name ||
-    !record.configuration ||
-    record.deletionClaim != null ||
+    typeof record.parkedAt !== 'string' ||
+    record.configuration !== JSON.stringify([['disk.dataPartition.size', String(8 * 1024 ** 3)]]) ||
+    record.deletionClaim !== undefined ||
     (expectedName && record.name !== expectedName)
   ) {
     throw new Error('parked Android emulator identity or creation configuration is invalid');

--- a/scripts/agent-benchmark/golden-state.test.mjs
+++ b/scripts/agent-benchmark/golden-state.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchesGoldenPreparation } from './golden-state.mjs';
+import { matchesGoldenPreparation, preparedAndroidEmulator } from './golden-state.mjs';
 
 const expected = {
   fixtureCommit: 'fixture',
@@ -20,5 +20,75 @@ describe('golden preparation provenance', () => {
     expect(matchesGoldenPreparation({ ...expected, stimVersion: '1.0.0-rc.14' }, expected)).toBe(false);
     expect(matchesGoldenPreparation({ ...expected, stimIntegrity: 'sha512-old' }, expected)).toBe(false);
     expect(matchesGoldenPreparation({ ...expected, stimCliSha256: 'cli-old' }, expected)).toBe(false);
+  });
+});
+
+describe('prepared Android pool', () => {
+  const systemImage = 'system-images;android-36;google_apis;arm64-v8a';
+  const record = {
+    udid: 'stim-seed',
+    name: 'stim-seed',
+    systemImage,
+    configuration: '[["disk.dataPartition.size","8589934592"]]',
+  };
+  const avd = {
+    name: record.name,
+    config: { 'disk.dataPartition.size': '8589934592' },
+    systemImage,
+    deviceTypeIdentifier: 'medium_phone',
+    runtimeIdentifier: 'Android-36',
+  };
+  const input = {
+    config: { pool: { androidParkedMax: 1 }, parked: { android: [record] } },
+    avds: [avd],
+    activeNames: [],
+    systemImage,
+    expectedName: record.name,
+  };
+
+  it('returns the exact parked device identity for dispatch and collection', () => {
+    expect(preparedAndroidEmulator(input)).toEqual({
+      ...record,
+      deviceTypeIdentifier: 'medium_phone',
+      runtimeIdentifier: 'Android-36',
+    });
+  });
+
+  it('refuses disabled, missing, or ambiguous pools instead of timing a fresh boot', () => {
+    for (const config of [
+      null,
+      {},
+      { ...input.config, pool: { androidParkedMax: 0 } },
+      { ...input.config, parked: { android: [] } },
+      { ...input.config, parked: { android: [record, record] } },
+    ]) {
+      expect(() => preparedAndroidEmulator({ ...input, config })).toThrow('exactly one parked');
+    }
+  });
+
+  it('refuses an absent, replaced, incompatible, or still-running AVD', () => {
+    for (const override of [
+      { avds: [] },
+      { expectedName: 'stim-other' },
+      { systemImage: 'other-image' },
+      { avds: [{ ...avd, systemImage: 'other-image' }] },
+      { activeNames: [record.name] },
+      { avds: [{ ...avd, config: { 'disk.dataPartition.size': '6442450944' } }] },
+    ]) {
+      expect(() => preparedAndroidEmulator({ ...input, ...override })).toThrow(/parked Android emulator/);
+    }
+  });
+
+  it('refuses unowned names, legacy configuration, and an in-progress deletion', () => {
+    for (const replacement of [
+      { ...record, name: 'user-device' },
+      { ...record, udid: 'different' },
+      { ...record, configuration: undefined },
+      { ...record, deletionClaim: { pid: 42 } },
+    ]) {
+      expect(() =>
+        preparedAndroidEmulator({ ...input, config: { ...input.config, parked: { android: [replacement] } } }),
+      ).toThrow('identity or creation configuration');
+    }
   });
 });

--- a/scripts/agent-benchmark/golden-state.test.mjs
+++ b/scripts/agent-benchmark/golden-state.test.mjs
@@ -28,6 +28,7 @@ describe('prepared Android pool', () => {
   const record = {
     udid: 'stim-seed',
     name: 'stim-seed',
+    parkedAt: '2026-09-09T00:00:00.000Z',
     systemImage,
     configuration: '[["disk.dataPartition.size","8589934592"]]',
   };
@@ -82,13 +83,30 @@ describe('prepared Android pool', () => {
   it('refuses unowned names, legacy configuration, and an in-progress deletion', () => {
     for (const replacement of [
       { ...record, name: 'user-device' },
+      { ...record, name: 'stim-invalid/name', udid: 'stim-invalid/name' },
       { ...record, udid: 'different' },
+      { ...record, parkedAt: undefined },
       { ...record, configuration: undefined },
+      { ...record, deletionClaim: null },
       { ...record, deletionClaim: { pid: 42 } },
     ]) {
       expect(() =>
         preparedAndroidEmulator({ ...input, config: { ...input.config, parked: { android: [replacement] } } }),
       ).toThrow('identity or creation configuration');
     }
+  });
+
+  it('refuses a consistent pool and AVD that Stim cannot adopt with benchmark defaults', () => {
+    const replacement = {
+      ...record,
+      configuration: JSON.stringify([['disk.dataPartition.size', String(10 * 1024 ** 3)]]),
+    };
+    expect(() =>
+      preparedAndroidEmulator({
+        ...input,
+        config: { ...input.config, parked: { android: [replacement] } },
+        avds: [{ ...avd, config: { 'disk.dataPartition.size': String(10 * 1024 ** 3) } }],
+      }),
+    ).toThrow('identity or creation configuration');
   });
 });

--- a/scripts/agent-benchmark/watch-app-selection.test.mjs
+++ b/scripts/agent-benchmark/watch-app-selection.test.mjs
@@ -137,6 +137,16 @@ describe('benchmark Android emulator selection', () => {
     ).toMatchObject({ error: 'control-emulator-mismatch' });
   });
 
+  it('rejects a different Stim AVD even when its image and profile match the prepared pool', () => {
+    const expectedStim = { ...expectedAndroid, name: 'stim-seed' };
+    const options = { arm: 'stim', baseline: new Set(), expectedControl: expectedAndroid, expectedStim };
+    const prepared = { ...androidDevice, name: 'stim-seed' };
+    expect(selectAndroidCandidate([prepared], options)).toEqual({ candidate: prepared });
+    expect(selectAndroidCandidate([{ ...prepared, name: 'stim-fresh' }], options)).toMatchObject({
+      error: 'stim-emulator-mismatch',
+    });
+  });
+
   it('rejects baseline and ambiguous Android emulators', () => {
     expect(
       selectAndroidCandidate([androidDevice], {

--- a/scripts/agent-benchmark/watch-app.mjs
+++ b/scripts/agent-benchmark/watch-app.mjs
@@ -179,7 +179,7 @@ while (Date.now() < deadline) {
             arm,
             baseline,
             expectedControl,
-            expectedStim: { ...expectedControl, name: undefined, namePrefix: expectedStimName },
+            expectedStim: { ...expectedControl, name: expectedStimName },
           })
         : selectIosCandidate(devices(), {
             arm,


### PR DESCRIPTION
## Description

Android benchmarks still create a fresh AVD for Stim, so they cannot measure emulator reuse. That policy dates to the [original Android benchmark](https://github.com/appandflow/stim/commit/ea416bf71ff6902453b7ca5ca2adea05faad10af), before [Android pooling](https://github.com/appandflow/stim/commit/ea0292b121a76cde79dec234d5ce52a7cf5d22e1).

## Solution

Prepare one parked Android emulator and require Stim to adopt that exact device, matching the existing iOS methodology. Reject missing, running, or incompatible pool state before dispatch and verify the emulator returns to the pool after cleanup. Control still creates a fresh device. Old Android golden state must be prepared again; published results are not changed by this PR.

## Test plan

- Regression checks reject disabled/missing pools, changed AVD configuration, a running or deleted device, and a different Stim AVD with the same model/image.
- The candidate passed a real Android pool lifecycle smoke test on API 36 arm64, including app-data reset and retained-APK installation skipping.
- Campaign preparation and dispatch remain untested until publication.

Fixes #573.
