### PR TITLE
feat: select an explicit iOS build scheme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ Do not infer and rebuild commands from project scripts. Bare React Native hosts
 Metro from the project's dependencies. Expo runs its fixed start command. iOS
 and Android use fixed `xcodebuild` and Gradle arguments.
 
-The supported build selectors are `ios --configuration <name>` and
+The supported build selectors are `ios --scheme <name>`, `ios --configuration <name>`, and
 `android --variant <name>`. `ios --device-type <name>`, `ios --runtime
 <version>`, and `android --system-image <id>` select the model and version of
 the owned simulator or emulator for one invocation, overriding

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -180,6 +180,7 @@ export interface BuildRunOptions {
   variant?: string;
   abi?: string;
   configuration?: string;
+  scheme?: string;
   buildConfiguration?: string;
   isSimulator?: boolean;
   device?: string | boolean | null;
@@ -216,7 +217,11 @@ export function buildCacheKey(platform: string, fingerprintHash: string, options
   const abi = platform === 'android' && typeof opts.abi === 'string' ? slug(opts.abi) : '';
   const compiler = typeof opts.compiler === 'string' ? slug(opts.compiler) : '';
   const profile = typeof opts.buildProfile === 'string' ? slug(opts.buildProfile) : '';
-  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}${abi ? `-${abi}` : ''}${compiler ? `-${compiler}` : ''}${profile ? `-${profile}` : ''}`;
+  const scheme =
+    platform === 'ios' && typeof opts.scheme === 'string' && opts.scheme
+      ? createHash('sha256').update(opts.scheme).digest('hex')
+      : '';
+  return `${fingerprintHash}-${buildVariant(platform, opts)}-${buildTarget(opts)}${abi ? `-${abi}` : ''}${compiler ? `-${compiler}` : ''}${profile ? `-${profile}` : ''}${scheme ? `-scheme-${scheme}` : ''}`;
 }
 
 export interface RegisterOptions {

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -62,6 +62,12 @@ Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.
 
+Use `stim ios --scheme "App Staging"` when a project has several shared Xcode
+app schemes. Combine it with `--configuration Release` if needed. Without the
+flag, Stim keeps its automatic scheme selection. Explicit schemes use separate
+artifact caches and Xcode build directories; run `stim guide lifecycle builds`
+for provider behavior. This selects an Xcode scheme, not a URL scheme.
+
 Launch evidence does not prove that the UI is interactive. Apps can optionally
 [declare readiness with two debug log messages](https://appandflow.github.io/stim/docs/dev-server-and-logs#optional-app-declared-readiness),
 without a package or SDK. A captured pending message extends the default

--- a/packages/stim-cli/src/__tests__/cache-packages.test.ts
+++ b/packages/stim-cli/src/__tests__/cache-packages.test.ts
@@ -17,6 +17,46 @@ async function waitForRegistration(dir: string, timeoutMs = 5000) {
   return null;
 }
 
+test('standalone Expo cache artifacts do not cross explicit iOS schemes or the automatic key', async () => {
+  const state = mkdtempSync(join(tmpdir(), 'stim-pkg-schemes-'));
+  process.env.STIM_HOME = state;
+  process.env.STIM_BUILD_CACHE = join(state, 'cache');
+  try {
+    const provider = await import('@stim-cli/expo-build-cache');
+    const schemes = ['App/Stage', 'App_Stage', 'App-Stage', 'app-stage'];
+    for (const [index, scheme] of schemes.entries()) {
+      const app = join(state, `${index}.app`);
+      mkdirSync(app);
+      writeFileSync(join(app, 'identity'), scheme);
+      await provider.uploadBuildCache({
+        platform: 'ios',
+        fingerprintHash: 'same-inputs',
+        buildPath: app,
+        runOptions: { scheme },
+      });
+    }
+    const paths = new Set<string>();
+    for (const scheme of schemes) {
+      const app = await provider.resolveBuildCache({
+        platform: 'ios',
+        fingerprintHash: 'same-inputs',
+        runOptions: { scheme },
+      });
+      assert(app);
+      paths.add(app);
+      expect(readFileSync(join(app, 'identity'), 'utf8')).toBe(scheme);
+    }
+    expect(paths.size).toBe(schemes.length);
+    expect(
+      await provider.resolveBuildCache({ platform: 'ios', fingerprintHash: 'same-inputs', runOptions: {} }),
+    ).toBeNull();
+  } finally {
+    delete process.env.STIM_BUILD_CACHE;
+    delete process.env.STIM_HOME;
+    rmSync(state, { recursive: true, force: true });
+  }
+});
+
 test('the Expo build cache provider registers itself on this Node, at the right depth', async () => {
   const home = mkdtempSync(join(tmpdir(), 'stim-pkg-home-'));
   const cacheRoot = mkdtempSync(join(tmpdir(), 'stim-pkg-bc-'));

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -37,6 +37,7 @@ import doctorCommand, { doctorSuccessLines, parseDoctorPlatform, shadowedStimFin
 import type { Finding } from '../doctor.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import type { EasAuthResult } from '../engine/remote-cache.ts';
+import { workspaceDerivedData } from '../paths.ts';
 import assert from 'node:assert';
 import {
   analyzeStimVersions,
@@ -101,6 +102,22 @@ test('checkMainCheckout filters native warm state and CocoaPods by platform', ()
   } finally {
     rmSync(project, { recursive: true, force: true });
   }
+});
+
+test('doctor recognizes explicit-scheme build products but not an empty scheme directory', () => {
+  const project = join(testHome, 'project');
+  mkdirSync(join(project, 'ios'), { recursive: true });
+  mkdirSync(join(project, 'node_modules'));
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'app' }));
+  const schemeDir = join(
+    workspaceDerivedData(project),
+    `scheme-${createHash('sha256').update('App Staging').digest('hex')}`,
+  );
+  mkdirSync(schemeDir, { recursive: true });
+  const findings = () => checkMainCheckout(project, { platform: 'ios', brokenPods: [], upstream: null });
+  expect(findings().some((finding) => finding.title.includes('iOS warm build output'))).toBe(true);
+  mkdirSync(join(schemeDir, 'Build', 'Products'), { recursive: true });
+  expect(findings()).toEqual([]);
 });
 
 test('parseDoctorPlatform accepts the two native platforms and rejects other values', () => {

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { makeExecutor } from './_factories.ts';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
@@ -345,7 +346,7 @@ describe('listSchemes and resolveScheme', () => {
     expect(error.remedy).toMatch(/-list/);
   });
 
-  test('resolveScheme names ambiguous schemes and gives a naming remedy instead of claiming they are not shared', () => {
+  test('resolveScheme names ambiguous schemes and offers an explicit selector', () => {
     setExecutor({
       run: () => '',
       runQuiet: () => null,
@@ -356,7 +357,18 @@ describe('listSchemes and resolveScheme', () => {
     assert(error);
     expect(error.code).toBe('STIM_NO_SCHEME');
     expect(error.message).toMatch(/schemes: one, two/);
-    expect(error.remedy).toMatch(/workspace\/project name/);
+    expect(error.remedy).toContain('--scheme');
+  });
+
+  test('an explicit scheme wins over the automatic app and unknown names list choices', () => {
+    setExecutor(makeExecutor({ runFile: () => '{"project":{"name":"App","schemes":["App","App Staging"]}}' }));
+    expect(resolveScheme(project, { scheme: 'App Staging' })).toEqual({
+      scheme: 'App Staging',
+      schemes: ['App', 'App Staging'],
+    });
+    const { error } = resolveScheme(project, { scheme: 'app staging' });
+    expect(error?.code).toBe('STIM_NO_SCHEME');
+    expect(error?.message).toContain('App, App Staging');
   });
 
   test.each([
@@ -949,6 +961,49 @@ describe('buildIos with a mocked executor', () => {
     mkdirSync(join(dir, `${name}.app`), { recursive: true });
     return join(dir, `${name}.app`);
   }
+
+  test.each(['ambiguous', 'unavailable'])(
+    'explicit schemes do not guess a product when metadata is %s',
+    async (mode) => {
+      const child = fakeChild();
+      harness(tmp, { child });
+      const dd = join(tmp, 'dd');
+      makeProduct(dd, 'App');
+      makeProduct(dd, 'Other');
+      setExecutor(
+        makeExecutor({
+          runFile: (file, args) => {
+            if (file === 'xcodebuild' && args?.includes('-list')) return '{"project":{"name":"App","schemes":["App"]}}';
+            if (mode === 'unavailable') throw new Error('build settings unavailable');
+            return JSON.stringify(
+              ['App', 'Other'].map((name) => ({
+                buildSettings: {
+                  PRODUCT_TYPE: 'com.apple.product-type.application',
+                  PLATFORM_NAME: 'iphonesimulator',
+                  TARGET_BUILD_DIR: productsDir(dd),
+                  FULL_PRODUCT_NAME: `${name}.app`,
+                },
+              })),
+            );
+          },
+          spawn: () => child as unknown as ChildProcess,
+        }),
+      );
+      const promise = buildIos({
+        root: tmp,
+        scheme: 'App',
+        udid: 'u',
+        logWriter: recordingWriter(),
+        derivedDataPath: dd,
+        compilationCache: [],
+      });
+      child.emit('close', 0, null);
+      const result = asResult(await promise);
+      expect(result.failed).toBe(true);
+      expect(result.code).toBe('STIM_BUILD_FAILED');
+      expect(result.appPath).toBeUndefined();
+    },
+  );
 
   test('an injected set of settings lands on the argv, after the action', async () => {
     const child = fakeChild();
@@ -1647,6 +1702,31 @@ const LIVE = xcodebuildAvailable() ? false : 'xcodebuild is not available on thi
 const LIVE_DESTINATION = 'generic/platform=iOS Simulator';
 
 describe('buildIos against a real xcodebuild', { skip: LIVE as unknown as boolean }, () => {
+  test('an explicitly named scheme builds its actual product even when its name differs', async () => {
+    resetExecutor();
+    writeScratchProject(tmp, { workspace: true });
+    const dir = join(tmp, 'ios', 'Scratch.xcodeproj', 'xcshareddata', 'xcschemes');
+    writeFileSync(join(dir, 'Staging App.xcscheme'), SCRATCH_SCHEME);
+    const writer = createNdjsonWriter(join(workspaceLogsDir(tmp), 'explicit-scheme.ndjson'));
+    try {
+      const result = asResult(
+        await buildIos({
+          root: tmp,
+          scheme: 'Staging App',
+          destination: LIVE_DESTINATION,
+          logWriter: writer,
+          compilationCache: [],
+        }),
+      );
+      expect(result.failed).toBeUndefined();
+      expect(result.scheme).toBe('Staging App');
+      expect(result.appPath).toMatch(/scheme-[a-f0-9]{64}\/Build\/Products\/Debug-iphonesimulator\/Scratch\.app$/);
+      expect(existsSync(result.appPath)).toBe(true);
+      expect(result.bundleId).toBe('com.stimcli.scratch');
+    } finally {
+      writer.close();
+    }
+  }, 120_000);
   test('resolves a real workspace scheme and uses the app name after the workspace is renamed', () => {
     resetExecutor();
     writeScratchProject(tmp, { workspace: true });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -167,7 +167,7 @@ interface RecordedArgs {
   [key: string]: unknown;
   installIosApp: { appPath?: unknown; proveInstalled?: unknown };
   launchIosApp: { devClientScheme?: unknown; metroPort?: unknown; bundleId?: unknown };
-  buildIos: { configuration?: unknown; root?: unknown; optimizations?: unknown };
+  buildIos: { configuration?: unknown; scheme?: unknown; root?: unknown; optimizations?: unknown };
   swapJsBundle: { cachedAppPath?: unknown; isExpo?: unknown; root?: unknown };
   verifyReleaseLaunch: { pid?: unknown };
   readBundleId: unknown;
@@ -3102,6 +3102,79 @@ test('a miss with no prior entry (or a first build) prints the plain miss line, 
   expect(buildRecords().some((r) => r.event === 'fingerprint_diff')).toBe(false);
 });
 
+describe('explicit Xcode schemes', () => {
+  const schemeDeps: LooseDeps = {
+    discoverXcodeProject: () => ({ kind: 'workspace', flag: '-workspace', path: '/app/ios/App.xcworkspace' }),
+    resolveScheme: (_project, options) => ({ scheme: options?.scheme, schemes: ['App', 'App Staging'] }),
+  };
+
+  test('explicit selection separates lookup, lock and storage keys and is not a dev-client URL scheme', async () => {
+    reserve();
+    const normal = await run({ json: true });
+    const selected = await run({ scheme: 'App Staging', json: true }, schemeDeps);
+    expect(selected.exitCode).toBeNull();
+    const key = selected.calls.args.resolveBuild.key;
+    expect(key).not.toBe(normal.calls.args.resolveBuild.key);
+    expect(selected.calls.args.acquireBuildLock.key).toBe(key);
+    expect(selected.calls.args.storeBuild.key).toBe(key);
+    expect(selected.calls.args.buildIos.scheme).toBe('App Staging');
+    expect(selected.calls.args.launchIosApp.devClientScheme).toBeUndefined();
+    expect(parseFirst(selected.logs).scheme).toBe('App Staging');
+    expect(selected.calls.order).not.toContain('loadProjectProvider');
+  });
+
+  test('an unknown explicit scheme refuses before any device, cache lookup, or native build', async () => {
+    reserve();
+    const result = await run(
+      { scheme: 'unknown', json: true },
+      {
+        ...schemeDeps,
+        resolveScheme: () => ({
+          error: {
+            code: 'STIM_NO_SCHEME',
+            message: 'Available: App, App Staging',
+            remedy: 'Choose --scheme from the available names.',
+          },
+        }),
+      },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(parseFirst(result.logs).code).toBe('STIM_NO_SCHEME');
+    expect(result.calls.order).not.toContain('ensureOwnedDevice');
+    expect(result.calls.order).not.toContain('resolveBuild');
+    expect(result.calls.order).not.toContain('buildIos');
+  });
+
+  test('blank schemes refuse instead of silently selecting the default app', async () => {
+    const result = await run({ scheme: '  ', json: true });
+    expect(result.exitCode).toBe(1);
+    expect(parseFirst(result.logs).code).toBe('STIM_BAD_ARG');
+    expect(result.calls.order).not.toContain('buildIos');
+  });
+
+  test('a matching explicit-scheme cache hit still validates selection and skips compilation', async () => {
+    reserve();
+    let validated = false;
+    const result = await run(
+      { scheme: 'App Staging', json: true },
+      {
+        ...schemeDeps,
+        resolveScheme: () => {
+          validated = true;
+          return { scheme: 'App Staging' };
+        },
+        resolveBuild: () => {
+          expect(validated).toBe(true);
+          return join(root, 'build', 'Fixture.app');
+        },
+      },
+    );
+    expect(result.exitCode).toBeNull();
+    expect(parseFirst(result.logs)).toMatchObject({ scheme: 'App Staging', cacheHit: 'local' });
+    expect(result.calls.order).not.toContain('buildIos');
+  });
+});
+
 describe('configuration resolution', () => {
   test('flag > setting > default', () => {
     expect(resolveConfiguration('Release', { ios: { configuration: 'Staging' } })).toBe('Release');
@@ -3367,30 +3440,40 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
     expect(stderr).toContain(`unavailable after ${mutation}; the build will be installed but not cached`);
   });
 
-  test('the store key is the key the NEXT run looks up across a prebuild boundary', async () => {
-    reserve();
-    const lookedUp: string[] = [];
-    const cold = await run(
-      {},
-      {
-        detectIsExpo: () => true,
-        needsPrebuild: () => true,
-        readPodState: () => ({ hasPodfile: true, lockText: 'A', manifestText: 'B' }),
-        fingerprintProject: shifting(),
-        resolveBuild: (_platform, key) => {
-          lookedUp.push(key);
-          return null;
+  test.each([undefined, 'App Staging'])(
+    'post-prebuild storage matches the next lookup with scheme %s',
+    async (scheme) => {
+      reserve();
+      const lookedUp: string[] = [];
+      const cold = await run(
+        { scheme },
+        {
+          detectIsExpo: () => true,
+          needsPrebuild: () => true,
+          readPodState: () => ({ hasPodfile: true, lockText: 'A', manifestText: 'B' }),
+          fingerprintProject: shifting(),
+          resolveBuild: (_platform, key) => {
+            lookedUp.push(key);
+            return null;
+          },
         },
-      },
-    );
-    expect(cold.exitCode).toBe(null);
-    const storedKey = cold.calls.args.storeBuild.key;
-    expect(lookedUp[0]).toMatch(new RegExp(`^${COLD}`));
-    expect(String(storedKey)).toMatch(new RegExp(`^${WARM}`));
+      );
+      expect(cold.exitCode).toBe(null);
+      const storedKey = cold.calls.args.storeBuild.key;
+      expect(lookedUp[0]).toMatch(new RegExp(`^${COLD}`));
+      expect(String(storedKey)).toMatch(new RegExp(`^${WARM}`));
 
-    const warm = await run({}, { fingerprintProject: async () => ({ hash: WARM, sources: [] }) });
-    expect(warm.calls.args.resolveBuild.key).toBe(storedKey);
-  });
+      const warm = await run(
+        { scheme },
+        {
+          fingerprintProject: async () => ({ hash: WARM, sources: [] }),
+          discoverXcodeProject: () => ({ kind: 'workspace', flag: '-workspace', path: '/app/ios/App.xcworkspace' }),
+          resolveScheme: () => ({ scheme: scheme ?? 'App' }),
+        },
+      );
+      expect(warm.calls.args.resolveBuild.key).toBe(storedKey);
+    },
+  );
 
   test('the shift is one dim line naming both short hashes, and the payload reports what was stored', async () => {
     reserve();

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -153,6 +153,10 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
         'simulator, wired to the reserved Metro port. Requires a running dev server (`stim start`).',
     )
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
+    .option(
+      '--scheme <name>',
+      'Shared Xcode app scheme to build; overrides automatic scheme selection, not the app URL scheme',
+    )
     .option('--no-metro-check', 'Skip the "is this workspace\'s dev server running?" gate and build anyway')
     .option(
       '--no-build-cache',
@@ -199,6 +203,21 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     .action(async (opts: IosCommandOptions) => {
       await runIos({ ...opts, waitConflict: waitFlagConflict(process.argv) }, deps);
     });
+}
+
+function explicitSchemeRefusal(root: string, scheme: string | undefined, isExpo: boolean, d: IosDeps): FailArgs | null {
+  if (scheme === undefined) return null;
+  if (!scheme.trim()) {
+    return {
+      code: 'STIM_BAD_ARG',
+      message: '--scheme must name a non-empty shared Xcode app scheme.',
+      remedy: 'Pass the exact scheme name shown by xcodebuild -list.',
+    };
+  }
+  if (d.needsPrebuild(root, PLATFORM, isExpo)) return null;
+  const project = d.discoverXcodeProject(root);
+  if (project.error) return project.error;
+  return d.resolveScheme(project, { scheme }).error ?? null;
 }
 
 async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> = {}): Promise<IosFacts | null> {
@@ -392,6 +411,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   }
 
   const configuration = resolveConfiguration(opts.configuration, settings);
+  const buildScheme = opts.scheme;
   const release = isReleaseConfiguration(configuration);
   const cachePolicy = artifactCachePolicy(optimizations, useBuildCache, release);
   useBuildCache = cachePolicy.read;
@@ -445,6 +465,8 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   const waitSeconds = waitParsed.seconds;
 
   const isExpo = d.detectIsExpo(root);
+  const schemeRefusal = explicitSchemeRefusal(root, buildScheme, isExpo, d);
+  if (schemeRefusal) return fail(schemeRefusal);
   const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
   const modelRefusal = deviceModelRefusal({
     deviceTypeFlag: opts.deviceType,
@@ -757,6 +779,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
     }
     fingerprint = computedFingerprint;
     cacheKey = buildCacheKey(PLATFORM, fingerprint, {
+      scheme: buildScheme,
       ...(configuration ? { configuration } : {}),
       isSimulator: !physical,
       ...(buildProfile ? { buildProfile } : {}),
@@ -810,7 +833,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   }
 
   async function resolveRemoteArtifact(): Promise<void> {
-    if (physical || !cachePolicy.remote || buildProfile) return;
+    if (physical || !cachePolicy.remote || buildProfile || buildScheme) return;
     if (!appPath) {
       const loaded: LoadProjectProviderResult = await d.loadProjectProvider(root, { isExpo });
       if (loaded?.unavailable) {
@@ -1157,6 +1180,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
             storeHash = after.hash;
             storeSources = after.sources;
             storeKey = buildCacheKey(PLATFORM, after.hash, {
+              scheme: buildScheme,
               ...(configuration ? { configuration } : {}),
               isSimulator: !physical,
               ...(buildProfile ? { buildProfile } : {}),
@@ -1193,6 +1217,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
           phase('build', `compiling ${configuration || 'Debug'} with xcodebuild`);
           const result: BuildIosResultLike = await d.buildIos({
             root,
+            scheme: buildScheme,
             udid,
             destination: remoteDevice ? GENERIC_SIM_DESTINATION : null,
             ...(physical ? { sdk: IPHONEOS_SDK } : {}),
@@ -1319,6 +1344,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         json,
         release,
         configuration,
+        buildScheme,
         isExpo,
         metroCheck,
         metroPort,

--- a/packages/stim-cli/src/commands/ios/dependencies.ts
+++ b/packages/stim-cli/src/commands/ios/dependencies.ts
@@ -42,7 +42,13 @@ import {
 } from '../../engine/remote-cache.ts';
 import { readRunEstimates, recordRunStats } from '../../engine/stats.ts';
 import { swapJsBundle } from '../../engine/js-swap.ts';
-import { buildIos, readBundleExecutable, readBundleId } from '../../engine/xcode.ts';
+import {
+  buildIos,
+  discoverXcodeProject,
+  resolveScheme,
+  readBundleExecutable,
+  readBundleId,
+} from '../../engine/xcode.ts';
 import { isPidAlive, resolveProjectMetro } from '../../metro.ts';
 import { createNdjsonWriter } from '../../ndjson.ts';
 import { detectBundleId, detectIsExpo, findProjectRoot, projectShortcut } from '../../project.ts';
@@ -100,6 +106,8 @@ export interface IosDeps {
   podsAreStale: typeof podsAreStale;
   runPodInstall: typeof runPodInstall;
   buildIos: typeof buildIos;
+  discoverXcodeProject: typeof discoverXcodeProject;
+  resolveScheme: typeof resolveScheme;
   listIosDevices: typeof listIosDevices;
   hostLanCandidates: typeof hostLanCandidates;
   ensureLanReachable: typeof ensureLanReachable;
@@ -180,6 +188,8 @@ export const DEFAULT_DEPS: IosDeps = {
   podsAreStale,
   runPodInstall,
   buildIos,
+  discoverXcodeProject,
+  resolveScheme,
   listIosDevices,
   hostLanCandidates,
   ensureLanReachable,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -332,6 +332,7 @@ interface FinishIosRunArgs {
   json: boolean;
   release: boolean;
   configuration: string | null;
+  buildScheme?: string;
   isExpo: boolean;
   metroCheck: boolean;
   metroPort: number | null;
@@ -473,6 +474,7 @@ export async function finishIosRun({
   json,
   release,
   configuration,
+  buildScheme,
   isExpo,
   metroCheck,
   metroPort,
@@ -810,6 +812,7 @@ export async function finishIosRun({
     json,
     release,
     configuration,
+    buildScheme,
     metroCheck,
     metroPort,
     logsDir,

--- a/packages/stim-cli/src/commands/ios/result.ts
+++ b/packages/stim-cli/src/commands/ios/result.ts
@@ -62,6 +62,7 @@ export function iosFacts({
   runtime = null,
   fingerprint,
   configuration = null,
+  scheme = null,
   cacheKey,
   cacheHit,
   cacheSkipped = false,
@@ -83,6 +84,7 @@ export function iosFacts({
   runtime?: string | null;
   fingerprint?: string | null;
   configuration?: string | null;
+  scheme?: string | null;
   cacheKey?: string | null;
   cacheHit?: boolean | string;
   cacheSkipped?: boolean;
@@ -106,6 +108,7 @@ export function iosFacts({
     runtime: runtime ?? null,
     fingerprint,
     configuration: configuration ?? null,
+    ...(scheme ? { scheme } : {}),
     cacheKey,
     cacheHit: cacheLevel(cacheHit),
     cacheSkipped: Boolean(cacheSkipped),
@@ -170,6 +173,7 @@ export interface ReportIosResultArgs {
   json: boolean;
   release: boolean;
   configuration: string | null;
+  buildScheme?: string | null;
   metroCheck: boolean;
   metroPort: number | null;
   logsDir: string;
@@ -202,6 +206,7 @@ export function reportIosResult({
   json,
   release,
   configuration,
+  buildScheme = null,
   metroCheck,
   metroPort,
   logsDir,
@@ -253,6 +258,7 @@ export function reportIosResult({
     runtime: device?.runtime,
     fingerprint: storeHash,
     configuration,
+    scheme: buildScheme,
     cacheKey: storeKey,
     cacheHit,
     compilationCache,

--- a/packages/stim-cli/src/commands/ios/types.ts
+++ b/packages/stim-cli/src/commands/ios/types.ts
@@ -70,6 +70,7 @@ export interface IosCommandOptions {
   metroCheck?: boolean;
   buildCache?: boolean;
   configuration?: string;
+  scheme?: string;
   deviceType?: string;
   runtime?: string;
   device?: string | boolean;

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,5 +1,5 @@
 import { resolveOptimizations, type Optimizations } from './optimizations.ts';
-import { existsSync, readFileSync, realpathSync, rmSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, realpathSync, rmSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
@@ -158,6 +158,19 @@ function brokenPodLinks(podsRoot: string): string[] {
   }
 }
 
+function hasIosWarmOutput(root: string): boolean {
+  if (existsSync(join(root, 'ios', 'build'))) return true;
+  const derivedData = workspaceDerivedData(root);
+  if (existsSync(join(derivedData, 'Build', 'Products'))) return true;
+  try {
+    return readdirSync(derivedData).some(
+      (entry) => /^scheme-[a-f0-9]{64}$/.test(entry) && existsSync(join(derivedData, entry, 'Build', 'Products')),
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function checkMainCheckout(
   projectRoot: string,
   {
@@ -245,12 +258,7 @@ export function checkMainCheckout(
   }
 
   const coldPlatforms = [
-    platform !== 'android' &&
-    existsSync(join(mainRoot, 'ios')) &&
-    !existsSync(join(mainRoot, 'ios', 'build')) &&
-    !existsSync(join(workspaceDerivedData(mainRoot), 'Build', 'Products'))
-      ? 'iOS'
-      : null,
+    platform !== 'android' && existsSync(join(mainRoot, 'ios')) && !hasIosWarmOutput(mainRoot) ? 'iOS' : null,
     platform !== 'ios' &&
     existsSync(join(mainRoot, 'android')) &&
     !existsSync(join(mainRoot, 'android', 'build')) &&

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import chalk from 'chalk';
 import { register } from '../cache-manifest.ts';
@@ -131,7 +132,10 @@ export function listSchemes(
   }
 }
 
-export function resolveScheme(project: XcodeProject, { exec = null }: { exec?: Executor | null } = {}): SchemeResult {
+export function resolveScheme(
+  project: XcodeProject,
+  { exec = null, scheme: requested = null }: { exec?: Executor | null; scheme?: string | null } = {},
+): SchemeResult {
   const listing = listSchemes(project, { exec });
   if (listing === null) {
     return {
@@ -139,6 +143,16 @@ export function resolveScheme(project: XcodeProject, { exec = null }: { exec?: E
         code: 'STIM_NO_SCHEME',
         message: `Could not list schemes for ${project.path}.`,
         remedy: `Run \`xcodebuild ${project.flag} ${project.path} -list\` to see what it reports.`,
+      },
+    };
+  }
+  if (requested !== null) {
+    if (listing.schemes.includes(requested)) return { scheme: requested, schemes: listing.schemes };
+    return {
+      error: {
+        code: 'STIM_NO_SCHEME',
+        message: `No shared Xcode scheme named ${JSON.stringify(requested)} in ${project.path}. Available schemes: ${listing.schemes.join(', ') || 'none'}.`,
+        remedy: 'Pass an exact available name with --scheme, or share the intended app scheme in Xcode.',
       },
     };
   }
