### PR TITLE
fix: retain benchmark compatibility after cleanup

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -121,6 +121,11 @@ native compatibility adapter compensates. The policy, its digest, and the
 probe results are retained with the private run metadata; a refused run keeps
 its probe results in its run directory.
 
+Recollecting after recorded worktree cleanup can retain a previously passing
+compatibility check when run identity, captured evidence hashes, and the pinned
+manifest are unchanged. Other audit checks and derived timings are recalculated;
+missing or changed evidence does not inherit the earlier verdict.
+
 This boundary prevents accidental benchmark-data access, not adversarial host
 access: native system services and pre-existing processes are not sandboxed by
 the runner policy. Strong isolation from a malicious agent requires a separate

--- a/scripts/agent-benchmark/native-compat.mjs
+++ b/scripts/agent-benchmark/native-compat.mjs
@@ -211,7 +211,15 @@ export function collectedNativeCompatibility(meta, worktree) {
   try {
     if (!meta.preflight.nativeCompatibilityProbe?.processIdentity)
       throw new Error('sandbox compatibility probe missing');
-    if (!worktree || !existsSync(worktree)) throw new Error('run worktree missing for compatibility validation');
+    if (!worktree || !existsSync(worktree)) {
+      if (fileHash(join(expected.directory, 'manifest.json')) !== expected.manifestSha256)
+        throw new Error('native compatibility manifest changed');
+      return {
+        valid: false,
+        reason: 'run worktree missing for compatibility validation',
+        manifestSha256: expected.manifestSha256,
+      };
+    }
     verifyNativeCompatibility(
       join(expected.directory, 'manifest.json'),
       expected.manifestSha256,

--- a/scripts/agent-benchmark/native-compat.test.mjs
+++ b/scripts/agent-benchmark/native-compat.test.mjs
@@ -6,6 +6,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -62,6 +63,22 @@ test('compatibility refuses changed package bytes, permissions, fixture patch, a
     };
     assert.equal(collectedNativeCompatibility(meta, fixture).valid, true);
     assert.equal(collectedNativeCompatibility(meta, null).valid, false);
+    assert.equal(collectedNativeCompatibility(meta, null).manifestSha256, hash);
+    assert.equal(
+      collectedNativeCompatibility(
+        {
+          preflight: {
+            ...meta.preflight,
+            nativeCompatibility: { ...meta.preflight.nativeCompatibility, manifestSha256: 'changed' },
+          },
+        },
+        null,
+      ).manifestSha256,
+      undefined,
+    );
+    writeFileSync(manifest, `${readFileSync(manifest, 'utf8')}\n`);
+    assert.equal(collectedNativeCompatibility(meta, null).manifestSha256, undefined);
+    writeFileSync(manifest, readFileSync(manifest, 'utf8').slice(0, -1));
     assert.equal(collectedNativeCompatibility(meta, join(root, 'removed-worktree')).valid, false);
     assert.equal(
       collectedNativeCompatibility({ preflight: { nativeCompatibility: meta.preflight.nativeCompatibility } }, fixture)

--- a/scripts/agent-benchmark/run-record.mjs
+++ b/scripts/agent-benchmark/run-record.mjs
@@ -36,10 +36,35 @@ export function durableRunRecord(previous, next, cleanupCompleted = false) {
     sameEvidence(previous, next)
   ) {
     const invalidReasons = next.invalidReasons.filter((reason) => reason !== 'launch-crash-source-missing');
-    return {
+    next = {
       ...next,
       proof: previous.proof,
       evidenceSha256: { ...next.evidenceSha256, proof: previous.evidenceSha256.proof },
+      invalidReasons,
+      valid: invalidReasons.length === 0,
+    };
+  }
+  if (
+    cleanupCompleted &&
+    previous?.valid === true &&
+    ['runId', 'stage', 'runner', 'model', 'arm', 'variant', 'worktree'].every(
+      (key) => typeof previous[key] === 'string' && previous[key] && previous[key] === next[key],
+    ) &&
+    previous.nativeCompatibility?.valid === true &&
+    next.nativeCompatibility?.valid === false &&
+    next.nativeCompatibility.reason === 'run worktree missing for compatibility validation' &&
+    previous.nativeCompatibility.manifestSha256 &&
+    previous.nativeCompatibility.manifestSha256 === next.nativeCompatibility.manifestSha256 &&
+    ['events', 'settingsPng', 'transcript', 'proof', 'recording'].every(
+      (key) => previous.evidenceSha256?.[key] && previous.evidenceSha256[key] === next.evidenceSha256?.[key],
+    )
+  ) {
+    const invalidReasons = next.invalidReasons.filter(
+      (reason) => reason !== 'native-compatibility-changed-or-unverified',
+    );
+    return {
+      ...next,
+      nativeCompatibility: previous.nativeCompatibility,
       invalidReasons,
       valid: invalidReasons.length === 0,
     };

--- a/scripts/agent-benchmark/run-record.test.mjs
+++ b/scripts/agent-benchmark/run-record.test.mjs
@@ -5,6 +5,91 @@ const hashes = { events: 'events', settingsPng: 'settings', transcript: 'transcr
 const valid = { valid: true, invalidReasons: [], evidenceSha256: hashes, collectedAt: 'first' };
 
 describe('durable benchmark run records', () => {
+  it('retains verified native compatibility after cleanup while recalculating the audit and timings', () => {
+    const previous = {
+      ...valid,
+      runId: 'crash-run',
+      stage: 'sol-android-launch-error',
+      runner: 'codex',
+      model: 'sol',
+      arm: 'stim',
+      variant: 'launch-crash',
+      worktree: '/worktree/run',
+      nativeCompatibility: { valid: true, manifestSha256: 'manifest' },
+      proof: { valid: true, kind: 'launch-crash-source-repair', sourceSha256: 'source' },
+      evidenceSha256: { ...hashes, proof: 'source', recording: 'video' },
+      dispatchToDiagnosisSeconds: 120,
+    };
+    const next = {
+      ...previous,
+      valid: false,
+      nativeCompatibility: {
+        valid: false,
+        reason: 'run worktree missing for compatibility validation',
+        manifestSha256: 'manifest',
+      },
+      invalidReasons: ['launch-crash-source-missing', 'native-compatibility-changed-or-unverified'],
+      proof: { valid: false, reason: 'launch-crash-source-missing' },
+      evidenceSha256: { ...previous.evidenceSha256, proof: null },
+      dispatchToDiagnosisSeconds: 100,
+      collectedAt: 'second',
+    };
+    expect(durableRunRecord(previous, next, true)).toMatchObject({
+      valid: true,
+      invalidReasons: [],
+      nativeCompatibility: previous.nativeCompatibility,
+      proof: previous.proof,
+      dispatchToDiagnosisSeconds: 100,
+      collectedAt: 'second',
+    });
+    expect(
+      durableRunRecord(previous, { ...next, invalidReasons: [...next.invalidReasons, 'timeout'] }, true),
+    ).toMatchObject({ valid: false, invalidReasons: ['timeout'] });
+    expect(durableRunRecord(previous, next)).toBe(next);
+    for (const key of ['runId', 'stage', 'runner', 'model', 'arm', 'variant', 'worktree']) {
+      expect(durableRunRecord(previous, { ...next, [key]: 'changed' }, true).invalidReasons).toContain(
+        'native-compatibility-changed-or-unverified',
+      );
+    }
+    for (const key of ['events', 'settingsPng', 'transcript', 'recording']) {
+      for (const value of ['changed', null]) {
+        expect(
+          durableRunRecord(previous, { ...next, evidenceSha256: { ...next.evidenceSha256, [key]: value } }, true)
+            .invalidReasons,
+        ).toContain('native-compatibility-changed-or-unverified');
+      }
+    }
+    for (const nativeCompatibility of [
+      { ...next.nativeCompatibility, manifestSha256: 'changed' },
+      { valid: false, reason: 'run worktree missing for compatibility validation' },
+      { ...next.nativeCompatibility, reason: 'agent-device compatibility package changed' },
+    ]) {
+      expect(durableRunRecord(previous, { ...next, nativeCompatibility }, true).invalidReasons).toContain(
+        'native-compatibility-changed-or-unverified',
+      );
+    }
+    for (const prior of [
+      null,
+      { ...previous, valid: false },
+      { ...previous, nativeCompatibility: { valid: false, manifestSha256: 'manifest' } },
+      { ...previous, evidenceSha256: { ...previous.evidenceSha256, proof: 'changed' } },
+    ]) {
+      expect(durableRunRecord(prior, next, true).invalidReasons).toContain(
+        'native-compatibility-changed-or-unverified',
+      );
+    }
+    const readiness = { ...previous, variant: 'javascript' };
+    const changedProof = {
+      ...next,
+      variant: 'javascript',
+      proof: { valid: true },
+      evidenceSha256: { ...previous.evidenceSha256, proof: 'changed' },
+    };
+    expect(durableRunRecord(readiness, changedProof, true).invalidReasons).toContain(
+      'native-compatibility-changed-or-unverified',
+    );
+  });
+
   it('retains verified crash repair evidence after cleanup without retaining a stale audit verdict', () => {
     const previous = {
       runId: 'crash-run',


### PR DESCRIPTION
## Description

Recollecting a completed benchmark after cleanup rejects its native compatibility check because the worktree is gone. This blocked timing corrections even though the original run passed and its captured evidence was unchanged. Fixes #638.

## Solution

Retain the prior passing compatibility check only after recorded cleanup, matching run identity, unchanged captured evidence hashes, and a matching on-disk compatibility manifest. Missing worktrees remain invalid without that prior evidence. Keep the newly calculated timings and other audit failures rather than restoring the old verdict.

## Test plan

Replayed both retained Sol Android crash records against their post-cleanup recollections: each retains verified compatibility and the corrected diagnosis time, without rerunning the agent or changing recorded evidence. Regression cases cover changed identity, missing or changed evidence, changed manifests, previously unverified runs, and unrelated new audit failures.
