### PR TITLE
test: isolate iOS command EAS ownership ledger

### DIFF
--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -45,6 +45,7 @@ import {
 } from '../commands/ios.ts';
 import { asProcessExit, makeChildProcess, makeError, makeExecutor, makeMetroResolution } from './_factories.ts';
 import { ensureBooted } from '../engine/device.ts';
+import { ensureRemoteBootOwned } from '../engine/device-remote.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { RELEASE_VERIFY_WAIT_MS } from '../engine/app-install.ts';
 import { DEVICECTL_INSTALL_TIMEOUT_MS, LAUNCH_PROBE_TIMEOUT_MS } from '../engine/ios-device.ts';
@@ -192,6 +193,7 @@ function harness(overrides: LooseDeps = {}) {
   const appPath = join(root, 'build', 'Fixture.app');
 
   const deps: LooseDeps = {
+    ensureRemoteBootOwned: (args) => ensureRemoteBootOwned({ ...args, ledgerRoot: join(tmpHome, 'machine-eas') }),
     findProjectRoot: () => root,
     gitCommonDir: () => null,
     repoRoot: () => null,


### PR DESCRIPTION
## Description

Mocked iOS EAS tests lock the real user's machine ledger despite setting a temporary `STIM_HOME`. They fail in a sandbox and can persist fake session claims outside it.

## Solution

Pass the existing `ledgerRoot` option from the command test harness. Ownership recording and locking still execute, but under the test's disposable directory. Production behavior is unchanged.

## Test plan

Run `pnpm exec vitest run packages/stim-cli/src/__tests__/ios-command.test.ts -t 'remote|EAS|preview'` with the real home unwritable. All 39 selected tests pass, including EAS device, session-reuse and preview cases, without creating a real-home lock or claim.

Fixes #611.
