### PR TITLE
fix: recognize already populated Metro QA caches

### DIFF
--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -900,22 +900,20 @@ async function settle(dir, label, { firstGrowthMs = 90000, quietMs = 6000, timeo
   const startedAtMs = Date.now();
   const baseline = dirStats(dir);
   let last = baseline;
-  let moved = false;
+  let populated = baseline.files > 0;
   let stableSince = Date.now();
   while (Date.now() - startedAtMs < timeoutMs) {
     await sleep(stepMs);
     const now = dirStats(dir);
     if (now.files !== last.files || now.bytes !== last.bytes) {
       last = now;
-      moved = true;
+      populated ||= now.files > 0;
       stableSince = Date.now();
       continue;
     }
-    if (!moved) {
+    if (!populated) {
       if (Date.now() - startedAtMs >= firstGrowthMs) {
-        log(
-          `${label}: no growth at all in ${Math.round(firstGrowthMs / 1000)}s (${baseline.files} files, unchanged) -- reported as EMPTY, not as settled`,
-        );
+        log(`${label}: still empty after waiting ${Math.round(firstGrowthMs / 1000)}s for cache entries`);
         return last;
       }
       continue;


### PR DESCRIPTION
## Description

The native cache QA suite waited 90 seconds and labeled a populated Metro store `EMPTY` when it had finished filling before observation began. Fixes #583.

## Solution

Let nonempty stores settle after the existing six-second quiet period. Keep the first-write wait for empty stores: the [original guard](https://github.com/appandflow/stim/blob/0a8b1e3786d036b62067a291afbc364fd8af0408/test/e2e/native/run-cache-e2e.mjs#L961-L985) prevents a delayed cold write from being mistaken for a settled cache. Cache-growth/reuse assertions and the overall timeout are unchanged; this affects QA only, not published CLI behavior.

## Test plan

- Exercised the exact helper with real temporary directories and a controlled clock: prefilled, empty, delayed writes, continuous writes, byte-size-only changes, and zero-byte entries. The old helper reproduces the 90-second/`EMPTY` result; the fix preserves the empty/delayed-write and timeout behavior.
- Measured the helper against a completed real iOS QA Metro store: 2,757 entries settled in 6.3 seconds using the real clock.
