### PR TITLE
fix: accept benchmark proof on custom Metro ports

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -236,8 +236,10 @@ the same UDID recorded by the independent app watcher, all required commands
 completed in order after dispatch, the PNG has a valid signature and
 dimensions, its timestamps fit the run, and the copied file exists. It also
 requires an integrity-bound MP4 between the recorded start and stop commands.
-The JavaScript source and captured Metro bundle must contain the changed
-subtitle. iOS native must expose the exact run marker in the live window
+JavaScript runs retain an integrity-bound copy of the edited source and require
+the isolated Settings-screen wait to find the changed subtitle before capturing
+the screenshot and recording. No extra Metro bundle request is required; the
+agent may choose any available Metro port. iOS native must expose the exact run marker in the live window
 accessibility node; Android native must preserve the same marker from the
 installed APK application label.
 Missing proof makes the attempt invalid even when the app process is alive.

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -9,6 +9,13 @@ The driver runs the iOS and Android readiness suites plus the JavaScript
 launch-failure suite described in [`../../docs/agent-benchmark.md`](../../docs/agent-benchmark.md).
 Runs are sequential. Never dispatch two cells against the same benchmark root.
 
+JavaScript proof combines the retained source edit with the isolated Settings
+screen proof, not a second bundle request. A legacy bundle-watcher timeout is
+retained as a warning only when independently observed app liveness and both
+proofs succeed. Other watcher failures still invalidate the run. Control cleanup
+discovers listening ports and stops only a verified Metro endpoint whose process
+working directory is exactly the canonical run worktree.
+
 ## Machine-local layout
 
 Create a benchmark root outside the repository with these entries:

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -1,3 +1,5 @@
+import { javascriptProof, appAliveErrorIsSuperseded } from './javascript-proof.mjs';
+import { ownedMetroListeners } from './metro-listeners.mjs';
 import {
   chmodSync,
   copyFileSync,
@@ -2069,7 +2071,21 @@ function copyRollout(runDir) {
   return target;
 }
 
-function proofFor(meta, appAlive, runDir, worktree, commandItems) {
+function proofFor(meta, appAlive, runDir, worktree, commandItems, screen) {
+  if (meta.variant === 'javascript') {
+    const sourcePath = worktree ? join(worktree, 'app', '(tabs)', 'settings.tsx') : null;
+    const proof = javascriptProof(
+      sourcePath && existsSync(sourcePath) ? readFileSync(sourcePath, 'utf8') : null,
+      sourcePath,
+      screen,
+    );
+    if (proof.valid) {
+      const target = join(runDir, 'proof', 'settings-source.tsx');
+      copyFileSync(sourcePath, target);
+      return { ...proof, target };
+    }
+    return proof;
+  }
   if (meta.variant === launchCrashVariant) {
     if (!worktree) {
       return { valid: false, reason: 'launch-crash-worktree-missing' };
@@ -2143,33 +2159,6 @@ function proofFor(meta, appAlive, runDir, worktree, commandItems) {
   if (appAlive.error === 'proof-timeout-after-app-alive') {
     return { valid: false, reason: 'changed-metro-bundle-not-found' };
   }
-  if (meta.variant === 'javascript') {
-    const expected = 'Keep saved trail maps available offline';
-    const proofDir = join(runDir, 'proof');
-    const preserved = existsSync(proofDir)
-      ? readdirSync(proofDir)
-          .filter((name) => name.endsWith('.bundle'))
-          .map((name) => join(proofDir, name))
-          .find((path) => {
-            try {
-              run('grep', ['-a', '-F', '-q', expected, path]);
-              return true;
-            } catch {
-              return false;
-            }
-          })
-      : null;
-    if (preserved) {
-      const port = Number(preserved.match(/metro-(\d+)/)?.[1]);
-      return {
-        valid: true,
-        kind: 'preserved-metro-bundle-string',
-        expected,
-        target: preserved,
-        ...(Number.isInteger(port) ? { port } : {}),
-      };
-    }
-  }
   if (!appAlive.simulator?.udid || !worktree) {
     return { valid: false, reason: 'missing-simulator-or-worktree' };
   }
@@ -2187,35 +2176,7 @@ function proofFor(meta, appAlive, runDir, worktree, commandItems) {
       target: eventsPath,
     };
   }
-  const expected = 'Keep saved trail maps available offline';
-  const sourcePath = join(worktree, 'app', '(tabs)', 'settings.tsx');
-  if (!existsSync(sourcePath) || !readFileSync(sourcePath, 'utf8').includes(expected)) {
-    return { valid: false, reason: 'source-edit-missing', sourcePath };
-  }
-  for (let port = 8081; port <= 8090; port += 1) {
-    const target = join(runDir, 'proof', `metro-${port}.bundle`);
-    try {
-      execFileSync(
-        'curl',
-        [
-          '--fail',
-          '--silent',
-          '--show-error',
-          '--max-time',
-          '60',
-          '--output',
-          target,
-          `http://127.0.0.1:${port}/.expo/.virtual-metro-entry.bundle?platform=${meta.platform ?? 'ios'}&dev=true&minify=false`,
-        ],
-        { cwd: worktree, timeout: 70_000 },
-      );
-      run('grep', ['-a', '-F', '-q', expected, target]);
-      return { valid: true, kind: 'metro-bundle-string', expected, target, port };
-    } catch {
-      rmSync(target, { force: true });
-    }
-  }
-  return { valid: false, reason: 'changed-metro-bundle-not-found' };
+  return { valid: false, reason: 'unsupported-proof-variant' };
 }
 
 function completedCleanup(runDir) {
@@ -2267,7 +2228,7 @@ function collect(runDir) {
     ccacheLogEvidence({ runDir, meta, commands: commandAudit.commands, worktree, capture: true }),
   );
   const nativeCompatibility = collectedNativeCompatibility(meta, worktree);
-  const proof = proofFor(meta, appAlive, runDir, worktree, commandAudit.completedEvents);
+  const proof = proofFor(meta, appAlive, runDir, worktree, commandAudit.completedEvents, screen);
   const rollout =
     meta.runner === 'claude'
       ? eventsPath
@@ -2301,7 +2262,7 @@ function collect(runDir) {
     diagnosis?.valid && meta.runner !== 'claude' ? usageAtOrBefore(rollout, diagnosis.observedAt) : null;
   const invalidReasons = [
     ...(nativeCompatibility && !nativeCompatibility.valid ? ['native-compatibility-changed-or-unverified'] : []),
-    ...(appAlive.error ? [appAlive.error] : []),
+    ...(appAlive.error && !appAliveErrorIsSuperseded(appAlive, proof, screen) ? [appAlive.error] : []),
     ...(meta.runnerResult?.code === 0 ? [] : [`runner-exit-${meta.runnerResult?.code}`]),
     ...(runnerMetrics?.isError ? [`runner-${runnerMetrics.terminalReason ?? 'error'}`] : []),
     ...(runnerMetrics?.subagentsSpawned ? ['runner-used-subagents'] : []),
@@ -2338,6 +2299,7 @@ function collect(runDir) {
     valid: invalidReasons.length === 0,
     nativeCompatibility,
     invalidReasons,
+    watcherWarnings: appAliveErrorIsSuperseded(appAlive, proof, screen) ? [appAlive.error] : [],
     dispatchToAppAliveSeconds: appAlive.dispatchToAppAliveSeconds ?? null,
     dispatchToProofSeconds: appAlive.dispatchToProofSeconds ?? null,
     dispatchToScreenReadySeconds: screen.dispatchToScreenReadySeconds ?? null,
@@ -2524,20 +2486,11 @@ function cleanup(runDir) {
       }
     }
     if (worktree && existsSync(worktree)) {
-      for (let port = 8081; port <= 8090; port += 1) {
+      for (const { pid, port } of ownedMetroListeners(worktree)) {
         try {
-          const pids = run('/usr/sbin/lsof', ['-t', `-iTCP:${port}`, '-sTCP:LISTEN'])
-            .split('\n')
-            .filter(Boolean);
-          for (const pid of pids) {
-            const cwd = run('/usr/sbin/lsof', ['-a', '-p', pid, '-d', 'cwd', '-Fn'])
-              .split('\n')
-              .find((line) => line.startsWith('n'))
-              ?.slice(1);
-            if (cwd?.startsWith(worktree)) {
-              process.kill(Number(pid), 'SIGTERM');
-              actions.push(`terminate Metro pid ${pid}`);
-            }
+          if (ownedMetroListeners(worktree).some((candidate) => candidate.pid === pid && candidate.port === port)) {
+            process.kill(pid, 'SIGTERM');
+            actions.push(`terminate Metro pid ${pid}`);
           }
         } catch {}
       }

--- a/scripts/agent-benchmark/javascript-proof.mjs
+++ b/scripts/agent-benchmark/javascript-proof.mjs
@@ -1,0 +1,25 @@
+export function javascriptProof(source, sourcePath, screen) {
+  const expected = 'Keep saved trail maps available offline';
+  if (typeof source !== 'string' || !source.includes(expected))
+    return { valid: false, reason: 'source-edit-missing', sourcePath };
+  if (screen?.valid !== true || screen.expected !== expected) return { valid: false, reason: 'screen-proof-failed' };
+  return {
+    valid: true,
+    kind: 'source-edit-and-settings-screen',
+    expected,
+    target: sourcePath,
+    screenTarget: screen.target,
+  };
+}
+
+export function appAliveErrorIsSuperseded(appAlive, proof, screen) {
+  return (
+    appAlive.error === 'proof-timeout-after-app-alive' &&
+    typeof appAlive.simulator?.udid === 'string' &&
+    appAlive.simulator.udid.length > 0 &&
+    Number.isFinite(Date.parse(appAlive.observedAt)) &&
+    proof.valid === true &&
+    proof.kind === 'source-edit-and-settings-screen' &&
+    screen.valid === true
+  );
+}

--- a/scripts/agent-benchmark/javascript-proof.test.mjs
+++ b/scripts/agent-benchmark/javascript-proof.test.mjs
@@ -1,0 +1,34 @@
+import { expect, it } from 'vitest';
+import { javascriptProof, appAliveErrorIsSuperseded } from './javascript-proof.mjs';
+
+const expected = 'Keep saved trail maps available offline';
+const screen = { valid: true, expected, target: '/proof/settings.png' };
+
+it('requires both the requested source edit and validated changed Settings screen', () => {
+  expect(javascriptProof(expected, '/settings.tsx', screen)).toMatchObject({
+    valid: true,
+    kind: 'source-edit-and-settings-screen',
+  });
+  expect(javascriptProof('old text', '/settings.tsx', screen)).toMatchObject({
+    valid: false,
+    reason: 'source-edit-missing',
+  });
+  expect(javascriptProof(null, null, screen).valid).toBe(false);
+  expect(javascriptProof(expected, '/settings.tsx', { ...screen, valid: false }).valid).toBe(false);
+  expect(javascriptProof(expected, '/settings.tsx', { ...screen, expected: 'old text' }).valid).toBe(false);
+});
+
+it('supersedes only a legacy bundle timeout with live-device and changed-screen proof', () => {
+  const alive = {
+    error: 'proof-timeout-after-app-alive',
+    observedAt: '2026-09-10T22:50:00Z',
+    simulator: { udid: 'owned-device' },
+  };
+  const proof = javascriptProof(expected, '/settings.tsx', screen);
+  expect(appAliveErrorIsSuperseded(alive, proof, screen)).toBe(true);
+  for (const change of [{ error: 'wrong-device' }, { observedAt: null }, { simulator: {} }]) {
+    expect(appAliveErrorIsSuperseded({ ...alive, ...change }, proof, screen)).toBe(false);
+  }
+  expect(appAliveErrorIsSuperseded(alive, { valid: false }, screen)).toBe(false);
+  expect(appAliveErrorIsSuperseded(alive, proof, { valid: false })).toBe(false);
+});

--- a/scripts/agent-benchmark/metro-listeners.mjs
+++ b/scripts/agent-benchmark/metro-listeners.mjs
@@ -1,0 +1,45 @@
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+
+export function ownedMetroListeners(worktree, execute = execFileSync) {
+  const run = (file, args) =>
+    execute(file, args, { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] });
+  let root, listing;
+  try {
+    root = realpathSync(worktree);
+    listing = run('/usr/sbin/lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-Fpn']);
+  } catch {
+    return [];
+  }
+  let listedPid;
+  const candidates = new Map();
+  for (const line of listing.split('\n')) {
+    if (/^p\d+$/.test(line)) listedPid = Number(line.slice(1));
+    const port = /^n.*:(\d+)$/.exec(line)?.[1];
+    if (Number.isSafeInteger(listedPid) && listedPid > 0 && port && Number(port) > 0 && Number(port) < 65536)
+      candidates.set(`${listedPid}:${port}`, { pid: listedPid, port: Number(port) });
+  }
+  return [...candidates.values()].filter(({ pid, port }) => {
+    try {
+      const cwd = run('/usr/sbin/lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'])
+        .split('\n')
+        .find((line) => line.startsWith('n'))
+        ?.slice(1);
+      return (
+        cwd &&
+        realpathSync(cwd) === root &&
+        run('curl', [
+          '--noproxy',
+          '*',
+          '--fail',
+          '--silent',
+          '--max-time',
+          '2',
+          `http://127.0.0.1:${port}/status`,
+        ]).trim() === 'packager-status:running'
+      );
+    } catch {
+      return false;
+    }
+  });
+}

--- a/scripts/agent-benchmark/metro-listeners.test.mjs
+++ b/scripts/agent-benchmark/metro-listeners.test.mjs
@@ -1,0 +1,79 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { expect, it } from 'vitest';
+import { ownedMetroListeners } from './metro-listeners.mjs';
+
+it.skipIf(process.platform !== 'darwin')(
+  'recognizes a real custom-port Metro listener without adopting a sibling server',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'bench-metro-live-'));
+    const sibling = join(root, 'other');
+    mkdirSync(sibling);
+    const children = [];
+    try {
+      const launch = async (cwd) => {
+        const child = spawn(
+          process.execPath,
+          [
+            '--input-type=module',
+            '-e',
+            "import http from 'node:http'; const s = http.createServer((q,r)=>r.end('packager-status:running')); s.listen(0,'127.0.0.1',()=>console.log(s.address().port));",
+          ],
+          { cwd, stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        children.push(child);
+        const [data] = await once(child.stdout, 'data');
+        return { pid: child.pid, port: Number(data.toString().trim()) };
+      };
+      const owned = await launch(root);
+      const foreign = await launch(sibling);
+      expect(ownedMetroListeners(root)).toEqual([owned]);
+      expect(ownedMetroListeners(sibling)).toEqual([foreign]);
+    } finally {
+      await Promise.all(
+        children.map(async (child) => {
+          const closed = once(child, 'close');
+          child.kill();
+          await closed;
+        }),
+      );
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  20000,
+);
+
+it('discovers custom ports only for the exact canonical worktree and a verified Metro endpoint', () => {
+  const root = mkdtempSync(join(tmpdir(), 'bench-metro-'));
+  try {
+    const worktree = join(root, 'app');
+    const sibling = join(root, 'app-other');
+    const alias = join(root, 'alias');
+    mkdirSync(worktree);
+    mkdirSync(sibling);
+    symlinkSync(worktree, alias);
+    const execute = (file, args) => {
+      if (args.includes('-Fpn'))
+        return 'p100\nn*:18081\nn127.0.0.1:18081\np101\nn*:18082\np102\nn*:18083\np103\nn*:18084\n';
+      if (args.includes('cwd')) {
+        const pid = args[args.indexOf('-p') + 1];
+        if (pid === '103') throw new Error('process exited');
+        return `p${pid}\nn${pid === '101' ? sibling : alias}\n`;
+      }
+      if (file === 'curl') return args.at(-1).includes(':18081/') ? 'packager-status:running' : 'other server';
+      throw new Error('unexpected command');
+    };
+    expect(ownedMetroListeners(worktree, execute)).toEqual([{ pid: 100, port: 18081 }]);
+    expect(
+      ownedMetroListeners(worktree, () => {
+        throw new Error('denied');
+      }),
+    ).toEqual([]);
+    expect(ownedMetroListeners(join(root, 'missing'), execute)).toEqual([]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/agent-benchmark/watch-app-selection.mjs
+++ b/scripts/agent-benchmark/watch-app-selection.mjs
@@ -1,5 +1,4 @@
 export function readinessProofKind(platform, variant) {
-  if (variant === 'javascript') return 'javascript';
   if (variant === 'native' && platform === 'android') return 'android-native';
   return null;
 }

--- a/scripts/agent-benchmark/watch-app-selection.test.mjs
+++ b/scripts/agent-benchmark/watch-app-selection.test.mjs
@@ -25,7 +25,7 @@ const device = {
 it('does not wait for an edited APK label or JS marker during launch-error recovery', () => {
   for (const platform of ['ios', 'android']) {
     expect(readinessProofKind(platform, 'launch-crash')).toBeNull();
-    expect(readinessProofKind(platform, 'javascript')).toBe('javascript');
+    expect(readinessProofKind(platform, 'javascript')).toBeNull();
   }
   expect(readinessProofKind('android', 'native')).toBe('android-native');
   expect(readinessProofKind('ios', 'native')).toBeNull();

--- a/scripts/agent-benchmark/watch-app.mjs
+++ b/scripts/agent-benchmark/watch-app.mjs
@@ -98,35 +98,6 @@ function alive(udid) {
   }
 }
 
-function captureJavascriptProof() {
-  const expected = 'Keep saved trail maps available offline';
-  for (let port = 8081; port <= 8090; port += 1) {
-    const target = join(dirname(outputPath), 'proof', `metro-${port}-at-app-alive.bundle`);
-    try {
-      execFileSync(
-        'curl',
-        [
-          '--fail',
-          '--silent',
-          '--show-error',
-          '--max-time',
-          '60',
-          '--output',
-          target,
-          `http://127.0.0.1:${port}/.expo/.virtual-metro-entry.bundle?platform=${platform}&dev=true&minify=false`,
-        ],
-        { timeout: 70_000 },
-      );
-      const contents = readFileSync(target);
-      if (contents.includes(Buffer.from(expected))) {
-        return { valid: true, kind: 'metro-bundle-string-at-app-alive', expected, target, port };
-      }
-    } catch {}
-    if (existsSync(target)) rmSync(target);
-  }
-  return { valid: false, reason: 'changed-metro-bundle-not-found-at-app-alive' };
-}
-
 function androidBuildTool(name) {
   const sdk = process.env.ANDROID_HOME ?? process.env.ANDROID_SDK_ROOT;
   if (!sdk) return null;
@@ -197,12 +168,7 @@ while (Date.now() < deadline) {
         simulator: selection.candidate,
       };
       const proofKind = readinessProofKind(platform, variant);
-      const proof =
-        proofKind === 'javascript'
-          ? captureJavascriptProof()
-          : proofKind === 'android-native'
-            ? captureAndroidNativeProof(selection.candidate.udid)
-            : null;
+      const proof = proofKind === 'android-native' ? captureAndroidNativeProof(selection.candidate.udid) : null;
       if (proof && !proof.valid) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         continue;

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -626,10 +626,12 @@ function readinessApplicationProofFailure({ runDir, record, meta, eventsPath, co
     if (
       !existsSync(applicationProofPath) ||
       record.evidenceSha256?.proof !== fileSha256(applicationProofPath) ||
-      !applicationProofPath.endsWith('.bundle') ||
+      !(record.proof.kind === 'source-edit-and-settings-screen'
+        ? basename(applicationProofPath) === 'settings-source.tsx' && record.proof.expected === record.screen.expected
+        : applicationProofPath.endsWith('.bundle')) ||
       !readFileSync(applicationProofPath).includes(record.proof.expected)
     ) {
-      return 'JavaScript bundle proof mismatch';
+      return 'JavaScript application proof mismatch';
     }
     return null;
   }

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -16,6 +16,7 @@ import { timeBenchmarkFromFirstActivity } from './benchmark-timing.mjs';
 import { stripVTControlCharacters } from 'node:util';
 import { launchCrashDiagnosis, launchCrashRecovery, podfileChecksumChanges } from './launch-crash-benchmark.mjs';
 import { reconstructCommandEvidence } from './agent-benchmark/command-evidence.mjs';
+import { appAliveErrorIsSuperseded } from './agent-benchmark/javascript-proof.mjs';
 import { ccacheLogEvidence } from './agent-benchmark/ccache-evidence.mjs';
 import { benchmarkCommandPresentation } from './benchmark-command-presentation.mjs';
 import {
@@ -796,7 +797,7 @@ function validateReadinessRecord(runDir, record, meta) {
   if (!existsSync(appAlivePath)) return reject('app-alive evidence missing');
   const appAlive = readJson(appAlivePath);
   if (
-    appAlive.error ||
+    (appAlive.error && !appAliveErrorIsSuperseded(appAlive, record.proof, record.screen)) ||
     appAlive.dispatchToAppAliveSeconds !== record.dispatchToAppAliveSeconds ||
     appAlive.simulator?.udid !== record.simulator?.udid
   ) {

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1221,7 +1221,19 @@ describe('benchmark viewer export', () => {
     record.proof = { ...record.proof, kind: 'source-edit-and-settings-screen', target: sourceProofPath };
     record.evidenceSha256.proof = sha256(sourceProofPath);
     writeFileSync(recordPath, JSON.stringify(record));
+    const alive = {
+      dispatchToAppAliveSeconds: 5,
+      observedAt: '2026-09-04T12:00:05.000Z',
+      simulator: { udid },
+      error: 'proof-timeout-after-app-alive',
+    };
+    writeFileSync(join(runDir, 'app-alive.json'), JSON.stringify(alive));
     expect(exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof')).runs).toHaveLength(1);
+    writeFileSync(join(runDir, 'app-alive.json'), JSON.stringify({ ...alive, error: 'wrong-device' }));
+    expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+      'no valid benchmark runs found',
+    );
+    writeFileSync(join(runDir, 'app-alive.json'), JSON.stringify(alive));
     writeFileSync(sourceProofPath, 'wrong text');
     expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
       'no valid benchmark runs found',

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1216,6 +1216,17 @@ describe('benchmark viewer export', () => {
     writeFileSync(recordPath, JSON.stringify(record));
 
     expect(exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof')).runs).toHaveLength(1);
+    const sourceProofPath = join(proofDir, 'settings-source.tsx');
+    writeFileSync(sourceProofPath, 'Keep saved trail maps available offline');
+    record.proof = { ...record.proof, kind: 'source-edit-and-settings-screen', target: sourceProofPath };
+    record.evidenceSha256.proof = sha256(sourceProofPath);
+    writeFileSync(recordPath, JSON.stringify(record));
+    expect(exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof')).runs).toHaveLength(1);
+    writeFileSync(sourceProofPath, 'wrong text');
+    expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+      'no valid benchmark runs found',
+    );
+    writeFileSync(sourceProofPath, 'Keep saved trail maps available offline');
     delete record.screen.recordingCopyCommandId;
     writeFileSync(recordPath, JSON.stringify(record));
     expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(


### PR DESCRIPTION
## Description

A control agent can display the requested Settings change on Metro port 18081 yet fail validation because the harness only probes 8081–8090. Cleanup misses that port too. Fixes #676.

## Solution

Use the retained source edit plus isolated Settings-screen proof instead of another bundle request. The [original bundle guard](https://github.com/appandflow/stim/commit/a19b03a4476c9490c162275541e2df4f0980c039) verified the edit; the required changed-text wait and screenshot now provide runtime evidence without constraining Metro ports.

Old bundle evidence remains exportable. A legacy bundle timeout becomes a warning only with valid app-liveness and changed-screen proof; other failures remain invalid.

Cleanup discovers listeners, verifies Metro's status response and exact canonical worktree cwd, and rechecks before terminating. No published CLI behavior changes.

## Test plan

On macOS, real Node HTTP listeners on dynamically allocated ports verify custom-port discovery and rejection of a neighboring worktree's server. Regression tests reject absent source edits, wrong Settings text, failed screen proof, unrelated watcher errors and unavailable ownership evidence. Export tests accept retained source proof and reject tampering or incomplete recording proof.
