### PR TITLE
fix: preserve shared-build waits after native preparation

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2130,18 +2130,22 @@ describe('single-flight builds', () => {
     expect(h.stdout.length).toBe(1);
   });
 
-  test('a builder that failed makes the waiter take over and build', async () => {
+  test.each([false, true])('a missing artifact is rebuilt after a released lock: %s', async (released) => {
     let acquires = 0;
     const h = harness({
       acquireLock: () => (++acquires === 1 ? heldBy() : { acquired: true, path: '/lock', lock: { pid: process.pid } }),
-      waitForBuild: async () => ({ builderFailed: 'the build lock was released without an artifact', waitedMs: 4000 }),
+      waitForBuild: async () =>
+        released
+          ? { lockReleased: true as const, waitedMs: 4000 }
+          : { builderFailed: 'the builder (pid 41233) is gone', waitedMs: 4000 },
     });
     const result = await h.run();
     expect(result.ok).toBe(true);
     expect(acquires).toBe(2);
     expect(h.calls.build.length).toBe(1);
     expect(h.calls.releaseLock.length).toBe(1);
-    expect(h.stderr.join('\n')).toMatch(/without an artifact/);
+    expect(result.facts?.waitedForBuild).toBeNull();
+    expect(/FAILED without an artifact|RETRY:/.test(h.stderr.join('\n'))).toBe(!released);
   });
 
   test('losing the takeover race waits for the new holder and installs its artifact', async () => {
@@ -3624,14 +3628,28 @@ describe('re-fingerprint after prebuild', () => {
     expect(readState().lastBuild.cacheKey).toBe(h.calls.storeCached[0]?.[1]);
   });
 
-  test('a post-shift hit installs the cached APK and runs no gradle build', async () => {
+  test.each([false, true])('a post-shift hit preserves a prior shared-build wait: %s', async (waited) => {
     cngProject();
+    let acquires = 0;
     const cachedApk = join(home, 'build-cache', 'android', `${WARM}-debug-sim`, 'app-debug.apk');
     const h = harness({
       fingerprint: shifting(),
       resolveCached: (_platform: string, key: string) => (key.startsWith(WARM) ? cachedApk : null),
       build: never('gradle'),
       storeCached: never('the store'),
+      ...(waited
+        ? {
+            acquireLock: () =>
+              ++acquires === 1
+                ? { held: { pid: 41233, projectRoot: '/w/builder', startedAt: null, logFile: null } }
+                : {
+                    acquired: true as const,
+                    path: '/lock',
+                    lock: { pid: process.pid, projectRoot: root, startedAt: null, logFile: null },
+                  },
+            waitForBuild: async () => ({ lockReleased: true as const, waitedMs: 4000 }),
+          }
+        : {}),
     });
     const result = await h.run();
     expect(result.ok).toBe(true);
@@ -3641,6 +3659,9 @@ describe('re-fingerprint after prebuild', () => {
     expect(result.facts?.cacheHit).toBe('local');
     expect(result.facts?.fingerprint).toBe(WARM);
     expect(result.facts?.cacheKey).toBe(`${WARM}-debug-sim`);
+    expect(result.facts?.waitedForBuild).toEqual(waited ? { pid: 41233, ms: 4000 } : null);
+    expect(h.stderr.join('\n')).not.toMatch(/FAILED without an artifact|RETRY:/);
+    expect(/waited 4s for \/w\/builder's build -> installed from cache/.test(h.stderr.join('\n'))).toBe(waited);
   });
 
   test('a post-shift hit on a release variant swaps the APK, gated on THAT entry manifest', async () => {

--- a/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
@@ -265,7 +265,7 @@ describe('waitForBuild', () => {
     expect(polls).toBe(3);
   });
 
-  test('the lock disappearing with no artifact means the builder failed', async () => {
+  test('a released lock does not claim failure when native preparation may have changed the key', async () => {
     lockOn();
     const path = buildLockPath(PLATFORM, KEY);
     let polls = 0;
@@ -279,8 +279,8 @@ describe('waitForBuild', () => {
       }),
     );
     expect(result.hit).toBe(undefined);
-    expect(result.builderFailed).toBeTruthy();
-    expect(result.builderFailed).toMatch(/lock/i);
+    expect(result.lockReleased).toBe(true);
+    expect(result.builderFailed).toBeUndefined();
   });
 
   test('a dead builder means the same, without waiting for the lock to go', async () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1648,25 +1648,26 @@ describe('single-flight builds', () => {
     expect(logs.length).toBe(1);
   });
 
-  test('a builder that failed makes the waiter take over and build', async () => {
+  test.each([false, true])('a missing artifact is rebuilt after a released lock: %s', async (released) => {
     reserve();
     let acquires = 0;
-    const { exitCode, calls, stderr } = await run(
-      {},
+    const { exitCode, calls, stderr, logs } = await run(
+      { json: true },
       {
         acquireBuildLock: () =>
           ++acquires === 1 ? heldBy() : { acquired: true, path: '/lock', lock: { pid: process.pid } },
-        waitForBuild: async () => ({
-          builderFailed: 'the build lock was released without an artifact',
-          waitedMs: 4000,
-        }),
+        waitForBuild: async () =>
+          released
+            ? { lockReleased: true as const, waitedMs: 4000 }
+            : { builderFailed: 'the builder (pid 41233) is gone', waitedMs: 4000 },
       },
     );
     expect(exitCode).toBe(null);
     expect(acquires).toBe(2);
     expect(calls.order.includes('buildIos')).toBeTruthy();
     expect(calls.order.includes('releaseBuildLock')).toBeTruthy();
-    expect(stderr).toMatch(/without an artifact/);
+    expect(parseFirst(logs).waitedForBuild).toBeNull();
+    expect(/FAILED without an artifact|RETRY:/.test(stderr)).toBe(!released);
   });
 
   test('losing the takeover race waits for the new holder and installs its artifact', async () => {
@@ -3414,8 +3415,9 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
     expect((state.lastBuild as Record<string, unknown>).cacheKey).toBe(calls.args.storeBuild.key);
   });
 
-  test('a post-shift hit installs the cached app and compiles nothing', async () => {
+  test.each([false, true])('a post-shift hit preserves a prior shared-build wait: %s', async (waited) => {
     reserve();
+    let acquires = 0;
     const cachedApp = join(tmpHome, 'build-cache', 'ios', `${WARM}-debug-sim`, 'Fixture.app');
     const { logs, errs, calls } = await run(
       { json: true },
@@ -3424,6 +3426,19 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
         needsPrebuild: () => true,
         fingerprintProject: shifting(),
         resolveBuild: (_platform, key) => (key.startsWith(WARM) ? cachedApp : null),
+        ...(waited
+          ? {
+              acquireBuildLock: () =>
+                ++acquires === 1
+                  ? { held: { pid: 41233, projectRoot: '/w/builder', startedAt: null, logFile: null } }
+                  : {
+                      acquired: true as const,
+                      path: '/lock',
+                      lock: { pid: process.pid, projectRoot: root, startedAt: null, logFile: null },
+                    },
+              waitForBuild: async () => ({ lockReleased: true as const, waitedMs: 4000 }),
+            }
+          : {}),
       },
     );
     expect(calls.order.includes('runPrebuild')).toBe(true);
@@ -3436,6 +3451,9 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
     expect(facts.cacheHit).toBe('local');
     expect(facts.fingerprint).toBe(WARM);
     expect(facts.cacheKey).toBe(`${WARM}-debug-sim`);
+    expect(facts.waitedForBuild).toEqual(waited ? { pid: 41233, ms: 4000 } : null);
+    expect(errs.join('\n')).not.toMatch(/FAILED without an artifact|RETRY:/);
+    expect(/waited 4s for \/w\/builder's build -> installed from cache/.test(errs.join('\n'))).toBe(waited);
   });
 
   test('a post-shift hit on a Release build swaps the JS in, exactly as a first-pass hit does', async () => {

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1215,6 +1215,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     await resolveRemoteArtifact();
 
     let waitedForBuild: WaitedForBuild | null = null;
+    let releasedWait: { facts: WaitedForBuild; who: string } | null = null;
     async function waitForSharedBuild(): Promise<boolean> {
       if (!useBuildCache) return true;
       const waitStarted = now();
@@ -1236,6 +1237,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
           if (previous) phase('build', chalk.yellow(takeoverLine(previous)));
           break;
         } else if (attempt?.held) {
+          releasedWait = null;
           const holder = attempt.held;
           const who = holder.projectRoot || 'another workspace';
           phase(
@@ -1276,6 +1278,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
             record.cacheHit = 'local';
             waitedForBuild = { pid: holder.pid, ms: waited.waitedMs };
             phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+          } else if (waited?.lockReleased) {
+            failedHolder = undefined;
+            releasedWait = { facts: { pid: holder.pid, ms: waited.waitedMs }, who };
+            phase('build', `${who}'s build lock was released; rechecking this workspace before building`);
           } else {
             phase(
               'build',
@@ -1398,6 +1404,13 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
                   apkPath = prepared;
                   record.cacheHit = 'local';
                   phase('cache', `hit ${shortHash(storeHash)} (post-prebuild key)`);
+                  if (releasedWait) {
+                    waitedForBuild = releasedWait.facts;
+                    phase(
+                      'build',
+                      `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache`,
+                    );
+                  }
                 }
               }
             }

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -594,6 +594,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
     note(chalk.dim(phaseLine('cache', PROVIDER_SKIPPED_ON_DEVICE)));
   }
   let waitedForBuild: WaitedForBuild | null = null;
+  let releasedWait: { facts: WaitedForBuild; who: string } | null = null;
   let swapDir: string | null = null;
   let swapFellBack = false;
   let buildFailure: BuildFailureFields = {};
@@ -895,6 +896,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         if (previous) note(chalk.yellow(phaseLine('build', takeoverLine(previous))));
         break;
       } else if (attempt?.held) {
+        releasedWait = null;
         const held = attempt.held;
         const who = held.projectRoot || 'another workspace';
         phase(
@@ -935,6 +937,10 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
           cacheHit = 'local';
           waitedForBuild = { pid: held.pid, ms: waited.waitedMs };
           phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+        } else if (waited?.lockReleased) {
+          failedHolder = undefined;
+          releasedWait = { facts: { pid: held.pid, ms: waited.waitedMs }, who };
+          phase('build', `${who}'s build lock was released; rechecking this workspace before building`);
         } else {
           note(
             chalk.yellow(
@@ -1171,6 +1177,13 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
                 appPath = prepared;
                 cacheHit = 'local';
                 phase('cache', `hit ${shortHash(storeHash)} (post-${mutatingSteps.join('/')} key)`);
+                if (releasedWait) {
+                  waitedForBuild = releasedWait.facts;
+                  phase(
+                    'build',
+                    `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache`,
+                  );
+                }
               }
             }
           }

--- a/packages/stim-cli/src/engine/build-lock.ts
+++ b/packages/stim-cli/src/engine/build-lock.ts
@@ -78,6 +78,7 @@ interface WaitForBuildOptions {
 export interface WaitForBuildResult {
   hit?: string;
   waitedMs?: number;
+  lockReleased?: true;
   builderFailed?: string;
   holder?: BuildLockRecord | null;
 }
@@ -305,7 +306,7 @@ export async function waitForBuild({
 
     if (!info) {
       return {
-        builderFailed: 'the build lock was released without an artifact',
+        lockReleased: true,
         holder,
         waitedMs: now() - started,
       };

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -646,6 +646,12 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   and install the artifact the builder stored. They report cacheHit: "local"
   plus waitedForBuild: { pid, ms }.
 
+  Native preparation can move the builder's cache key. A released lock with no
+  artifact at the original key does not prove the build failed. The waiter
+  rechecks after its own native preparation; a matching post-preparation cache
+  hit retains waitedForBuild. Artifacts remain stored only under their final
+  fingerprint, never under the old key.
+
   Nothing can deadlock on it. The lock is held by a PID, so a builder that
   crashes, is killed, or whose build simply fails frees it: the waiters see a
   released lock with no artifact, and one of them takes over and builds. The


### PR DESCRIPTION
## Description

When Expo prebuild changes the fingerprint during a shared build, the waiter looks for the artifact under the old key. It incorrectly reports that the builder failed, then finds the actual artifact after its own prebuild but returns `waitedForBuild: null`. The Android cache suite reproduces this even though only one workspace compiled and both apps launched.

Fixes #576.

## Solution

Treat a released lock as an unknown old-key outcome, not proof of failure. On iOS and Android, a waiter that later finds a matching artifact retains its wait metadata and prints the normal cache-handoff result. It still prepares and fingerprints its own workspace before accepting the artifact; storage remains exclusively under the final key.

The dead-builder takeover warning from [d31e702f25](https://github.com/appandflow/stim/commit/d31e702f25093ff72d5335c3b64cfa697656d32e) stays; a released lock also allows a fresh build, but does not claim failure.

## Test plan

The real Expo Android cache suite passed on bbd7956: six checks passed, two iOS-only checks skipped. The unchanged race assertions observed one compiler and a cache-hit waiter retaining a 41.1s wait, without the false failure warning. Both race launches verified bundle loading, and all five cleanup checks passed.

Run the cold Expo Android cache suite:

```sh
node test/e2e/native/run-cache-e2e.mjs --framework expo --platform android --summary /tmp/cache-summary.json
```

Metro reused all 714 transforms; Gradle restored 89 tasks from cache. The auxiliary forced-compile and same-tree reinstall checks returned launch unverified (no fresh bundle request); those prove caching, not a new healthy launch. Initial cold and cross-worktree cached launches were verified. Regression coverage also checks the equivalent iOS post-preparation hit and rebuilding when no artifact exists.
