### PR TITLE
fix: retain cache evidence from scoped benchmark commands

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -68,6 +68,10 @@ crashed command that could have compiled still fails closed.
 Completed tool output triggers an immediate `CACHE ALERT` and preserves
 `cache-alerts.json`. A flagged attempt stays available for investigation and is
 excluded from published comparisons; investigate the cause before retrying.
+When a completed build fails later during launch, collection can retain the
+owned workspace's timestamped compiler statistics. A literal `cd` to that
+worktree followed by `&& stim android ...; echo "EXIT=$?"` is also eligible;
+additional commands, a different directory, or ambiguous status reports are not.
 
 Android golden preparation and every preflight require a structured doctor
 report without cost findings. Repair the fixture with

--- a/scripts/agent-benchmark/ccache-evidence.mjs
+++ b/scripts/agent-benchmark/ccache-evidence.mjs
@@ -1,9 +1,26 @@
 import { createHash } from 'node:crypto';
 import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
-import { ccacheMeasurements, shellCommandSegments } from './run-guards.mjs';
+import { ccacheMeasurements, shellCommandSegments, topLevelShellCommand } from './run-guards.mjs';
 
 const hash = (value) => createHash('sha256').update(value).digest('hex');
+
+function singleBuildCommand(entry, worktree) {
+  const segments = shellCommandSegments(entry.command);
+  if (segments.length === 1) return true;
+  if (segments.length !== 3 || entry.exitCode !== 0) return false;
+  const [directory, build, report] = segments;
+  const statuses = [...String(entry.output ?? '').matchAll(/^EXIT=([01])\r?$/gm)];
+  return (
+    [worktree, `'${worktree}'`, `"${worktree}"`].some((path) => directory === `cd ${path}`) &&
+    /^stim android(?:\s|$)/.test(build) &&
+    !/[`$\n]/.test(build) &&
+    report === 'echo "EXIT=$?"' &&
+    topLevelShellCommand(entry.command) === `${directory} && ${build}; ${report}` &&
+    statuses.length === 1 &&
+    [...String(entry.output ?? '').matchAll(/^EXIT=.*$/gm)].length === 1
+  );
+}
 
 export function ccacheLogEvidence({ runDir, meta, commands, worktree, capture = false }) {
   if (meta.arm !== 'stim' || meta.platform !== 'android' || !worktree) return null;
@@ -18,7 +35,7 @@ export function ccacheLogEvidence({ runDir, meta, commands, worktree, capture = 
     [...entry.output.matchAll(/build\s+compiling/g)].length !== 1 ||
     !entry.id ||
     entry.parallelTimingAmbiguous ||
-    shellCommandSegments(entry.command).length !== 1 ||
+    !singleBuildCommand(entry, worktree) ||
     ![0, 1].includes(entry.exitCode) ||
     !/build\s+ok\b/.test(entry.output) ||
     ccacheMeasurements(entry.output).length

--- a/scripts/agent-benchmark/ccache-evidence.test.mjs
+++ b/scripts/agent-benchmark/ccache-evidence.test.mjs
@@ -38,6 +38,39 @@ afterEach(() => rmSync(root, { recursive: true, force: true }));
 const evidence = (capture = true) => ccacheLogEvidence({ runDir, meta, commands, worktree, capture });
 
 describe('captured compiler cache evidence', () => {
+  it('retains exact command identity for a scoped build with a reported launch failure', () => {
+    commands[0].command = `cd ${worktree} && stim android --system-image "system-images;android-36;arm64-v8a"; echo "EXIT=$?"`;
+    commands[0].exitCode = 0;
+    commands[0].output += '\nEXIT=1\n';
+    const before = JSON.stringify(commands);
+    expect(evidence()).toMatchObject({ hits: 2, misses: 0, commandId: 'build' });
+    expect(JSON.stringify(commands)).toBe(before);
+    expect(evidence(false)).not.toBeNull();
+  });
+
+  it.each([
+    'wrong directory',
+    'unconditional cd',
+    'extra command',
+    'missing status',
+    'duplicate status',
+    'bad status',
+    'substitution',
+  ])('rejects scoped wrappers with %s', (failure) => {
+    commands[0].command = `cd ${worktree} && stim android; echo "EXIT=$?"`;
+    commands[0].exitCode = 0;
+    commands[0].output += '\nEXIT=1\n';
+    if (failure === 'wrong directory') commands[0].command = commands[0].command.replace(worktree, `${root}/other`);
+    if (failure === 'unconditional cd') commands[0].command = commands[0].command.replace(' && ', '; ');
+    if (failure === 'extra command') commands[0].command += '; echo done';
+    if (failure === 'missing status') commands[0].output = commands[0].output.replace('EXIT=1', '');
+    if (failure === 'duplicate status') commands[0].output += 'EXIT=0\n';
+    if (failure === 'bad status') commands[0].output = commands[0].output.replace('EXIT=1', 'EXIT=143');
+    if (failure === 'substitution')
+      commands[0].command = commands[0].command.replace('stim android', 'stim android "$(echo extra)"');
+    expect(evidence()).toBeNull();
+  });
+
   it('captures the completed build independently of launch and survives cleanup without editing commands', () => {
     const before = JSON.stringify(commands);
     const measurement = evidence();


### PR DESCRIPTION
## Description

Opus's native benchmark hit the compiler cache 386/386 times, but the audit discarded the evidence because its command wrapped Stim in `cd ... && stim android ...; echo "EXIT=$?"`. Fixes #669.

## Solution

Accept this narrow wrapper only for the recorded worktree with one explicit status report. Preserve the command/event hashes, unique-build requirement and stats-log timestamp checks introduced in [#646](https://github.com/appandflow/stim/commit/2acde6e53433e9499e8b723f37df3c025756eb62). Unrelated commands and directories still refuse. This changes benchmark analysis only; the device-cleanup retry remains in the timing.

## Test plan

Replay the retained Opus build: recover 386 hits and zero misses without editing commands. Regression cases reject wrong directories, unconditional `cd`, extra commands, substitutions and missing/duplicate/invalid status reports.
