### PR TITLE
fix: relaunch stuck Android apps with an explicit launcher intent

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2804,7 +2804,9 @@ describe('launch verification', () => {
     const text = h.stderr.join('\n');
     expect(text).toMatch(/UNVERIFIED/);
     expect(text).toMatch(/DEVELOPMENT SERVERS/);
-    expect(text).toMatch(/adb -s emulator-5584 shell monkey -p com\.example\.app 1/);
+    expect(text).toContain(
+      'adb -s emulator-5584 shell am force-stop com.example.app && adb -s emulator-5584 shell am start -n com.example.app/.MainActivity',
+    );
     expect(text).not.toMatch(/simctl/);
     expect(h.stdout.join('\n')).toMatch(/UNVERIFIED/);
     expect(h.stdout[0]).toContain(phaseLine('metro', 'state unverified on port 8082'));

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -1102,18 +1102,36 @@ describe('unverifiedLaunchLines', () => {
     expect(text).toMatch(/xcrun simctl launch --console U1 com\.x/);
   });
 
-  test('Android recovery restarts the reported app before launching it again', () => {
+  test('Android recovery restarts the reported app through its resolved launcher activity', () => {
     const text = unverifiedLaunchLines({
       platform: 'android',
       metroPort: 8082,
       bundleId: 'com.x',
       serial: 'emulator-5584',
+      component: 'com.x/.MainActivity',
     }).join('\n');
     expect(text).not.toMatch(/simctl/);
     expect(text).toContain(
+      'adb -s emulator-5584 shell am force-stop com.x && adb -s emulator-5584 shell am start -n com.x/.MainActivity',
+    );
+    expect(text).not.toMatch(/monkey/);
+    expect(text).toMatch(/DEVELOPMENT SERVERS/);
+  });
+
+  test('a dev-client launch without a resolved activity restarts through the deep link, not monkey', () => {
+    const base = { platform: 'android', metroPort: 8082, bundleId: 'com.x', serial: 'emulator-5584' };
+    const url = devClientUrl('com.x', 8082);
+    const deepLink = unverifiedLaunchLines({ ...base, devClientUrl: url }).join('\n');
+    expect(deepLink).toContain(
+      `adb -s emulator-5584 shell am force-stop com.x && adb -s emulator-5584 shell am start -a android.intent.action.VIEW -d '${url}' --ez EXDevMenuDisableAutoLaunch true`,
+    );
+    expect(deepLink).not.toMatch(/monkey/);
+    const both = unverifiedLaunchLines({ ...base, devClientUrl: url, component: 'com.x/.MainActivity' }).join('\n');
+    expect(both).toContain('am force-stop com.x && adb -s emulator-5584 shell am start -n com.x/.MainActivity');
+    const noActivity = unverifiedLaunchLines(base).join('\n');
+    expect(noActivity).toContain(
       'adb -s emulator-5584 shell am force-stop com.x && adb -s emulator-5584 shell monkey -p com.x 1',
     );
-    expect(text).toMatch(/DEVELOPMENT SERVERS/);
   });
 
   test('every printed retry command carries disableOnboarding inside the project url', () => {
@@ -1194,7 +1212,7 @@ describe('unverifiedLaunchLines: the action comes first', () => {
       serial: 'emulator-5584',
     });
     const picker = lines.findIndex((l) => /DEVELOPMENT SERVERS/.test(l));
-    const relaunch = lines.findIndex((l) => /monkey -p com\.x/.test(l));
+    const relaunch = lines.findIndex((l) => /am force-stop com\.x/.test(l));
     expect(picker !== -1 && relaunch !== -1).toBeTruthy();
     expect(picker < relaunch).toBeTruthy();
     expect(!lines.some((l) => /Open in <app>/.test(l))).toBeTruthy();

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -78,6 +78,7 @@ interface VerifyAndroidRunArgs {
   isExpo: boolean;
   physical: boolean;
   scheme?: string | null;
+  component?: string | null;
   phase: (label: unknown, text: string) => void;
 }
 
@@ -98,6 +99,7 @@ async function verifyAndroidRun({
   isExpo,
   physical,
   scheme,
+  component = null,
   phase,
 }: VerifyAndroidRunArgs): Promise<{ state: boolean | string; warning?: string }> {
   const readNativeCrashes = () =>
@@ -270,6 +272,7 @@ async function verifyAndroidRun({
     waitedMs: verification?.waitedMs,
     bundleId: androidPackage,
     serial,
+    component,
     devClientUrl: scheme ? androidDevClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT, physical) : null,
     mode: isExpo ? MODE_EXPO : MODE_BARE,
   }))
@@ -645,6 +648,7 @@ export async function finishAndroidRun({
     isExpo,
     physical,
     scheme,
+    component: launched.component ?? null,
     phase,
   });
   if (launchState === LAUNCH_FATAL) {

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -1150,6 +1150,7 @@ export function unverifiedLaunchLines({
   lanOrigin = null,
   metroOrigin = null,
   localNetworkPending = false,
+  component = null,
 }: {
   platform: string;
   metroPort: number | string;
@@ -1165,6 +1166,7 @@ export function unverifiedLaunchLines({
   lanOrigin?: string | null;
   metroOrigin?: string | null;
   localNetworkPending?: boolean;
+  component?: string | null;
   // Explicit return type: isolatedDeclarations requires one at every module
   // boundary.
 }): string[] {
@@ -1307,9 +1309,12 @@ export function unverifiedLaunchLines({
     }
     push(picker);
     if (serial && bundleId) {
-      push(
-        `If the app is stuck, restart its process: adb -s ${serial} shell am force-stop ${bundleId} && adb -s ${serial} shell monkey -p ${bundleId} 1`,
-      );
+      const restart = component
+        ? `adb -s ${serial} shell am force-stop ${bundleId} && adb -s ${serial} shell am start -n ${component}`
+        : url
+          ? `adb -s ${serial} shell am force-stop ${bundleId} && adb -s ${serial} shell am start -a android.intent.action.VIEW -d '${url}' --ez ${ANDROID_DISABLE_AUTO_LAUNCH_EXTRA} true`
+          : `adb -s ${serial} shell am force-stop ${bundleId} && adb -s ${serial} shell monkey -p ${bundleId} 1`;
+      push(`If the app is stuck, restart its process: ${restart}`);
     }
   }
   lines.push(`Then check \`stim logs --source metro\`${mode ? ` (${mode})` : ''} for a bundle request.`);


### PR DESCRIPTION
## Description

When `stim android` cannot verify a launch, the recovery text tells the agent to restart the app with `adb shell am force-stop <pkg> && adb shell monkey -p <pkg> 1`. On emulator images with no physical keys, `monkey` exits 251 with `SYS_KEYS has no physical keys but with factor 2.0%`, so the printed remedy stalls before the app restarts.

## Solution

The remedy now prints `am start -n <component>` with the launcher activity Stim already resolved for its own launch through `cmd package resolve-activity`. The launch result carries that component into the unverified-launch lines.

Printed deep-link commands preserve quoting through both the host shell and adb's device shell, so URL query parameters and the trailing intent extras survive copy/paste.

An implicit `am start -a MAIN -c LAUNCHER -p <pkg>` is not a substitute: activity starts add `MATCH_DEFAULT_ONLY`, and the React Native template's `MainActivity` filter has no `CATEGORY_DEFAULT`, so it fails with "unable to resolve Intent" on a real app. A dev-client launch that went through a deep link never resolved a component, so its remedy is the force-stop followed by the same deep-link command, kept as one line an agent can paste. Only when neither exists does the `monkey` fallback remain, which matches the launch path's own fallback in `launchAndroidApp`.

## Test plan

- On a booted Pixel_9 AVD (API 36) with the trailhead Expo dev client installed, `adb shell am start -n com.appandflow.trailhead/.MainActivity` prints `Starting: Intent { cmp=com.appandflow.trailhead/.MainActivity }` and exits 0. The implicit `am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -p com.appandflow.trailhead` fails with `Error: Activity not started, unable to resolve Intent` and exit 1 on the same app. This AVD declares physical keys, so the exit 251 from the issue did not reproduce here; the new command never consults that configuration.
- Follow-up on Stim-owned `emulator-5556`, Android 36 arm64, Expo 58 canary / RN 0.87: executed the exact rendered resend, deep-link restart and explicit-component restart commands through `/bin/sh` and real adb. Android activity state retained the complete URL including `&disableFab=1`, and `am start` retained the extras. Both force-stop paths created new app PIDs (6578 → 6801 → 6848); the app rendered Trails and `stim logs --errors --json` was empty. The shell regression additionally covers an apostrophe in the URL.

Fixes #603
