### PR TITLE
fix: warn about multi-architecture Debug Pods

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor-ios-architectures.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-ios-architectures.test.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { inspectIosDebugArchitectures, parseIosDebugArchitectures } from '../doctor-ios-architectures.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
+
+function target(settings: Record<string, unknown> = {}, name = 'NativePod') {
+  return {
+    target: name,
+    buildSettings: {
+      CONFIGURATION: 'Debug',
+      PLATFORM_NAME: 'iphonesimulator',
+      PRODUCT_TYPE: 'com.apple.product-type.library.static',
+      ONLY_ACTIVE_ARCH: 'NO',
+      ARCHS: 'arm64 x86_64',
+      VALID_ARCHS: 'arm64 x86_64',
+      ...settings,
+    },
+  };
+}
+
+test('resolved Pod overrides are detected even when the app builds only its active architecture', () => {
+  const report = parseIosDebugArchitectures(
+    JSON.stringify([
+      target({ ONLY_ACTIVE_ARCH: 'YES', PRODUCT_TYPE: 'com.apple.product-type.application' }, 'App'),
+      target(),
+    ]),
+  );
+  expect(report).toEqual({ affected: [{ target: 'NativePod', architectures: ['arm64', 'x86_64'] }], unknown: false });
+});
+
+test.each([
+  { ONLY_ACTIVE_ARCH: 'YES' },
+  { ARCHS: 'arm64' },
+  { ARCHS: 'arm64 arm64' },
+  { EXCLUDED_ARCHS: 'x86_64' },
+  { VALID_ARCHS: 'arm64' },
+  { PRODUCT_TYPE: 'com.apple.product-type.bundle' },
+])('single-architecture and non-compiling targets do not produce a cost warning: %j', (settings) => {
+  expect(parseIosDebugArchitectures(JSON.stringify([target(settings)]))).toEqual({ affected: [], unknown: false });
+});
+
+test.each([
+  { CONFIGURATION: 'Release' },
+  { PLATFORM_NAME: 'iphoneos' },
+  { ARCHS: '$(ARCHS_STANDARD)' },
+  { EXCLUDED_ARCHS: '$(inherited)' },
+  { ONLY_ACTIVE_ARCH: undefined },
+  { PRODUCT_TYPE: undefined },
+  { PRODUCT_TYPE: 'unknown-product' },
+])('unexpected or unresolved settings remain unverified without false architecture warnings: %j', (settings) => {
+  expect(parseIosDebugArchitectures(JSON.stringify([target(settings)]))).toEqual({ affected: [], unknown: true });
+});
+
+test.each(['not JSON', '[]', '[null]', '[{"target":"Pod","buildSettings":{},"error":"unavailable"}]'])(
+  'unavailable metadata remains unverified: %s',
+  (output) => {
+    expect(parseIosDebugArchitectures(output)).toEqual({ affected: [], unknown: true });
+  },
+);
+
+let home: string;
+let project: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-doctor-architectures-'));
+  process.env.STIM_HOME = join(home, 'state');
+  project = join(home, 'app with spaces');
+  mkdirSync(join(project, 'ios', 'App.xcodeproj'), { recursive: true });
+});
+
+afterEach(() => {
+  resetExecutor();
+  delete process.env.STIM_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+test('doctor reports generated Pod helper effects using bounded metadata calls without evaluating Ruby', () => {
+  mkdirSync(join(project, 'ios', 'Pods', 'Pods.xcodeproj'), { recursive: true });
+  writeFileSync(
+    join(project, 'ios', 'Podfile'),
+    "require_relative '../helpers/pods'\npost_install { |installer| configure_pods(installer) }\n",
+  );
+  const calls: string[][] = [];
+  setExecutor({
+    runFile(file: string, args: string[], options: { timeoutMs: number }) {
+      expect(file).toBe('xcodebuild');
+      calls.push(args);
+      expect(options.timeoutMs).toBeGreaterThan(0);
+      expect(options.timeoutMs).toBeLessThanOrEqual(30_000);
+      return JSON.stringify([target({ ONLY_ACTIVE_ARCH: args[1]?.includes('/Pods/') ? 'NO' : 'YES' })]);
+    },
+  });
+  const findings = inspectIosDebugArchitectures(project);
+  expect(findings).toHaveLength(1);
+  expect(findings[0]).toMatchObject({ code: 'ios-debug-architectures', level: 'cost' });
+  expect(findings[0]?.detail).toContain('ios/Pods/Pods.xcodeproj');
+  expect(findings[0]?.detail).toContain('NativePod (arm64, x86_64)');
+  expect(calls).toHaveLength(2);
+  for (const args of calls) {
+    expect(args.slice(2)).toEqual([
+      '-alltargets',
+      '-configuration',
+      'Debug',
+      '-sdk',
+      'iphonesimulator',
+      '-showBuildSettings',
+      '-json',
+      '-disableAutomaticPackageResolution',
+      '-skipPackageUpdates',
+    ]);
+  }
+});
+
+test('missing Pods and failed app metadata produce an unverified note without a cost warning', () => {
+  writeFileSync(join(project, 'ios', 'Podfile'), 'post_install {}\n');
+  setExecutor({
+    runFile() {
+      throw new Error('timed out');
+    },
+  });
+  const findings = inspectIosDebugArchitectures(project);
+  expect(findings).toHaveLength(1);
+  expect(findings[0]).toMatchObject({ code: 'ios-debug-architectures-unknown', level: 'note' });
+  expect(findings[0]?.detail).toContain('Pods project (not generated)');
+  expect(findings[0]?.detail).toContain('ios/App.xcodeproj');
+});
+
+test('ungenerated iOS projects do not invoke Xcode', () => {
+  setExecutor({
+    runFile() {
+      throw new Error('must not run');
+    },
+  });
+  expect(inspectIosDebugArchitectures(home)).toEqual([]);
+});
+
+test('metadata inspection stops at its total deadline and keeps partial findings', () => {
+  mkdirSync(join(project, 'ios', 'Pods', 'Pods.xcodeproj'), { recursive: true });
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+  let calls = 0;
+  try {
+    setExecutor({
+      runFile() {
+        calls++;
+        clock.mockReturnValue(61_001);
+        return JSON.stringify([target()]);
+      },
+    });
+    expect(inspectIosDebugArchitectures(project).map((finding) => finding.code)).toEqual([
+      'ios-debug-architectures',
+      'ios-debug-architectures-unknown',
+    ]);
+    expect(calls).toBe(1);
+  } finally {
+    clock.mockRestore();
+  }
+});

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -440,6 +440,37 @@ test('the ccache finding belongs to the Android group and is filtered out by --p
   }
 });
 
