### PR TITLE
feat: report linked libraries whose Git metadata enters the fingerprint

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -25,6 +25,7 @@ import {
   checkFingerprintParity,
   checkMetroCache,
   detectFingerprintParity,
+  detectLinkedLibraryGitMetadata,
   checkRemoteDevice,
   checkSimSlim,
   checkMainCheckout,
@@ -76,6 +77,71 @@ test('checkMainCheckout reports missing dependencies, Pods, and native output', 
     expect(findings[0]?.fix).toMatch(/npm ci/);
     expect(findings[1]?.fix).toMatch(/pod install/);
     expect(findings[2]?.fix).toMatch(/stim ios/);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('a fingerprinted library directory that still hashes .git gets both .fingerprintignore entries', async () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-linked-git-'));
+  try {
+    const library = join(project, 'library');
+    mkdirSync(join(library, 'android'), { recursive: true });
+    writeFileSync(join(library, '.git'), 'gitdir: /elsewhere/.git/worktrees/library\n');
+    mkdirSync(join(project, 'node_modules', '@org'), { recursive: true });
+    symlinkSync(library, join(project, 'node_modules', '@org', 'native-lib'));
+    const calls: unknown[] = [];
+    const dir = (filePath: string, children: string[]) => ({
+      type: 'dir',
+      filePath,
+      reasons: [],
+      debugInfo: { path: filePath, hash: 'h', children: children.map((path) => ({ path, hash: 'h' })) },
+    });
+    let sources = [
+      dir('android', ['android/build.gradle']),
+      dir('node_modules/@org/native-lib', [
+        'node_modules/@org/native-lib/.git',
+        'node_modules/@org/native-lib/android',
+      ]),
+      dir('node_modules/ignored-lib', ['node_modules/ignored-lib/android']),
+    ];
+    const createFingerprint = (async (_root: string, options?: unknown) => {
+      calls.push(options);
+      return { hash: 'abc', sources };
+    }) as unknown as typeof import('@expo/fingerprint').createFingerprintAsync;
+
+    const result = await detectLinkedLibraryGitMetadata(project, { createFingerprint, platform: 'android' });
+    expect(calls).toEqual([expect.objectContaining({ platforms: ['android'], debug: true, silent: true })]);
+    expect(result?.code).toBe('linked-library-git-metadata');
+    expect(result?.detail).toContain('node_modules/@org/native-lib/.git');
+    expect(result?.detail).not.toContain('ignored-lib');
+    expect(result?.fix).toContain('`node_modules/@org/native-lib/.git`, `node_modules/@org/native-lib/.git/**/*`');
+
+    sources = [...sources, dir('../other-lib', ['../other-lib/.git', '../other-lib/ios'])];
+    const two = await detectLinkedLibraryGitMetadata(project, { createFingerprint });
+    expect(two?.title).toMatch(/^2 linked/);
+    expect(two?.fix).toContain('`../other-lib/.git`, `../other-lib/.git/**/*`');
+
+    sources = [dir('node_modules/@org/native-lib', ['node_modules/@org/native-lib/android'])];
+    expect(await detectLinkedLibraryGitMetadata(project, { createFingerprint })).toBeNull();
+    const failing = (async () => {
+      throw new Error('no fingerprint');
+    }) as unknown as typeof createFingerprint;
+    expect(await detectLinkedLibraryGitMetadata(project, { createFingerprint: failing })).toBeNull();
+
+    rmSync(join(project, 'node_modules', '@org'), { recursive: true, force: true });
+    const before = calls.length;
+    expect(await detectLinkedLibraryGitMetadata(project, { createFingerprint })).toBeNull();
+    expect(calls.length).toBe(before);
+
+    execSync('git init -q', { cwd: project });
+    const app = join(project, 'apps', 'mobile');
+    mkdirSync(app, { recursive: true });
+    writeFileSync(join(app, 'package.json'), JSON.stringify({ name: 'mobile', dependencies: { 'react-native': '*' } }));
+    symlinkSync(library, join(project, 'node_modules', 'hoisted-lib'));
+    sources = [dir('../../node_modules/hoisted-lib', ['../../node_modules/hoisted-lib/.git'])];
+    const hoisted = await detectLinkedLibraryGitMetadata(app, { createFingerprint });
+    expect(hoisted?.fix).toContain('`../../node_modules/hoisted-lib/.git`, `../../node_modules/hoisted-lib/.git/**/*`');
   } finally {
     rmSync(project, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/build-cache.ts
+++ b/packages/stim-cli/src/build-cache.ts
@@ -61,13 +61,20 @@ export async function fingerprintProject(
   {
     platform,
     createFingerprint = expoFingerprint.createFingerprintAsync,
-  }: { platform?: string; createFingerprint?: typeof expoFingerprint.createFingerprintAsync } = {},
+    debug = false,
+  }: { platform?: string; createFingerprint?: typeof expoFingerprint.createFingerprintAsync; debug?: boolean } = {},
 ): Promise<ProjectFingerprint | null> {
   const platforms =
     platform && FINGERPRINT_PLATFORMS.has(platform)
       ? { platforms: [platform] as FingerprintOptions['platforms'] }
       : undefined;
-  const options: FingerprintOptions = { ...platforms, ignorePaths: DEFAULT_FINGERPRINT_IGNORES };
+  // With DEBUG set, @expo/fingerprint profiles sourcers on stdout unless silent.
+  const options: FingerprintOptions = {
+    ...platforms,
+    ...(debug ? { debug } : {}),
+    ignorePaths: DEFAULT_FINGERPRINT_IGNORES,
+    silent: true,
+  };
   const result = await createFingerprint(projectRoot, options);
   const hash = result?.hash ?? null;
   if (!hash) return null;

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -11,7 +11,7 @@ import {
   sandboxAllowance,
   sandboxFinding,
 } from '../sandbox.ts';
-import { detectFingerprintParity, detectXcodeMajor, runDoctor } from '../doctor.ts';
+import { detectFingerprintParity, detectLinkedLibraryGitMetadata, detectXcodeMajor, runDoctor } from '../doctor.ts';
 import type { DoctorPlatform, Finding } from '../doctor.ts';
 import { phaseLine } from '../command-output.ts';
 import { compareStimVersions, inspectStimVersions, type StimVersionReport } from '../stim-installations.ts';
@@ -206,6 +206,8 @@ export default function doctorCommand(
 
       const parity = await detectFingerprintParity(root, { platform: opts.platform });
       if (parity) findings.push(parity);
+      const linkedGit = await detectLinkedLibraryGitMetadata(root, { platform: opts.platform });
+      if (linkedGit) findings.push(linkedGit);
 
       if (detectHarness()) {
         const sandbox = sandboxFinding(repoRoot(root) ?? root);

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -1,5 +1,5 @@
 import { resolveOptimizations, type Optimizations } from './optimizations.ts';
-import { existsSync, readFileSync, realpathSync, rmSync } from 'fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, rmSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { plural } from './command-output.ts';
 import { getExecutor } from './exec.ts';
@@ -9,6 +9,7 @@ import { inspectIosDebugArchitectures } from './doctor-ios-architectures.ts';
 import { appProjectProblem, detectIsExpo } from './project.ts';
 import * as expoFingerprint from '@expo/fingerprint';
 import { diffFingerprintSources, fingerprintProject } from './build-cache.ts';
+import type { DebugInfoDir, FingerprintSource } from '@expo/fingerprint';
 import { dirtyFingerprintFiles, gitCommonDir, listWorktrees, repoRoot } from './worktree.ts';
 import { workspaceDerivedData } from './paths.ts';
 import { type Config, type ConcurrencyLimits, getConcurrencyLimits, loadConfig } from './config.ts';
@@ -889,6 +890,91 @@ export function checkFingerprintParity({
     `A clean detached worktree of HEAD computes a different @expo/fingerprint hash than this checkout, so worktrees will MISS the cache entries this checkout fills (and vice versa) until the two agree.${differing} ${cause} (To measure this, doctor ran a real fingerprint twice and briefly created a temporary git worktree -- .git/worktrees metadata was touched and cleaned up.)`,
     'Commit the dirty fingerprint inputs, or list the build-irrelevant ones in .fingerprintignore (same syntax as .gitignore, at the project root; Stim already ignores android/local.properties and android/.idea). Only the ones that genuinely cannot change the native build belong there -- generated reports, local env files, a lockfile whose checksums embed absolute machine paths. Never ignore a real native input (a Podfile, a gradle file, the app config) to force a hit: that trades a slow build for a wrong one.',
   );
+}
+
+function gitMetadataAt(path: string): boolean {
+  try {
+    const git = lstatSync(join(path, '.git'));
+    return git.isFile() || git.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listDirectory(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function hasLinkedPackageWithGit(projectRoot: string): boolean {
+  const root = repoRoot(projectRoot) ?? projectRoot;
+  for (let dir = projectRoot; ; dir = dirname(dir)) {
+    if (linkedPackageWithGitIn(join(dir, 'node_modules'))) return true;
+    if (dir === root || dirname(dir) === dir || relative(root, dirname(dir)).startsWith('..')) return false;
+  }
+}
+
+function linkedPackageWithGitIn(nodeModules: string): boolean {
+  return listDirectory(nodeModules)
+    .filter((entry) => !entry.startsWith('.'))
+    .flatMap((entry) =>
+      entry.startsWith('@') ? listDirectory(join(nodeModules, entry)).map((child) => join(entry, child)) : [entry],
+    )
+    .some((name) => {
+      const root = join(nodeModules, name);
+      try {
+        return lstatSync(root).isSymbolicLink() && gitMetadataAt(root);
+      } catch {
+        return false;
+      }
+    });
+}
+
+/**
+ * A linked native library (a `link:` or `file:` dependency, or a workspace
+ * symlink) brings its checkout's Git metadata into a directory the fingerprint
+ * hashes whole. That metadata changes with every Git operation in the linked
+ * checkout, so workspaces rarely hash alike even when the library's native
+ * sources match. The fingerprint's own debug output says which directories
+ * still hash a .git entry, whatever ignore mechanism the project uses. Linked
+ * packages can be hoisted, so the gate looks at every node_modules from the
+ * app up to the repository root.
+ */
+export async function detectLinkedLibraryGitMetadata(
+  projectRoot: string,
+  {
+    createFingerprint = expoFingerprint.createFingerprintAsync,
+    platform,
+  }: { createFingerprint?: typeof expoFingerprint.createFingerprintAsync; platform?: DoctorPlatform } = {},
+): Promise<Finding | null> {
+  const mainRoot = mainCheckoutProjectRoot(projectRoot);
+  if (!hasLinkedPackageWithGit(mainRoot)) return null;
+  let sources: FingerprintSource[];
+  try {
+    sources = (await fingerprintProject(mainRoot, { platform, createFingerprint, debug: true }))?.sources ?? [];
+  } catch {
+    return null;
+  }
+  const directories = sources.flatMap((source) => {
+    if (source.type !== 'dir' || typeof source.filePath !== 'string') return [];
+    const children = (source.debugInfo as DebugInfoDir | undefined)?.children ?? [];
+    return children.some((child) => child?.path === `${source.filePath}/.git`) ? [source.filePath] : [];
+  });
+  if (!directories.length) return null;
+  const several = directories.length > 1;
+  const entries = directories.flatMap((dir) => [`${dir}/.git`, `${dir}/.git/**/*`]);
+  return {
+    ...finding(
+      'note',
+      `${several ? `${directories.length} linked native libraries carry` : 'A linked native library carries'} Git metadata into the fingerprint`,
+      `${directories.map((dir) => `${dir}/.git`).join(', ')} ${several ? 'are' : 'is'} inside a directory the fingerprint hashes whole. Git rewrites that metadata on every commit, checkout, or worktree of the linked checkout (a worktree turns a .git directory into a pointer file), so this workspace and its worktrees rarely compute the same fingerprint even when the library's native sources match, and each one compiles instead of reusing the artifact.`,
+      `When the native build does not read that Git state, add ${entries.map((entry) => `\`${entry}\``).join(', ')} to .fingerprintignore at the project root: the first form matches the pointer file a worktree has, the second excludes a .git directory's contents. Ignore only the .git entry, not the package: its native sources still have to move the key.`,
+    ),
+    code: 'linked-library-git-metadata',
+  };
 }
 
 export async function detectFingerprintParity(

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -36,6 +36,8 @@ Doctor reports cross-volume staging and build-cache copies; read guide settings
 for placement overrides and guide lifecycle options for warm behavior.
 For iOS Debug architecture findings, review the project's overrides and imported
 Podfile helpers using guide lifecycle options. Doctor --fix does not change them.
+For a linked native library carrying Git metadata, add the printed .git entries to
+.fingerprintignore only when the native build does not read Git state.
 
   stim doctor --platform ios          # or: --platform android
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -647,6 +647,14 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   embed machine paths -- ignoring a path any project might read turns a slow
   build into a wrong one.
 
+  A linked native library (a \`link:\` or \`file:\` dependency, or a workspace
+  symlink) brings its checkout's .git into a directory the fingerprint hashes
+  whole; Git rewrites that metadata on every commit, checkout, or worktree, so
+  workspaces rarely agree. \`stim doctor\` names the entries to ignore when the
+  native build does not read Git state: the .git path as the fingerprint sees
+  it and its /**/* form, which is what skips a .git directory's contents.
+  Ignore those entries only, never the package.
+
   \`.fingerprintignore\` at the project root (same syntax as .gitignore) is the
   answer. Put in it only what genuinely cannot change the native build: a
   generated report, a local env file, a lockfile whose checksums embed absolute

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -36,7 +36,8 @@ stim doctor [--platform <ios|android>] [--json] [--fix]
 ```
 
 Inspects the main checkout. It reports missing or stale dependencies, CocoaPods
-state, cache conflicts, device capacity, and remote session problems. On a
+state, cache conflicts, device capacity, remote session problems, and a linked
+native library whose Git metadata enters the fingerprint. On a
 checkout without installed dependencies, it also reports fingerprint
 differences against a fresh worktree. The check is read-only unless `--fix` is
 passed.


### PR DESCRIPTION
## Description

`stim doctor` now names any `.git` inside a directory the native fingerprint hashes, such as a symlinked `link:` or `file:` library under `node_modules`, and prints the exact `.fingerprintignore` lines for it.

A linked dependency is a symlink into another checkout, so that checkout's `.git` lands in a directory `@expo/fingerprint` hashes whole. Git rewrites that metadata on every commit, checkout, or worktree of the linked checkout, so workspaces rarely compute the same fingerprint even when the library's native sources match, and every worktree compiles instead of reusing the artifact. Issue #595 measured this on the react-native-safe-area-context example: 231 differing files, all under the linked package's `.git`, and equal fingerprints once that one path was ignored.

## Solution

The check first looks for a symlinked package whose target holds a `.git` entry in every `node_modules` from the app directory up to the repository root, so hoisted workspace links count; that is a handful of `lstat` calls. only then does it run the project fingerprint once in debug mode and walk its `dir` sources, reporting a directory only when the fingerprint's own debug output shows it hashed a `.git` child. The printed path is therefore the one the fingerprint uses (the `node_modules` alias or a real path, whichever autolinking reported), packages that never enter the fingerprint are not mentioned, and a `.git` the project already excludes through `.fingerprintignore` or `fingerprint.config.js` is not reported, whatever pattern it used. It inspects the main checkout like the sibling doctor checks and honours `--platform`. `fingerprintProject` also passes `silent: true` now, because with `DEBUG` set `@expo/fingerprint` prints profiling lines to stdout, which would break `doctor --json`.

Two lines are printed per directory, `<dir>/.git` and `<dir>/.git/**/*`. The installed `@expo/fingerprint` matches ignore patterns per file and only skips a directory for patterns ending in `/**/*`, `/**` or `/`, so the first form covers the pointer file a worktree has and the second the directory a main checkout has.

**Doctor does not write the file.** The remedy holds only when the native build does not read Git state, which is the project's judgment, so the note says to ignore those entries alone, never the package. The guide's fingerprint section, the agent guide, and the commands page describe the finding.

## Test plan

- `doctor.test.ts` drives `detectLinkedLibraryGitMetadata` with a stub fingerprint whose debug output lists a scoped package that hashed `.git`, one that did not, and `android`. It asserts only the first is named with both ignore lines, that `--platform`, `debug` and `silent` reach the fingerprint call, the plural form with a real-path source, silence once no directory hashes `.git`, silence on a failing fingerprint, that no fingerprint runs when no `node_modules` holds a symlinked package with `.git`, and a hoisted link found from an app directory inside a repository.
- Ran the built CLI at `11c0ec9` against the real safe-area-context example with its linked native library. `doctor --platform android --json` reported only `linked-library-git-metadata` before the narrow ignore; after applying its exact printed `.git` and `.git/**/*` entries, findings were empty. Both outputs parsed as one JSON payload with `DEBUG=expo:fingerprint`. The disposable fixture was restored to its clean baseline afterward; no native build or original repository changed.

Fixes #595




