### PR TITLE
fix: recognize benchmark launch log variables

### DIFF
--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -55,6 +55,8 @@ function successfulLaunch(command, arm, platform) {
   if (!prefix) return false;
   if (/^cd\s/.test(prefix[0]) && !/&&\s*$/.test(prefix[0])) return false;
   let pipeline = value.slice(prefix[0].length);
+  const logVariable = pipeline.match(/^([A-Za-z_]\w*)=([\w/.-]+)\s*&&\s*/);
+  if (logVariable) pipeline = pipeline.slice(logVariable[0].length);
   const report = /;\s*echo "PIPELINE_EXIT=\$\?"\s*$/.exec(pipeline);
   if (report) {
     const statuses = [...String(command.output ?? '').matchAll(/^PIPELINE_EXIT=(\d+)\s*$/gm)];
@@ -62,6 +64,12 @@ function successfulLaunch(command, arm, platform) {
     pipeline = pipeline.slice(0, report.index);
   }
   let [launch, ...filters] = pipeline.replace(/\s+2>&1(?=\s|$)/g, '').split(/\s*\|\s*/);
+  if (logVariable) {
+    const variablePath = new RegExp(`^(tee(?: -a)?) "([\\w/.-]*)\\$${logVariable[1]}(?=[^A-Za-z0-9_])([\\w/.-]*)"$`);
+    filters = filters.map((filter) =>
+      filter.replace(variablePath, (_, tee, before, after) => `${tee} ${before}${logVariable[2]}${after}`),
+    );
+  }
   if (arm === 'control' && platform === 'android')
     launch = launch.replace(/^adb\s+-s\s+emulator-\d+\s+reverse\s+tcp:\d+\s+tcp:\d+\s*&&\s*/, '');
   const group = /^\{\s*([\s\S]*?);\s*\}$/.exec(launch);
@@ -106,7 +114,11 @@ function errorCaptureCommand(command, arm, platform) {
     /\b(?:tail|rg|grep|sed|cat)\b[\s\S]*(?:\.log\b|(?:^|[\s'"])(?:\.?\/)?(?:tmp|logs?|\.expo\/dev\/logs)\/)/.test(
       command,
     );
-  if (platform === 'android') return /\badb\s+(?:-s\s+\S+\s+)?logcat\b/.test(command) || explicitLogFile;
+  if (platform === 'android')
+    return (
+      shellCommandSegments(command).some((segment) => /^adb\s+(?:-s\s+\S+\s+)?logcat\b/.test(shellCommand(segment))) ||
+      explicitLogFile
+    );
   return /\bxcrun\s+simctl\s+spawn\b|\blog\s+(?:show|stream)\b/.test(command) || explicitLogFile;
 }
 

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -315,6 +315,47 @@ done`;
       output: 'BUILD SUCCESSFUL\nPIPELINE_EXIT=0\nShell cwd was reset to /tmp/fixture',
     };
     expect(launchCrashDiagnosis([...before, pipeline, logs], options)).toMatchObject({ valid: true });
+    const variablePipeline = {
+      ...pipeline,
+      command: pipeline.command
+        .replace('npx expo', 'RUNID=run-123 && CI=1 ORG_GRADLE_PROJECT_reactNativeArchitectures=arm64-v8a npx expo')
+        .replace('/tmp/native.log', '"/tmp/$RUNID-native.log"'),
+    };
+    expect(launchCrashDiagnosis([...before, variablePipeline, logs], options)).toMatchObject({
+      valid: true,
+      initialLaunchCommandId: 'launch',
+      commandId: 'logs',
+    });
+    const deviceLogs = {
+      ...logs,
+      command:
+        'sleep 20; "$ANDROID_HOME/platform-tools/adb" -s emulator-5554 logcat -d | rg "ReactNativeJS" | tail -40',
+    };
+    expect(launchCrashDiagnosis([variablePipeline, deviceLogs], options)).toMatchObject({
+      valid: true,
+      commandId: 'logs',
+      observedAt: logs.endedAt,
+    });
+    expect(
+      launchCrashDiagnosis([variablePipeline, { ...deviceLogs, command: 'echo "adb logcat -d"' }], options),
+    ).toMatchObject({ valid: false, reason: 'launch-crash-error-capture-missing' });
+    for (const changed of [
+      { command: variablePipeline.command.replace('RUNID=run-123', 'RUNID=$(cat /tmp/id)') },
+      { command: variablePipeline.command.replace('RUNID=run-123', 'RUNID=`cat /tmp/id`') },
+      { command: variablePipeline.command.replace('$RUNID-native', '$OTHER-native') },
+      { command: variablePipeline.command.replace('$RUNID-native', '$RUNID_suffix-native') },
+      { command: variablePipeline.command.replace('$RUNID-native', '$(cat /tmp/id)-native') },
+      { command: variablePipeline.command.replace('run-123 &&', 'run-123;') },
+      { command: variablePipeline.command.replace('run-123 &&', 'run-123 && cat /tmp/unrelated &&') },
+      { command: variablePipeline.command.replace('tail -40', 'cat /tmp/unrelated') },
+      { output: 'BUILD SUCCESSFUL\nPIPELINE_EXIT=1' },
+      { output: 'BUILD SUCCESSFUL' },
+      { output: 'PIPELINE_EXIT=1\nPIPELINE_EXIT=0' },
+    ])
+      expect(launchCrashDiagnosis([{ ...variablePipeline, ...changed }, logs], options)).toMatchObject({
+        valid: false,
+        reason: 'launch-crash-initial-launch-evidence-missing',
+      });
     const forwardedLaunch = {
       ...launch,
       command:


### PR DESCRIPTION
## Description

Opus successfully built, diagnosed and repaired the Android crash fixture, but the benchmark rejected its shell wrappers. The launch used a literal `RUNID` in its log path, and the subsequent logcat used a quoted Android SDK path after `sleep`.

## Solution

Recognize one local literal assignment in the pipefail launch pipeline and normalize the Android tool path at each command boundary. Keep the constrained launch/filter grammar and reported-exit checks introduced in [#515](https://github.com/appandflow/stim/commit/ca7df6cd2dfccd453171cf59d03197e5de84f6bc); no shell evaluation or benchmark timing changes. This affects benchmark analysis only, not Stim runtime.

## Test plan

Replay the original Opus transcript: it identifies the successful Expo invocation and the first logcat result at 21:49:43.992Z, before source inspection. Regression cases reject substituted/unknown variables, unrelated output, missing or failed pipeline status, and an echoed logcat command.

Fixes #672
