### PR TITLE
docs: run the theme cross-fade as a view transition

### DIFF
--- a/website/src/components/ThemeSwitch.module.css
+++ b/website/src/components/ThemeSwitch.module.css
@@ -32,6 +32,7 @@
   height: 10px;
   border-radius: 50%;
   background: currentColor;
+  view-transition-name: stim-theme-thumb;
 }
 
 :global([data-theme='dark']) .thumb {
@@ -50,9 +51,7 @@
     transform: scale(1.05);
   }
 
-  .thumb {
-    transition:
-      transform 250ms ease,
-      background-color 250ms ease;
+  :global(html:not(.stim-theme-transition)) .thumb {
+    transition: transform 250ms ease;
   }
 }

--- a/website/src/components/ThemeSwitch.test.ts
+++ b/website/src/components/ThemeSwitch.test.ts
@@ -16,6 +16,11 @@ describe('ThemeSwitch', () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     theme.colorMode = 'light';
     theme.setColorMode.mockReset();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: false })),
+    );
+    Object.defineProperty(document, 'startViewTransition', { configurable: true, get: () => undefined });
     container = document.createElement('div');
     document.body.append(container);
     root = createRoot(container);
@@ -25,19 +30,58 @@ describe('ThemeSwitch', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(document, 'startViewTransition');
+    document.documentElement.classList.remove('stim-theme-transition');
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: false });
   });
 
