### PR TITLE
fix: clear completed recording state before parking

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -355,6 +355,15 @@ control, remove its worktree and branch and shut down and delete only the newly
 created benchmark simulator or emulator. Do not touch unrelated physical-device
 leases or automation sessions.
 
+Before stopping a pooled Android emulator, cleanup also retires completed
+agent-device recording manifests. It requires the exact owned device, the
+matching run's hash-verified saved video, absent remote video chunks, and proof
+that every original recording process is gone (including a different process
+start time after PID reuse). It archives the manifest and removes only that
+metadata; it never signals the replacement process. Unknown, incomplete, live,
+or changed evidence stops cleanup. This runs after timing, not by prebooting a
+parked emulator before the next agent starts.
+
 ## JavaScript launch-crash extension
 
 A launch-crash diagnostic is a separate suite, not a fifth performance cell.

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -39,6 +39,7 @@ import {
 } from './watch-app-selection.mjs';
 import { completedCleanupRecord, durableRunRecord } from './run-record.mjs';
 import { ccacheLogEvidence } from './ccache-evidence.mjs';
+import { retireAndroidRecording } from './recording-cleanup.mjs';
 import {
   isolatedRunnerInvocation,
   prepareRunnerIsolation,
@@ -2405,6 +2406,17 @@ function cleanup(runDir) {
   }
   if (meta.arm === 'stim' && worktree && existsSync(worktree)) {
     const stimHome = join(runDir, 'stim-home');
+    if (meta.platform === 'android') {
+      const serial = appAlive.simulator?.udid;
+      const retired = retireAndroidRecording({
+        runDir,
+        ownerHome: stimHome,
+        ownerWorktree: worktree,
+        serial,
+        adb: (args) => run('adb', ['-s', serial, ...args], { timeout: 10_000 }),
+      });
+      actions.push(`verified completed recording metadata cleared before parking: ${retired.length} manifests`);
+    }
     const env = {
       ...cleanRubyEnvironment(process.env),
       STIM_HOME: stimHome,

--- a/scripts/agent-benchmark/recording-cleanup.mjs
+++ b/scripts/agent-benchmark/recording-cleanup.mjs
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const read = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+export function retireAndroidRecording({ runDir, ownerHome, ownerWorktree, serial, adb }) {
+  const verifyOwner = () => {
+    const projects = read(join(ownerHome, 'config.json')).projects ?? {};
+    const project = Object.entries(projects).find(([path]) => realpathSync(path) === realpathSync(ownerWorktree))?.[1];
+    const device = project?.platforms?.android;
+    if (
+      device?.owned !== true ||
+      !device.avdName?.startsWith('stim-') ||
+      serial !== `emulator-${device.consolePort}` ||
+      adb(['emu', 'avd', 'name']).trim().split(/\r?\n/)[0] !== device.avdName
+    )
+      throw new Error('Android recording cleanup cannot prove emulator ownership');
+  };
+  verifyOwner();
+  const retired = [];
+  for (const directory of ['/sdcard', '/data/local/tmp']) {
+    const listing = () => adb(['shell', 'ls', '-a', directory]).trim().split(/\s+/);
+    const path = `${directory}/agent-device-recording-active.json`;
+    if (!listing().includes('agent-device-recording-active.json')) continue;
+    const text = adb(['shell', 'cat', path]);
+    const manifest = JSON.parse(text);
+    const record = read(join(runDir, 'run.json'));
+    const meta = read(join(runDir, 'meta.json'));
+    if (
+      record.valid !== true ||
+      record.recording?.valid !== true ||
+      meta.platform !== 'android' ||
+      meta.runId !== record.runId ||
+      manifest.version !== 1 ||
+      manifest.resourceKind !== 'screen-recording' ||
+      manifest.sessionId !== (meta.agentDevice?.session ?? meta.runId) ||
+      manifest.deviceId !== serial ||
+      manifest.transportMode !== 'local' ||
+      manifest.pendingRemotePath !== undefined ||
+      manifest.completion?.backend !== 'adb screenrecord' ||
+      !Number.isFinite(manifest.startedAt) ||
+      !Number.isFinite(manifest.completion.completedAt) ||
+      manifest.completion.completedAt < manifest.startedAt ||
+      manifest.outputPath !== `/tmp/${meta.runId}-session.mp4` ||
+      manifest.completion.outPath !== manifest.outputPath ||
+      !Array.isArray(manifest.chunks) ||
+      !manifest.chunks.length ||
+      hash(readFileSync(join(runDir, 'proof', 'session.mp4'))) !== record.evidenceSha256?.recording
+    )
+      throw new Error('Android recording cleanup requires a completed benchmark recording with saved proof');
+    const verifyEnded = () => {
+      const processes = new Set(adb(['shell', 'ls', '/proc']).trim().split(/\s+/));
+      const files = listing();
+      for (const chunk of manifest.chunks) {
+        const name = chunk.remotePath?.slice(directory.length + 1);
+        if (
+          typeof chunk.remotePid !== 'string' ||
+          !/^\d+$/.test(chunk.remotePid) ||
+          typeof chunk.remoteStartTime !== 'string' ||
+          !/^\d+$/.test(chunk.remoteStartTime) ||
+          !chunk.remotePath?.startsWith(`${directory}/`) ||
+          !/^agent-device-recording-\d+\.mp4$/.test(name ?? '') ||
+          files.includes(name)
+        )
+          throw new Error('Android recording cleanup cannot retire a chunk with remaining or unknown artifacts');
+        if (!processes.has(chunk.remotePid)) continue;
+        const stat = adb(['shell', 'cat', `/proc/${chunk.remotePid}/stat`]);
+        const end = stat.lastIndexOf(')');
+        const start =
+          end < 0
+            ? null
+            : stat
+                .slice(end + 1)
+                .trim()
+                .split(/\s+/)[19];
+        if (!stat.startsWith(`${chunk.remotePid} (`) || !/^\d+$/.test(start ?? '') || start === chunk.remoteStartTime)
+          throw new Error('Android recording cleanup cannot prove the original recorder has ended');
+      }
+    };
+    verifyEnded();
+    const evidence = { checkedAt: new Date().toISOString(), serial, path, manifestSha256: hash(text), manifest };
+    writeFileSync(
+      join(runDir, `recording-retirement-${directory === '/sdcard' ? 'sdcard' : 'tmp'}.json`),
+      JSON.stringify(evidence, null, 2),
+    );
+    verifyOwner();
+    if (adb(['shell', 'cat', path]) !== text) throw new Error('Android recording manifest changed during cleanup');
+    verifyEnded();
+    adb(['shell', 'rm', '-f', path]);
+    if (listing().includes('agent-device-recording-active.json'))
+      throw new Error('Android recording manifest remains after cleanup');
+    retired.push(path);
+  }
+  return retired;
+}

--- a/scripts/agent-benchmark/recording-cleanup.test.mjs
+++ b/scripts/agent-benchmark/recording-cleanup.test.mjs
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { retireAndroidRecording } from './recording-cleanup.mjs';
+
+let root, runDir, ownerHome, ownerWorktree, manifest, config, calls, files, processStart, changedManifest, changedOwner;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'recording-cleanup-'));
+  runDir = join(root, 'run');
+  ownerHome = join(root, 'home');
+  ownerWorktree = join(root, 'worktree');
+  for (const path of [join(runDir, 'proof'), ownerHome, ownerWorktree]) mkdirSync(path, { recursive: true });
+  config = {
+    projects: { [ownerWorktree]: { platforms: { android: { owned: true, avdName: 'stim-pool', consolePort: 5554 } } } },
+  };
+  writeFileSync(join(ownerHome, 'config.json'), JSON.stringify(config));
+  writeFileSync(join(runDir, 'meta.json'), JSON.stringify({ runId: 'test', platform: 'android' }));
+  writeFileSync(join(runDir, 'proof/session.mp4'), 'saved video');
+  writeFileSync(
+    join(runDir, 'run.json'),
+    JSON.stringify({
+      runId: 'test',
+      valid: true,
+      recording: { valid: true },
+      evidenceSha256: { recording: createHash('sha256').update('saved video').digest('hex') },
+    }),
+  );
+  manifest = {
+    version: 1,
+    resourceKind: 'screen-recording',
+    sessionId: 'test',
+    deviceId: 'emulator-5554',
+    transportMode: 'local',
+    startedAt: 1,
+    outputPath: '/tmp/test-session.mp4',
+    chunks: [{ remotePid: '42', remoteStartTime: '100', remotePath: '/sdcard/agent-device-recording-123.mp4' }],
+    completion: { backend: 'adb screenrecord', completedAt: 2, outPath: '/tmp/test-session.mp4' },
+  };
+  calls = [];
+  files = ['agent-device-recording-active.json'];
+  processStart = '200';
+  changedManifest = false;
+  changedOwner = false;
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+const adb = (args) => {
+  const command = args.join(' ');
+  calls.push(command);
+  if (command === 'emu avd name')
+    return changedOwner && calls.filter((x) => x === command).length > 1 ? 'other\nOK' : 'stim-pool\nOK';
+  if (command === 'shell ls -a /sdcard') return files.join('\n');
+  if (command === 'shell ls -a /data/local/tmp') return '';
+  if (command === 'shell cat /sdcard/agent-device-recording-active.json')
+    return JSON.stringify(
+      changedManifest && calls.filter((x) => x === command).length > 1
+        ? { ...manifest, sessionId: 'changed' }
+        : manifest,
+    );
+  if (command === 'shell ls /proc') return processStart === null ? '1 2' : '1 2 42';
+  if (command === 'shell cat /proc/42/stat') {
+    if (processStart === 'unreadable') throw Error('permission denied');
+    return `42 (binder thread) ${Array(19).fill('0').join(' ')} ${processStart}`;
+  }
+  if (command === 'shell rm -f /sdcard/agent-device-recording-active.json') {
+    files = [];
+    return '';
+  }
+  throw Error(`Unexpected adb call: ${command}`);
+};
+const retire = () => retireAndroidRecording({ runDir, ownerHome, ownerWorktree, serial: 'emulator-5554', adb });
+
+it.each(['missing', 'reused'])(
+  'retires completed metadata with saved proof and a %s recorder without signaling a process',
+  (state) => {
+    if (state === 'missing') processStart = null;
+    expect(retire()).toEqual(['/sdcard/agent-device-recording-active.json']);
+    expect(calls.filter((x) => x.includes('rm ') || x.includes('kill'))).toEqual([
+      'shell rm -f /sdcard/agent-device-recording-active.json',
+    ]);
+    expect(JSON.parse(readFileSync(join(runDir, 'recording-retirement-sdcard.json'))).manifest).toEqual(manifest);
+  },
+);
+
+it('leaves devices without recording manifests unchanged', () => {
+  files = [];
+  expect(retire()).toEqual([]);
+  expect(calls.some((x) => x.includes('rm ') || x.includes('/proc'))).toBe(false);
+});
+
+it.each([
+  'live',
+  'unreadable',
+  'malformed stat',
+  'incomplete',
+  'wrong session',
+  'wrong device',
+  'foreign path',
+  'remaining video',
+  'modified proof',
+  'unowned',
+  'changed owner',
+  'changed manifest',
+  'numeric identity',
+])('refuses %s evidence without deleting metadata', (failure) => {
+  if (failure === 'live') processStart = '100';
+  if (failure === 'unreadable') processStart = 'unreadable';
+  if (failure === 'malformed stat') processStart = 'unknown';
+  if (failure === 'incomplete') delete manifest.completion;
+  if (failure === 'wrong session') manifest.sessionId = 'another-run';
+  if (failure === 'wrong device') manifest.deviceId = 'emulator-5556';
+  if (failure === 'foreign path') manifest.chunks[0].remotePath = '/sdcard/someone-elses.mp4';
+  if (failure === 'remaining video') files.push('agent-device-recording-123.mp4');
+  if (failure === 'modified proof') writeFileSync(join(runDir, 'proof/session.mp4'), 'different');
+  if (failure === 'unowned') {
+    config.projects[ownerWorktree].platforms.android.owned = false;
+    writeFileSync(join(ownerHome, 'config.json'), JSON.stringify(config));
+  }
+  if (failure === 'changed owner') changedOwner = true;
+  if (failure === 'changed manifest') changedManifest = true;
+  if (failure === 'numeric identity') manifest.chunks[0].remoteStartTime = 100;
+  expect(retire).toThrow(/Android recording|permission denied/);
+  expect(calls.some((x) => x.includes('rm ') || x.includes('kill'))).toBe(false);
+});


### PR DESCRIPTION
## Description

A pooled Android emulator retained a completed agent-device recording manifest. After its PID was reused, the next benchmark could repair the app but could not start its required video. Fixes #648; upstream report: https://github.com/callstack/agent-device/issues/2476.

## Solution

Retire completed recording metadata during benchmark cleanup, before stopping and parking the emulator. Require the owned device, matching saved-video hash, absent remote chunks, and proof that each original recorder is gone. Archive the manifest and delete only that metadata; never signal the replacement process. Unknown or changing evidence stops cleanup. This changes neither the published CLI nor agent-device, and does not preboot the next run's emulator outside timing.

## Test plan

On the retained Android36 emulator, verified the old PID belonged to a different process with a different start time and the old video was absent. The helper archived and removed the completed manifest; a separate diagnostic session then successfully started and stopped a new recording on the same emulator. Regression cases refuse live/unreadable identities, incomplete/foreign manifests, altered video proof, remaining chunks, and ownership/manifest changes.
