### PR TITLE
feat: name the two workflows, and report main-checkout problems only to the one they affect

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -125,6 +125,40 @@ test('checkMainCheckout says nothing about the seed when the repository has no l
       'The main checkout has 1 uncommitted tracked change',
       'The main checkout is on feature, not the default branch main',
     ]);
+
+    rmSync(join(base, 'linked'), { recursive: true, force: true });
+    expect(checkMainCheckout(main, { platform: 'ios' })).toEqual([]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('an interrupted rebase is named instead of the dirty and detached remedies git would reject', () => {
+  const { base, main, git } = seedRepo('stim-doctor-rebase-');
+  try {
+    writeFileSync(join(main, 'README.md'), 'theirs\n');
+    git('git commit -q -am theirs');
+    git('git checkout -q -b side HEAD~1');
+    writeFileSync(join(main, 'README.md'), 'ours\n');
+    git('git commit -q -am ours');
+    expect(() => git('git rebase main')).toThrow(/rebase/);
+    git('git worktree add -q -b task ../linked');
+
+    const findings = checkMainCheckout(main, { platform: 'ios' });
+    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has a rebase in progress']);
+    expect(findings[0]?.fix).toBe(`Finish it, or run \`git -C '${main}' rebase --abort\`.`);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('a tag sharing the branch name does not turn the branch into an ambiguous ref', () => {
+  const { base, main, git } = seedRepo('stim-doctor-ambiguous-');
+  try {
+    git('git tag main HEAD');
+    git('git worktree add -q -b task ../linked');
+
+    expect(checkMainCheckout(main, { platform: 'ios' })).toEqual([]);
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
@@ -135,6 +169,14 @@ test('seed findings are reported from inside a linked worktree, about the main c
   try {
     writeFileSync(join(main, 'README.md'), 'edited\n');
     git('git worktree add -q -b task ../linked');
+
+    writeFileSync(join(main, 'second.txt'), 'tracked\n');
+    git('git add second.txt');
+    expect(checkMainCheckout(join(base, 'linked'), { platform: 'ios' }).map((entry) => entry.title)).toEqual([
+      'The main checkout has 2 uncommitted tracked changes',
+    ]);
+    git('git rm -q --cached second.txt');
+    rmSync(join(main, 'second.txt'));
 
     const findings = checkMainCheckout(join(base, 'linked'), { platform: 'ios' });
     expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has 1 uncommitted tracked change']);
@@ -170,14 +212,10 @@ test('a main checkout that is ahead of and behind its upstream is reported as di
     git('git worktree add -q -b task ../linked');
 
     const findings = checkMainCheckout(main, { platform: 'ios' });
-    const diverged = findings.find((entry) => entry.title === 'The main checkout has diverged from origin/main');
-    expect(findings.map((entry) => entry.title)).toEqual([
-      'The main checkout is 1 commit behind origin/main',
-      'The main checkout has diverged from origin/main',
-    ]);
-    expect(diverged?.detail).toContain('main is 1 ahead of and 1 behind origin/main');
-    expect(diverged?.detail).toContain('refuses rather than merging or resetting');
-    expect(diverged?.fix).toBe('Rebase or merge main onto origin/main yourself.');
+    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has diverged from origin/main']);
+    expect(findings[0]?.detail).toContain('main is 1 ahead of and 1 behind origin/main');
+    expect(findings[0]?.detail).toContain('refuses rather than merging or resetting');
+    expect(findings[0]?.fix).toBe('Rebase or merge main onto origin/main yourself.');
   } finally {
     rmSync(base, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -80,6 +81,128 @@ test('checkMainCheckout reports missing dependencies, Pods, and native output', 
     expect(findings[2]?.fix).toMatch(/stim ios/);
   } finally {
     rmSync(project, { recursive: true, force: true });
+  }
+});
+
+function seedRepo(prefix: string) {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  const main = join(base, 'main');
+  mkdirSync(main, { recursive: true });
+  const git = (command: string) => execSync(command, { cwd: main, encoding: 'utf-8' }).trim();
+  git('git init -q -b main');
+  git('git config user.email test@example.com');
+  git('git config user.name test');
+  git('git config commit.gpgsign false');
+  git('git config remote.origin.url ../origin.git');
+  git("git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'");
+  writeFileSync(join(main, 'README.md'), 'seed\n');
+  git('git add -A');
+  git('git commit -q -m first');
+  git('git commit -q --allow-empty -m second');
+  const upstreamHead = git('git rev-parse HEAD');
+  git(`git update-ref refs/remotes/origin/main ${upstreamHead}`);
+  git('git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main');
+  const trackOrigin = (branch: string) => {
+    git(`git config branch.${branch}.remote origin`);
+    git(`git config branch.${branch}.merge refs/heads/main`);
+  };
+  trackOrigin('main');
+  return { base, main, git, trackOrigin };
+}
+
+test('checkMainCheckout says nothing about the seed when the repository has no linked worktree', () => {
+  const { base, main, git, trackOrigin } = seedRepo('stim-doctor-single-checkout-');
+  try {
+    git('git checkout -q -B feature HEAD~1');
+    trackOrigin('feature');
+    writeFileSync(join(main, 'README.md'), 'edited\n');
+
+    expect(checkMainCheckout(main, { platform: 'ios' })).toEqual([]);
+
+    git('git worktree add -q --detach ../linked');
+    expect(checkMainCheckout(main, { platform: 'ios' }).map((entry) => entry.title)).toEqual([
+      'The main checkout is 1 commit behind origin/main',
+      'The main checkout has 1 uncommitted tracked change',
+      'The main checkout is on feature, not the default branch main',
+    ]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('seed findings are reported from inside a linked worktree, about the main checkout', () => {
+  const { base, main, git } = seedRepo('stim-doctor-from-worktree-');
+  try {
+    writeFileSync(join(main, 'README.md'), 'edited\n');
+    git('git worktree add -q -b task ../linked');
+
+    const findings = checkMainCheckout(join(base, 'linked'), { platform: 'ios' });
+    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has 1 uncommitted tracked change']);
+    expect(findings[0]?.level).toBe('note');
+    expect(findings[0]?.detail).toContain('stim worktree warm --refresh');
+    expect(findings[0]?.detail).toContain('README.md');
+    expect(findings[0]?.fix).toBe(`Commit them, or run \`git -C '${main}' stash push -u -m warm-refresh\`.`);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('a detached main checkout is reported, and nothing compares its missing branch to the default', () => {
+  const { base, main, git } = seedRepo('stim-doctor-detached-');
+  try {
+    git('git checkout -q --detach HEAD~1');
+    git('git worktree add -q -b task ../linked');
+
+    const findings = checkMainCheckout(main, { platform: 'ios' });
+    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has a detached HEAD']);
+    expect(findings[0]?.detail).toContain('there is no branch to fast-forward');
+    expect(findings[0]?.fix).toBe(`Run \`git -C '${main}' checkout <branch>\`.`);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('a main checkout that is ahead of and behind its upstream is reported as diverged', () => {
+  const { base, main, git } = seedRepo('stim-doctor-diverged-');
+  try {
+    git('git checkout -q -B main HEAD~1');
+    git('git commit -q --allow-empty -m local');
+    git('git worktree add -q -b task ../linked');
+
+    const findings = checkMainCheckout(main, { platform: 'ios' });
+    const diverged = findings.find((entry) => entry.title === 'The main checkout has diverged from origin/main');
+    expect(findings.map((entry) => entry.title)).toEqual([
+      'The main checkout is 1 commit behind origin/main',
+      'The main checkout has diverged from origin/main',
+    ]);
+    expect(diverged?.detail).toContain('main is 1 ahead of and 1 behind origin/main');
+    expect(diverged?.detail).toContain('refuses rather than merging or resetting');
+    expect(diverged?.fix).toBe('Rebase or merge main onto origin/main yourself.');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('worktree.defaultBranch outranks origin/HEAD, and neither resolving stays silent', () => {
+  const { base, main, git } = seedRepo('stim-doctor-default-branch-');
+  try {
+    git('git worktree add -q -b task ../linked');
+    expect(checkMainCheckout(main, { platform: 'ios' })).toEqual([]);
+
+    writeFileSync(join(main, '.stim.json'), JSON.stringify({ worktree: { defaultBranch: 'release' } }));
+    const configured = checkMainCheckout(main, { platform: 'ios' });
+    expect(configured.map((entry) => entry.title)).toEqual([
+      'The main checkout is on main, not the default branch release',
+    ]);
+    expect(configured[0]?.detail).toContain("carries main's dependencies");
+    expect(configured[0]?.fix).toContain(`git -C '${main}' checkout release`);
+
+    rmSync(join(main, '.stim.json'));
+    git('git symbolic-ref -d refs/remotes/origin/HEAD');
+    git('git checkout -q -b feature');
+    expect(checkMainCheckout(main, { platform: 'ios' })).toEqual([]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
   }
 });
 
@@ -393,6 +516,7 @@ test('checkMainCheckout reports stale dependencies and the locally known upstrea
     const findings = checkMainCheckout(project, {
       npmTreeValid: false,
       upstream: { name: 'origin/main', ahead: 0, behind: 2 },
+      linkedWorktrees: true,
     });
     expect(findings.some((finding) => /dependency tree is stale/.test(finding.title))).toBe(true);
     expect(findings.some((finding) => /2 commits behind origin\/main/.test(finding.title))).toBe(true);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -357,15 +357,13 @@ test('the agent workflow checks errors before and after edits, before cleanup', 
   expect(renderSection('lifecycle', 'readiness')).toContain('[stim:readiness] ready');
 });
 
-test('the agent and lifecycle guides name both workflows and scope the main-checkout rules to one', () => {
+test('the agent and lifecycle guides name both workflows', () => {
   for (const guide of [renderTopic('agent'), renderTopic('lifecycle')]) {
     assert(guide);
     expect(guide).toContain('SINGLE CHECKOUT');
     expect(guide).toContain('WORKTREE:');
     expect(guide).toMatch(/is infrastructure, not a workspace/);
-    expect(guide).toMatch(/main[- ]checkout rules?[\s\S]{0,40}belongs? to/);
   }
-  expect(renderTopic('agent')).toMatch(/only once the repository has at least one linked\s+worktree/);
 });
 
 test('the agent guide routes to every detailed topic', () => {

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -357,6 +357,17 @@ test('the agent workflow checks errors before and after edits, before cleanup', 
   expect(renderSection('lifecycle', 'readiness')).toContain('[stim:readiness] ready');
 });
 
+test('the agent and lifecycle guides name both workflows and scope the main-checkout rules to one', () => {
+  for (const guide of [renderTopic('agent'), renderTopic('lifecycle')]) {
+    assert(guide);
+    expect(guide).toContain('SINGLE CHECKOUT');
+    expect(guide).toContain('WORKTREE:');
+    expect(guide).toMatch(/is infrastructure, not a workspace/);
+    expect(guide).toMatch(/main[- ]checkout rules?[\s\S]{0,40}belongs? to/);
+  }
+  expect(renderTopic('agent')).toMatch(/only once the repository has at least one linked\s+worktree/);
+});
+
 test('the agent guide routes to every detailed topic', () => {
   const agent = renderTopic('agent');
   assert(agent);

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -182,11 +182,21 @@ function hasIosWarmOutput(root: string): boolean {
 function hasLinkedWorktree(projectRoot: string): boolean {
   const root = repoRoot(projectRoot);
   if (!root) return false;
-  return listWorktrees(root).length > 1;
+  return listWorktrees(root).filter((entry) => !entry.prunable).length > 1;
 }
 
-function headName(root: string): string | null {
-  return getExecutor().runFileQuiet('git', ['-C', root, 'rev-parse', '--abbrev-ref', 'HEAD'])?.trim() || null;
+function headBranch(root: string): string | null {
+  const ref = getExecutor().runFileQuiet('git', ['-C', root, 'symbolic-ref', '--quiet', 'HEAD'])?.trim();
+  return ref?.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : null;
+}
+
+function mainOperation(root: string): 'rebase' | 'merge' | null {
+  const gitDir = getExecutor()
+    .runFileQuiet('git', ['-C', root, 'rev-parse', '--path-format=absolute', '--git-dir'])
+    ?.trim();
+  if (!gitDir) return null;
+  if (existsSync(join(gitDir, 'rebase-merge')) || existsSync(join(gitDir, 'rebase-apply'))) return 'rebase';
+  return existsSync(join(gitDir, 'MERGE_HEAD')) ? 'merge' : null;
 }
 
 function dirtyTrackedPaths(root: string): string[] {
@@ -215,40 +225,54 @@ function resolveDefaultBranch(root: string): string | null {
 
 function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding[] {
   const findings: Finding[] = [];
-  const quotedMain = quotedPath(mainRoot);
+  const root = repoRoot(mainRoot);
+  const quotedRoot = quotedPath(root ?? mainRoot);
 
-  if (upstream && upstream.behind > 0) {
+  if (upstream && upstream.behind > 0 && upstream.ahead === 0) {
     findings.push(
       finding(
         'note',
-        `The main checkout is ${upstream.behind} commit${upstream.behind === 1 ? '' : 's'} behind ${upstream.name}`,
+        `The main checkout is ${plural(upstream.behind, 'commit')} behind ${upstream.name}`,
         'The count uses the locally known upstream ref. A fetch can reveal additional commits. A later rebase or merge can change native inputs and invalidate work done from the older base.',
-        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the main checkout, or \`git -C ${quotedMain} fetch --prune\` and inspect the branch yourself.`,
+        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the main checkout, or \`git -C ${quotedRoot} fetch --prune\` and inspect the branch yourself.`,
       ),
     );
   }
+  if (root === null) return findings;
 
-  const dirty = dirtyTrackedPaths(mainRoot);
+  const operation = mainOperation(root);
+  if (operation) {
+    findings.push(
+      finding(
+        'note',
+        `The main checkout has a ${operation} in progress`,
+        '`stim worktree warm --refresh` refuses a main checkout it cannot move, and the branch stays where the interrupted operation left it.',
+        `Finish it, or run \`git -C ${quotedRoot} ${operation} --abort\`.`,
+      ),
+    );
+    return findings;
+  }
+
+  const dirty = dirtyTrackedPaths(root);
   if (dirty.length) {
     findings.push(
       finding(
         'note',
-        `The main checkout has ${dirty.length} uncommitted tracked change${dirty.length === 1 ? '' : 's'}`,
+        `The main checkout has ${plural(dirty.length, 'uncommitted tracked change')}`,
         `\`stim worktree warm --refresh\` refuses a main checkout it cannot move, so the seed stays where it is until this is cleared. First: ${dirty[0]}.`,
-        `Commit them, or run \`git -C ${quotedMain} stash push -u -m warm-refresh\`.`,
+        `Commit them, or run \`git -C ${quotedRoot} stash push -u -m warm-refresh\`.`,
       ),
     );
   }
 
-  const branch = headName(mainRoot);
-  if (branch === null) return findings;
-  if (branch === 'HEAD') {
+  const branch = headBranch(root);
+  if (branch === null) {
     findings.push(
       finding(
         'note',
         'The main checkout has a detached HEAD',
         '`stim worktree warm --refresh` refuses: there is no branch to fast-forward.',
-        `Run \`git -C ${quotedMain} checkout <branch>\`.`,
+        `Run \`git -C ${quotedRoot} checkout <branch>\`.`,
       ),
     );
     return findings;
@@ -265,14 +289,14 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     );
   }
 
-  const defaultBranch = resolveDefaultBranch(mainRoot);
+  const defaultBranch = resolveDefaultBranch(root);
   if (defaultBranch !== null && defaultBranch !== branch) {
     findings.push(
       finding(
         'note',
         `The main checkout is on ${branch}, not the default branch ${defaultBranch}`,
         `Every worktree warmed from here carries ${branch}'s dependencies. \`stim worktree warm --refresh\` warns and continues; it never switches a branch under another checkout.`,
-        `Run \`git -C ${quotedMain} checkout ${defaultBranch}\`, or set worktree.defaultBranch in the repository-root .stim.json when ${defaultBranch} is not the branch worktrees should be seeded from.`,
+        `Run \`git -C ${quotedRoot} checkout ${defaultBranch}\`.`,
       ),
     );
   }

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -179,17 +179,120 @@ function hasIosWarmOutput(root: string): boolean {
   }
 }
 
+function hasLinkedWorktree(projectRoot: string): boolean {
+  const root = repoRoot(projectRoot);
+  if (!root) return false;
+  return listWorktrees(root).length > 1;
+}
+
+function headName(root: string): string | null {
+  return getExecutor().runFileQuiet('git', ['-C', root, 'rev-parse', '--abbrev-ref', 'HEAD'])?.trim() || null;
+}
+
+function dirtyTrackedPaths(root: string): string[] {
+  const out = getExecutor().runFileQuiet('git', ['-C', root, 'diff', '--name-only', 'HEAD']);
+  return (out ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function resolveDefaultBranch(root: string): string | null {
+  const settings = resolveSettings({ gitCommonDir: gitCommonDir(root), repoRoot: repoRoot(root) ?? root });
+  const worktree = settings.worktree;
+  const configured =
+    worktree && typeof worktree === 'object' && !Array.isArray(worktree)
+      ? (worktree as { defaultBranch?: unknown }).defaultBranch
+      : undefined;
+  if (typeof configured === 'string' && configured.trim()) return configured.trim();
+  const head = getExecutor()
+    .runFileQuiet('git', ['-C', root, 'symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+    ?.trim();
+  if (!head) return null;
+  const cut = head.indexOf('/');
+  return cut > 0 ? head.slice(cut + 1) : head;
+}
+
+function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding[] {
+  const findings: Finding[] = [];
+  const quotedMain = quotedPath(mainRoot);
+
+  if (upstream && upstream.behind > 0) {
+    findings.push(
+      finding(
+        'note',
+        `The main checkout is ${upstream.behind} commit${upstream.behind === 1 ? '' : 's'} behind ${upstream.name}`,
+        'The count uses the locally known upstream ref. A fetch can reveal additional commits. A later rebase or merge can change native inputs and invalidate work done from the older base.',
+        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the main checkout, or \`git -C ${quotedMain} fetch --prune\` and inspect the branch yourself.`,
+      ),
+    );
+  }
+
+  const dirty = dirtyTrackedPaths(mainRoot);
+  if (dirty.length) {
+    findings.push(
+      finding(
+        'note',
+        `The main checkout has ${dirty.length} uncommitted tracked change${dirty.length === 1 ? '' : 's'}`,
+        `\`stim worktree warm --refresh\` refuses a main checkout it cannot move, so the seed stays where it is until this is cleared. First: ${dirty[0]}.`,
+        `Commit them, or run \`git -C ${quotedMain} stash push -u -m warm-refresh\`.`,
+      ),
+    );
+  }
+
+  const branch = headName(mainRoot);
+  if (branch === null) return findings;
+  if (branch === 'HEAD') {
+    findings.push(
+      finding(
+        'note',
+        'The main checkout has a detached HEAD',
+        '`stim worktree warm --refresh` refuses: there is no branch to fast-forward.',
+        `Run \`git -C ${quotedMain} checkout <branch>\`.`,
+      ),
+    );
+    return findings;
+  }
+
+  if (upstream && upstream.ahead > 0 && upstream.behind > 0) {
+    findings.push(
+      finding(
+        'note',
+        `The main checkout has diverged from ${upstream.name}`,
+        `${branch} is ${upstream.ahead} ahead of and ${upstream.behind} behind ${upstream.name}, so it cannot fast-forward. \`stim worktree warm --refresh\` refuses rather than merging or resetting.`,
+        `Rebase or merge ${branch} onto ${upstream.name} yourself.`,
+      ),
+    );
+  }
+
+  const defaultBranch = resolveDefaultBranch(mainRoot);
+  if (defaultBranch !== null && defaultBranch !== branch) {
+    findings.push(
+      finding(
+        'note',
+        `The main checkout is on ${branch}, not the default branch ${defaultBranch}`,
+        `Every worktree warmed from here carries ${branch}'s dependencies. \`stim worktree warm --refresh\` warns and continues; it never switches a branch under another checkout.`,
+        `Run \`git -C ${quotedMain} checkout ${defaultBranch}\`, or set worktree.defaultBranch in the repository-root .stim.json when ${defaultBranch} is not the branch worktrees should be seeded from.`,
+      ),
+    );
+  }
+
+  return findings;
+}
+
 export function checkMainCheckout(
   projectRoot: string,
   {
     npmTreeValid,
     brokenPods = undefined,
     upstream = undefined,
+    linkedWorktrees = undefined,
     platform,
   }: {
     npmTreeValid?: boolean | null;
     brokenPods?: string[];
     upstream?: UpstreamState | null;
+    linkedWorktrees?: boolean;
     platform?: DoctorPlatform;
   } = {},
 ): Finding[] {
@@ -285,16 +388,9 @@ export function checkMainCheckout(
     );
   }
 
-  const knownUpstream = upstream === undefined ? locallyKnownUpstream(mainRoot) : upstream;
-  if (knownUpstream && knownUpstream.behind > 0) {
-    findings.push(
-      finding(
-        'note',
-        `The main checkout is ${knownUpstream.behind} commit${knownUpstream.behind === 1 ? '' : 's'} behind ${knownUpstream.name}`,
-        'The count uses the locally known upstream ref. A fetch can reveal additional commits. A later rebase or merge can change native inputs and invalidate work done from the older base.',
-        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the main checkout, or \`git -C ${quotedPath(mainRoot)} fetch --prune\` and inspect the branch yourself.`,
-      ),
-    );
+  const linked = linkedWorktrees === undefined ? hasLinkedWorktree(projectRoot) : linkedWorktrees;
+  if (linked) {
+    findings.push(...seedFindings(mainRoot, upstream === undefined ? locallyKnownUpstream(mainRoot) : upstream));
   }
 
   return findings;

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -7,18 +7,37 @@ device with another workspace. Prefer plain output: it streams each phase and
 ends with the facts the next step needs. Use --json only when a script must
 parse a stable payload.
 
+TWO WORKFLOWS
+
+SINGLE CHECKOUT: work in place, on whatever branch the task needs, in one
+directory. start, ios, android, logs, stop, and never a linked worktree. That
+directory is your workspace, and no main-checkout rule below applies to it.
+
+WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
+branch, and every task gets a linked worktree warmed from it. In this workflow
+the main checkout is infrastructure, not a workspace: you edit, build, and run
+in the worktree, and you keep the seed fit to copy. Every main-checkout rule
+below belongs to this workflow.
+
+Doctor reports the main checkout's fitness as a seed -- how far behind it is,
+uncommitted tracked changes, a detached HEAD, a diverged branch, a branch that
+is not the default one -- only once the repository has at least one linked
+worktree. A single-checkout session is never told that its own branch is a
+problem.
+
 NORMAL WORKFLOW
 
 Work in the current checkout by default. When the task needs another branch or
-an isolated environment, create a linked worktree with Git and warm its
-ignored state. If a harness already created this linked worktree, run
-stim worktree warm here instead of creating another one. It copies missing
-ignored paths from the main checkout, including eligible .env and local
-configuration files. It preserves the branch, tracked files, and every existing
-destination entry; existing ignored directories are skipped whole, not filled in.
-Add --refresh to fast-forward the main checkout and install what moved there
-before the copy; it refuses a main checkout with local work and never switches
-branches. Read guide lifecycle options for exclusions and incomplete-copy remedies.
+an isolated environment, take the worktree workflow: create a linked worktree
+with Git and warm its ignored state. If a harness already created this linked
+worktree, run stim worktree warm here instead of creating another one. It
+copies missing ignored paths from the main checkout, including eligible .env
+and local configuration files. It preserves the branch, tracked files, and
+every existing destination entry; existing ignored directories are skipped
+whole, not filled in. Add --refresh to fast-forward the main checkout and
+install what moved there before the copy; it refuses a main checkout with local
+work and never switches branches. Read guide lifecycle options for exclusions
+and incomplete-copy remedies.
 
 Wait for warm to exit successfully (exit code 0) before running stim start,
 stim ios, stim android, or a dependency install in that worktree. If the shell
@@ -31,7 +50,8 @@ If warm fails or reports incomplete, resolve the reported failure first.
 
 Before native worktree work, run doctor for the platform in scope. It checks
 the main checkout from a linked worktree. Fix relevant findings and inspect the
-upstream gap. It also prints the running CLI version and the stim installation
+upstream gap; in the single-checkout workflow those seed findings do not
+appear. It also prints the running CLI version and the stim installation
 resolved from PATH. If that resolved installation is older than another one,
 fix PATH or the installation before continuing so commands and guidance match.
 Doctor reports cross-volume staging and build-cache copies; read guide settings

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -11,19 +11,20 @@ TWO WORKFLOWS
 
 SINGLE CHECKOUT: work in place, on whatever branch the task needs, in one
 directory. start, ios, android, logs, stop, and never a linked worktree. That
-directory is your workspace, and no main-checkout rule below applies to it.
+directory is your workspace, and no rule below about keeping the main checkout
+fit as a seed applies to it.
 
 WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
 branch, and every task gets a linked worktree warmed from it. In this workflow
 the main checkout is infrastructure, not a workspace: you edit, build, and run
-in the worktree, and you keep the seed fit to copy. Every main-checkout rule
-below belongs to this workflow.
+in the worktree, and you keep the seed fit to copy. Every rule below about the
+main checkout's fitness as a seed belongs to this workflow.
 
-Doctor reports the main checkout's fitness as a seed -- how far behind it is,
-uncommitted tracked changes, a detached HEAD, a diverged branch, a branch that
-is not the default one -- only once the repository has at least one linked
-worktree. A single-checkout session is never told that its own branch is a
-problem.
+Doctor reports that fitness -- how far behind the seed is, uncommitted tracked
+changes, an interrupted rebase or merge, a detached HEAD, a diverged branch, a
+branch that is not the default one -- only once the repository has at least
+one linked worktree, so read it from inside the worktree. A single-checkout
+session is never told that its own branch is a problem.
 
 NORMAL WORKFLOW
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -5,6 +5,17 @@ const lifecycle: GuideTopic = {
     'The full worktree -> start -> ios/android -> logs -> teardown flow, with sections for builds, devices and flags',
   preamble: () => `ENVIRONMENT LIFECYCLE
 
+Two workflows share steps 2 through 6.
+
+SINGLE CHECKOUT: work in place, on a branch, in one directory. Skip steps 1
+and 7; that directory is your workspace, and no rule here about the main
+checkout applies to it.
+
+WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
+branch so every worktree warmed from it starts current. Here the main checkout
+is infrastructure, not a workspace. Steps 1 and 7 are this workflow's ends,
+and every main-checkout rule below belongs to it.
+
   # 1. Create a linked worktree with Git, unless a harness already did.
   #    Choose the branch, path, and base ref with Git.
   git worktree add -b app/412 ../app-412 HEAD

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -7,14 +7,15 @@ const lifecycle: GuideTopic = {
 
 Two workflows share steps 2 through 6.
 
-SINGLE CHECKOUT: work in place, on a branch, in one directory. Skip steps 1
-and 7; that directory is your workspace, and no rule here about the main
-checkout applies to it.
+SINGLE CHECKOUT: work in place, on a branch, in one directory. There is no
+step 1, and step 7 reclaims the environment without deleting the tree, which
+stays because it is the main checkout. That directory is your workspace, and
+no rule here about keeping the main checkout fit as a seed applies to it.
 
 WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
 branch so every worktree warmed from it starts current. Here the main checkout
-is infrastructure, not a workspace. Steps 1 and 7 are this workflow's ends,
-and every main-checkout rule below belongs to it.
+is infrastructure, not a workspace, and every rule below about its fitness as
+a seed belongs to this workflow.
 
   # 1. Create a linked worktree with Git, unless a harness already did.
   #    Choose the branch, path, and base ref with Git.

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -450,6 +450,7 @@ export function deleteBranch(cwd: string, branch: string, expectedSha: string): 
 export interface WorktreeEntry {
   path: string;
   branch?: string;
+  prunable?: boolean;
 }
 
 function parseWorktrees(out: string): WorktreeEntry[] {
@@ -461,6 +462,8 @@ function parseWorktrees(out: string): WorktreeEntry[] {
       current = { path: line.slice('worktree '.length) };
     } else if (line.startsWith('branch ')) {
       current.branch = line.slice('branch '.length).replace('refs/heads/', '');
+    } else if (line === 'prunable' || line.startsWith('prunable ')) {
+      current.prunable = true;
     }
   }
   if (current.path) entries.push(current as WorktreeEntry);


### PR DESCRIPTION
## Description

Stim supports two ways of working, and the guide only ever described one.

- **Single checkout.** Work in place, on a branch, in one directory. `start`, `ios`, `android`, `logs`, `stop`. Never a linked worktree.
- **Worktree.** The checkout you cloned is a *seed*: it stays clean and current, and every task gets a linked worktree warmed from it.

`guide agent` gestured at the split in one line and then gave main-checkout guidance without saying that none of it applies to the first workflow. `guide lifecycle` opened directly on `git worktree add`, so the worktree workflow read as *the* workflow.

The same confusion was a live bug in `doctor`. `checkMainCheckout` reported `The main checkout is N commits behind <upstream>` unconditionally, so someone working the single-checkout way on a feature branch was told their checkout was a problem. For them it is not a problem; it is the job.

**Depends on #651** (`worktree warm --refresh`), which is not merged. **Merge this after #651.** The new findings name `stim worktree warm --refresh`, which does not exist until then, and #651 is what declares and documents the `worktree.defaultBranch` setting this branch reads. #651 also edits `doctor.ts` and `guide/lifecycle.ts`, so this branch stays deliberately narrow and expects a rebase onto `main` once #651 lands. AGENTS.md asks a dependent change to branch from the parent pull request's branch and `gh stack link` the two; #651 has no open pull request to stack onto yet, so this branches from `main` instead.

**At rebase time, preserve two things #651 owns.** `git merge-tree` reports conflicts in `doctor.ts` and `guide/agent.ts`. #651 rewrites the behind-finding's fix line to point at `stim worktree warm --refresh`; this branch moved that same block into `seedFindings` still carrying the older `git fetch --prune` text, so take #651's wording. And once #651 has landed, `resolveDefaultBranch` should become one shared function rather than the two equivalent copies that exist while both branches are open.

## Solution

**The gate.** `hasLinkedWorktree(projectRoot)` resolves the repository root and asks whether `git worktree list --porcelain` reports more than one non-prunable entry. Git lists the main working tree first and every linked worktree after it, so more than one entry means at least one linked worktree exists. `prunable` entries are excluded because a worktree directory that was deleted rather than removed stays listed until `git worktree prune` -- and someone who once tried a worktree and then `rm -rf`'d it is exactly the single-checkout user this change stops nagging. The answer is the same from the main checkout and from inside a linked worktree, which is the case doctor already handled. Not a git repository, or git unavailable, means no linked worktrees and therefore silence. An injectable `linkedWorktrees` option matches the existing `upstream` / `brokenPods` / `npmTreeValid` seams.

Behind the gate: the existing behind-finding, plus five `note` findings, each predicting a refusal or a surprise that #651 introduces, so someone learns about it from `doctor` rather than from a failed `warm --refresh` ten minutes later.

- A rebase or merge in progress, with #651's `--abort` remedy. It is reported *instead of* the two below, because during an interrupted operation git rejects both of their fix lines and `git checkout <branch>` would abandon the rebase. This is one more than the four the issue enumerates; without it doctor names the wrong cause and prints a remedy that fails.
- Uncommitted tracked changes, with the first path and #651's `git stash push -u -m warm-refresh` remedy.
- Detached HEAD; there is no branch to fast-forward.
- Diverged from upstream (ahead *and* behind); `--refresh` refuses rather than merging or resetting. The behind-finding is suppressed in that case, matching #651, whose `checkoutPlan` returns a single `diverged` outcome -- and whose `git fetch --prune` remedy would not help a diverged branch anyway.
- Not on the default branch; every worktree warmed from here carries that branch's dependencies.

They are `note`, not `cost`: none of them makes a build slower, and a dirty main checkout is a choice, not a defect. They say the seed is not currently fit to seed.

The default branch resolves exactly the way #651 resolves it, so the two agree: `worktree.defaultBranch` in the repository-root `.stim.json`, else `git symbolic-ref --short refs/remotes/origin/HEAD` minus the remote prefix, else silence -- an unresolvable default branch is not a finding and not an error. Its remedy names only `git checkout <default>`, not the setting, because `worktree.defaultBranch` is registered and documented by #651; naming it here would tell a user to set a key that this branch's `worktree warm`, `start`, `ios` and `android` would then warn is unread.

Two further details. The branch is read as a full symbolic ref (`git symbolic-ref --quiet HEAD`, then strip `refs/heads/`) rather than through an abbreviated ref, so a tag that happens to share the branch's name cannot yield `heads/main` and produce a false "not on the default branch" finding whose remedy is a no-op. And remedies name the repository root rather than the app subdirectory, matching #651, since a stash or a checkout acts on the whole working tree.

The dependency, CocoaPods, and warm-output findings are **not** gated. They are true costs in either workflow, and the issue scopes the gate to the seed-fitness findings.

Guide framing: both topics now name SINGLE CHECKOUT and WORKTREE and say which rules belong to which, with the load-bearing rule stated plainly -- in the worktree workflow the main checkout is infrastructure, not a workspace. The scoping is worded as "rules about keeping the main checkout fit as a seed" rather than "main-checkout rules", because some main-checkout rules (repository-wide worktree-copy settings, `worktree remove` reclaiming a single checkout's environment) do apply to both. `guide agent` also says the seed findings appear once the repository has a linked worktree, so they are read from inside it.

Terminology stays "main checkout", matching the codebase; #654 proposes the repository-wide rename and lands separately.

## Test plan

From the repository root, all green:

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run knip` (clean, no findings)
- `pnpm test` -- 121 files, 3878 passed, 1 skipped

New tests build real git repositories in temp directories (invariant 9) rather than mocking git, so the gate and the branch state are read by the real tool:

- A repository with no linked worktree produces **no** seed findings even though its main checkout is simultaneously dirty, one commit behind `origin/main`, and on a non-default branch; adding one linked worktree makes exactly those three findings appear; deleting that worktree's directory without pruning silences them again.
- The same findings are produced when `checkMainCheckout` runs from inside the linked worktree, about the main checkout, in both the singular and plural dirty-count forms.
- A conflicted `git rebase` in the main checkout produces only the rebase-in-progress finding, with the `git rebase --abort` fix line.
- A detached main checkout produces the detached finding and nothing comparing its missing branch to the default.
- A main checkout one ahead of and one behind its upstream produces the diverged finding alone, with its exact fix line.
- A tag named after the checked-out branch produces no finding, which is what fails if the branch is ever read through an abbreviated ref again.
- `worktree.defaultBranch` in the repository-root `.stim.json` outranks `origin/HEAD`; with neither resolvable, the finding stays silent.

One existing test (`checkMainCheckout reports stale dependencies and the locally known upstream gap`) injects an upstream in a non-repository temp directory and now passes `linkedWorktrees: true`, because the behind-finding is a worktree-workflow finding.

A guide contract test asserts that both topics name both workflows and state that the main checkout is infrastructure rather than a workspace.

Closes #655
