### PR TITLE
fix: improve website keyboard access and contrast

### DIFF
--- a/website/src/components/BenchmarkTimeline.module.css
+++ b/website/src/components/BenchmarkTimeline.module.css
@@ -430,7 +430,20 @@
 .commandFailed {
   border-color: color-mix(in srgb, #dc2626 45%, var(--bench-line));
   background: color-mix(in srgb, #dc2626 12%, var(--bench-surface));
-  color: #dc2626;
+  color: #b91c1c;
+}
+
+:global([data-theme='dark']) .commandFailed {
+  color: #fca5a5;
+}
+
+:global([data-theme='dark']) .summary span {
+  color: #5eead4;
+}
+
+.viewer :is(button, input, select):focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
 }
 
 .terminal {

--- a/website/src/components/BenchmarkTimeline.test.ts
+++ b/website/src/components/BenchmarkTimeline.test.ts
@@ -8,6 +8,13 @@ import type { BenchmarkRun } from './benchmarkData';
 vi.mock('@docusaurus/useBaseUrl', () => ({ default: (path: string) => path }));
 
 describe('benchmark timeline presentation', () => {
+  it('names the keyboard-scrollable timeline and exposes playback time to assistive technology', () => {
+    const run = { ...opus.runs[0], totalSeconds: 90 } as BenchmarkRun;
+    const html = renderToStaticMarkup(createElement(BenchmarkTimeline, { run }));
+    expect(html).toContain('role="region" aria-label="Benchmark command timeline"');
+    expect(html).toContain('aria-valuetext="0.0s of 1m 30s"');
+  });
+
   it('shows full-run Claude usage even when diagnosis usage is absent', () => {
     const run: BenchmarkRun = {
       ...(opus.runs[0] as BenchmarkRun),

--- a/website/src/components/BenchmarkTimeline.tsx
+++ b/website/src/components/BenchmarkTimeline.tsx
@@ -354,6 +354,7 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
             max={Math.max(0.01, run.totalSeconds)}
             step={0.1}
             value={cursorSeconds}
+            aria-valuetext={`${formatSeconds(cursorSeconds)} of ${formatSeconds(run.totalSeconds)}`}
             onChange={(event) => {
               setPlaying(false);
               setPlaybackMode(true);
@@ -394,6 +395,7 @@ export default function BenchmarkTimeline({ run }: { run: BenchmarkRun }): React
         ref={timelineScroller}
         className={styles.timelineScroller}
         tabIndex={0}
+        role="region"
         aria-label="Benchmark command timeline"
         onTouchStart={beginPinch}
         onTouchMove={updatePinch}

--- a/website/src/pages/benchmarks.module.css
+++ b/website/src/pages/benchmarks.module.css
@@ -399,11 +399,24 @@
 }
 
 .gain {
-  color: #16a34a;
+  color: #15803d;
 }
 
 .loss {
   color: #c2410c;
+}
+
+:global([data-theme='dark']) .gain {
+  color: #4ade80;
+}
+
+:global([data-theme='dark']) .loss {
+  color: #fb923c;
+}
+
+:global([data-theme='dark']) .benchmarkPicker button[aria-pressed='true'],
+:global([data-theme='dark']) .runTabs button[aria-pressed='true'] {
+  color: #15121d;
 }
 
 .neutral {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -68,7 +68,7 @@
   width: 100%;
   font-size: 12px;
   font-weight: 500;
-  margin-bottom: 44px;
+  margin-bottom: 64px;
   color: var(--stim-purple);
 }
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -19,7 +19,7 @@ function tapIllustration({ currentTarget }: MouseEvent<HTMLButtonElement>) {
 
 export default function Home(): ReactNode {
   const assetBase = useBaseUrl('/img/branding/');
-  const contentRef = useRef<HTMLElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const tilt = useRef({ x: 0, y: 0, targetX: 0, targetY: 0, frame: null as number | null });
 
   useEffect(() => {
@@ -106,166 +106,172 @@ export default function Home(): ReactNode {
       wrapperClassName={styles.page}
       description="Stim gives coding agents fast, isolated React Native and Expo environments with shared build caches and owned devices."
     >
-      <main className={styles.content} ref={contentRef}>
-        <header className={styles.hero}>
-          <nav className={styles.nav} aria-label="Main navigation">
-            <Link to="/" aria-label="Stim home" className={`${styles.logo} stim-logo`}>
-              <ThemedImage
-                sources={{ light: `${assetBase}logo.svg`, dark: `${assetBase}logo-dark.svg` }}
-                alt=""
-                width="48"
-                height="48"
-              />
-            </Link>
-            <Link to="/docs/getting-started">Docs</Link>
-            <Link to="/benchmarks">Benchmarks</Link>
-            <a href="https://github.com/appandflow/stim" aria-label="Stim on GitHub" className={styles.github}>
-              <ThemedImage
-                sources={{ light: `${assetBase}github.svg`, dark: `${assetBase}github-dark.svg` }}
-                alt=""
-                width="16"
-                height="16"
-              />
-              GitHub
-            </a>
-            <ThemeSwitch />
-          </nav>
-          <Heading as="h1">Fast, isolated React Native environments for agents</Heading>
-          <p className={styles.lead}>
-            Give each coding agent a fast, isolated React Native environment. Stim shares build caches across worktrees,
-            owns each device and port, supports local and remote simulators, and cleans up when the work is done.
-          </p>
-          <div className={styles.actions}>
-            <Link className={styles.primaryButton} to="/docs/getting-started">
-              Get started
-            </Link>
-            <div className={styles.install}>
-              <StimInstallTabs />
-            </div>
-          </div>
-        </header>
-        <button
-          type="button"
-          aria-label="Tilt the Stim can"
-          className={styles.heroIllustration}
-          data-reveal=""
-          onClick={tapIllustration}
-          onPointerMove={tiltIllustration}
-          onPointerLeave={resetTilt}
-          onPointerCancel={resetTilt}
-        >
-          <ThemedImage
-            sources={{ light: `${assetBase}hero.svg`, dark: `${assetBase}hero-dark.svg` }}
-            alt=""
-            width="520"
-            height="520"
-            fetchPriority="high"
-          />
-        </button>
-        <section aria-label="Features" className={styles.features}>
-          <article className={styles.feature}>
-            <Heading as="h2">Fast builds across worktrees</Heading>
-            <p>
-              Native artifacts, Xcode compilation data, Gradle output, and Metro transforms are shared safely. A new
-              worktree can install a cached app when its native inputs match. Concurrent misses use one build.
-            </p>
-            <Link to="/docs/build-caches" aria-label="Read about build caches">
-              View doc <span aria-hidden="true">&#8599;</span>
-            </Link>
-            <div className={styles.fastIllustration} data-reveal="">
-              <ThemedImage
-                sources={{ light: `${assetBase}fast-builds.svg`, dark: `${assetBase}fast-builds-dark.svg` }}
-                alt=""
-                width="448"
-                height="250"
-                loading="lazy"
-              />
-            </div>
-          </article>
-          <article className={styles.feature}>
-            <Heading as="h2">Parallel agents without collisions</Heading>
-            <p>
-              Each checkout gets its own Metro port and owned device. Agents can create isolated git worktrees and work
-              in parallel. Small, streaming output and focused errors reduce waiting and token use.
-            </p>
-            <Link to="/docs/worktrees" aria-label="Read about isolated worktrees">
-              View doc <span aria-hidden="true">&#8599;</span>
-            </Link>
-            <div className={styles.parallelIllustration} data-reveal="">
-              <ThemedImage
-                sources={{ light: `${assetBase}parallel-agents.svg`, dark: `${assetBase}parallel-agents-dark.svg` }}
-                alt=""
-                width="324"
-                height="298"
-                loading="lazy"
-              />
-            </div>
-          </article>
-          <article className={styles.feature}>
-            <Heading as="h2">React Native and Expo, here or remote</Heading>
-            <p>
-              Stim works with React Native Community CLI and Expo projects. It builds locally, then launches on an owned
-              simulator or emulator, connected phone, or configured remote device. The agent gets the exact device and
-              launch state.
-            </p>
-            <Link to="/docs/owned-devices" aria-label="Read about supported devices">
-              View doc <span aria-hidden="true">&#8599;</span>
-            </Link>
-            <div className={styles.deviceIllustration} data-reveal="">
-              <ThemedImage
-                sources={{ light: `${assetBase}react-native-expo.svg`, dark: `${assetBase}react-native-expo-dark.svg` }}
-                alt=""
-                width="386"
-                height="248"
-                loading="lazy"
-              />
-            </div>
-          </article>
-          <article className={styles.feature}>
-            <Heading as="h2">Owned resources and complete cleanup</Heading>
-            <p>
-              Stim tracks every port, process, build, device, and remote session it creates. <code>stop</code>,{' '}
-              <code>worktree remove</code>, and <code>gc</code> reclaim resources without touching devices Stim does not
-              own.
-            </p>
-            <Link to="/docs/commands" aria-label="Read about cleanup commands">
-              View doc <span aria-hidden="true">&#8599;</span>
-            </Link>
-            <div className={styles.cleanupIllustration} data-reveal="">
-              <ThemedImage
-                sources={{ light: `${assetBase}cleanup.svg`, dark: `${assetBase}cleanup-dark.svg` }}
-                alt=""
-                width="338"
-                height="433"
-                loading="lazy"
-              />
-            </div>
-          </article>
-        </section>
-        <section className={styles.why} aria-labelledby="why-stim">
-          <Heading as="h2" id="why-stim">
-            Why Stim
-          </Heading>
-          <p>
-            React Native toolchains were built for one developer working in one checkout. Coding agents often work
-            across several worktrees at once. Stim lets those worktrees share build work while keeping their devices,
-            ports, and running apps separate.
-          </p>
-          <Link to="/docs/why">
-            More about Stim <span aria-hidden="true">&#8599;</span>
+      <div className={styles.content} ref={contentRef}>
+        <nav className={styles.nav} aria-label="Main navigation">
+          <Link to="/" aria-label="Stim home" className={`${styles.logo} stim-logo`}>
+            <ThemedImage
+              sources={{ light: `${assetBase}logo.svg`, dark: `${assetBase}logo-dark.svg` }}
+              alt=""
+              width="48"
+              height="48"
+            />
           </Link>
-        </section>
-        <section className={styles.agentSetup} aria-labelledby="agent-setup">
-          <Heading as="h2" id="agent-setup">
-            Give your agent the skill
-          </Heading>
-          <CodeBlock language="bash">npx skills add appandflow/stim</CodeBlock>
-          <p>Then ask your agent: &quot;Build and run the app on iOS.&quot;</p>
-          <p>Stim needs no initialization. Runtime state stays outside the project.</p>
-          <Link to="/docs/agent-skills">
-            Agent setup <span aria-hidden="true">&#8599;</span>
-          </Link>
-        </section>
+          <Link to="/docs/getting-started">Docs</Link>
+          <Link to="/benchmarks">Benchmarks</Link>
+          <a href="https://github.com/appandflow/stim" aria-label="Stim on GitHub" className={styles.github}>
+            <ThemedImage
+              sources={{ light: `${assetBase}github.svg`, dark: `${assetBase}github-dark.svg` }}
+              alt=""
+              width="16"
+              height="16"
+            />
+            GitHub
+          </a>
+          <ThemeSwitch />
+        </nav>
+        <main>
+          <header className={styles.hero}>
+            <Heading as="h1">Fast, isolated React Native environments for agents</Heading>
+            <p className={styles.lead}>
+              Give each coding agent a fast, isolated React Native environment. Stim shares build caches across
+              worktrees, owns each device and port, supports local and remote simulators, and cleans up when the work is
+              done.
+            </p>
+            <div className={styles.actions}>
+              <Link className={styles.primaryButton} to="/docs/getting-started">
+                Get started
+              </Link>
+              <div className={styles.install}>
+                <StimInstallTabs />
+              </div>
+            </div>
+          </header>
+          <button
+            type="button"
+            aria-label="Tilt the Stim can"
+            className={styles.heroIllustration}
+            data-reveal=""
+            onClick={tapIllustration}
+            onPointerMove={tiltIllustration}
+            onPointerLeave={resetTilt}
+            onPointerCancel={resetTilt}
+          >
+            <ThemedImage
+              sources={{ light: `${assetBase}hero.svg`, dark: `${assetBase}hero-dark.svg` }}
+              alt=""
+              width="520"
+              height="520"
+              fetchPriority="high"
+            />
+          </button>
+          <section aria-label="Features" className={styles.features}>
+            <article className={styles.feature}>
+              <Heading as="h2">Fast builds across worktrees</Heading>
+              <p>
+                Native artifacts, Xcode compilation data, Gradle output, and Metro transforms are shared safely. A new
+                worktree can install a cached app when its native inputs match. Concurrent misses use one build.
+              </p>
+              <Link to="/docs/build-caches" aria-label="Read about build caches">
+                View doc <span aria-hidden="true">&#8599;</span>
+              </Link>
+              <div className={styles.fastIllustration} data-reveal="">
+                <ThemedImage
+                  sources={{ light: `${assetBase}fast-builds.svg`, dark: `${assetBase}fast-builds-dark.svg` }}
+                  alt=""
+                  width="448"
+                  height="250"
+                  loading="lazy"
+                />
+              </div>
+            </article>
+            <article className={styles.feature}>
+              <Heading as="h2">Parallel agents without collisions</Heading>
+              <p>
+                Each checkout gets its own Metro port and owned device. Agents can create isolated git worktrees and
+                work in parallel. Small, streaming output and focused errors reduce waiting and token use.
+              </p>
+              <Link to="/docs/worktrees" aria-label="Read about isolated worktrees">
+                View doc <span aria-hidden="true">&#8599;</span>
+              </Link>
+              <div className={styles.parallelIllustration} data-reveal="">
+                <ThemedImage
+                  sources={{ light: `${assetBase}parallel-agents.svg`, dark: `${assetBase}parallel-agents-dark.svg` }}
+                  alt=""
+                  width="324"
+                  height="298"
+                  loading="lazy"
+                />
+              </div>
+            </article>
+            <article className={styles.feature}>
+              <Heading as="h2">React Native and Expo, here or remote</Heading>
+              <p>
+                Stim works with React Native Community CLI and Expo projects. It builds locally, then launches on an
+                owned simulator or emulator, connected phone, or configured remote device. The agent gets the exact
+                device and launch state.
+              </p>
+              <Link to="/docs/owned-devices" aria-label="Read about supported devices">
+                View doc <span aria-hidden="true">&#8599;</span>
+              </Link>
+              <div className={styles.deviceIllustration} data-reveal="">
+                <ThemedImage
+                  sources={{
+                    light: `${assetBase}react-native-expo.svg`,
+                    dark: `${assetBase}react-native-expo-dark.svg`,
+                  }}
+                  alt=""
+                  width="386"
+                  height="248"
+                  loading="lazy"
+                />
+              </div>
+            </article>
+            <article className={styles.feature}>
+              <Heading as="h2">Owned resources and complete cleanup</Heading>
+              <p>
+                Stim tracks every port, process, build, device, and remote session it creates. <code>stop</code>,{' '}
+                <code>worktree remove</code>, and <code>gc</code> reclaim resources without touching devices Stim does
+                not own.
+              </p>
+              <Link to="/docs/commands" aria-label="Read about cleanup commands">
+                View doc <span aria-hidden="true">&#8599;</span>
+              </Link>
+              <div className={styles.cleanupIllustration} data-reveal="">
+                <ThemedImage
+                  sources={{ light: `${assetBase}cleanup.svg`, dark: `${assetBase}cleanup-dark.svg` }}
+                  alt=""
+                  width="338"
+                  height="433"
+                  loading="lazy"
+                />
+              </div>
+            </article>
+          </section>
+          <section className={styles.why} aria-labelledby="why-stim">
+            <Heading as="h2" id="why-stim">
+              Why Stim
+            </Heading>
+            <p>
+              React Native toolchains were built for one developer working in one checkout. Coding agents often work
+              across several worktrees at once. Stim lets those worktrees share build work while keeping their devices,
+              ports, and running apps separate.
+            </p>
+            <Link to="/docs/why">
+              More about Stim <span aria-hidden="true">&#8599;</span>
+            </Link>
+          </section>
+          <section className={styles.agentSetup} aria-labelledby="agent-setup">
+            <Heading as="h2" id="agent-setup">
+              Give your agent the skill
+            </Heading>
+            <CodeBlock language="bash">npx skills add appandflow/stim</CodeBlock>
+            <p>Then ask your agent: &quot;Build and run the app on iOS.&quot;</p>
+            <p>Stim needs no initialization. Runtime state stays outside the project.</p>
+            <Link to="/docs/agent-skills">
+              Agent setup <span aria-hidden="true">&#8599;</span>
+            </Link>
+          </section>
+        </main>
         <footer className={styles.footer}>
           <nav aria-label="Footer navigation">
             <Link to="/docs/why">Why Stim</Link>
@@ -285,7 +291,7 @@ export default function Home(): ReactNode {
             loading="lazy"
           />
         </div>
-      </main>
+      </div>
     </Layout>
   );
 }


### PR DESCRIPTION
## Description

The landing page's skip link still leads through its navigation. Benchmark status text also has low contrast in places, and timeline controls lack clear keyboard focus. Fixes #592.

## Solution

Keep navigation outside the main landmark so the skip link bypasses it without changing the layout. Adjust benchmark colors for both themes, add visible focus outlines, and give the timeline and playback position readable accessibility labels.

## Test plan

Native VoiceOver has not been tested; this is not a full WCAG audit.

- At 320px, the landing page and getting-started docs have no page-level horizontal overflow. The landing skip link now leads to Get started, bypassing navigation.
- Keyboard: theme switch, playback slider, and timeline command selection work; focused controls have visible outlines in both themes.
- Accessibility tree: named navigation and main landmarks, labeled controls, and playback time text are present.

![Keyboard focus on a timeline note in dark mode](https://github.com/user-attachments/assets/ce5c134c-cd57-4ed0-bf80-f91bb96cb4f1)
