### PR TITLE
perf: load CLI commands lazily

### DIFF
--- a/packages/stim-cli/bin/cli.ts
+++ b/packages/stim-cli/bin/cli.ts
@@ -1,40 +1,39 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
-import doctorCommand from '../src/commands/doctor.ts';
-import worktreeCommand from '../src/commands/worktree.ts';
-import startCommand from '../src/commands/start.ts';
-import stopCommand from '../src/commands/stop.ts';
-import iosCommand from '../src/commands/ios.ts';
-import androidCommand from '../src/commands/android.ts';
-import reloadCommand from '../src/commands/reload.ts';
-import deviceCommand from '../src/commands/device.ts';
-import logsCommand from '../src/commands/logs.ts';
-import statusCommand from '../src/commands/status.ts';
-import statsCommand from '../src/commands/stats.ts';
-import gcCommand from '../src/commands/gc.ts';
-import guideCommand from '../src/commands/guide.ts';
+
+type CommandModule = { default: (program: Command, version: string) => void };
+
+const commands = new Map<string, () => Promise<CommandModule>>([
+  ['doctor', () => import('../src/commands/doctor.ts')],
+  ['worktree', () => import('../src/commands/worktree.ts')],
+  ['start', () => import('../src/commands/start.ts')],
+  ['stop', () => import('../src/commands/stop.ts')],
+  ['ios', () => import('../src/commands/ios.ts')],
+  ['android', () => import('../src/commands/android.ts')],
+  ['reload', () => import('../src/commands/reload.ts')],
+  ['device', () => import('../src/commands/device.ts')],
+  ['logs', () => import('../src/commands/logs.ts')],
+  ['status', () => import('../src/commands/status.ts')],
+  ['stats', () => import('../src/commands/stats.ts')],
+  ['gc', () => import('../src/commands/gc.ts')],
+  ['guide', () => import('../src/commands/guide.ts')],
+]);
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
 const program = new Command();
 program.name('stim').description('Isolated React Native dev environments per project/worktree').version(pkg.version);
 
