### PR TITLE
fix: retain harmless benchmark session refusals

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -287,6 +287,11 @@ events and reruns the current session audit. It can clear only the sole
 `agent-device-run-session-not-applied` reason; every evidence check still applies.
 Keep the original verdict and correction provenance private, outside Git.
 
+Literal unscoped screenshot/snapshot attempts that report `SESSION_NOT_FOUND`
+without reaching a device remain visible in timing but do not fail isolation.
+Successful unscoped reads, explicit device/session overrides and ambiguous
+multi-command results still fail the audit.
+
 For launch-error runs, `launch-error-audit-review.json` records a review of each
 unrecognized setup command. It contains `schemaVersion: 1`, `runId`,
 `originalRecordSha256`, `metaSha256`, `policySha256` (the launch-crash audit source),

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -200,9 +200,30 @@ export function agentDeviceAuxiliarySessions(commands, expectedPrefix, target) {
   });
 }
 
+function failedUnscopedRead(entry) {
+  const source = topLevelShellCommand(entry.command).replace(/\s+2>&1(?=\s*(?:;|$))/g, '');
+  if (/[$`|&]/.test(source)) return false;
+  const segments = shellCommandSegments(source);
+  if (segments.length < 1 || segments.length > 2) return false;
+  const args = literalShellArguments(segments[0]);
+  if (args?.[0] !== 'agent-device') return false;
+  const readOnly =
+    (args[1] === 'screenshot' && args.length === 3 && args[2].startsWith('/tmp/')) ||
+    (args[1] === 'snapshot' && (args.length === 2 || (args.length === 3 && args[2] === '-i')));
+  if (!readOnly) return false;
+  if (segments[1] && literalShellArguments(segments[1])?.[0] !== 'echo') return false;
+  const output = String(entry.output ?? '');
+  return (
+    /^(?:Exit code 1\n)?Error \(SESSION_NOT_FOUND\): No active session\. Run open first\./.test(output) &&
+    !/^(?:Opened:|Session state:|Page:)/m.test(output)
+  );
+}
+
 export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix, target) {
   const segments = commands.flatMap((command) =>
-    shellCommandSegments(command.command).map((segment) => segment.replace(/^do\s+/, '')),
+    failedUnscopedRead(command)
+      ? []
+      : shellCommandSegments(command.command).map((segment) => segment.replace(/^do\s+/, '')),
   );
   const auxiliary = new Set(
     agentDeviceAuxiliarySessions(commands, expectedPrefix, target).flatMap((session) =>

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -34,6 +34,39 @@ const refusal = (output, exitCode = 1) => [{ id: 'refusal', command: 'stim andro
 describe('agent-device session isolation', () => {
   const prefix = 'env AGENT_DEVICE_STATE_DIR=/tmp/bench-state AGENT_DEVICE_SESSION=bench-run agent-device ';
 
+  it('retains harmless no-session read attempts without allowing successful or ambiguous device use', () => {
+    const output = 'Error (SESSION_NOT_FOUND): No active session. Run open first.\nHint: Run open first.';
+    for (const command of [
+      'agent-device screenshot /tmp/initial.png',
+      'agent-device snapshot -i',
+      'agent-device screenshot /tmp/initial.png 2>&1; echo "retrying with run session"',
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command, output }], prefix)).toEqual([]);
+      expect(agentDeviceIsolationInvalidReasons([{ command, output: '/tmp/initial.png (320x640)' }], prefix)).toContain(
+        'agent-device-run-session-not-applied',
+      );
+    }
+    for (const command of [
+      'agent-device open app',
+      'agent-device screenshot /tmp/a.png --serial emulator-5554',
+      'agent-device snapshot --session default',
+      'agent-device screenshot /tmp/a.png; agent-device close',
+      'echo "Error (SESSION_NOT_FOUND): No active session. Run open first."; agent-device screenshot /tmp/a.png',
+      'agent-device screenshot /tmp/$(agent-device close).png',
+      'agent-device snapshot | head -1',
+    ]) {
+      expect(agentDeviceIsolationInvalidReasons([{ command, output }], prefix)).toContain(
+        'agent-device-run-session-not-applied',
+      );
+    }
+    expect(
+      agentDeviceIsolationInvalidReasons(
+        [{ command: 'agent-device snapshot', output: `${output}\nPage: other` }],
+        prefix,
+      ),
+    ).toContain('agent-device-run-session-not-applied');
+  });
+
   it('recognizes scoped loop bodies without allowing an unscoped iteration command', () => {
     const scoped = `for i in 1 2 3; do ${prefix}press 'text="Open"' --settle 2>&1 | tail -4; done`;
     expect(agentDeviceIsolationInvalidReasons([{ command: scoped }], prefix)).toEqual([]);


### PR DESCRIPTION
## Description

A complete Android control benchmark was rejected because one bare screenshot attempt returned `SESSION_NOT_FOUND`. It never reached a device; every successful interaction used the required run session.

## Solution

Keep the [per-command isolation policy](https://github.com/appandflow/stim/commit/782b8c5046cf300fb54dddf509ca9240cdb61cf5), but exempt literal screenshot/snapshot attempts with a captured no-session refusal. Successful unscoped commands, explicit target overrides and ambiguous command chains still fail. The failed attempt and its elapsed time remain in the result.

## Test plan

Replayed all 54 retained commands from the affected run: the session audit now passes without modifying its transcript. Settings and recording proof remain subject to the existing checks. Regression cases reject successful reads, overrides, hidden commands and output that indicates a device was reached.

Fixes #663.
