### PR TITLE
docs: restore README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img width="1200" height="630" alt="OG_Image" src="https://github.com/user-attachments/assets/c3642b3f-3974-448c-89f6-3d87cbfbc5b0" />
 
 ### About
+
 App&Flow is a Montreal-based React Native engineering and consulting studio. We partner with the world’s top companies and are recommended by [Expo](https://expo.dev/consultants). Need a hand? Let’s build together. team@appandflow.com
 
 # Stim


### PR DESCRIPTION
## Description
The README update makes the required format check fail.

## Solution
Add the formatter-required blank line after the About heading without changing content.

## Test plan
`oxfmt --check README.md` passes. No runtime change.

Fixes #633.