### PR TITLE
fix: compact Metro error bodies in Android crash previews

### DIFF
--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -215,6 +215,117 @@ test('Android crash buffer retains the exception from a dead app but not another
   expect(recordMatches(records[0], buildCriteria({ errorsOnly: true, sources: ['metro'] }))).toBe(false);
 });
 
+test('a DebugServerException previews the Metro error it carries instead of the JSON body', () => {
+  const root = '/app/root';
+  const frame =
+    "\\u001b[0m\\u001b[31m\\u001b[1m>\\u001b[22m\\u001b[39m\\u001b[90m 1 |\\u001b[39m \\u001b[36mimport\\u001b[39m \\u001b[32m'./stim-582-missing'\\u001b[39m\\u001b[33m;\\u001b[39m\\n \\u001b[90m   |\\u001b[39m         \\u001b[31m\\u001b[1m^\\u001b[22m\\u001b[39m\\u001b[0m";
+  const body =
+    '{"type":"UnableToResolveError","originModulePath":"/app/root/app/_layout.tsx","targetModuleName":"./stim-582-missing",' +
+    '"message":"Unable to resolve module ./stim-582-missing from /app/root/app/_layout.tsx: \\n\\nNone of these files exist:\\n  * app/stim-582-missing(.android.ts|.native.ts|.ts|.tsx)\\n  * app/stim-582-missing\\n' +
+    frame +
+    '","cause":{"candidates":{"file":{"type":"sourceFile","filePathPrefix":"app/stim-582-missing","candidateExts":["",".android.ts",".ts"]}},' +
+    '"_expoImportStack":"Import stack:\\n\\n app/_layout.tsx\\n | import \\"./stim-582-missing\\"\\n\\n app (require.context)\\n","name":"Error",' +
+    '"message":"The module could not be resolved because none of these files exist:\\n\\n  * /app/root/app/stim-582-missing",' +
+    '"stack":"Error: The module could not be resolved\\n    at resolve (/app/root/node_modules/metro-resolver/src/resolve.js:53:13)\\n    at resolveRequest (/app/root/node_modules/@expo/cli/build/src/start/server/metro/withMetroResolvers.js:75:32)"},' +
+    '"name":"Error","stack":"Error: Unable to resolve module ./stim-582-missing\\n    at ModuleResolver.resolveDependency (/app/root/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:143:15)",' +
+    '"errors":[{"description":"Unable to resolve module ./stim-582-missing from /app/root/app/_layout.tsx"}]}';
+  const split = body.indexOf('withMetroResolvers.js') + 8;
+  const text = [
+    '1000.000 E/AndroidRuntime( 44): FATAL EXCEPTION: main',
+    '1000.001 E/AndroidRuntime( 44): Process: app.test, PID: 44',
+    '1000.002 E/AndroidRuntime( 44): com.facebook.react.common.DebugServerException: The development server returned response error code: 500',
+    '1000.002 E/AndroidRuntime( 44): URL: http://10.0.2.2:8082/index.bundle?platform=android&dev=true',
+    '1000.002 E/AndroidRuntime( 44): Body:',
+    `1000.002 E/AndroidRuntime( 44): ${body.slice(0, split)}`,
+    `1000.002 E/AndroidRuntime( 44): ${body.slice(split)}`,
+    '1000.003 E/AndroidRuntime( 44): \tat com.facebook.react.devsupport.BundleDownloader.processBundleResult(BundleDownloader.kt:305)',
+    '1000.003 E/AndroidRuntime( 44): \tat okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)',
+  ].join('\n');
+  const target = { platform: 'android' as const, deviceId: 'emulator-5554', appId: 'app.test', since: 1000000 };
+  const [record] = parseAndroidCrashes(text, target, 0);
+  expect(record).toBeDefined();
+  const preview = launchErrorPreview([record!], root).join('\n');
+  expect(preview.match(/DebugServerException: The development server returned response error code: 500/g)).toHaveLength(
+    1,
+  );
+  expect(preview).toContain('UnableToResolveError: Unable to resolve module ./stim-582-missing from app/_layout.tsx:');
+  expect(preview).toContain("> 1 | import './stim-582-missing';");
+  expect(preview).toContain('Import stack:\n app/_layout.tsx\n | import "./stim-582-missing"');
+  expect(preview).toContain('[Metro error body compacted; full text in stim logs]');
+  expect(preview).toContain(
+    'at com.facebook.react.devsupport.BundleDownloader.processBundleResult(BundleDownloader.kt:305)',
+  );
+  expect(preview).not.toContain('\u001b');
+  expect(preview).not.toContain('originModulePath');
+  expect(preview).not.toContain('candidateExts');
+  expect(preview).not.toContain('metro-resolver');
+  expect(preview).not.toContain('Error stack:\n  at resolve');
+  const full = launchErrorPreview([record!], root, { full: true }).join('\n');
+  expect(full).toContain('"originModulePath":"/app/root/app/_layout.tsx"');
+  expect(full).not.toContain('Metro error body compacted');
+  const metroFirst = launchErrorPreview(
+    [
+      {
+        src: 'metro',
+        event: 'bundling_error',
+        msg: 'Unable to resolve module ./stim-582-missing from /app/root/app/_layout.tsx: \n\nNone of these files exist:\n  * app/stim-582-missing',
+      },
+      record!,
+    ],
+    root,
+  ).join('\n');
+  expect(metroFirst).toContain(
+    'UnableToResolveError: Unable to resolve module ./stim-582-missing from app/_layout.tsx: (diagnosis above)',
+  );
+  expect(metroFirst.match(/None of these files exist/g)).toHaveLength(1);
+  expect(metroFirst).not.toContain("> 1 | import './stim-582-missing';");
+  const mentioned = launchErrorPreview(
+    [
+      { src: 'client', msg: 'assertion: expected "Unable to resolve module ./stim-582-missing from app/_layout.tsx:"' },
+      record!,
+    ],
+    root,
+  ).join('\n');
+  expect(mentioned).toContain("> 1 | import './stim-582-missing';");
+  expect(mentioned).not.toContain('(diagnosis above)');
+
+  const rebuild = (variant: string, at: number) =>
+    parseAndroidCrashes(
+      text.replace(body.slice(0, split), variant.slice(0, at)).replace(body.slice(split), variant.slice(at)),
+      target,
+      0,
+    )[0]!;
+  const splitPreview = launchErrorPreview([rebuild(body, body.indexOf('\\n    at ModuleResolver') + 2)], root).join(
+    '\n',
+  );
+  expect(splitPreview).toContain(
+    'UnableToResolveError: Unable to resolve module ./stim-582-missing from app/_layout.tsx:',
+  );
+  expect(splitPreview).not.toContain('ModuleResolution.js');
+  expect(splitPreview).toContain(
+    'at com.facebook.react.devsupport.BundleDownloader.processBundleResult(BundleDownloader.kt:305)',
+  );
+
+  const stackKey = body.replace('None of these files exist:', 'const options = { stack: \\"first\\\\nsecond\\" };');
+  const stackKeyPreview = launchErrorPreview([rebuild(stackKey, split)], root).join('\n');
+  expect(stackKeyPreview).toContain('const options = { stack: "first\\nsecond" };');
+  expect(stackKeyPreview).not.toContain('Error stack:\nfirst');
+
+  const appJson = launchErrorPreview(
+    [
+      {
+        src: 'device',
+        platform: 'android',
+        proc: 'ReactNativeJS(44)',
+        msg: 'API failed: {"type":"HttpError","message":"Unauthorized","status":401}',
+      },
+    ],
+    root,
+  ).join('\n');
+  expect(appJson).toContain('API failed: {"type":"HttpError","message":"Unauthorized","status":401}');
+  expect(appJson).not.toContain('compacted');
+});
+
 test('a native crash before any Metro request ends verification without calling the app healthy or merely unverified', async () => {
   let time = 1000;
   const crash = {

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -162,7 +162,10 @@ WHAT WRITES WHAT
                        order, with an omitted-frame count. Escaped
                        component stacks print one frame per line. Long bundle
                        URLs are shortened and labeled unsymbolicated; shortening
-                       is not source-map resolution. All logs commands show full
+                       is not source-map resolution. A Metro error body that an
+                       Android DebugServerException embeds prints as the
+                       error's message and import stack, not its JSON. All
+                       logs commands show full
                        captured stacks, including \`stim logs --errors\`.
                        Use \`stim logs --source all\` for all sources/history,
                        or add \`--json\` for raw

--- a/packages/stim-cli/src/launch-error-preview.ts
+++ b/packages/stim-cli/src/launch-error-preview.ts
@@ -1,3 +1,5 @@
+import { stripAnsi } from './process-output.ts';
+
 type RecordLike = { msg?: unknown; stack?: unknown; componentStack?: unknown; [key: string]: unknown };
 type StackKind = 'Error' | 'Component' | 'Native' | 'Caused-by';
 
@@ -40,6 +42,72 @@ function expandStackFields(message: string): string {
       return `${prefix}\n${field === 'componentStack' ? 'Component' : 'Error'} stack:\n${decodeStack(value)}`;
     },
   );
+}
+
+function jsonStringField(blob: string, field: string): string | null {
+  const match = new RegExp(`"${field}":"((?:[^"\\\\]|\\\\.)*)"`).exec(blob);
+  if (!match) return null;
+  try {
+    return JSON.parse(`"${match[1]}"`) as string;
+  } catch {
+    return null;
+  }
+}
+
+function jsonObjectComplete(blob: string): boolean {
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < blob.length; i++) {
+    const char = blob[i];
+    if (inString) {
+      if (char === '\\') i++;
+      else if (char === '"') inString = false;
+    } else if (char === '"') inString = true;
+    else if (char === '{') depth++;
+    else if (char === '}' && --depth === 0) return true;
+  }
+  return false;
+}
+
+/**
+ * React Native's DebugServerException embeds Metro's serialized bundling error
+ * after a `Body:` line, and logcat splits that JSON across lines past 4 KiB.
+ */
+function compactMetroErrorBody(
+  text: string,
+  root: string | undefined,
+  printed: readonly string[],
+): { head: string; lines: string[]; tail: string } | null {
+  if (!text.includes('DebugServerException')) return null;
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.includes('{"type":"'));
+  if (start < 0) return null;
+  const prefix = lines[start]!.slice(0, lines[start]!.indexOf('{"type":"'));
+  let blob = lines[start]!.slice(prefix.length);
+  let end = start + 1;
+  while (
+    end < lines.length &&
+    !jsonObjectComplete(blob) &&
+    lines[end]!.trim() &&
+    !/^(?:\tat\s|\s*Caused by:)/.test(lines[end]!)
+  )
+    blob += lines[end++]!;
+  const type = /^\{"type":"([^"]*)"/.exec(blob)?.[1];
+  const message = jsonStringField(blob, 'message');
+  if (!type || !message) return null;
+  const stripRoot = (value: string) => (root ? value.replaceAll(`${root}/`, '') : value);
+  const [firstLine = '', ...rest] = stripRoot(stripAnsi(message)).trim().split(/\r?\n/);
+  const first = firstLine.trim();
+  const importStack = jsonStringField(blob, '_expoImportStack')?.trim();
+  const replacement =
+    first && printed.some((line) => stripRoot(line).trim() === first)
+      ? [`${type}: ${first} (diagnosis above)`]
+      : [`${type}: ${first}`, ...rest, ...(importStack ? importStack.split('\n') : [])];
+  return {
+    head: [...lines.slice(0, start), ...(prefix.trim() ? [prefix] : [])].join('\n'),
+    lines: [...replacement, '[Metro error body compacted; full text in stim logs]'],
+    tail: lines.slice(end).join('\n'),
+  };
 }
 
 function shortFrame(frame: string, root?: string): string {
@@ -133,7 +201,12 @@ export function launchErrorPreview(
     if (source !== nextSource) flush();
     source = nextSource;
     if (record.msg != null) {
-      for (const line of expandStackFields(String(record.msg)).split(/\r?\n/)) consume(line);
+      const msg = String(record.msg);
+      const compacted = full ? null : compactMetroErrorBody(msg, root, lines);
+      const chunks = compacted
+        ? [expandStackFields(compacted.head), ...compacted.lines, expandStackFields(compacted.tail)]
+        : [expandStackFields(msg)];
+      for (const chunk of chunks) for (const line of chunk.split(/\r?\n/)) consume(line);
     }
     const stack = typeof record.stack === 'string' ? record.stack.split(/\r?\n/) : structuredFrames(record.stack);
     if (stack.length) {


### PR DESCRIPTION
## Description

When Metro answers a bundle request with HTTP 500, React Native throws `DebugServerException` with the response body embedded after a `Body:` line. The `stim android` launch preview rendered that body as escaped JSON with literal `[31m` sequences and several dependency-only "Error stack" blocks expanded from the embedded `stack` fields, burying the native exception and the module diagnosis.

## Solution

Before the preview expands a record's message, it finds Metro's `{"type":"...` envelope in a record that mentions `DebugServerException` and replaces it with the error's own message (ANSI stripped, project root removed) plus the Expo import stack, followed by a marker that the body was compacted. The replacement lines bypass the stack-field expander, so a code frame that happens to contain `stack: "..."` prints verbatim. App log lines that carry their own `type` and `message` JSON are left alone.

- Fields are pulled with a JSON-string regex rather than `JSON.parse`: logcat splits messages past 4 KiB across lines and truncates the ReactNative copy, which leaves the object unparseable while the message is still complete. Split lines are joined until the object's braces balance, so a split that lands on an `at ...` frame inside the JSON `stack` string is still part of the body, while a tab-indented Java frame ends it.
- The crash shows `<type>: <first line> (diagnosis above)` only when the complete message and import context were already printed. A matching title alone never suppresses a previously unseen code frame or import stack.

Full mode, which `stim logs` uses, is untouched and keeps the raw JSON. The guide's logs topic gains one sentence describing the compaction.

## Test plan

- Real follow-up on Stim-owned `emulator-5556`, Android 36 arm64, Expo 58 canary / RN 0.87: added a missing import in the disposable Trailhead fixture and ran the built PR CLI. Android reported a real `FATAL EXCEPTION` / `DebugServerException` and exited with `STIM_LAUNCH_FAILED`. The preview retained the relative source location, decoded code frame, import stack and recovery command without nested JSON or escaped ANSI. Both human `logs --errors` and JSON retained the full captured Metro envelope. Raw output is retained in the release QA task under `android-review-610-613/`.

- The fixture is condensed from a real body captured on a Pixel_9 AVD (API 36) running the trailhead Expo 57 dev client against a Metro serving a nonexistent import; the field layout, ANSI code frame, nested `cause` and `_expoImportStack` are the captured ones, with the extension list and stacks shortened. The test splits it across two logcat lines the way the captured DevLauncher copy was split. That launcher shows the error on its own screen rather than crashing, so the FATAL EXCEPTION wrapper follows the standard AndroidRuntime shape rather than a captured one.
- The new test in `crash-diagnostics.test.ts` runs the crash-buffer group through `parseAndroidCrashes` and `launchErrorPreview`, asserting the compacted diagnosis, a single exception line, no JSON keys, dependency stacks or ANSI, the raw JSON in full mode, the dedupe against a preceding Metro record but not against an unrelated mention, a split inside the JSON `stack` string, a code frame containing `stack: "..."`, and an app JSON log line left untouched.

Fixes #582


