### PR TITLE
test: allow time for real Xcode scheme queries

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -1740,7 +1740,7 @@ describe('buildIos against a real xcodebuild', { skip: LIVE as unknown as boolea
     expect(resolveScheme(renamed).error?.code).toBe('STIM_NO_SCHEME');
     writeFileSync(join(tmp, 'app.json'), '{"name":"Scratch"}');
     expect(resolveScheme(renamed)).toEqual({ scheme: 'Scratch', schemes: ['Other', 'Scratch'] });
-  });
+  }, 30_000);
 
   test.each([
     { compilationCache: true, swiftCompilationCache: false, prefixMapping: true },


### PR DESCRIPTION
## Description

The real Xcode workspace-scheme test intermittently exceeds the default 5-second unit deadline during a full run. It invokes Xcode three times, so the harness can fail before an incorrect scheme result is observed. Fixes #618.

## Solution

Give only this external-tool test a bounded 30-second deadline. Keep its assertions, production command deadlines, and the global test timeout unchanged.

## Test plan

The full run timed out at 5.052 seconds; the focused rerun passed in about 2 seconds. Run the same test and full suite with the explicit deadline, retaining the actual workspace rename and scheme-selection assertions.
