### PR TITLE
feat: tilt the can toward the tap position

### DIFF
--- a/website/src/components/canTilt.test.ts
+++ b/website/src/components/canTilt.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest';
+import { canTilt } from './canTilt';
+
+test('opposite tap edges produce opposite tilt axes, regardless of page position', () => {
+  const bounds = { left: 100, top: 300, width: 200, height: 200 };
+  expect(canTilt(bounds, 100, 400)).toEqual({ x: 0, y: -6 });
+  expect(canTilt(bounds, 300, 400)).toEqual({ x: 0, y: 6 });
+  expect(canTilt(bounds, 200, 300)).toEqual({ x: 6, y: 0 });
+  expect(canTilt(bounds, 200, 500)).toEqual({ x: -6, y: 0 });
+  expect(canTilt(bounds, 200, 400)).toEqual({ x: 0, y: 0 });
+  expect(canTilt(bounds, 250, 350)).toEqual({ x: 3, y: 3 });
+});

--- a/website/src/components/canTilt.ts
+++ b/website/src/components/canTilt.ts
@@ -1,0 +1,10 @@
+export function canTilt(
+  bounds: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number,
+): { x: number; y: number } {
+  return {
+    x: (0.5 - (clientY - bounds.top) / bounds.height) * 12,
+    y: ((clientX - bounds.left) / bounds.width - 0.5) * 12,
+  };
+}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -221,11 +221,16 @@
   border: 1px solid var(--home-border);
   background: transparent;
   cursor: pointer;
+  perspective: 900px;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .heroIllustration img {
   width: 100%;
   height: 100%;
+  pointer-events: none;
 }
 
 .features {
@@ -365,7 +370,7 @@
 
 @media (prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine) {
   .heroIllustration img {
-    transform: perspective(900px) rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg)) scale(1.1);
+    transform: rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg)) scale(1.1);
   }
 
   .primaryButton:hover:not(:active) {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -7,14 +7,20 @@ import Heading from '@theme/Heading';
 import ThemedImage from '@theme/ThemedImage';
 import { StimInstallTabs } from '@site/src/components/StimTabs';
 import ThemeSwitch from '@site/src/components/ThemeSwitch';
+import { canTilt } from '../components/canTilt';
 import styles from './index.module.css';
 
-function tapIllustration({ currentTarget }: MouseEvent<HTMLButtonElement>) {
+function tapIllustration({ currentTarget, clientX, clientY, detail }: MouseEvent<HTMLButtonElement>) {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
   const illustration = currentTarget.querySelector('img')!;
+  const { x, y } = detail === 0 ? { x: -4, y: 4 } : canTilt(currentTarget.getBoundingClientRect(), clientX, clientY);
+  const angle = Math.hypot(x, y);
   for (const animation of illustration.getAnimations()) animation.cancel();
-  illustration.animate({ rotate: ['0deg', '-5deg', '2deg', '0deg'] }, { duration: 600, easing: 'ease-in-out' });
+  illustration.animate(
+    { rotate: ['0deg', `${x} ${y} 0 ${angle}deg`, `${x} ${y} 0 ${-angle / 3}deg`, '0deg'] },
+    { duration: 600, easing: 'ease-in-out' },
+  );
 }
 
 export default function Home(): ReactNode {
@@ -63,12 +69,8 @@ export default function Home(): ReactNode {
       return;
     }
 
-    const bounds = currentTarget.getBoundingClientRect();
-    setTilt(
-      currentTarget,
-      (0.5 - (clientY - bounds.top) / bounds.height) * 12,
-      ((clientX - bounds.left) / bounds.width - 0.5) * 12,
-    );
+    const { x, y } = canTilt(currentTarget.getBoundingClientRect(), clientX, clientY);
+    setTilt(currentTarget, x, y);
   }
 
   function resetTilt({ currentTarget }: PointerEvent<HTMLButtonElement>) {
@@ -150,6 +152,7 @@ export default function Home(): ReactNode {
           className={styles.heroIllustration}
           data-reveal=""
           onClick={tapIllustration}
+          onContextMenu={(event) => event.preventDefault()}
           onPointerMove={tiltIllustration}
           onPointerLeave={resetTilt}
           onPointerCancel={resetTilt}
@@ -160,6 +163,7 @@ export default function Home(): ReactNode {
             width="520"
             height="520"
             fetchPriority="high"
+            draggable={false}
           />
         </button>
         <section aria-label="Features" className={styles.features}>


### PR DESCRIPTION
## Description

The landing-page can always wobbles the same way, regardless of where it is tapped, and a long press can open the browser's image menu. Fixes #591.

## Solution

Use the tap position for a short 3D tilt and rebound. Keyboard activation keeps a small diagonal tilt, and reduced-motion preferences disable the animation. Selection and context-menu suppression apply only to the can; scrolling and pinch zoom remain unrestricted.

## Test plan

- Browser preview: opposite-edge clicks produce opposite rotation axes and settle back to neutral; Enter activates the can.
- Position regression test covers all four edges, the center, and a corner.
- Physical iPhone long-press behavior still needs a Safari check.

https://github.com/user-attachments/assets/b083e9e1-226c-4024-913c-e40c667b6afb
