### PR TITLE
fix: time actionable initial launch diagnostics

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -358,6 +358,9 @@ commands. The injected error text is unique per run so the
 collector can prove that the reported stack and repair refer to this failure.
 The unique token and source location must appear in captured runtime errors;
 the earlier successful launch command does not have to print the token inline.
+When that launch response already contains the runtime error and root-layout
+context, its completion establishes diagnosis time rather than a later log
+query. The separate successful log capture remains required for validation.
 Before capture, normal guide, doctor, worktree warming, and narrowly scoped
 installed-dependency resolution are setup, not application-source inspection.
 

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -391,7 +391,7 @@ export function launchCrashDiagnosis(
     typeof capture.output === 'string' &&
     capture.output.includes(token) &&
     sourceMarkers.some((marker) => capture.output.includes(marker));
-  const index = captureIsActionable
+  let index = captureIsActionable
     ? errorCaptureIndex
     : ordered.findIndex(
         (command) =>
@@ -401,6 +401,17 @@ export function launchCrashDiagnosis(
           command.output.includes(token) &&
           sourceMarkers.some((marker) => command.output.includes(marker)),
       );
+  const initialLaunch = ordered[initialLaunchIndex];
+  const launchOutput = String(initialLaunch.output ?? '');
+  const launchIsActionable =
+    launchOutput.split('\n').some((line) => line.includes(token) && /\b(?:Error|Exception)\b/.test(line)) &&
+    sourceMarkers.some((marker) => launchOutput.includes(marker));
+  if (
+    launchIsActionable &&
+    (index === -1 || timestamp(initialLaunch, 'endedAt') <= timestamp(ordered[index], 'endedAt'))
+  ) {
+    index = initialLaunchIndex;
+  }
   if (index === -1) {
     return { valid: false, reason: 'actionable-launch-crash-diagnosis-missing' };
   }

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -11,6 +11,61 @@ import {
 } from './launch-crash-benchmark.mjs';
 
 describe('launch crash benchmark', () => {
+  it.each([
+    ['stim', 'ios', 'stim ios', 'stim logs --errors'],
+    ['stim', 'android', 'stim android', 'stim logs --errors'],
+    ['control', 'ios', 'npx expo run:ios', 'tail -40 /tmp/metro.log'],
+    ['control', 'android', 'npx expo run:android', 'adb -s emulator-5554 logcat -d'],
+  ])(
+    'times actionable initial launch output for %s/%s without waiving log capture',
+    (arm, platform, command, logCommand) => {
+      const token = launchCrashToken('initial-diagnosis');
+      const launch = {
+        id: 'launch',
+        command,
+        exitCode: 0,
+        startedAt: '2026-09-04T12:00:01Z',
+        endedAt: '2026-09-04T12:00:10Z',
+        output: `ERROR [Error: ${token}]\nError stack:\n  RootLayout (app/_layout.tsx:27:18)`,
+      };
+      const logs = {
+        id: 'logs',
+        command: logCommand,
+        exitCode: 0,
+        startedAt: '2026-09-04T12:00:11Z',
+        endedAt: '2026-09-04T12:00:15Z',
+        output: `${token}\nRootLayout (app/_layout.tsx:27:18)`,
+      };
+      const options = { dispatchAt: '2026-09-04T12:00:00Z', token, arm, platform };
+      expect(launchCrashDiagnosis([launch, logs], options)).toMatchObject({
+        valid: true,
+        commandId: 'launch',
+        errorCaptureCommandId: 'logs',
+        observedAt: launch.endedAt,
+        dispatchToDiagnosisSeconds: 10,
+        commandCount: 1,
+      });
+      expect(launchCrashDiagnosis([launch], options)).toEqual({
+        valid: false,
+        reason: 'launch-crash-error-capture-missing',
+      });
+      expect(launchCrashDiagnosis([launch, { ...logs, exitCode: 1 }], options).valid).toBe(false);
+      for (const output of [`${token} RootLayout`, `ERROR [Error: ${token}]`, 'ERROR unrelated\nRootLayout']) {
+        expect(launchCrashDiagnosis([{ ...launch, output }, logs], options)).toMatchObject({
+          commandId: 'logs',
+          dispatchToDiagnosisSeconds: 15,
+        });
+      }
+      expect(
+        launchCrashDiagnosis([{ ...launch, command: `echo 'ERROR ${token} RootLayout'; ${command}` }, logs], options)
+          .valid,
+      ).toBe(false);
+      expect(launchCrashDiagnosis([{ ...launch, endedAt: '2026-09-04T12:00:20Z' }, logs], options)).toMatchObject({
+        commandId: 'logs',
+        dispatchToDiagnosisSeconds: 15,
+      });
+    },
+  );
   it('requires explicit coordinator review for diagnostics falsely flagged as source inspection', () => {
     const diagnostic = {
       id: 'diagnostic',


### PR DESCRIPTION
## Description

Crash diagnosis timing ignores the initial launch response even when it already shows the runtime error and app stack, overstating time to diagnosis.

## Solution

Use actionable launch output when it arrives before the later diagnostic output, for both arms and platforms. Keep the separate successful log capture and source-inspection guards required for run validity; this changes derived timing, not the measured workflow.

## Test plan

Cases cover iOS/Android and Stim/control, missing or failed log capture, incomplete launch context, echoed source text, and overlapping commands whose logs finish first. Existing saved commands can be re-audited without rerunning agents.

Fixes #636.
