### PR TITLE
fix: allow busy iOS simulators more time to launch

### DIFF
--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -271,7 +271,7 @@ export function launchIosApp(
           // project directly; launch-then-openurl can create two React hosts.
           const initialUrl = new URL(url).searchParams.get('url')!;
           const pid = parseLaunchedPid(
-            e.runFile('xcrun', [...launchArgs, '--initialUrl', initialUrl], { timeoutMs: 10000 }),
+            e.runFile('xcrun', [...launchArgs, '--initialUrl', initialUrl], { timeoutMs: 60000 }),
           );
           return { ok: true, mode: 'launch', url, jsLocation: jsLocationValue(metroPort), pid };
         }
@@ -284,7 +284,7 @@ export function launchIosApp(
   }
 
   try {
-    const out = e.runFile('xcrun', launchArgs, { timeoutMs: 10000 });
+    const out = e.runFile('xcrun', launchArgs, { timeoutMs: 60000 });
     const result: IosLaunchResult = { ok: true, mode: 'launch', pid: parseLaunchedPid(out) };
     if (metroPort !== null) result.jsLocation = jsLocationValue(metroPort);
     return result;

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -79,6 +79,11 @@ new JavaScript or observe the resulting UI. Verify the expected screen or
 interaction on the reported device and inspect \`stim logs --errors\` before
 claiming recovery; exit 0 alone does not prove it.
 
+An iOS simulator launch command has a 60-second deadline. This is separate
+from bundle delivery and readiness verification: it gives CoreSimulator time
+to accept the launch, not the app extra time to report readiness. A timeout
+still fails the launch; Stim does not automatically retry it.
+
 For an unverified Android launch, follow the emitted device-specific remedy.
 If the app is stuck before loading its first bundle, restart its process with
 the printed force-stop and launcher commands. Foregrounding the same process


### PR DESCRIPTION
## Description

Concurrent cold simulator boots can leave `stim ios` failing at its 10-second `simctl launch` deadline after a successful cached build. Three concurrent-boot QA runs hit this timeout; the underlying delay remains unexplained.

## Solution

Increase the [deadline added with crash capture](https://github.com/appandflow/stim/commit/dfd342114e6edc926f1d74ef26adc985560744ae) to 60 seconds for direct and initial-URL simulator launches. No launch retries or readiness/crash checks change. A genuinely hung launch takes up to 50 seconds longer to refuse.

## Test plan

The real branch rerun passed all seven applicable cache checks and owned cleanup. It exercised the slow path: one concurrent `simctl launch` succeeded after **53.112 seconds**, while the other took 762 ms. Both apps passed launch verification. Exactly one build compiled (115/115 compilation-cache hits); the other workspace waited 46.155 seconds and installed that artifact.

Reproduce with `node test/e2e/native/run-cache-e2e.mjs --framework bare --platform ios`. This demonstrates a launch that the old deadline would abort; it does not explain or eliminate CoreSimulator's intermittent delay.

Fixes #578.
