### PR TITLE
feat: reset Metro caches for one app

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -45,6 +45,12 @@ errors in the captured logs. Exit code 0 alone means the query succeeded, even
 when it prints errors; an empty result does not prove launch or log capture
 succeeded.
 
+Use `stim start --reset-cache` to recover from stale Metro transforms or file-map
+state. It restarts only this app's verified owned Metro, keeping its port and
+devices. A fresh persistent cache namespace bypasses old entries without deleting
+shared stores or changing other apps or native build caches. Expo requires SDK
+54+ and Stim's config adapter. See `stim guide lifecycle` for scope and limitations.
+
 Use `stim doctor --platform ios` or `stim doctor --platform android` when only
 one native platform is in scope; shared project checks still run. Doctor also
 prints the running CLI version and the `stim` installation resolved from PATH,

--- a/packages/stim-cli/shim/expo-metro-config.cjs
+++ b/packages/stim-cli/shim/expo-metro-config.cjs
@@ -6,6 +6,7 @@ const path = require('node:path');
 const { createRequire } = require('node:module');
 const { pathToFileURL } = require('node:url');
 const { bundleResponseMiddleware } = require('./bundle-response.cjs');
+const { applyMetroCacheGeneration } = require('./metro-cache-generation.cjs');
 
 const projectRoot = process.env.STIM_PROJECT_ROOT;
 const storeRoot = process.env.STIM_METRO_STORE;
