### PR TITLE
fix: audit non-login benchmark shell commands

### DIFF
--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -62,7 +62,7 @@ export function benchmarkTarget(config, selection) {
 
 export function topLevelShellCommand(command) {
   const trimmed = String(command ?? '').trim();
-  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -lc\s+([\s\S]+)$/);
+  const match = trimmed.match(/^\/bin\/(?:zsh|bash|sh) -l?c\s+([\s\S]+)$/);
   if (!match) return trimmed;
   const input = match[1];
   let source = '';

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -438,6 +438,19 @@ describe('benchmark run guards', () => {
     expect(topLevelShellCommand('/bin/zsh -lc "unterminated')).toBe('/bin/zsh -lc "unterminated');
   });
 
+  it.each(['zsh', 'bash', 'sh'])('audits non-login %s proof commands without hiding extra commands', (shell) => {
+    const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench AGENT_DEVICE_SESSION=run agent-device ';
+    const proof = `${prefix}open com.appandflow.trailhead --foreground --platform android --serial emulator-5554`;
+    const wrapped = `/bin/${shell} -c ${JSON.stringify(proof)}`;
+    expect(topLevelShellCommand(wrapped)).toBe(proof);
+    expect(agentDeviceIsolationInvalidReasons([{ command: wrapped }], prefix)).toEqual([]);
+    const chained = `/bin/${shell} -c ${JSON.stringify(`${proof}; agent-device close`)}`;
+    expect(topLevelShellCommand(chained)).not.toBe(proof);
+    expect(agentDeviceIsolationInvalidReasons([{ command: chained }], prefix)).not.toEqual([]);
+    const suffix = `${wrapped}; echo extra`;
+    expect(topLevelShellCommand(suffix)).toBe(suffix);
+  });
+
   it('rejects setup recovery inside the timer', () => {
     const commands = [
       { command: "/bin/zsh -lc 'stim guide agent'", exitCode: 1 },

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -933,6 +933,7 @@ describe('benchmark viewer export', () => {
         const stamped = JSON.parse(line);
         const event = JSON.parse(stamped.line);
         event.item.command = event.item.command.replace(/^agent-device /, prefix);
+        event.item.command = `/bin/zsh -c ${JSON.stringify(event.item.command)}`;
         stamped.line = JSON.stringify(event);
         return stamped;
       });


### PR DESCRIPTION
## Description

Benchmark audits reject successful proof commands when Codex uses a non-login shell (`/bin/zsh -c`), because only `-lc` wrappers are decoded. This also hides the explicit agent-device session from the isolation audit.

## Solution

Recognize `-c` alongside `-lc` for the existing supported shells. Keep quoting, standalone-command boundaries, and successful-exit requirements unchanged. This changes benchmark parsing only, not Stim or the measured agent workflow.

## Test plan

Regression cases cover non-login zsh/bash/sh proof commands, an unscoped chained command, and an extra shell suffix. The export fixture exercises complete proof validation through non-login wrappers.

Fixes #632.
