### PR TITLE
fix: preserve benchmark compiler cache evidence

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -126,6 +126,12 @@ compatibility check when run identity, captured evidence hashes, and the pinned
 manifest are unchanged. Other audit checks and derived timings are recalculated;
 missing or changed evidence does not inherit the earlier verdict.
 
+If a later launch failure omits compiler-cache counters, collection can preserve
+the workspace's per-build ccache log for one unambiguous completed Android build.
+Its modification time must fall within that command, and saved hashes bind it to
+the run, metadata, events, and command. Recollection and website export verify
+those hashes; multiple builds, stale logs, and low hit rates still need investigation.
+
 This boundary prevents accidental benchmark-data access, not adversarial host
 access: native system services and pre-existing processes are not sandboxed by
 the runner policy. Strong isolation from a malicious agent requires a separate

--- a/scripts/agent-benchmark/ccache-evidence.mjs
+++ b/scripts/agent-benchmark/ccache-evidence.mjs
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { ccacheMeasurements, shellCommandSegments } from './run-guards.mjs';
+
+const hash = (value) => createHash('sha256').update(value).digest('hex');
+
+export function ccacheLogEvidence({ runDir, meta, commands, worktree, capture = false }) {
+  if (meta.arm !== 'stim' || meta.platform !== 'android' || !worktree) return null;
+  const builds = commands.filter(
+    (entry) =>
+      shellCommandSegments(entry.command).some((segment) => /^stim android(?:\s|$)/.test(segment)) &&
+      /build\s+compiling/.test(entry.output),
+  );
+  if (builds.length !== 1) return null;
+  const entry = builds[0];
+  if (
+    [...entry.output.matchAll(/build\s+compiling/g)].length !== 1 ||
+    !entry.id ||
+    entry.parallelTimingAmbiguous ||
+    shellCommandSegments(entry.command).length !== 1 ||
+    ![0, 1].includes(entry.exitCode) ||
+    !/build\s+ok\b/.test(entry.output) ||
+    ccacheMeasurements(entry.output).length
+  )
+    return null;
+  const start = Date.parse(entry.startedAt),
+    end = Date.parse(entry.endedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+  const statsPath = join(runDir, 'ccache-evidence.log');
+  const recordPath = join(runDir, 'ccache-evidence.json');
+  try {
+    const identity = {
+      schemaVersion: 1,
+      runId: meta.runId,
+      worktree: resolve(worktree),
+      commandId: entry.id,
+      commandSha256: hash(JSON.stringify(entry)),
+      metaSha256: hash(JSON.stringify(meta)),
+      eventsSha256: hash(readFileSync(join(runDir, 'events.jsonl'))),
+    };
+    if (capture && !existsSync(recordPath) && !existsSync(statsPath)) {
+      const home = realpathSync(join(runDir, 'stim-home'));
+      if (!home.startsWith(`${realpathSync(runDir)}${sep}`)) return null;
+      const projects = Object.keys(JSON.parse(readFileSync(join(home, 'config.json'), 'utf8')).projects ?? {});
+      if (projects.length !== 1 || realpathSync(projects[0]) !== realpathSync(worktree)) return null;
+      const workspaceHome = join(home, 'workspaces');
+      if (!realpathSync(workspaceHome).startsWith(`${home}${sep}`)) return null;
+      const logs = readdirSync(workspaceHome)
+        .map((name) => join(workspaceHome, name, 'logs', 'ccache-stats.log'))
+        .filter((path) => existsSync(path));
+      if (
+        logs.length !== 1 ||
+        !realpathSync(logs[0]).startsWith(`${realpathSync(workspaceHome)}${sep}`) ||
+        !lstatSync(logs[0]).isFile()
+      )
+        return null;
+      const before = statSync(logs[0]);
+      if (before.mtimeMs < start || before.mtimeMs > end) return null;
+      const bytes = readFileSync(logs[0]);
+      const after = statSync(logs[0]);
+      if (before.mtimeMs !== after.mtimeMs || before.size !== after.size) return null;
+      writeFileSync(statsPath, bytes, { flag: 'wx' });
+      writeFileSync(
+        recordPath,
+        JSON.stringify({ ...identity, statsSha256: hash(bytes), modifiedAtMs: before.mtimeMs }, null, 2),
+        { flag: 'wx' },
+      );
+    }
+    if (!lstatSync(recordPath).isFile() || !lstatSync(statsPath).isFile()) return null;
+    const evidence = JSON.parse(readFileSync(recordPath, 'utf8'));
+    const bytes = readFileSync(statsPath);
+    if (
+      Object.entries(identity).some(([key, value]) => evidence[key] !== value) ||
+      evidence.statsSha256 !== hash(bytes) ||
+      !Number.isFinite(evidence.modifiedAtMs) ||
+      evidence.modifiedAtMs < start ||
+      evidence.modifiedAtMs > end
+    )
+      return null;
+    const lines = bytes
+      .toString('utf8')
+      .split('\n')
+      .map((line) => line.trim());
+    const hits = lines.filter((line) => line === 'direct_cache_hit' || line === 'preprocessed_cache_hit').length;
+    const misses = lines.filter((line) => line === 'cache_miss').length;
+    if (hits + misses === 0) return null;
+    return {
+      commandId: entry.id,
+      hits,
+      misses,
+      hitRatePercent: (100 * hits) / (hits + misses),
+      source: 'stats-log',
+      statsLogSha256: evidence.statsSha256,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/scripts/agent-benchmark/ccache-evidence.test.mjs
+++ b/scripts/agent-benchmark/ccache-evidence.test.mjs
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ccacheLogEvidence } from './ccache-evidence.mjs';
+import { benchmarkCcache } from './run-guards.mjs';
+
+let root, runDir, worktree, statsLog, meta, commands;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'bench-ccache-evidence-'));
+  runDir = join(root, 'run');
+  worktree = join(root, 'worktree');
+  statsLog = join(runDir, 'stim-home/workspaces/owned/logs/ccache-stats.log');
+  mkdirSync(join(runDir, 'stim-home/workspaces/owned/logs'), { recursive: true });
+  mkdirSync(worktree);
+  writeFileSync(join(runDir, 'stim-home/config.json'), JSON.stringify({ projects: { [worktree]: {} } }));
+  writeFileSync(join(runDir, 'events.jsonl'), 'captured events');
+  writeFileSync(statsLog, '# a.cpp\ndirect_cache_hit\n# b.cpp\npreprocessed_cache_hit\n');
+  meta = {
+    runId: 'run',
+    arm: 'stim',
+    platform: 'android',
+    variant: 'native',
+    timingTarget: { ccacheMinHitRatePercent: 50 },
+  };
+  commands = [
+    {
+      id: 'build',
+      command: 'stim android',
+      startedAt: new Date(Date.now() - 1000).toISOString(),
+      endedAt: new Date(Date.now() + 1000).toISOString(),
+      exitCode: 1,
+      output: 'build compiling debug\nbuild ok (28s)\nerror STIM_LAUNCH_FAILED: device offline',
+    },
+  ];
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+const evidence = (capture = true) => ccacheLogEvidence({ runDir, meta, commands, worktree, capture });
+
+describe('captured compiler cache evidence', () => {
+  it('captures the completed build independently of launch and survives cleanup without editing commands', () => {
+    const before = JSON.stringify(commands);
+    const measurement = evidence();
+    expect(measurement).toMatchObject({ commandId: 'build', hits: 2, misses: 0, source: 'stats-log' });
+    expect(benchmarkCcache(meta, commands, measurement)).toMatchObject({ status: 'measured', invalidReasons: [] });
+    expect(JSON.stringify(commands)).toBe(before);
+    rmSync(join(runDir, 'stim-home'), { recursive: true });
+    rmSync(worktree, { recursive: true });
+    expect(evidence(false)).toEqual(measurement);
+  });
+
+  it('keeps low-hit alerts and refuses to reuse the last log for multiple or ambiguous builds', () => {
+    writeFileSync(statsLog, 'direct_cache_hit\ncache_miss\ncache_miss\n');
+    expect(benchmarkCcache(meta, commands, evidence()).invalidReasons).toContain('ccache-hit-rate-below-target');
+    commands.push({ ...commands[0], id: 'second' });
+    expect(evidence(false)).toBeNull();
+    commands.pop();
+    commands[0].parallelTimingAmbiguous = true;
+    expect(evidence(false)).toBeNull();
+  });
+
+  it.each(['stale', 'late', 'wrong workspace', 'multiple logs', 'unfinished', 'chained', 'repeated build'])(
+    'refuses %s capture',
+    (failure) => {
+      if (failure === 'stale') utimesSync(statsLog, new Date(0), new Date(0));
+      if (failure === 'late') utimesSync(statsLog, new Date(Date.now() + 60000), new Date(Date.now() + 60000));
+      if (failure === 'wrong workspace') writeFileSync(join(runDir, 'stim-home/config.json'), '{"projects":{}}');
+      if (failure === 'multiple logs') {
+        mkdirSync(join(runDir, 'stim-home/workspaces/other/logs'), { recursive: true });
+        writeFileSync(join(runDir, 'stim-home/workspaces/other/logs/ccache-stats.log'), 'cache_miss');
+      }
+      if (failure === 'unfinished') commands[0].exitCode = null;
+      if (failure === 'chained') commands[0].command = 'stim android; echo done';
+      if (failure === 'repeated build') commands[0].output += '\nbuild compiling debug\nbuild ok (1s)';
+      expect(evidence()).toBeNull();
+      expect(benchmarkCcache(meta, commands).invalidReasons).toContain('ccache-evidence-missing');
+    },
+  );
+
+  it.each(['stats', 'events', 'meta', 'command', 'worktree', 'missing log', 'missing record'])(
+    'refuses changed %s evidence without recapturing it',
+    (failure) => {
+      expect(evidence()).not.toBeNull();
+      if (failure === 'stats') writeFileSync(join(runDir, 'ccache-evidence.log'), 'cache_miss');
+      if (failure === 'events') writeFileSync(join(runDir, 'events.jsonl'), 'changed events');
+      if (failure === 'meta') meta.runId = 'other';
+      if (failure === 'command') commands[0].output += '\nchanged';
+      if (failure === 'worktree') worktree = join(root, 'other-worktree');
+      if (failure === 'missing log') rmSync(join(runDir, 'ccache-evidence.log'));
+      if (failure === 'missing record') rmSync(join(runDir, 'ccache-evidence.json'));
+      expect(evidence()).toBeNull();
+    },
+  );
+
+  it('does not override unavailable command counters or excuse another attempt with missing evidence', () => {
+    const measurement = evidence();
+    commands.push({ id: 'unknown', command: 'stim android', exitCode: 1, output: 'unexpected failure' });
+    expect(benchmarkCcache(meta, commands, measurement).invalidReasons).toContain('ccache-evidence-missing');
+    commands.pop();
+    commands[0].output += '\ncompilation cache unavailable';
+    expect(benchmarkCcache(meta, commands, measurement).invalidReasons).toContain('ccache-evidence-missing');
+    expect(readFileSync(join(runDir, 'ccache-evidence.log'), 'utf8')).toContain('preprocessed_cache_hit');
+  });
+});

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -38,6 +38,7 @@ import {
   matchesExpectedIosSimulator,
 } from './watch-app-selection.mjs';
 import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
+import { ccacheLogEvidence } from './ccache-evidence.mjs';
 import {
   isolatedRunnerInvocation,
   prepareRunnerIsolation,
@@ -2226,7 +2227,6 @@ function collect(runDir) {
     : { error: 'missing-app-alive-record' };
   const eventsPath = join(runDir, 'events.jsonl');
   const commandAudit = commandEvidence(meta, eventsPath, runDir, appAlive.simulator);
-  const ccache = benchmarkCcache(meta, commandAudit.commands);
   const screen = screenEvidence(meta, appAlive, commandAudit.commands, runDir);
   const timing = benchmarkTiming(
     meta.timingTarget,
@@ -2237,6 +2237,11 @@ function collect(runDir) {
   const recording = recordingEvidence(meta, commandAudit.commands, runDir, screen);
   const worktreeRecord = worktreeEvidence(runDir, meta, eventsPath);
   const worktree = worktreeRecord?.path ?? null;
+  const ccache = benchmarkCcache(
+    meta,
+    commandAudit.commands,
+    ccacheLogEvidence({ runDir, meta, commands: commandAudit.commands, worktree, capture: true }),
+  );
   const nativeCompatibility = collectedNativeCompatibility(meta, worktree);
   const proof = proofFor(meta, appAlive, runDir, worktree, commandAudit.completedEvents);
   const rollout =

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -423,7 +423,7 @@ function preBuildRefusal(entry) {
   );
 }
 
-export function benchmarkCcache(meta, commands) {
+export function benchmarkCcache(meta, commands, statsLogMeasurement = null) {
   const minimum = meta.timingTarget?.ccacheMinHitRatePercent ?? null;
   const result = { minimumHitRatePercent: minimum, status: 'not-applicable', builds: [], invalidReasons: [] };
   if (meta.arm !== 'stim' || meta.platform !== 'android') return result;
@@ -433,6 +433,7 @@ export function benchmarkCcache(meta, commands) {
   );
   for (const entry of attemptedBuilds) {
     const measurements = ccacheMeasurements(entry.output);
+    if (!measurements.length && statsLogMeasurement?.commandId === entry.id) measurements.push(statsLogMeasurement);
     result.builds.push(...measurements.map((measurement) => ({ commandId: entry.id ?? null, ...measurement })));
     if (
       /compilation cache\s+unavailable/.test(entry.output) ||

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -16,11 +16,13 @@ import { timeBenchmarkFromFirstActivity } from './benchmark-timing.mjs';
 import { stripVTControlCharacters } from 'node:util';
 import { launchCrashDiagnosis, launchCrashRecovery, podfileChecksumChanges } from './launch-crash-benchmark.mjs';
 import { reconstructCommandEvidence } from './agent-benchmark/command-evidence.mjs';
+import { ccacheLogEvidence } from './agent-benchmark/ccache-evidence.mjs';
 import { benchmarkCommandPresentation } from './benchmark-command-presentation.mjs';
 import {
   agentDeviceIsolationInvalidReasons,
   agentDeviceAuxiliarySessions,
   benchmarkSetupInvalidReasons,
+  benchmarkCcache,
   topLevelShellCommand,
 } from './agent-benchmark/run-guards.mjs';
 
@@ -1185,6 +1187,16 @@ export function exportBenchmark(stageDir, outputPath, proofDir, machine = {}) {
     .map((runDir) => {
       const meta = readJson(join(runDir, 'meta.json'));
       const record = publicationRecord(runDir, meta);
+      if (
+        existsSync(join(runDir, 'ccache-evidence.json')) ||
+        record.ccache?.builds?.some((build) => build.source === 'stats-log')
+      ) {
+        const stamped = readFileSync(join(runDir, 'events.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
+        const { commands } = reconstructCommandEvidence(meta.runner, stamped);
+        const evidence = ccacheLogEvidence({ runDir, meta, commands, worktree: record.worktree });
+        if (!evidence || JSON.stringify(benchmarkCcache(meta, commands, evidence)) !== JSON.stringify(record.ccache))
+          record.valid = false;
+      }
       return {
         runDir,
         record,

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -921,6 +921,12 @@ describe('benchmark viewer export', () => {
     expect(payload.runs).toHaveLength(1);
     expect(payload.runs[0].commands[0].output).toBe('emulator <simulator-udid>');
 
+    writeFileSync(recordPath, JSON.stringify({ ...record, ccache: { builds: [{ source: 'stats-log' }] } }));
+    expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+      /no valid benchmark runs/,
+    );
+    writeFileSync(recordPath, JSON.stringify(record));
+
     const eventsPath = join(runDir, 'events.jsonl');
     const metaPath = join(runDir, 'meta.json');
     const originalEvents = readFileSync(eventsPath, 'utf8');


### PR DESCRIPTION
## Description

A native benchmark compiled successfully, then failed during launch before Stim printed its compiler-cache counters. The agent recovered, but the audit rejected the run despite its per-build log proving 386 hits and no misses. Fixes #645; #644 tracks improving the CLI output separately.

## Solution

Capture the run's ccache log only for one unambiguous completed build whose command lacks counters. Require the isolated workspace, a log modification time inside that command, and hashes binding the capture to its metadata, events and command. Recollection and website export verify the capture; missing evidence and low-hit alerts still apply. Multiple builds remain unsupported because Stim resets the log on each build.

## Test plan

Replayed the retained Luna native commands and original timestamped stats log in a separate temporary capture: 386/386 hits, above the 95% target, without modifying the recorded commands. Regression cases reject stale, ambiguous, modified, missing, or misattributed evidence and retain low-hit alerts. Website export rejects a record claiming log-based counters without its capture. No published CLI or benchmark prompt changes.