@@ -124,19 +125,24 @@ function appendStore(config, defaultConfig) {
   const server = { ...defaultConfig.server, ...output.server };
   const enhanceMiddleware = server.enhanceMiddleware;
 
-  const observed = {
-    ...output,
-    server: {
-      ...server,
-      enhanceMiddleware(middleware, metroServer) {
-        const enhanced = enhanceMiddleware ? enhanceMiddleware(middleware, metroServer) : middleware;
-        const observe = bundleResponseMiddleware((record) =>
-          process.stderr.write(`stim-bundle-response: ${JSON.stringify(record)}\n`),
-        );
-        return (req, res, next) => observe(req, res, () => enhanced(req, res, next));
+  const observed = applyMetroCacheGeneration(
+    {
+      ...output,
+      cacheVersion: output.cacheVersion ?? defaultConfig.cacheVersion,
+      server: {
+        ...server,
+        enhanceMiddleware(middleware, metroServer) {
+          const enhanced = enhanceMiddleware ? enhanceMiddleware(middleware, metroServer) : middleware;
+          const observe = bundleResponseMiddleware((record) =>
+            process.stderr.write(`stim-bundle-response: ${JSON.stringify(record)}\n`),
+          );
+          return (req, res, next) => observe(req, res, () => enhanced(req, res, next));
+        },
       },
     },
-  };
+    process.env.STIM_METRO_CACHE_GENERATION,
+    process.env.STIM_METRO_FILE_MAP,
+  );
   if (!storeRoot) return observed;
   return {
     ...observed,

--- a/packages/stim-cli/shim/metro-cache-generation.cjs
+++ b/packages/stim-cli/shim/metro-cache-generation.cjs
@@ -1,0 +1,20 @@
+'use strict';
+
+const { createHash } = require('node:crypto');
+const { mkdirSync } = require('node:fs');
+const { join } = require('node:path');
+
+function applyMetroCacheGeneration(config, generation, directory) {
+  if (!generation) return config;
+  const fileMapCacheDirectory = join(directory, generation);
+  mkdirSync(fileMapCacheDirectory, { recursive: true });
+  return {
+    ...config,
+    cacheVersion: createHash('sha256')
+      .update(JSON.stringify([config.cacheVersion ?? '1.0', generation]))
+      .digest('hex'),
+    fileMapCacheDirectory,
+  };
+}
+
+module.exports = { applyMetroCacheGeneration };

--- a/packages/stim-cli/shim/metro-cache-generation.d.cts
+++ b/packages/stim-cli/shim/metro-cache-generation.d.cts
@@ -1,0 +1,5 @@
+export function applyMetroCacheGeneration<T extends { cacheVersion?: string }>(
+  config: T,
+  generation: string | undefined,
+  directory: string,
+): T;

--- a/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
+++ b/packages/stim-cli/src/__tests__/expo-metro-config.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expoMetroConfigPath, metroStoreConfirmedRoot } from '../supervisor/metro-store.ts';
+import { applyMetroCacheGeneration } from '../../shim/metro-cache-generation.cjs';
 
 let project: string;
 let adapter: string;
@@ -52,6 +53,48 @@ function run(extraEnv: Record<string, string> = {}) {
 }
 
 describe('the Expo Metro config adapter', () => {
+  test('reset changes transform and file-map keys without clearing project or shared stores', () => {
+    writeFileSync(
+      join(project, 'metro.config.cjs'),
+      `module.exports = { cacheVersion: 'app-v2', cacheStores: [{ _root: '/project/shared', clear() { throw new Error('shared cache cleared'); } }] };`,
+    );
+    const script = `Promise.resolve(require(process.env.ADAPTER)).then(config => console.log(JSON.stringify({
+      version: config.cacheVersion, map: config.fileMapCacheDirectory,
+      roots: config.cacheStores({ FileStore: class { constructor(opts) { this._root = opts.root; } } }).map(store => store._root)
+    })));`;
+    const load = (generation: string) => {
+      const result = spawnSync(process.execPath, ['-e', script], {
+        cwd: project,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ADAPTER: adapter,
+          STIM_PROJECT_ROOT: project,
+          STIM_METRO_STORE: '/cache/shared',
+          STIM_METRO_CACHE_GENERATION: generation,
+          STIM_METRO_FILE_MAP: join(project, 'file-map'),
+        },
+      });
+      expect(result.status).toBe(0);
+      return JSON.parse(result.stdout);
+    };
+    const before = load('');
+    const first = load('first');
+    expect(before.version).toBe('app-v2');
+    expect(first.version).not.toBe(before.version);
+    expect(load('first')).toEqual(first);
+    expect(load('second').version).not.toBe(first.version);
+    expect(first.map).toBe(join(project, 'file-map', 'first'));
+    expect(first.roots).toEqual(['/project/shared', '/cache/shared']);
+    expect(load('')).toEqual(before);
+    const config = { cacheVersion: 'app-v2' };
+    expect(applyMetroCacheGeneration(config, 'first', join(project, 'file-map')).cacheVersion).toBe(first.version);
+    expect(applyMetroCacheGeneration({ cacheVersion: 'app-v3' }, 'first', project).cacheVersion).not.toBe(
+      first.version,
+    );
+    expect(applyMetroCacheGeneration(config, undefined, project)).toBe(config);
+  });
+
   test.each(['/cache/adapter-test', ''])(
     'observes delivery without replacing project settings (shared store: %s)',
     (storeRoot) => {

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../engine/tunnel.ts';
 import { supervisorLogFile, workspaceLogsDir, workspaceMetadataFile } from '../paths.ts';
 import { writeWorkspaceState } from '../supervisor/run.ts';
-import { readMetroTunnel } from '../supervisor/state.ts';
+import { readMetroTunnel, readWorkspaceState } from '../supervisor/state.ts';
 import {
   liveSupervisor,
   parseWait,
@@ -481,6 +481,29 @@ describe('failureEvidence (issue #24)', () => {
 });
 
 describe('action: already running', () => {
+  test('cache reset refuses an external Metro without changing its cache state or device', async () => {
+    const port = 8149;
+    await metroListener(port);
+    setExecutor(metroExecutor({ listeners: { [port]: DEAD_LISTENER_PID } }));
+    upsertProject(root, { metroPort: port });
+    writeWorkspaceState(root, { metroCacheGeneration: 'before', lastBuild: { device: 'owned-device' } });
+    const before = readWorkspaceState(root);
+    const result = await runAction({ json: true, resetCache: true });
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.logs[0] ?? '').message).toContain('externally started');
+    expect(readWorkspaceState(root)).toEqual(before);
+    expect(getProject(root)?.metroPort).toBe(port);
+  });
+
+  test('cache reset refuses an unverifiable live supervisor without recording a new generation', async () => {
+    upsertProject(root, { metroPort: 8148 });
+    writeWorkspaceState(root, { supervisor: { pid: process.pid, port: 8148 } });
+    const result = await runAction({ json: true, resetCache: true });
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.logs[0] ?? '').message).toContain('identity');
+    expect(readWorkspaceState(root)?.metroCacheGeneration).toBeUndefined();
+  });
+
   test('a healthy dev server with a live supervisor record is a no-op exit 0', async () => {
     const port = 8151;
     const server = await metroListener(port);
@@ -1862,38 +1885,46 @@ describe('action: spawning the supervisor', () => {
     expect(stderr.includes('noise 4')).toBeTruthy();
   });
 
-  test('a supervisor that exits during startup ends the wait immediately', async () => {
-    const port = 8156;
-    const exec = metroExecutor({ listeners: {} });
-    const handlers: Record<string, (...args: unknown[]) => void> = {};
-    exec.spawn = (cmd, args, opts) => {
-      exec.calls.spawn.push({ cmd, args, opts });
-      const child: ChildStub = {
-        pid: process.pid,
-        unref() {},
-        on(event, cb) {
-          handlers[event] = cb;
-        },
+  test.each([false, true])(
+    'a supervisor that exits during startup ends the wait immediately (reset %s)',
+    async (resetCache) => {
+      const port = 8156;
+      const exec = metroExecutor({ listeners: {} });
+      const handlers: Record<string, (...args: unknown[]) => void> = {};
+      exec.spawn = (cmd, args, opts) => {
+        exec.calls.spawn.push({ cmd, args, opts });
+        const child: ChildStub = {
+          pid: process.pid,
+          unref() {},
+          on(event, cb) {
+            handlers[event] = cb;
+          },
+        };
+        setTimeout(() => handlers.exit?.(1, null), 5);
+        return child;
       };
-      setTimeout(() => handlers.exit?.(1, null), 5);
-      return child;
-    };
-    setExecutor(exec);
-    upsertProject(root, { metroPort: port });
+      setExecutor(exec);
+      upsertProject(root, { metroPort: port });
 
-    const started = Date.now();
-    const result = await runAction({ json: true, wait: '30' });
-    const elapsed = Date.now() - started;
+      const started = Date.now();
+      const result = await runAction({ json: true, wait: '30', resetCache });
+      const elapsed = Date.now() - started;
 
-    expect(result.exitCode).toBe(1);
-    expect(elapsed < 5000).toBeTruthy();
-    expect(result.errs.join('\n')).toMatch(/supervisor exited \(code 1\) before the dev server came up/);
-    const lastLog = result.logs.at(-1);
-    assert(lastLog);
-    const facts = JSON.parse(lastLog);
-    expect(facts.code).toBe('STIM_SUPERVISOR_EXITED');
-    expect(facts.remedy).toMatch(/start` again/);
-  });
+      expect(result.exitCode).toBe(1);
+      expect(elapsed < 5000).toBeTruthy();
+      expect(result.errs.join('\n')).toMatch(/supervisor exited \(code 1\) before the dev server came up/);
+      const lastLog = result.logs.at(-1);
+      assert(lastLog);
+      const facts = JSON.parse(lastLog);
+      expect(facts.code).toBe('STIM_SUPERVISOR_EXITED');
+      expect(facts.remedy).toMatch(/start` again/);
+      const generation = readWorkspaceState(root)?.metroCacheGeneration;
+      expect(typeof generation).toBe(resetCache ? 'string' : 'undefined');
+      const retry = await runAction({ json: true, wait: '30' });
+      expect(retry.exitCode).toBe(1);
+      expect(readWorkspaceState(root)?.metroCacheGeneration).toBe(generation);
+    },
+  );
 });
 
 describe('the error contract', () => {

--- a/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
+++ b/packages/stim-cli/src/__tests__/supervisor-bare.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../supervisor/server-bare.ts';
 import type { NdjsonRecord, NdjsonWriter } from '../ndjson.ts';
 import { asRequire, makeError, makeWriter } from './_factories.ts';
+import { writeWorkspaceState } from '../supervisor/state.ts';
 
 function caught(fn: () => unknown): Error & Record<string, unknown> {
   try {
@@ -383,6 +384,20 @@ describe('startBareServer wiring', () => {
     expect(calls.runServer.config.reporter).toBe(reporter);
     expect(calls.reporterDir).toBe(join(root, '.stim', 'logs'));
     expect(calls.runServer.config.resolver.platforms).toEqual(['android', 'ios', 'native']);
+  });
+
+  test('uses the saved per-app cache generation on every bare start', async () => {
+    writeWorkspaceState(root, { metroCacheGeneration: 'fresh' });
+    const { deps, calls } = fakeDeps();
+    await startBareServer({
+      root,
+      port: 8099,
+      logsDir: join(tmpHome, 'logs'),
+      deps,
+      cacheStore: false,
+      reporterFactory: null,
+    });
+    expect(calls.runServer.config).toMatchObject({ fileMapCacheDirectory: join(tmpHome, 'metro-file-map', 'fresh') });
   });
 
   test('wires both middlewares and merges both websocket endpoint sets', async () => {

--- a/packages/stim-cli/src/commands/start.ts
+++ b/packages/stim-cli/src/commands/start.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import type { ChildProcess } from 'node:child_process';
 import { mkdirSync, openSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import type { Command } from 'commander';
 import { phaseLine, stepTimer } from '../command-output.ts';
 import type { StartError, StartFacts, SupervisorRecord } from '../types.ts';
@@ -21,7 +22,8 @@ import {
   writeWorkspaceState,
 } from '../supervisor/state.ts';
 import { CACHE_PROVIDER_ENV, cacheProviderEnv } from '@stim-cli/cache';
-import { workspaceProcessLockError } from '../engine/workspace-process-lock.ts';
+import { workspaceProcessLockError, withWorkspaceProcessLock } from '../engine/workspace-process-lock.ts';
+import { resetMetroCache } from '../supervisor/cache-reset.ts';
 import { spawnEntry } from '../spawn-entry.ts';
 import {
   publicUrlSetting,
@@ -195,6 +197,7 @@ interface StartOptions {
   json?: boolean;
   wait?: string;
   remote?: boolean;
+  resetCache?: boolean;
 }
 
 interface StartCommandDeps {
@@ -268,6 +271,7 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
     .option('--wait <seconds>', `How long to wait for the dev server to answer (default ${DEFAULT_WAIT_SECONDS})`)
     .option('--remote', 'Prepare the dev server for a remote device')
+    .option('--reset-cache', 'Restart owned Metro with fresh per-app transform and file-map cache state')
     .action(async (opts: StartOptions) => {
       const json = Boolean(opts.json);
       const waitTimer = stepTimer();
@@ -391,6 +395,20 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
           androidPackage: detectAndroidPackage(root) ?? undefined,
           isExpo,
         });
+
+        if (opts.resetCache) {
+          try {
+            await resetMetroCache(root);
+          } catch (error) {
+            const failure = error as Error & { code?: string; remedy?: string };
+            return fail({
+              code: failure.code ?? 'STIM_WORKSPACE_STATE',
+              message: failure.message,
+              remedy: failure.remedy,
+            });
+          }
+          note(phaseLine('cache', 'fresh Metro cache state for this app; shared cache entries and devices preserved'));
+        }
 
         const logsDir = workspaceLogsDir(root);
         const logFile = supervisorLogFile(root);
@@ -870,9 +888,23 @@ export function registerStart(program: Command, overrides: Partial<StartCommandD
         report({ json, out, port, supervisor, logsDir, alreadyRunning: false, waited: waitTimer() });
       };
 
-      if (!managedRemote) return runStart();
+      const startLocked = async () => {
+        try {
+          return await withWorkspaceProcessLock(dirname(workspaceLogsDir(root)), 'metro-start', runStart, {
+            external: true,
+          });
+        } catch (error) {
+          if (workspaceProcessLockError(error) !== 'timeout') throw error;
+          return fail({
+            code: 'STIM_METRO_TIMEOUT',
+            message: 'Another Metro start or reset is still running for this app.',
+            remedy: 'Wait for it to finish, then retry `stim start`.',
+          });
+        }
+      };
+      if (!managedRemote) return startLocked();
       try {
-        return await d.withWorktreeLock(worktreeRoot, runStart);
+        return await d.withWorktreeLock(worktreeRoot, startLocked);
       } catch (err) {
         const lockError = workspaceProcessLockError(err);
         if (lockError === 'refused') {

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -79,6 +79,9 @@ RULES DURING THE LOOP
   run stim start and retry.
 - Run ios or android again after a native input changes. A JavaScript-only
   change does not need one.
+- For stale Metro transforms or file-map state, use stim start --reset-cache.
+  It restarts only this app's verified owned Metro, preserving devices and other
+  apps' caches. See guide lifecycle for reset scope and Expo requirements.
 - Reload is not part of the normal workflow. Use stim reload on an owned local
   simulator or emulator after a failed first bundle load, when an error screen
   remains after the fix, or when you explicitly need an app restart. For a

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -20,6 +20,15 @@ const lifecycle: GuideTopic = {
     port       8082 (reserved)
     supervisor pid 41233
 
+  # If stale Metro transforms or file-map state require recovery:
+  stim start --reset-cache
+  # Restarts only this app's verified owned Metro, retaining its port/devices.
+  # Uses a fresh persistent cache namespace, not deletion of shared cache files.
+  # Other apps and worktrees keep their caches. Subsequent starts reuse the new
+  # namespace; another reset changes it again. Native build caches are unchanged.
+  # Expo requires SDK 54+ and Stim's config adapter. Custom file-map cache
+  # managers must honor Metro's fileMapCacheDirectory for file-map invalidation.
+
   # 3. Owned device booted, native inputs fingerprinted, cached build
   #    installed (or built), app launched wired to port 8082, device-log
   #    collector attached.
@@ -750,7 +759,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
       summary:
         'every flag per command, Android variants and flavors, the per-run simulator model, runtime and system image',
       body: () => `THE OPTION SURFACE, IN FULL
-  start           --json --wait <seconds> --remote
+  start           --json --wait <seconds> --remote --reset-cache
   ios             --json --no-metro-check --no-build-cache --scheme <name> --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
   android         --json --no-metro-check --no-build-cache --variant <name> --system-image <id> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
   reload          [ios|android] --json

--- a/packages/stim-cli/src/supervisor/cache-reset.ts
+++ b/packages/stim-cli/src/supervisor/cache-reset.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'node:crypto';
+import { getProject, clearSupervisor } from '../config.ts';
+import { killMetroTree, resolveProjectMetro } from '../metro.ts';
+import { waitForProcessExit } from '../process-identity.ts';
+import { detectIsExpo } from '../project.ts';
+import { resolveSupervisorTarget } from './ownership.ts';
+import { expoSdkMajor } from './server-expo.ts';
+import { expoMetroConfigPath } from './metro-store.ts';
+import { clearWorkspaceSupervisor, readWorkspaceState, writeWorkspaceState } from './state.ts';
+import { supervisorError } from './errors.ts';
+
+export async function resetMetroCache(root: string): Promise<void> {
+  if (detectIsExpo(root) && ((expoSdkMajor(root) ?? 0) < 54 || !expoMetroConfigPath())) {
+    throw supervisorError(
+      'STIM_BAD_ARG',
+      'An isolated Metro cache reset requires Expo SDK 54 or newer and the Stim Metro config adapter.',
+      'Upgrade Expo or repair the Stim installation before retrying. The running server was not changed.',
+    );
+  }
+  const project = getProject(root);
+  const port = project?.metroPort;
+  const target = resolveSupervisorTarget({
+    state: readWorkspaceState(root)?.supervisor,
+    record: project?.supervisor,
+    reservedPort: port,
+  });
+  if (target.status === 'unverified') {
+    throw supervisorError(
+      'STIM_SUPERVISOR_EXITED',
+      `Cannot reset Metro: ${target.reason}.`,
+      'Stop it with the tool that started it, then retry. Stim leaves unverified processes alone.',
+    );
+  }
+  if (port && target.status !== 'ours' && !(await resolveProjectMetro(port, root)).missing) {
+    throw supervisorError(
+      'STIM_SUPERVISOR_EXITED',
+      'Cannot reset an externally started dev server.',
+      'Stop it with the tool that started it, then retry `stim start --reset-cache`.',
+    );
+  }
+  if (target.status === 'ours') {
+    const expected = { pid: target.pid, processToken: target.processToken };
+    if (!killMetroTree(target.pid, target.processToken) || !(await waitForProcessExit(expected, 10_000))) {
+      throw supervisorError(
+        'STIM_SUPERVISOR_EXITED',
+        'The owned Metro supervisor could not be stopped for a cache reset.',
+        'Inspect `stim status` and `stim logs`, then retry. No cache reset was recorded.',
+      );
+    }
+    if (port && !(await resolveProjectMetro(port, root)).missing) {
+      throw supervisorError(
+        'STIM_SUPERVISOR_EXITED',
+        `Port ${port} is still occupied after stopping Metro.`,
+        'Inspect the listener before retrying. Stim does not terminate unrecorded processes.',
+      );
+    }
+    clearWorkspaceSupervisor(root, expected);
+    clearSupervisor(root, expected);
+  }
+  writeWorkspaceState(root, { metroCacheGeneration: randomUUID() });
+}

--- a/packages/stim-cli/src/supervisor/server-bare.ts
+++ b/packages/stim-cli/src/supervisor/server-bare.ts
@@ -1,10 +1,12 @@
 import { createRequire } from 'node:module';
-import { isAbsolute, join, relative, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { projectMetroSharedCache } from '../settings.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { appendCacheStore, metroStoreRoot, registerMetroStore } from './metro-store.ts';
 import { supervisorError } from './errors.ts';
 import { bundleResponseMiddleware } from '../../shim/bundle-response.cjs';
+import { applyMetroCacheGeneration } from '../../shim/metro-cache-generation.cjs';
+import { readWorkspaceState } from './state.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type BareModule = any;
@@ -298,7 +300,11 @@ export async function startBareServer({
   const { metro, devMiddleware, serverApi } = deps || resolveBareDeps(root);
   const makeReporter = reporterFactory === undefined ? loadNdjsonReporter(root) : reporterFactory;
 
-  const config = await metro.loadConfig({ cwd: root, port });
+  const config = applyMetroCacheGeneration(
+    await metro.loadConfig({ cwd: root, port }),
+    readWorkspaceState(root)?.metroCacheGeneration,
+    join(dirname(logsDir), 'metro-file-map'),
+  );
   const sharedStoreInstalled = installSharedCacheStore({
     root,
     config,

--- a/packages/stim-cli/src/supervisor/server-expo.ts
+++ b/packages/stim-cli/src/supervisor/server-expo.ts
@@ -14,6 +14,7 @@ import {
   registerMetroStore,
 } from './metro-store.ts';
 import { supervisorError } from './errors.ts';
+import { readWorkspaceState } from './state.ts';
 
 function delay(ms: number): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -297,6 +298,14 @@ export async function startExpoServer({
 
   const args = tunnel ? ['start', '--port', String(port), '--tunnel'] : ['start', '--port', String(port)];
   const storeEnv = resolveMetroStoreInjection(root, { log, env: process.env });
+  const generation = readWorkspaceState(root)?.metroCacheGeneration;
+  if (generation && !storeEnv) {
+    throw supervisorError(
+      'STIM_BAD_ARG',
+      'The saved Metro cache reset requires the Expo config adapter.',
+      'Use Expo SDK 54 or newer and repair the Stim installation before starting this app.',
+    );
+  }
 
   const child = spawn(bin, args, {
     cwd: root,
@@ -307,6 +316,8 @@ export async function startExpoServer({
       FORCE_COLOR: '0',
       ...expoProxyEnv(process.env),
       ...storeEnv,
+      STIM_METRO_CACHE_GENERATION: generation ?? '',
+      STIM_METRO_FILE_MAP: join(dirname(logsDir), 'metro-file-map'),
       // Expo's legacy tunnel uses port 8081; v2 uses this workspace's reserved port.
       ...(tunnel ? { EXPO_UNSTABLE_TUNNEL_V2: '1' } : {}),
     },

--- a/packages/stim-cli/src/supervisor/state.ts
+++ b/packages/stim-cli/src/supervisor/state.ts
@@ -9,6 +9,7 @@ export const MODE_BARE = 'bare-inproc';
 export const MODE_EXPO = 'expo-child';
 
 export interface WorkspaceState {
+  metroCacheGeneration?: string;
   supervisor?: Record<string, unknown>;
   collectors?: Record<string, unknown>;
   lastBuild?: Record<string, unknown>;

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -57,7 +57,7 @@ failure signatures and the manual settings.
 ## `start`
 
 ```text
-stim start [--wait <seconds>] [--remote] [--json]
+stim start [--wait <seconds>] [--remote] [--reset-cache] [--json]
 ```
 
 Starts the project dev server on the workspace's reserved port. Stim supervises
@@ -66,6 +66,13 @@ project is reused.
 
 - `--wait <seconds>` changes the startup timeout. The default is 60 seconds.
 - `--remote` prepares Metro for a remote device.
+- `--reset-cache` restarts only this app's verified owned Metro, preserving its
+  port and devices. A fresh persistent namespace invalidates transform keys and
+  the default Metro file-map cache without deleting shared cache entries. Other
+  apps, worktrees, and native build caches are unchanged. Subsequent starts reuse
+  the new namespace. Expo requires SDK 54+ and Stim's config adapter; custom
+  file-map cache managers must honor `fileMapCacheDirectory`. Externally started
+  servers are left alone, and a failed startup can be retried with `stim start`.
 - `--json` prints one stable result object on stdout.
 
 ## `ios`


### PR DESCRIPTION
## Description

Recovering one app from stale Metro state should not clear caches used by other apps or shut down its device. Plain `start` currently reuses the server, so it cannot do that recovery. Fixes #606.

## Solution

`stim start --reset-cache` restarts only the app's verified owned Metro and preserves its port and devices. A saved cache generation bypasses old transform entries and selects a fresh file-map directory without deleting shared stores; ordinary starts reuse that generation. Starts and resets serialize per app, and unverified or externally started processes are left alone.

Expo requires SDK 54+ and the config adapter. Custom file-map cache managers must honor `fileMapCacheDirectory`; native caches are unchanged. Old entries remain on disk rather than being reclaimed by this command.

## Test plan

Ran real bare RN and Expo Metro servers together using a shared transform store. Reset each app in turn: its PID changed, its port stayed fixed, transforms reran, and the other app retained its PID and cached transforms. A subsequent ordinary restart reused the new cache; Metro wrote the new file-map cache. Smoke coverage was limited to Metro.
