### PR TITLE
fix: retain artifact hits after launch failures

### DIFF
--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -401,7 +401,9 @@ function structuredCcaches(output) {
 
 function artifactCacheHit(entry) {
   return (
-    entry.exitCode === 0 &&
+    (entry.exitCode === 0 ||
+      (entry.exitCode === 1 &&
+        /"code"\s*:\s*"STIM_LAUNCH_FAILED"|^\s*error\s+STIM_LAUNCH_FAILED:/m.test(entry.output))) &&
     (structuredCcaches(entry.output).some((cache) => cache.status === 'not-run') ||
       /cache\s+hit\b|fingerprint\s+[0-9a-f]+\.\.\s+hit\b|compilation cache\s+not run; artifact cache supplied the app/.test(
         entry.output,

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -262,6 +262,49 @@ describe('compiler cache health', () => {
     'fingerprint abcdef.. hit (1s)\ncompilation cache not run; artifact cache supplied the app',
   );
 
+  it('retains an artifact hit when adopted-device cleanup fails before a successful retry', () => {
+    const failed =
+      'fingerprint abcdef.. hit (3.3s)\ndevice seed adopted (71ms)\n  error STIM_LAUNCH_FAILED: Could not clean adopted emulator: pm clear failed';
+    const structured = JSON.stringify({
+      code: 'STIM_LAUNCH_FAILED',
+      facts: { ccache: { status: 'not-run' } },
+    });
+    for (const output of [failed, structured]) {
+      expect(benchmarkCcache(meta, [...refusal(output), ...artifactHit])).toMatchObject({
+        status: 'artifact-hit',
+        builds: [],
+        invalidReasons: [],
+      });
+    }
+  });
+
+  it('does not let a launch failure or a later hit hide missing or unhealthy build evidence', () => {
+    const launchError = '\n  error STIM_LAUNCH_FAILED: App did not launch';
+    for (const output of [
+      launchError,
+      `fingerprint abcdef.. hit\nbuild compiling debug${launchError}`,
+      `fingerprint abcdef.. hit\ncompilation cache unavailable${launchError}`,
+      `fingerprint abcdef.. hit\n${JSON.stringify({ ccache: { status: 'unavailable' } })}${launchError}`,
+      'fingerprint abcdef.. hit\nTypeError: Unexpected failure',
+    ]) {
+      expect(benchmarkCcache(meta, [...refusal(output), ...artifactHit]).invalidReasons).toContain(
+        'ccache-evidence-missing',
+      );
+    }
+    for (const exitCode of [null, 137]) {
+      expect(
+        benchmarkCcache(meta, [...refusal(`fingerprint abcdef.. hit${launchError}`, exitCode), ...artifactHit])
+          .invalidReasons,
+      ).toContain('ccache-evidence-missing');
+    }
+    expect(
+      benchmarkCcache(meta, [
+        ...refusal(`build compiling debug\ncompilation cache 9 hits / 308 misses (2.8%)${launchError}`),
+        ...artifactHit,
+      ]).invalidReasons,
+    ).toContain('ccache-hit-rate-below-target');
+  });
+
   it('does not blame the compiler cache for a STIM_NO_METRO refusal that precedes an artifact hit', () => {
     expect(benchmarkCcache(meta, [...refusal(noMetro), ...artifactHit])).toMatchObject({
       status: 'artifact-hit',


### PR DESCRIPTION
## Description

An Android benchmark hit the artifact cache, failed during adopted-emulator cleanup, then recovered successfully. The cache audit rejected it for missing compiler statistics even though it never compiled. Fixes #640.

## Solution

Accept explicit artifact-hit evidence after a reported `STIM_LAUNCH_FAILED`, while retaining checks for compilation, unavailable counters, and ambiguous failures. This changes only the cache audit: launch failures and recovery overhead stay in the run, and app-proof requirements are unchanged.

The [original audit](https://github.com/appandflow/stim/commit/872bb1f09616fa0c95a377e191ec105b82069837) required exit zero for an artifact hit; that guard conflates a later launch failure with compilation.

## Test plan

Replayed the retained Luna Android JavaScript commands through the updated audit: artifact-hit, no compilation, no cache rejection. Regression cases cover cleanup failure plus recovery, JSON output, missing/unavailable statistics, compilation after a hit, interrupted commands, and a poorly cached build followed by a successful retry. No published CLI or recorded commands changed.