-doctorCommand(program, pkg.version);
-worktreeCommand(program);
-startCommand(program);
-stopCommand(program);
-iosCommand(program);
-androidCommand(program);
-reloadCommand(program);
-deviceCommand(program);
-logsCommand(program);
-statusCommand(program);
-statsCommand(program);
-gcCommand(program);
-guideCommand(program, pkg.version);
-
 try {
+  const first = process.argv[2];
+  const loadCommand = commands.get((first === 'help' ? process.argv[3] : first) ?? '');
+  if (loadCommand) {
+    (await loadCommand()).default(program, pkg.version);
+  } else if (first !== '--version' && first !== '-V') {
+    const modules = await Promise.all([...commands.values()].map((load) => load()));
+    for (const module of modules) module.default(program, pkg.version);
+  }
   await program.parseAsync();
 } catch (err) {
   if ((err as { code?: string })?.code === 'STIM_CONFIG_CORRUPT') {

--- a/test/e2e/cli.e2e.js
+++ b/test/e2e/cli.e2e.js
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = new URL('../../packages/stim-cli/', import.meta.url);
+const version = JSON.parse(readFileSync(new URL('package.json', packageRoot), 'utf8')).version;
+const entries = ['bin/cli.ts', 'dist/cli.mjs'];
+let home;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-cli-e2e-'));
+  process.env.STIM_HOME = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+function run(entry, args, allowedCommand) {
+  const nodeArgs = [];
+  if (allowedCommand !== undefined) {
+    const hook = `
+      import { registerHooks } from 'node:module';
+      registerHooks({
+        resolve(specifier, context, nextResolve) {
+          if (specifier === '@expo/fingerprint' ||
+              (specifier.includes('/commands/') && !specifier.endsWith('/${allowedCommand}.ts'))) {
+            throw new Error('Unexpected command dependency: ' + specifier);
+          }
+          return nextResolve(specifier, context);
+        }
+      });
+    `;
+    nodeArgs.push('--import', `data:text/javascript,${encodeURIComponent(hook)}`);
+  }
+  return spawnSync(process.execPath, [...nodeArgs, fileURLToPath(new URL(entry, packageRoot)), ...args], {
+    env: process.env,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+}
+
+for (const entry of entries) {
+  test(`${entry}: version prints without loading commands`, () => {
+    for (const flag of ['--version', '-V']) {
+      const result = run(entry, [flag], 'none');
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), version);
+    }
+  });
+
+  test(`${entry}: guides render without loading other commands or fingerprinting`, () => {
+    for (const args of [['guide'], ['guide', 'agent'], ['guide', 'errors', 'STIM_NO_METRO']]) {
+      const result = run(entry, args, 'guide');
+      assert.equal(result.status, 0, result.stderr);
+      assert(result.stdout.trim());
+    }
+  });
+
+  test(`${entry}: direct and help-command routes retain the same options`, () => {
+    for (const command of ['guide', 'start', 'worktree', 'device', 'ios', 'android']) {
+      const direct = run(entry, [command, '--help']);
+      const help = run(entry, ['help', command]);
+      assert.equal(direct.status, 0, direct.stderr);
+      assert.equal(help.status, 0, help.stderr);
+      assert.equal(help.stdout, direct.stdout);
+      assert.match(direct.stdout, new RegExp(`Usage: stim ${command} `));
+    }
+    const nested = run(entry, ['device', 'lock', '--help']);
+    assert.equal(nested.status, 0, nested.stderr);
+    assert.match(nested.stdout, /Usage: stim device lock /);
+    assert.match(nested.stdout, /--for <duration>/);
+  });
+
+  test(`${entry}: root help and unknown-command suggestions include other commands`, () => {
+    const help = run(entry, ['--help']);
+    assert.equal(help.status, 0, help.stderr);
+    for (const command of [
+      'doctor',
+      'worktree',
+      'start',
+      'stop',
+      'ios',
+      'android',
+      'reload',
+      'device',
+      'logs',
+      'status',
+      'stats',
+      'gc',
+      'guide',
+    ]) {
+      assert.match(help.stdout, new RegExp(`\\n  ${command}[ \\[]`));
+    }
+    const unknown = run(entry, ['strt']);
+    assert.equal(unknown.status, 1);
+    assert.match(unknown.stderr, /Did you mean start/);
+  });
+
+  test(`${entry}: selected commands retain JSON errors and literal arguments`, () => {
+    const invalid = run(entry, ['start', '--wait', '0', '--json']);
+    assert.equal(invalid.status, 1);
+    assert.equal(JSON.parse(invalid.stdout).code, 'STIM_BAD_ARG');
+    const literal = run(entry, ['guide', '--', '--version']);
+    assert.equal(literal.status, 1);
+    assert.notEqual(literal.stdout.trim(), version);
+  });
+}

--- a/test/runtime-floor.mjs
+++ b/test/runtime-floor.mjs
@@ -43,3 +43,8 @@ const version = execFileSync(process.execPath, ['packages/stim-cli/dist/cli.mjs'
 }).trim();
 const cliPackage = JSON.parse(readFileSync(join(repositoryRoot, 'packages', 'stim-cli', 'package.json'), 'utf8'));
 assert.equal(version, cliPackage.version);
+
+execFileSync(process.execPath, ['packages/stim-cli/dist/cli.mjs', '--help'], {
+  cwd: repositoryRoot,
+  stdio: 'pipe',
+});


### PR DESCRIPTION
## Description

Text-only commands currently load native build and device code before printing. On this MacBook Pro, lazy loading reduces `--version` from 72.3 to 26.1 ms and `guide agent` from 73.3 to 33.5 ms.

## Solution

Load the selected command and its dependencies; leading `--version` / `-V` loads none. Root help and unknown commands still register everything to preserve descriptions and suggestions. This makes root `--help` about 8 ms slower (73.4 to 81.3 ms).

## Test plan

- `pnpm run test:runtime` invokes both `--version` and `--help`, so the Node 20 compatibility check evaluates every command chunk.
- `node --test test/e2e/cli.e2e.js` exercises source and built entrypoints, rejects unrelated imports during version/guide output, and checks help routing and JSON errors. The four lazy-loading checks fail on the base and pass with this change.
- Compared stdout, stderr, and exit status for 64 invocations against the base; all match.
- Timed 30 alternating fresh Node processes per variant after a warm-up, using built artifacts and Node v22.22.2 on Apple Silicon. Medians above measure CLI startup only, excluding `npx`, Metro, and device boot. `start --help` also improves from 72.4 to 41.7 ms.

Fixes #620

