### PR TITLE
fix: isolate same-name Android workspaces

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1418,14 +1418,49 @@ describe('ensureOwnedDevice: android', () => {
     }
   });
 
-  test('an existing AVD owned by ANOTHER project errors instead of being hijacked', async () => {
+  test('same-label workspaces receive distinct owned AVDs without touching the existing owner', async () => {
     const other = projectDir();
     const root = projectDir();
     try {
       setDevice(other, 'android', { avdName: 'stim-app', consolePort: 5554, owned: true });
-      const { exec } = androidExecutor({
+      const existing = getProject(other)?.platforms?.android;
+      const { run, spawn, exec } = androidExecutor({ avds: ['stim-app'] });
+      setExecutor(exec);
+      const result = await ensureOwnedDevice({
+        platform: 'android',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(result.avdName).toMatch(/^stim-app-[a-f0-9]{8}$/);
+      expect(result.consolePort).toBe(5556);
+      expect(getProject(root)?.platforms?.android).toMatchObject({
+        avdName: result.avdName,
+        owned: true,
+      });
+      expect(getProject(other)?.platforms?.android).toEqual(existing);
+      expect(run.filter((cmd) => /create avd/.test(cmd))).toHaveLength(1);
+      expect(run.some((cmd) => /delete avd| -s emulator-5554 /.test(cmd))).toBe(false);
+      expect(spawn).toHaveLength(1);
+      expect(spawn[0]?.args).toContain(result.avdName);
+      expect(spawn[0]?.args).not.toContain('stim-app');
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('an AVD claimed by another project during creation errors instead of being hijacked', async () => {
+    const other = projectDir();
+    const root = projectDir();
+    try {
+      const { spawn, exec } = androidExecutor({
         avds: ['stim-app'],
         createAvdError: 'Error: AVD stim-app already exists.',
+        beforeCreateAvdError: () => {
+          setDevice(other, 'android', { avdName: 'stim-app', consolePort: 5554, owned: true });
+        },
       });
       setExecutor(exec);
       await expect(
@@ -1436,7 +1471,10 @@ describe('ensureOwnedDevice: android', () => {
           label: 'app',
           settings: {},
         }),
-      ).rejects.toThrow(/owned by another project/);
+      ).rejects.toThrow(/owned by another project.*Retry to allocate a distinct owned emulator/);
+      expect(spawn).toEqual([]);
+      expect(getProject(root)?.platforms?.android).toBeUndefined();
+      expect(getProject(other)?.platforms?.android).toMatchObject({ avdName: 'stim-app', owned: true });
     } finally {
       rmSync(other, { recursive: true, force: true });
       rmSync(root, { recursive: true, force: true });

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -645,7 +645,10 @@ async function ensureOwnedAndroidDevice({
       if (current?.avdName && current.avdName !== record?.avdName) {
         throw new Error(`Another Stim run assigned AVD ${current.avdName} to this workspace. Retry to use it.`);
       }
-      if (readParked('android').some((entry) => entry.name === ownedAvdName(label)))
+      if (
+        readParked('android').some((entry) => entry.name === ownedAvdName(label)) ||
+        findOtherProjectOwningAvd(ownedAvdName(label), projectPath)
+      )
         label = `${label}-${randomUUID().slice(0, 8)}`;
       const result = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
       setDevice(projectPath, 'android', {
@@ -669,7 +672,7 @@ async function ensureOwnedAndroidDevice({
         const owner = findOtherProjectOwningAvd(avdName, projectPath);
         if (owner) {
           throw new Error(
-            `AVD ${avdName} already exists and is owned by another project (${owner}). Pass a distinct --label to avoid the collision instead of hijacking it.`,
+            `AVD ${avdName} already exists and is owned by another project (${owner}). Retry to allocate a distinct owned emulator.`,
             { cause: e },
           );
         }

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -391,6 +391,10 @@ result as proof instead of requiring an unrelated screenshot.`,
   Incompatible AVDs stay parked until eviction or GC. AVDs created by older
   versions without a recorded creation configuration are deleted at removal.
 
+  When a fresh AVD's preferred name belongs to another workspace or a parked
+  entry, Stim adds a short suffix instead of taking over that device. Always
+  use the actual device name and serial reported by the platform command.
+
   Android cleanup happens AFTER boot, before install or launch: \`adb shell
   pm clear\` clears the adopting app's data while retaining its APK, and
   other third-party apps are uninstalled. Failed cleanup blocks launch and


### PR DESCRIPTION
## Description

Bare monorepo worktrees often share an app-directory name such as `example`. On Android, the second workspace fails because `stim-example` already belongs to the first; the suggested `--label` flag no longer exists. Fixes #599.

## Solution

Extend the existing parked-name collision handling to names claimed by another workspace: allocate a suffixed name under the config lock. The original device and its ownership remain unchanged, and the late ownership check still refuses takeover if a claim appears during creation. No new flag or migration is needed.

## Test plan

Verified on the real bare safe-area-context example: the main app retained its stopped `stim-example`, while the linked worktree created `stim-example-6f178955` on a separate serial and launched in 39 seconds. Its APK was a cross-worktree cache hit, no native compilation ran, and `logs --errors` was empty. The main device record stayed identical. Independent review and CI remain required before merge.
