### PR TITLE
fix: identify real benchmark launch commands

### DIFF
--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -61,7 +61,9 @@ function successfulLaunch(command, arm, platform) {
     if (statuses.length !== 1 || statuses[0][1] !== '0') return false;
     pipeline = pipeline.slice(0, report.index);
   }
-  const [launch, ...filters] = pipeline.replace(/\s+2>&1(?=\s|$)/g, '').split(/\s*\|\s*/);
+  let [launch, ...filters] = pipeline.replace(/\s+2>&1(?=\s|$)/g, '').split(/\s*\|\s*/);
+  if (arm === 'control' && platform === 'android')
+    launch = launch.replace(/^adb\s+-s\s+emulator-\d+\s+reverse\s+tcp:\d+\s+tcp:\d+\s*&&\s*/, '');
   const group = /^\{\s*([\s\S]*?);\s*\}$/.exec(launch);
   const launches = group ? shellCommandSegments(group[1]) : [launch];
   return (
@@ -81,6 +83,7 @@ function shellCommand(command) {
 
 function launchCommand(command, arm, platform) {
   command = shellCommand(command);
+  if (/(?:^|\s)["']?(?:--help|--version|-h|-v)["']?(?=\s|$|[;&|])/.test(command)) return false;
   if (arm === 'stim')
     return shellCommandSegments(command).some((segment) => new RegExp(`^stim\\s+${platform}(?:\\s|$)`).test(segment));
   if (platform === 'android') {

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -315,6 +315,31 @@ done`;
       output: 'BUILD SUCCESSFUL\nPIPELINE_EXIT=0\nShell cwd was reset to /tmp/fixture',
     };
     expect(launchCrashDiagnosis([...before, pipeline, logs], options)).toMatchObject({ valid: true });
+    const forwardedLaunch = {
+      ...launch,
+      command:
+        'set -o pipefail; adb -s emulator-5554 reverse tcp:8081 tcp:8081 && ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a npx expo run:android --device emulator-5554 --no-bundler 2>&1 | tee /tmp/native.log',
+    };
+    for (const flag of ['--help', '-h', '--version', '-v', "'--help'", '"--help"']) {
+      const help = { ...before[0], id: 'help', command: `npx expo run:android ${flag} | sed -n '1,180p'` };
+      expect(launchCrashDiagnosis([help, logs], options)).toMatchObject({
+        valid: false,
+        reason: 'launch-crash-initial-launch-evidence-missing',
+      });
+      expect(launchCrashDiagnosis([help, forwardedLaunch, logs], options)).toMatchObject({
+        valid: true,
+        initialLaunchCommandId: 'launch',
+        commandId: 'logs',
+      });
+    }
+    for (const changed of [
+      { exitCode: 1 },
+      { command: forwardedLaunch.command.replace('&&', ';') },
+      { command: forwardedLaunch.command.replace('&&', '||') },
+      { command: forwardedLaunch.command.replace('&&', '&& cat app/_layout.tsx &&') },
+      { command: forwardedLaunch.command.replace('set -o pipefail', 'set +o pipefail') },
+    ])
+      expect(launchCrashDiagnosis([{ ...forwardedLaunch, ...changed }, logs], options)).toMatchObject({ valid: false });
     expect(
       launchCrashDiagnosis(
         [


### PR DESCRIPTION
## Description

The launch-crash audit could label `expo run:android --help` as the initial launch while rejecting the real launch preceded by `adb reverse`. This affects benchmark evidence, not Stim runtime behavior.

## Solution

Exclude help/version invocations and accept device-scoped Android port forwarding chained to a launch in a successful `pipefail` pipeline. Failed or status-masking commands remain rejected.

## Test plan

Replayed a retained Android control run: the initial-launch event now points to its real Expo invocation instead of help; the diagnosis event and timestamp are unchanged. Regression cases cover help flags, forwarding, failed launches, masked status, and intervening source reads.

Fixes #647.