+test('Android doctor skips iOS architecture metadata and findings', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-architectures-platform-'));
+  try {
+    mkdirSync(join(project, 'ios', 'App.xcodeproj'), { recursive: true });
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ dependencies: { 'react-native': '*' } }));
+    const queries: string[] = [];
+    setExecutor({
+      runFileQuiet: () => null,
+      runFile(file: string) {
+        queries.push(file);
+        return '';
+      },
+      runQuiet: () => null,
+    });
+    const options = { concurrency: { maxBuilds: 0, maxDevices: 0 }, lookupCcache: () => true };
+    expect(
+      runDoctor(project, { ...options, platform: 'android' }).some((f) =>
+        f.code?.startsWith('ios-debug-architectures'),
+      ),
+    ).toBe(false);
+    expect(queries).not.toContain('xcodebuild');
+    expect(
+      runDoctor(project, { ...options, platform: 'ios' }).some((f) => f.code === 'ios-debug-architectures-unknown'),
+    ).toBe(true);
+    expect(queries).toContain('xcodebuild');
+  } finally {
+    resetExecutor();
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('parseCmakeCacheLauncher reads the launcher a configure wrote into CMakeCache.txt', () => {
   const cache = [
     '//Compiler launcher for CXX.',

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -62,7 +62,7 @@ export function doctorSuccessLines(platform: DoctorPlatform | undefined, stim: S
 
   if (platform !== 'android') {
     lines.push('', 'iOS');
-    lines.push(phaseLine('setup', 'CocoaPods, warm state, dev client'));
+    lines.push(phaseLine('setup', 'CocoaPods, warm state, dev client, effective Debug simulator architectures'));
     lines.push(phaseLine('caches', 'Metro, Xcode compilation, ccache, build provider'));
     lines.push(phaseLine('devices', 'remote device, SimSlim profile'));
   }

--- a/packages/stim-cli/src/doctor-ios-architectures.ts
+++ b/packages/stim-cli/src/doctor-ios-architectures.ts
@@ -1,0 +1,152 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { Finding } from './doctor.ts';
+import { getExecutor } from './exec.ts';
+
+interface ArchitectureTarget {
+  target: string;
+  architectures: string[];
+}
+
+interface ArchitectureReport {
+  affected: ArchitectureTarget[];
+  unknown: boolean;
+}
+
+const COMPILED_PRODUCTS = new Set([
+  'com.apple.product-type.application',
+  'com.apple.product-type.application.on-demand-install-capable',
+  'com.apple.product-type.app-extension',
+  'com.apple.product-type.framework',
+  'com.apple.product-type.library.static',
+  'com.apple.product-type.library.dynamic',
+]);
+
+function architectureList(value: unknown): string[] | null {
+  if (typeof value !== 'string' || /[^\w\s-]/.test(value)) return null;
+  return [...new Set(value.split(/\s+/).filter(Boolean))];
+}
+
+export function parseIosDebugArchitectures(output: string): ArchitectureReport {
+  const report: ArchitectureReport = { affected: [], unknown: false };
+  let data: unknown;
+  try {
+    data = JSON.parse(output);
+  } catch {
+    return { ...report, unknown: true };
+  }
+  if (!Array.isArray(data) || data.length === 0) return { ...report, unknown: true };
+  let inspected = false;
+  for (const entry of data) {
+    if (!entry || typeof entry !== 'object' || entry.error || !entry.buildSettings) {
+      report.unknown = true;
+      continue;
+    }
+    const settings = entry.buildSettings;
+    if (settings.CONFIGURATION !== 'Debug' || settings.PLATFORM_NAME !== 'iphonesimulator') {
+      report.unknown = true;
+      continue;
+    }
+    if (!settings.PRODUCT_TYPE) continue;
+    if (settings.PRODUCT_TYPE === 'com.apple.product-type.bundle') {
+      inspected = true;
+      continue;
+    }
+    if (!COMPILED_PRODUCTS.has(settings.PRODUCT_TYPE)) {
+      report.unknown = true;
+      continue;
+    }
+    inspected = true;
+    if (settings.ONLY_ACTIVE_ARCH === 'YES') continue;
+    const archs = architectureList(settings.ARCHS);
+    const valid = settings.VALID_ARCHS === undefined ? archs : architectureList(settings.VALID_ARCHS);
+    const excluded = architectureList(settings.EXCLUDED_ARCHS ?? '');
+    if (
+      settings.ONLY_ACTIVE_ARCH !== 'NO' ||
+      !archs?.length ||
+      !valid ||
+      !excluded ||
+      typeof entry.target !== 'string'
+    ) {
+      report.unknown = true;
+      continue;
+    }
+    const architectures = archs.filter((arch) => valid.includes(arch) && !excluded.includes(arch));
+    if (architectures.length > 1) report.affected.push({ target: entry.target, architectures });
+  }
+  return { ...report, unknown: report.unknown || !inspected };
+}
+
+export function inspectIosDebugArchitectures(projectRoot: string): Finding[] {
+  const iosRoot = join(projectRoot, 'ios');
+  if (!existsSync(iosRoot)) return [];
+  const findings: Finding[] = [];
+  const unknown: string[] = [];
+  let projects: string[];
+  try {
+    projects = readdirSync(iosRoot)
+      .filter((name) => name.endsWith('.xcodeproj'))
+      .toSorted()
+      .map((name) => join(iosRoot, name));
+  } catch {
+    projects = [];
+  }
+  if (!projects.length) unknown.push('app project');
+  const pods = join(iosRoot, 'Pods', 'Pods.xcodeproj');
+  if (existsSync(pods)) projects.push(pods);
+  else if (existsSync(join(iosRoot, 'Podfile'))) unknown.push('Pods project (not generated)');
+  const deadline = Date.now() + 60_000;
+  for (const project of projects) {
+    const label = relative(projectRoot, project);
+    const timeoutMs = Math.min(30_000, deadline - Date.now());
+    if (timeoutMs <= 0) {
+      unknown.push(label);
+      continue;
+    }
+    try {
+      const output = getExecutor().runFile(
+        'xcodebuild',
+        [
+          '-project',
+          project,
+          '-alltargets',
+          '-configuration',
+          'Debug',
+          '-sdk',
+          'iphonesimulator',
+          '-showBuildSettings',
+          '-json',
+          '-disableAutomaticPackageResolution',
+          '-skipPackageUpdates',
+        ],
+        { cwd: iosRoot, timeoutMs },
+      );
+      const report = parseIosDebugArchitectures(output);
+      if (report.unknown) unknown.push(label);
+      if (report.affected.length) {
+        const targets = report.affected
+          .slice(0, 5)
+          .map(({ target, architectures }) => `${target} (${architectures.join(', ')})`)
+          .join('; ');
+        findings.push({
+          code: 'ios-debug-architectures',
+          level: 'cost',
+          title: 'iOS Debug targets build multiple simulator architectures',
+          detail: `${label}: ${report.affected.length} Debug target(s) resolve ONLY_ACTIVE_ARCH=NO with multiple architectures after exclusions: ${targets}${report.affected.length > 5 ? `; plus ${report.affected.length - 5} more` : ''}. This can compile extra native code when targeting one simulator.`,
+          fix: 'Review the Debug ONLY_ACTIVE_ARCH override in the project, xcconfig, or Podfile post_install helpers. Prefer YES for local Debug simulator builds where appropriate; preserve intentional Release and distribution settings. Regenerate Pods through the project workflow after changing a helper, then rerun stim doctor --platform ios. Doctor --fix does not change architecture settings.',
+        });
+      }
+    } catch {
+      unknown.push(label);
+    }
+  }
+  if (unknown.length)
+    findings.push({
+      code: 'ios-debug-architectures-unknown',
+      level: 'note',
+      title: 'iOS Debug architecture settings could not be fully inspected',
+      detail: `Effective Debug simulator settings are unavailable for ${unknown.join(', ')}. Architecture policy is not verified for those targets. Metadata inspection has a 60-second total budget.`,
+      fix: 'Ensure Xcode can read the generated app and Pods projects, then rerun stim doctor --platform ios. Doctor does not evaluate Podfiles or install Pods to inspect architecture settings.',
+    });
+  return findings;
+}

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -5,6 +5,7 @@ import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
 import { makeTemporaryDirectory } from './temporary.ts';
 import { checkStorageLayout } from './doctor-storage.ts';
+import { inspectIosDebugArchitectures } from './doctor-ios-architectures.ts';
 import { appProjectProblem, detectIsExpo } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
 import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
@@ -776,6 +777,7 @@ export function runDoctor(
   return [
     checkAppProject(projectRoot),
     ...checkMainCheckout(projectRoot, { platform }),
+    ...(platform === 'android' ? [] : inspectIosDebugArchitectures(mainCheckoutProjectRoot(projectRoot))),
     ...checkStorageLayout(projectRoot, { platform }),
     checkDevClient(pkg, isExpo),
     optimizations?.metroSharedCache ? checkMetroCache(metroConfig) : null,

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -34,6 +34,8 @@ resolved from PATH. If that resolved installation is older than another one,
 fix PATH or the installation before continuing so commands and guidance match.
 Doctor reports cross-volume staging and build-cache copies; read guide settings
 for placement overrides and guide lifecycle options for warm behavior.
+For iOS Debug architecture findings, review the project's overrides and imported
+Podfile helpers using guide lifecycle options. Doctor --fix does not change them.
 
   stim doctor --platform ios          # or: --platform android
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -508,6 +508,21 @@ when a build is blocked or slow. It reports what Stim cannot handle itself
 launcher, a fingerprint no fresh worktree reproduces, a provider on a key this
 SDK ignores) and settings for builds outside Stim.
 
+IOS DEBUG ARCHITECTURES
+Doctor reads Xcode's effective Debug simulator settings for app targets and
+generated Pods, including xcconfig inheritance and SDK-specific overrides.
+It warns when ONLY_ACTIVE_ARCH=NO leaves multiple architectures after ARCHS,
+VALID_ARCHS, and EXCLUDED_ARCHS are combined. A Podfile post_install helper can
+cause this even when the app target already uses ONLY_ACTIVE_ARCH=YES.
+Review that override for local Debug builds; preserve intentional Release and
+distribution settings. Regenerate Pods through the project's normal workflow
+after changing a helper, then rerun \`stim doctor --platform ios\`.
+Doctor never evaluates Podfile Ruby, installs Pods, or changes architecture
+settings, including under --fix. This inspection runs only in doctor, with
+30 seconds per Xcode query and 60 seconds total. Missing generated projects,
+failed metadata queries, and unresolved settings produce an unverified note
+rather than an architecture warning or a verified clean result.
+
 WHY ANDROID NEEDS CCACHE, AND WHAT IT COSTS
 Every AGP CMake task is uncacheable by Gradle, so --build-cache serves not one
 C++ compile. Without a launcher a fresh worktree recompiles every translation

--- a/test/e2e/doctor-architectures.e2e.js
+++ b/test/e2e/doctor-architectures.e2e.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  inspectIosDebugArchitectures,
+  parseIosDebugArchitectures,
+} from '../../packages/stim-cli/src/doctor-ios-architectures.ts';
+import { getExecutor } from '../../packages/stim-cli/src/exec.ts';
+
+test(
+  'doctor resolves inherited and SDK-conditioned Debug architecture settings with real Xcode',
+  { skip: process.platform !== 'darwin' },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), 'stim-architectures-e2e-'));
+    const previousHome = process.env.STIM_HOME;
+    process.env.STIM_HOME = join(root, 'state');
+    try {
+      cpSync(fileURLToPath(new URL('../fixtures/doctor-architectures/ios', import.meta.url)), join(root, 'ios'), {
+        recursive: true,
+      });
+      const findings = inspectIosDebugArchitectures(root);
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].code, 'ios-debug-architectures');
+      assert.match(findings[0].detail, /NativePod \(arm64, x86_64\)/);
+      assert.doesNotMatch(findings[0].detail, /App \(/);
+
+      const release = getExecutor().runFile(
+        'xcodebuild',
+        [
+          '-project',
+          join(root, 'ios', 'Architecture.xcodeproj'),
+          '-alltargets',
+          '-configuration',
+          'Release',
+          '-sdk',
+          'iphonesimulator',
+          '-showBuildSettings',
+          '-json',
+          '-disableAutomaticPackageResolution',
+          '-skipPackageUpdates',
+        ],
+        { timeoutMs: 15_000 },
+      );
+      assert.equal(parseIosDebugArchitectures(release).affected.length, 0);
+      assert.equal(
+        JSON.parse(release).find((target) => target.target === 'NativePod').buildSettings.ONLY_ACTIVE_ARCH,
+        'NO',
+      );
+
+      writeFileSync(
+        join(root, 'ios', 'Debug.xcconfig'),
+        'ONLY_ACTIVE_ARCH = NO\nEXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64\n',
+      );
+      assert.deepEqual(inspectIosDebugArchitectures(root), []);
+      writeFileSync(join(root, 'ios', 'Debug.xcconfig'), 'ONLY_ACTIVE_ARCH = $(inherited)\n');
+      assert.deepEqual(inspectIosDebugArchitectures(root), []);
+    } finally {
+      if (previousHome === undefined) delete process.env.STIM_HOME;
+      else process.env.STIM_HOME = previousHome;
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/fixtures/doctor-architectures/ios/Architecture.xcodeproj/project.pbxproj
+++ b/test/fixtures/doctor-architectures/ios/Architecture.xcodeproj/project.pbxproj
@@ -1,0 +1,99 @@
+{
+  archiveVersion = 1;
+  classes = {};
+  objectVersion = 56;
+  objects = {
+    A00000000000000000000001 = {
+      isa = PBXProject;
+      buildConfigurationList = A00000000000000000000002;
+      compatibilityVersion = "Xcode 14.0";
+      developmentRegion = en;
+      knownRegions = (en, Base);
+      mainGroup = A00000000000000000000003;
+      projectDirPath = "";
+      projectRoot = "";
+      targets = (A00000000000000000000010, A00000000000000000000020);
+    };
+    A00000000000000000000002 = {
+      isa = XCConfigurationList;
+      buildConfigurations = (A00000000000000000000004, A00000000000000000000005);
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+    A00000000000000000000003 = {
+      isa = PBXGroup;
+      children = (A00000000000000000000006);
+      sourceTree = "<group>";
+    };
+    A00000000000000000000004 = {
+      isa = XCBuildConfiguration;
+      buildSettings = { SDKROOT = iphoneos; ARCHS = "$(ARCHS_STANDARD)"; ONLY_ACTIVE_ARCH = YES; };
+      name = Debug;
+    };
+    A00000000000000000000005 = {
+      isa = XCBuildConfiguration;
+      buildSettings = { SDKROOT = iphoneos; ARCHS = "$(ARCHS_STANDARD)"; ONLY_ACTIVE_ARCH = NO; };
+      name = Release;
+    };
+    A00000000000000000000006 = {
+      isa = PBXFileReference;
+      lastKnownFileType = text.xcconfig;
+      path = Debug.xcconfig;
+      sourceTree = "<group>";
+    };
+    A00000000000000000000010 = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = A00000000000000000000011;
+      buildPhases = ();
+      buildRules = ();
+      dependencies = ();
+      name = App;
+      productName = App;
+      productType = "com.apple.product-type.application";
+    };
+    A00000000000000000000011 = {
+      isa = XCConfigurationList;
+      buildConfigurations = (A00000000000000000000012, A00000000000000000000013);
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+    A00000000000000000000012 = {
+      isa = XCBuildConfiguration;
+      buildSettings = { PRODUCT_NAME = "$(TARGET_NAME)"; ONLY_ACTIVE_ARCH = "$(inherited)"; };
+      name = Debug;
+    };
+    A00000000000000000000013 = {
+      isa = XCBuildConfiguration;
+      buildSettings = { PRODUCT_NAME = "$(TARGET_NAME)"; };
+      name = Release;
+    };
+    A00000000000000000000020 = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = A00000000000000000000021;
+      buildPhases = ();
+      buildRules = ();
+      dependencies = ();
+      name = NativePod;
+      productName = NativePod;
+      productType = "com.apple.product-type.library.static";
+    };
+    A00000000000000000000021 = {
+      isa = XCConfigurationList;
+      buildConfigurations = (A00000000000000000000022, A00000000000000000000023);
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+    A00000000000000000000022 = {
+      isa = XCBuildConfiguration;
+      baseConfigurationReference = A00000000000000000000006;
+      buildSettings = { PRODUCT_NAME = "$(TARGET_NAME)"; };
+      name = Debug;
+    };
+    A00000000000000000000023 = {
+      isa = XCBuildConfiguration;
+      buildSettings = { PRODUCT_NAME = "$(TARGET_NAME)"; };
+      name = Release;
+    };
+  };
+  rootObject = A00000000000000000000001;
+}

--- a/test/fixtures/doctor-architectures/ios/Debug.xcconfig
+++ b/test/fixtures/doctor-architectures/ios/Debug.xcconfig
@@ -1,0 +1,2 @@
+ONLY_ACTIVE_ARCH = $(inherited)
+ONLY_ACTIVE_ARCH[sdk=iphonesimulator*] = NO


### PR DESCRIPTION
## Description

Doctor could report a clean iOS setup while a Podfile helper forced Debug Pods to compile for both simulator architectures, even though the app used `ONLY_ACTIVE_ARCH=YES`.

## Solution

Inspect Xcode's resolved Debug simulator settings for the main checkout's app and generated Pods projects. Report affected compiling targets after architecture exclusions, and keep unavailable metadata explicitly unverified. This runs only in doctor and does not change project settings or evaluate Podfile Ruby, including under `--fix`.

The metadata work adds latency: the customer app's full `doctor --platform ios --json` took 9.4 seconds locally, versus roughly one second before this check. Queries have a 30-second limit and a 60-second total budget.

## Test plan

- Verified the retained before-fix generated Pods in two real apps: warnings identified 107 and 71 compiling Debug targets. The same check returned no findings after Pods were regenerated without the helper; both apps' effective Release policy remained unchanged.
- The built CLI emitted one parseable JSON payload containing the warning.
- Run `node --test test/e2e/doctor-architectures.e2e.js` on macOS with Xcode. Covers inherited settings, SDK overrides, and exclusions using real Xcode metadata.

Fixes #608.
