### PR TITLE
fix: accept lowercase benchmark status labels

### DIFF
--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -252,7 +252,7 @@ function commandSegmentsStartingWith(command, expected) {
 
 export function commandWithReportedStatus(command) {
   const source = topLevelShellCommand(command.command);
-  const report = /(?:;|\n)\s*echo "([A-Z_]+)=\$\?"\s*$/.exec(source);
+  const report = /(?:;|\n)\s*echo "([A-Za-z_][A-Za-z0-9_]*)=\$\?"\s*$/.exec(source);
   if (!report || shellCommandSegments(source).at(-1) !== `echo "${report[1]}=$?"`) return command;
   const body = source.slice(0, report.index).trim();
   const statuses = [...String(command.output ?? '').matchAll(new RegExp(`^${report[1]}=(\\d+)\\s*$`, 'gm'))];

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -560,36 +560,39 @@ describe('benchmark run guards', () => {
     expect(benchmarkSetupInvalidReasons({ arm: 'stim', platform: 'android' }, commands)).toEqual([]);
   });
 
-  it.skipIf(process.platform === 'win32')('uses reported warm status without losing completion ordering', () => {
-    const meta = { arm: 'stim', platform: 'android' };
-    const guide = { command: 'stim guide agent', exitCode: 0 };
-    const start = { command: 'stim start', exitCode: 0, startEventOffset: 3 };
-    for (const code of [0, 7]) {
-      const command = 'cd /tmp && stim worktree warm; echo "EXIT=$?"';
-      const result = spawnSync('/bin/bash', ['-c', `stim() { return ${code}; }; ${command}`], {
-        encoding: 'utf8',
-        timeout: 5000,
-      });
-      expect(result.status).toBe(0);
-      const warm = { command, exitCode: result.status, output: result.stdout, endEventOffset: 2 };
-      expect(benchmarkSetupInvalidReasons(meta, [guide, warm, start])).toEqual(
-        code === 0 ? [] : ['stim-worktree-warm-missing-or-failed'],
-      );
-      if (code !== 0) continue;
-      expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, endEventOffset: 4 }, start])).toEqual([
-        'stim-worktree-warm-not-complete-before-use',
-      ]);
-      for (const output of ['', 'EXIT=0\nEXIT=0\n', 'EXIT=7\n']) {
-        expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, output }, start])).toContain(
+  it.skipIf(process.platform === 'win32').each(['EXIT', 'exit', 'ExitCode2', '_status'])(
+    'uses reported warm status %s without losing completion ordering',
+    (label) => {
+      const meta = { arm: 'stim', platform: 'android' };
+      const guide = { command: 'stim guide agent', exitCode: 0 };
+      const start = { command: 'stim start', exitCode: 0, startEventOffset: 3 };
+      for (const code of [0, 7]) {
+        const command = `cd /tmp && stim worktree warm; echo "${label}=$?"`;
+        const result = spawnSync('/bin/bash', ['-c', `stim() { return ${code}; }; ${command}`], {
+          encoding: 'utf8',
+          timeout: 5000,
+        });
+        expect(result.status).toBe(0);
+        const warm = { command, exitCode: result.status, output: result.stdout, endEventOffset: 2 };
+        expect(benchmarkSetupInvalidReasons(meta, [guide, warm, start])).toEqual(
+          code === 0 ? [] : ['stim-worktree-warm-missing-or-failed'],
+        );
+        if (code !== 0) continue;
+        expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, endEventOffset: 4 }, start])).toEqual([
+          'stim-worktree-warm-not-complete-before-use',
+        ]);
+        for (const output of ['', `${label}=0\n${label}=0\n`, `${label}=7\n`, `${label}Wrong=0\n`]) {
+          expect(benchmarkSetupInvalidReasons(meta, [guide, { ...warm, output }, start])).toContain(
+            'stim-worktree-warm-missing-or-failed',
+          );
+        }
+        const background = { ...warm, command: `stim worktree warm &\necho "${label}=$?"` };
+        expect(benchmarkSetupInvalidReasons(meta, [guide, background, start])).toContain(
           'stim-worktree-warm-missing-or-failed',
         );
       }
-      const background = { ...warm, command: 'stim worktree warm &\necho "EXIT=$?"' };
-      expect(benchmarkSetupInvalidReasons(meta, [guide, background, start])).toContain(
-        'stim-worktree-warm-missing-or-failed',
-      );
-    }
-  });
+    },
+  );
 
   it('audits Claude-style chained commands', () => {
     const commands = [

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -49,6 +49,21 @@ describe('launch crash benchmark', () => {
         valid: false,
         reason: 'launch-crash-error-capture-missing',
       });
+      for (const label of ['EXIT', 'exit', 'ExitCode2']) {
+        const wrap = (entry) => ({
+          ...entry,
+          command: `${entry.command}; echo "${label}=$?"`,
+          output: `${entry.output}\n${label}=0\n`,
+        });
+        expect(launchCrashDiagnosis([wrap(launch), wrap(logs)], options)).toMatchObject({
+          valid: true,
+          commandId: 'launch',
+          observedAt: launch.endedAt,
+        });
+        expect(
+          launchCrashDiagnosis([{ ...wrap(launch), output: `${launch.output}\n${label}=1\n` }, wrap(logs)], options),
+        ).toMatchObject({ valid: false });
+      }
       expect(launchCrashDiagnosis([launch, { ...logs, exitCode: 1 }], options).valid).toBe(false);
       for (const output of [`${token} RootLayout`, `ERROR [Error: ${token}]`, 'ERROR unrelated\nRootLayout']) {
         expect(launchCrashDiagnosis([{ ...launch, output }, logs], options)).toMatchObject({


### PR DESCRIPTION
## Description

The Opus Android crash run completed warm and caught the injected error, but its lowercase `echo "exit=$?"` wrappers were rejected. The benchmark only recognized uppercase labels.

## Solution

Accept ASCII identifier labels while matching their output case exactly. Keep the single numeric status, successful wrapper, foreground completion and ordering checks from [#517](https://github.com/appandflow/stim/commit/9fe2934b655dc091ac6c549a2de22036f80051a1). Benchmark analysis only; no Stim runtime or recorded timing changes.

## Test plan

The existing real-shell warm test now covers uppercase, lowercase and mixed-case labels, including failed commands, missing/duplicate/mismatched reports and background work. Crash-evidence cases verify that wrapped launch output still determines diagnosis time and failed status is rejected.

Fixes #674
