### PR TITLE
fix: give bare iOS reload a usable fallback

### DIFF
--- a/packages/stim-cli/src/__tests__/reload-command.test.ts
+++ b/packages/stim-cli/src/__tests__/reload-command.test.ts
@@ -165,6 +165,13 @@ test("bare iOS leaves startup-overlay automation to the agent's existing session
       remedy: expect.stringContaining('agent-device snapshot -i --platform ios --udid U1'),
     },
   });
+  expect(result).toMatchObject({
+    error: {
+      remedy: expect.stringContaining(
+        'agent-device open com.example.ios --platform ios --udid U1 --metro-port 8082 --relaunch',
+      ),
+    },
+  });
 });
 
 test('reload turns owned-device inspection failures into actionable errors', async () => {

--- a/packages/stim-cli/src/commands/reload.ts
+++ b/packages/stim-cli/src/commands/reload.ts
@@ -318,12 +318,13 @@ export async function runReload({
       const stoppedAfterMetro = processFailure(target.platform, target.record, d);
       if (stoppedAfterMetro) return { ok: false, error: stoppedAfterMetro };
       const snapshot = `agent-device snapshot -i --platform ios --udid ${target.record.deviceId}`;
+      const relaunch = `agent-device open ${target.record.appId} --platform ios --udid ${target.record.deviceId} --metro-port ${port} --relaunch`;
       return {
         ok: false,
         error: failure(
           'STIM_RELOAD_FAILED',
           reloaded.reason ?? `No React Native app is connected to Metro on port ${port}.`,
-          `Continue in your existing automation session for ${target.record.appId} on ${target.record.deviceId}. Run \`${snapshot}\`, then press the Reload control by the exact ref or label it reports. Do not open another session or rerun \`stim ios\`.`,
+          `Continue in your existing automation session for ${target.record.appId} on ${target.record.deviceId}. Run \`${snapshot}\`, then press Reload if present. Otherwise run \`${relaunch}\` in that same session; this restarts the app and loses in-memory state. Keep your existing --session flag on these commands. Verify the expected UI afterward. Do not create another session or rerun \`stim ios\`.`,
         ),
       };
     }

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -614,13 +614,16 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   process-probe remedy.`,
     },
     STIM_RELOAD_FAILED: {
-      summary: 'the deep link, broadcast, or Metro websocket reload failed; press Reload yourself',
+      summary: 'the reload failed; use Reload or the exact-app relaunch remedy',
       body: () => `STIM_RELOAD_FAILED
   The exact deep link, Android reload broadcast, or targeted Metro websocket
   failed. If bare iOS has not connected or Metro cannot identify one iOS peer,
   the remedy tells the agent to continue in its existing automation session on
-  this workspace's exact simulator and press the Reload control. Stim does not
-  take over automation sessions.`,
+  this workspace's exact simulator and press Reload if present. If it is not
+  present, the printed agent-device open command relaunches that app on that
+  simulator with this workspace's Metro port. Keep the existing --session flag;
+  relaunch loses in-memory state. Verify the expected UI afterward. Stim does
+  not broadcast to unidentified peers or take over automation sessions.`,
     },
     STIM_WORKTREE_REMOVAL_IN_PROGRESS: {
       summary: 'a managed remote start found worktree remove holding the lock; wait, then rerun',


### PR DESCRIPTION
## Description

Bare iOS reload can refuse when Metro cannot identify a peer. The remedy then assumes a Reload control exists, but the RN 0.85.3 safe-area example can show only a collapsed error banner. Fixes #596.

## Solution

Keep the targeted-reload refusal and existing-session isolation from [the original reload change](https://github.com/appandflow/stim/commit/43da17e5e94fc920fdce65492432ee9f67411b28). When Reload is absent, print an agent-device relaunch command pinned to the recorded app, simulator and Metro port. Warn that relaunch loses in-memory state and require UI verification. No automatic relaunch or broadcast is added.

## Test plan

On the real bare RN 0.85.3 example and an owned iOS 26.5 simulator, provoke the peer-discovery refusal after a missing-import error. Restore the import, execute the printed fallback in the existing agent-device session, and verify the SafeAreaView sample renders again on the same device and Metro port. The fallback command completed successfully; UI verification is captured in the task evidence.