-  test('switches to the opposite color mode', () => {
-    const button = container.querySelector('button')!;
-    expect(button.getAttribute('aria-checked')).toBe('false');
-    act(() => button.click());
+  test('changes theme directly when view transitions are unavailable', () => {
+    act(() => container.querySelector('button')!.click());
     expect(theme.setColorMode).toHaveBeenCalledWith('dark');
+    expect(document.documentElement.classList.contains('stim-theme-transition')).toBe(false);
+  });
 
+  test('skips motion when reduced motion is requested', () => {
+    vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList);
+    const start = vi.fn<() => void>();
+    Object.defineProperty(document, 'startViewTransition', { configurable: true, get: () => start });
+    act(() => container.querySelector('button')!.click());
+    expect(theme.setColorMode).toHaveBeenCalledWith('dark');
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test('blocks overlapping reveals and clears the transition after completion', async () => {
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const start = vi.fn<(update: () => void) => { finished: Promise<void> }>((update) => {
+      update();
+      return { finished };
+    });
+    Object.defineProperty(document, 'startViewTransition', { configurable: true, get: () => start });
+    act(() => {
+      container.querySelector('button')!.click();
+      container.querySelector('button')!.click();
+    });
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(theme.setColorMode).toHaveBeenCalledWith('dark');
+    expect(document.documentElement.classList.contains('stim-theme-transition')).toBe(true);
+    await act(async () => {
+      finish();
+      await finished;
+    });
+    expect(document.documentElement.classList.contains('stim-theme-transition')).toBe(false);
     theme.colorMode = 'dark';
     act(() => root.render(createElement(ThemeSwitch)));
-    expect(button.getAttribute('aria-checked')).toBe('true');
-    act(() => button.click());
+    expect(container.querySelector('button')!.getAttribute('aria-checked')).toBe('true');
+    act(() => container.querySelector('button')!.click());
+    expect(start).toHaveBeenCalledTimes(2);
     expect(theme.setColorMode).toHaveBeenLastCalledWith('light');
+    await act(async () => {
+      await finished;
+    });
   });
 });

--- a/website/src/components/ThemeSwitch.tsx
+++ b/website/src/components/ThemeSwitch.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
 import { useColorMode } from '@docusaurus/theme-common';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import styles from './ThemeSwitch.module.css';
@@ -6,6 +7,24 @@ import styles from './ThemeSwitch.module.css';
 export default function ThemeSwitch(): ReactNode {
   const { colorMode, setColorMode } = useColorMode();
   const isBrowser = useIsBrowser();
+  const transitioning = useRef(false);
+
+  function toggle() {
+    if (transitioning.current) return;
+    const nextMode = colorMode === 'dark' ? 'light' : 'dark';
+    if (!document.startViewTransition || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setColorMode(nextMode);
+      return;
+    }
+
+    transitioning.current = true;
+    document.documentElement.classList.add('stim-theme-transition');
+    const transition = document.startViewTransition(() => flushSync(() => setColorMode(nextMode)));
+    void transition.finished.finally(() => {
+      document.documentElement.classList.remove('stim-theme-transition');
+      transitioning.current = false;
+    });
+  }
 
   return (
     <button
@@ -14,7 +33,7 @@ export default function ThemeSwitch(): ReactNode {
       aria-label="Dark mode"
       aria-checked={colorMode === 'dark'}
       disabled={!isBrowser}
-      onClick={() => setColorMode(colorMode === 'dark' ? 'light' : 'dark')}
+      onClick={toggle}
       className={styles.toggle}
     >
       <span className={styles.track} aria-hidden="true">

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -160,14 +160,3 @@
 .footer--dark {
   --ifm-footer-background-color: #20162e;
 }
-
-:where([data-theme], [data-theme] *),
-:where([data-theme] *)::before,
-:where([data-theme] *)::after {
-  transition:
-    background-color 250ms ease,
-    color 250ms ease,
-    border-color 250ms ease,
-    fill 250ms ease,
-    stroke 250ms ease;
-}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -160,3 +160,7 @@
 .footer--dark {
   --ifm-footer-background-color: #20162e;
 }
+
+::view-transition {
+  pointer-events: none;
+}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -128,9 +128,6 @@
   font-size: 14px;
   font-weight: 500;
   transform-origin: bottom center;
-  transition:
-    background-color 250ms ease,
-    color 250ms ease;
 }
 
 .primaryButton:hover {
@@ -158,10 +155,6 @@
   color: var(--stim-muted);
   font-size: 12px;
   line-height: 1.4;
-  transition:
-    background-color 250ms ease,
-    color 250ms ease,
-    border-color 250ms ease;
 }
 
 .install :global(.tabs__item--active) {
@@ -345,8 +338,7 @@
   .page [data-reveal] {
     transition:
       opacity 600ms ease,
-      translate 600ms cubic-bezier(0.22, 1, 0.36, 1),
-      border-color 250ms ease;
+      translate 600ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .page [data-reveal='pending'] {


### PR DESCRIPTION
## Description

#630 replaced the landing page's theme wipe with appandflow.com's per-element color transition. On Safari, body text then fades far slower than 250ms, while headings look right. On Chrome, the whole page appears to flicker. Issue #652 has the mechanism: WebKit starts a child's color transition toward its parent's mid-transition inherited value, so the ease compounds at every nesting level below the element that sets the text color, and Docusaurus swaps themed illustrations by `display`, so seven images jump to their other artwork on the first frame against a canvas that is still fading.

Only `website/` changes. No package code, guides, or CLI behavior.

## Solution

Run the theme change as a native view transition with the browser's default crossfade, the mechanism the switch used before #630 minus the custom wipe. The old and new snapshots of the page crossfade over 250ms as one composited animation, text and images alike, so no element needs its own color transition. Specifically:

- The switch component restores its view-transition plumbing from before #630: reduced-motion and capability guards, an overlap guard, and a root class that suspends the thumb's own slide during the transition. The thumb gets its view-transition name back so it slides as its own group instead of ghosting between positions.
- The global `:where([data-theme])` transition rule is removed, and with it the element-level patches #630 added for the button, install tabs, and hero frame, which only existed to work around that rule.
- Browsers without view transitions and users who prefer reduced motion switch instantly, as before #630.
- The view-transition overlay gets `pointer-events: none`, so the page stays interactive during the fade and the switch under the cursor keeps its hover state instead of dipping. Review follow-up.

The docs pages' stock Docusaurus toggle switches instantly, which is what it did before #630.

## Test plan

From the repo root on this branch:

```
pnpm run format:check   # pass
pnpm run lint           # pass
pnpm test               # website suites pass; see note
```

From `website/`:

```
pnpm run typecheck      # pass
pnpm run build          # pass
```

Evidence:

- The three restored switch unit tests pass: direct switch when view transitions are unavailable, reduced-motion skip, and the overlap guard with root-class cleanup.
- The built stylesheet carries the thumb's view-transition name and its guarded slide, and no `:where([data-theme])` transition rule; the bundle calls `startViewTransition`.
- The crossfade itself cannot be captured headlessly. Verify in Safari and Chrome with `pnpm --filter website start`: paragraphs and headings should reach their new color together within 250ms, and illustrations should crossfade rather than jump.

The full `pnpm test` run on the development Mac still fails the live `devicectl` test tracked in #631, which drives a phone attached to that machine and is unrelated.

Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qs5UvEQX8JDqpSbbY8wcL