### PR TITLE
fix: resolve app schemes in renamed iOS workspaces

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
@@ -268,7 +268,7 @@ describe('parseSchemeList', () => {
 });
 
 describe('pickScheme', () => {
-  test('the scheme named after the container wins, which is every generated RN project', () => {
+  test('the scheme named after the container wins', () => {
     expect(pickScheme(['MyApp', 'MyApp-tvOS', 'MyAppTests'], 'MyApp')).toBe('MyApp');
   });
 
@@ -345,7 +345,7 @@ describe('listSchemes and resolveScheme', () => {
     expect(error.remedy).toMatch(/-list/);
   });
 
-  test('resolveScheme names the schemes it did find when none of them is buildable', () => {
+  test('resolveScheme names ambiguous schemes and gives a naming remedy instead of claiming they are not shared', () => {
     setExecutor({
       run: () => '',
       runQuiet: () => null,
@@ -356,7 +356,59 @@ describe('listSchemes and resolveScheme', () => {
     assert(error);
     expect(error.code).toBe('STIM_NO_SCHEME');
     expect(error.message).toMatch(/schemes: one, two/);
-    expect(error.remedy).toMatch(/Shared/);
+    expect(error.remedy).toMatch(/workspace\/project name/);
+  });
+
+  test.each([
+    ['matching app name', '{"name":"safe-area-example"}', 'safe-area-example'],
+    ['missing app.json', null, undefined],
+    ['malformed app.json', '{', undefined],
+    ['null app.json', 'null', undefined],
+    ['non-string app name', '{"name":12}', undefined],
+    ['unlisted app name', '{"name":"absent"}', undefined],
+  ])('resolveScheme handles a renamed workspace with %s', (_label, appJson, expected) => {
+    const ios = join(tmp, 'ios');
+    mkdirSync(ios);
+    if (appJson !== null) writeFileSync(join(tmp, 'app.json'), appJson);
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: () =>
+        JSON.stringify({
+          workspace: { name: 'RNSACExample', schemes: ['Pods-ReactTestApp', 'ReactTestApp', 'safe-area-example'] },
+        }),
+    });
+    const result = resolveScheme({
+      flag: '-workspace',
+      path: join(ios, 'RNSACExample.xcworkspace'),
+      name: 'RNSACExample',
+      dir: ios,
+    });
+    expect(result.scheme).toBe(expected);
+    expect(result.error?.code).toBe(expected ? undefined : 'STIM_NO_SCHEME');
+  });
+
+  test('the workspace scheme retains priority over an app.json name', () => {
+    mkdirSync(join(tmp, 'ios'));
+    writeFileSync(join(tmp, 'app.json'), '{"name":"OtherApp"}');
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: () => JSON.stringify({ workspace: { name: 'App', schemes: ['App', 'OtherApp'] } }),
+    });
+    expect(resolveScheme({ ...project, dir: join(tmp, 'ios') }).scheme).toBe('App');
+  });
+
+  test('an empty scheme listing keeps the share-scheme remedy', () => {
+    setExecutor({
+      run: () => '',
+      runQuiet: () => null,
+      spawn: () => {},
+      runFile: () => '{"workspace":{"name":"App","schemes":[]}}',
+    });
+    expect(resolveScheme(project).error?.remedy).toMatch(/tick Shared/);
   });
 
   test('resolveScheme returns the scheme and the full list on success', () => {
@@ -1595,13 +1647,19 @@ const LIVE = xcodebuildAvailable() ? false : 'xcodebuild is not available on thi
 const LIVE_DESTINATION = 'generic/platform=iOS Simulator';
 
 describe('buildIos against a real xcodebuild', { skip: LIVE as unknown as boolean }, () => {
-  test('discovers the workspace and resolves its scheme through a real -list -json', () => {
+  test('resolves a real workspace scheme and uses the app name after the workspace is renamed', () => {
     resetExecutor();
     writeScratchProject(tmp, { workspace: true });
     const project = discoverXcodeProject(tmp);
     expect(project.kind).toBe('workspace');
     expect(project.path).toBe(join(tmp, 'ios', 'Scratch.xcworkspace'));
     expect(resolveScheme(project)).toEqual({ scheme: 'Scratch', schemes: ['Scratch'] });
+    renameSync(join(tmp, 'ios', 'Scratch.xcworkspace'), join(tmp, 'ios', 'Renamed.xcworkspace'));
+    writeFileSync(join(tmp, 'ios', 'Scratch.xcodeproj', 'xcshareddata', 'xcschemes', 'Other.xcscheme'), SCRATCH_SCHEME);
+    const renamed = discoverXcodeProject(tmp);
+    expect(resolveScheme(renamed).error?.code).toBe('STIM_NO_SCHEME');
+    writeFileSync(join(tmp, 'app.json'), '{"name":"Scratch"}');
+    expect(resolveScheme(renamed)).toEqual({ scheme: 'Scratch', schemes: ['Other', 'Scratch'] });
   });
 
   test.each([

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -142,15 +142,23 @@ export function resolveScheme(project: XcodeProject, { exec = null }: { exec?: E
       },
     };
   }
-  const scheme = pickScheme(listing.schemes, listing.name || project.name);
+  let scheme = pickScheme(listing.schemes, listing.name || project.name);
+  if (!scheme && project.dir) {
+    try {
+      const app = JSON.parse(readFileSync(join(project.dir, '..', 'app.json'), 'utf8'));
+      scheme = pickScheme(listing.schemes, app?.name);
+    } catch {}
+  }
   if (!scheme) {
     const found = listing.schemes.length ? listing.schemes.join(', ') : 'none';
     return {
       error: {
         code: 'STIM_NO_SCHEME',
-        message: `No buildable scheme found in ${project.path} (schemes: ${found}).`,
+        message: `Could not select an app scheme in ${project.path} (schemes: ${found}).`,
         remedy:
-          'Share the app scheme in Xcode (Product > Scheme > Manage Schemes, tick Shared) so xcodebuild can see it.',
+          listing.schemes.length > 0
+            ? 'In Xcode (Product > Scheme > Manage Schemes), make the intended shared app scheme match the workspace/project name or the top-level name in app.json. Stim does not guess between unmatched schemes.'
+            : 'Share the app scheme in Xcode (Product > Scheme > Manage Schemes, tick Shared) so xcodebuild can see it.',
       },
     };
   }

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -235,10 +235,13 @@ code, never on the message.`,
   signer-conflict retry performs.`,
     },
     STIM_NO_SCHEME: {
-      summary: 'no shared buildable Xcode scheme in ios/',
+      summary: 'Xcode schemes unavailable or no unambiguous app scheme in ios/',
       body: () => `STIM_NO_SCHEME
-  No buildable Xcode scheme was found in ios/. A scheme has to be shared to be
-  visible to xcodebuild.`,
+  Stim could not list or select an app scheme in ios/. Share the intended app
+  scheme so xcodebuild can see it. If it is already listed, make its name match
+  the workspace/project name or the top-level name in app.json. A workspace
+  name match wins; otherwise Stim accepts a sole non-test scheme, or a listed
+  scheme matching app.json. Unmatched ambiguous schemes are refused.`,
     },
     STIM_NO_PROFILE: {
       summary: 'no or undecodable embedded.mobileprovision; build once from Xcode',

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -422,6 +422,14 @@ result as proof instead of requiring an unrelated screenshot.`,
 
   Follow the normal ownership and consent rules in guide agent.
 
+IOS SCHEME SELECTION
+  Stim keeps a scheme matching the workspace/project name, or the sole non-test
+  scheme. When neither identifies one, it also checks the static top-level name
+  in the app directory's app.json against Xcode's listed schemes. It does not
+  execute app config or choose an arbitrary scheme from an ambiguous list.
+  If selection fails, share the intended app scheme in Xcode and make its name
+  match the workspace/project or app.json name. See guide errors STIM_NO_SCHEME.
+
 AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
   Both platforms store the artifact verbatim, so its hash is its identity.
   Before installing, Stim hashes the artifact it is about to install and the


### PR DESCRIPTION
## Description

`stim ios` rejected the safe-area-context example even though Xcode listed its shared app scheme: the workspace is named `RNSACExample`, while the app scheme is `safe-area-example`, alongside many CocoaPods schemes. It then suggested sharing an already-shared scheme. Fixes #589.

## Solution

Keep workspace-name and sole non-test scheme selection unchanged. If those cannot choose, match the static top-level `app.json` name against Xcode's actual scheme list. Missing, malformed, or unmatched names still refuse ambiguous selection; no project config is executed and no flags are added. The refusal and detailed guides now explain how to resolve a naming mismatch instead of treating every failure as an unshared scheme.

## Test plan

- Extended the real-Xcode test: rename a working workspace and add another shared scheme; selection fails until `app.json` identifies the intended scheme.
- Exercise populated Pod-style scheme lists, missing/malformed/non-string/unlisted app names, workspace-name priority, and the separate empty-list remedy.
- The actual prepared safe-area-context example now resolves `safe-area-example` from Xcode's 87 listed schemes without changing its workspace or scheme files.
