### PR TITLE
feat: tilt the landing can on tap

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -213,9 +213,14 @@
 }
 
 .heroIllustration {
+  display: block;
+  width: 100%;
+  padding: 0;
   aspect-ratio: 1;
   overflow: hidden;
   border: 1px solid var(--home-border);
+  background: transparent;
+  cursor: pointer;
 }
 
 .heroIllustration img {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type PointerEvent, type ReactNode } from 'react';
+import { useEffect, useRef, type MouseEvent, type PointerEvent, type ReactNode } from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
@@ -8,6 +8,14 @@ import ThemedImage from '@theme/ThemedImage';
 import { StimInstallTabs } from '@site/src/components/StimTabs';
 import ThemeSwitch from '@site/src/components/ThemeSwitch';
 import styles from './index.module.css';
+
+function tapIllustration({ currentTarget }: MouseEvent<HTMLButtonElement>) {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const illustration = currentTarget.querySelector('img')!;
+  for (const animation of illustration.getAnimations()) animation.cancel();
+  illustration.animate({ rotate: ['0deg', '-5deg', '2deg', '0deg'] }, { duration: 600, easing: 'ease-in-out' });
+}
 
 export default function Home(): ReactNode {
   const assetBase = useBaseUrl('/img/branding/');
@@ -22,7 +30,7 @@ export default function Home(): ReactNode {
     };
   }, []);
 
-  function setTilt(element: HTMLDivElement, x: number, y: number) {
+  function setTilt(element: HTMLButtonElement, x: number, y: number) {
     const motion = tilt.current;
     motion.targetX = x;
     motion.targetY = y;
@@ -47,7 +55,7 @@ export default function Home(): ReactNode {
     motion.frame = requestAnimationFrame(animate);
   }
 
-  function tiltIllustration({ currentTarget, clientX, clientY, pointerType }: PointerEvent<HTMLDivElement>) {
+  function tiltIllustration({ currentTarget, clientX, clientY, pointerType }: PointerEvent<HTMLButtonElement>) {
     if (
       pointerType !== 'mouse' ||
       !window.matchMedia('(prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine)').matches
@@ -63,7 +71,7 @@ export default function Home(): ReactNode {
     );
   }
 
-  function resetTilt({ currentTarget }: PointerEvent<HTMLDivElement>) {
+  function resetTilt({ currentTarget }: PointerEvent<HTMLButtonElement>) {
     setTilt(currentTarget, 0, 0);
   }
 
@@ -136,9 +144,12 @@ export default function Home(): ReactNode {
             </div>
           </div>
         </header>
-        <div
+        <button
+          type="button"
+          aria-label="Tilt the Stim can"
           className={styles.heroIllustration}
           data-reveal=""
+          onClick={tapIllustration}
           onPointerMove={tiltIllustration}
           onPointerLeave={resetTilt}
           onPointerCancel={resetTilt}
@@ -150,7 +161,7 @@ export default function Home(): ReactNode {
             height="520"
             fetchPriority="high"
           />
-        </div>
+        </button>
         <section aria-label="Features" className={styles.features}>
           <article className={styles.feature}>
             <Heading as="h2">Fast builds across worktrees</Heading>


### PR DESCRIPTION
## Description

The landing can responds to desktop hover but not touch. Add a short tilt on tap. Fixes #586.

## Solution

Use a button so tap, click, and keyboard activation share the same small wobble. It returns to rest, restarts on repeated activation, and skips animation when reduced motion is requested. Preserve desktop pointer tilt and normal touch scrolling.

## Test plan

- Verified the click-triggered rotation and return to rest in the browser at desktop and 390px widths, with no console errors.
- On a phone, tap the can repeatedly and scroll across it; the animation should settle without trapping scrolling. Enable Reduce Motion and confirm taps do not animate.
- All 3,765 unit tests pass (one skipped); formatting, lint, knip, builds, and repository/website typechecks pass.

Mobile-width browser capture:

https://github.com/user-attachments/assets/6c7a3532-2a40-4fef-a729-3ba39910ca72