@@ -157,7 +171,7 @@ export function resolveScheme(project: XcodeProject, { exec = null }: { exec?: E
         message: `Could not select an app scheme in ${project.path} (schemes: ${found}).`,
         remedy:
           listing.schemes.length > 0
-            ? 'In Xcode (Product > Scheme > Manage Schemes), make the intended shared app scheme match the workspace/project name or the top-level name in app.json. Stim does not guess between unmatched schemes.'
+            ? 'Pass --scheme <name> to select the intended shared app scheme. Stim does not guess between unmatched schemes.'
             : 'Share the app scheme in Xcode (Product > Scheme > Manage Schemes, tick Shared) so xcodebuild can see it.',
       },
     };
@@ -592,7 +606,11 @@ export async function buildIos({
   if (!udid && !destination) throw new TypeError('buildIos requires {udid} (or an explicit {destination})');
 
   const executor = exec || getExecutor();
-  const dd = derivedDataPath || workspaceDerivedData(root);
+  const dd =
+    derivedDataPath ||
+    (scheme
+      ? join(workspaceDerivedData(root), `scheme-${createHash('sha256').update(scheme).digest('hex')}`)
+      : workspaceDerivedData(root));
   const startedAt = now();
   const elapsed = () => now() - startedAt;
 
@@ -621,20 +639,16 @@ export async function buildIos({
   }
   const resolvedTarget = target as XcodeProject;
 
-  let chosenScheme: string | null = scheme;
-  if (!chosenScheme) {
-    const resolved = resolveScheme(resolvedTarget, { exec: executor });
-    if (resolved.error) {
-      reportError(resolved.error.message, resolved.error.remedy);
-      return failedResult({
-        code: resolved.error.code,
-        diagnostics: [{ message: resolved.error.message, remedy: resolved.error.remedy }],
-        durationMs: elapsed(),
-      });
-    }
-    chosenScheme = resolved.scheme ?? null;
+  const selected = resolveScheme(resolvedTarget, { exec: executor, scheme });
+  if (selected.error) {
+    reportError(selected.error.message, selected.error.remedy);
+    return failedResult({
+      code: selected.error.code,
+      diagnostics: [{ message: selected.error.message, remedy: selected.error.remedy }],
+      durationMs: elapsed(),
+    });
   }
-  const buildScheme = chosenScheme as string;
+  const buildScheme = selected.scheme as string;
 
   const buildSettings =
     compilationCache === undefined
@@ -771,10 +785,61 @@ export async function buildIos({
   }
 
   const products = productsDir(dd, { configuration, sdk });
-  const appPath = findAppBundle(products, buildScheme);
+  let appPath: string | null = null;
+  if (scheme) {
+    try {
+      const targets = JSON.parse(
+        executor.runFile(
+          'xcodebuild',
+          [
+            resolvedTarget.flag as string,
+            resolvedTarget.path as string,
+            '-scheme',
+            buildScheme,
+            '-configuration',
+            configuration,
+            '-sdk',
+            sdk,
+            '-destination',
+            destination || `id=${udid}`,
+            '-derivedDataPath',
+            dd,
+            ...extraArgs,
+            ...buildSettings,
+            '-showBuildSettings',
+            '-json',
+          ],
+          { timeoutMs: 30_000 },
+        ),
+      );
+      const paths = new Set<string>();
+      for (const item of Array.isArray(targets) ? targets : []) {
+        const settings = item?.buildSettings;
+        if (settings?.PRODUCT_TYPE !== 'com.apple.product-type.application' || settings.PLATFORM_NAME !== sdk) continue;
+        const dir = settings.TARGET_BUILD_DIR;
+        const name = settings.FULL_PRODUCT_NAME;
+        if (
+          typeof dir !== 'string' ||
+          !isAbsolute(dir) ||
+          typeof name !== 'string' ||
+          basename(name) !== name ||
+          !name.endsWith('.app')
+        )
+          continue;
+        const path = join(dir, name);
+        if (statSync(path).isDirectory()) paths.add(path);
+      }
+      if (paths.size === 1) appPath = [...paths][0]!;
+    } catch {}
+  } else {
+    appPath = findAppBundle(products, buildScheme);
+  }
   if (!appPath) {
-    const message = `xcodebuild reported success but no .app is in ${products}.`;
-    const remedy = 'Check that the scheme builds an application target, not a library or a test bundle.';
+    const message = scheme
+      ? `xcodebuild succeeded, but the built app for scheme ${JSON.stringify(buildScheme)} could not be identified unambiguously from its build settings.`
+      : `xcodebuild reported success but no .app is in ${products}.`;
+    const remedy =
+      'Check that the scheme builds one application target for this platform, not a library, test bundle, or several apps.';
     reportError(message, remedy);
     return failedResult({
       code: 'STIM_BUILD_FAILED',

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -238,8 +238,9 @@ code, never on the message.`,
       summary: 'Xcode schemes unavailable or no unambiguous app scheme in ios/',
       body: () => `STIM_NO_SCHEME
   Stim could not list or select an app scheme in ios/. Share the intended app
-  scheme so xcodebuild can see it. If it is already listed, make its name match
-  the workspace/project name or the top-level name in app.json. A workspace
+  scheme so xcodebuild can see it. Select an available exact name with
+  \`stim ios --scheme <name>\`. An unknown explicit name prints available choices.
+  Without an explicit selector, a workspace
   name match wins; otherwise Stim accepts a sole non-test scheme, or a listed
   scheme matching app.json. Unmatched ambiguous schemes are refused.`,
     },

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -63,6 +63,8 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
   configuration   the Xcode configuration that was built ("Release" from
                   --configuration or the ios.configuration setting); null for
                   the default Debug
+  scheme          the explicit shared Xcode scheme selected by --scheme;
+                  absent for automatic selection; not the app URL scheme
   cacheKey        the shared-build-cache key derived from it (the
                   configuration is part of it: -release-sim vs -debug-sim)
   cacheHit        WHICH LEVEL answered, not a boolean:

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -427,12 +427,27 @@ result as proof instead of requiring an unrelated screenshot.`,
   Follow the normal ownership and consent rules in guide agent.
 
 IOS SCHEME SELECTION
+  Pass \`stim ios --scheme "App Staging"\` to select an exact shared Xcode
+  app scheme. Unknown names refuse with the available choices. This is the
+  Xcode scheme, not the app's URL scheme. Combine it with --configuration
+  when choosing both an app scheme and a build configuration.
+
+  Without --scheme, automatic selection is unchanged:
   Stim keeps a scheme matching the workspace/project name, or the sole non-test
   scheme. When neither identifies one, it also checks the static top-level name
   in the app directory's app.json against Xcode's listed schemes. It does not
   execute app config or choose an arbitrary scheme from an ambiguous list.
-  If selection fails, share the intended app scheme in Xcode and make its name
-  match the workspace/project or app.json name. See guide errors STIM_NO_SCHEME.
+  If selection fails, pass --scheme with an available name, or share the app
+  scheme in Xcode first. See guide errors STIM_NO_SCHEME.
+
+  Explicit schemes have separate artifact keys, shared-build locks, and Xcode
+  build directories. Stim identifies the resulting application from Xcode's
+  resolved build settings, even when the scheme and product names differ;
+  ambiguous products refuse rather than installing another app. Local and
+  configured Stim cache providers use the scheme-specific key. The older Expo
+  buildCacheProvider tier is skipped for explicit schemes because a provider
+  may key only on the fingerprint and return another scheme's app. Omitting
+  --scheme retains the existing cache keys and provider behavior.
 
 AN ARTIFACT THE DEVICE ALREADY HOLDS IS NOT INSTALLED AGAIN
   Both platforms store the artifact verbatim, so its hash is its identity.
@@ -721,7 +736,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
         'every flag per command, Android variants and flavors, the per-run simulator model, runtime and system image',
       body: () => `THE OPTION SURFACE, IN FULL
   start           --json --wait <seconds> --remote
-  ios             --json --no-metro-check --no-build-cache --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
+  ios             --json --no-metro-check --no-build-cache --scheme <name> --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
   android         --json --no-metro-check --no-build-cache --variant <name> --system-image <id> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
   reload          [ios|android] --json
   device          lock <ios|android> [id] --for <duration> --wait <seconds> --json;

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -126,6 +126,7 @@ export interface IosFacts {
   runtime: string | null;
   fingerprint?: string | null;
   configuration: string | null;
+  scheme?: string;
   cacheKey?: string | null;
   cacheHit: CacheHitLevel;
   cacheSkipped: boolean;

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -71,7 +71,7 @@ project is reused.
 ## `ios`
 
 ```text
-stim ios [--configuration <name>] [--device-type <name>] [--runtime <version>]
+stim ios [--scheme <name>] [--configuration <name>] [--device-type <name>] [--runtime <version>]
          [--device [udid]] [--wait <seconds> | --no-wait] [--remote <proxy|eas>]
          [--no-metro-check] [--no-build-cache] [--json]
 ```
@@ -81,6 +81,9 @@ app, opens it, and checks launch logs. The build always runs on the local
 machine, including remote-device workflows.
 
 - `--configuration <name>` selects an Xcode configuration. The default is Debug.
+- `--scheme <name>` selects an exact shared Xcode scheme when the automatic
+  app selection is not the one you need. Explicit schemes have separate build
+  caches and DerivedData. This is a build scheme, not the app's URL scheme.
 - `--device-type <name>` creates this workspace's owned simulator as that model,
   overriding `ios.deviceType` for one invocation. A model no installed runtime
   can create refuses with `STIM_BAD_ARG` and prints the ones they do offer.


### PR DESCRIPTION
## Description

Some apps have several shared Xcode schemes, and automatic selection cannot express which one to build. `stim ios --scheme "App Staging"` selects an exact name while preserving automatic selection when omitted.

Fixes #605.

## Solution

An explicit scheme gets separate artifact keys, shared-build locks and DerivedData so another scheme's app cannot be reused. Exact, case-sensitive names stay isolated. Stim validates existing schemes before cache lookup and refuses ambiguous products after a build rather than installing another app.

The legacy Expo project-provider tier is skipped for explicit schemes because its artifacts may not be scheme-keyed. Stim's keyed local and configured cache providers remain available. This build selector does not change the dev client's URL scheme.

## Test plan

- Real Xcode simulator build: shared scheme `Staging App` produces `Scratch.app`, with the correct bundle ID and scheme-specific DerivedData.

No physical-device signing or remote-device session was exercised for this selector.
