### PR TITLE
fix: reload every app through the Metro websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ stim logs --errors
 stim stop
 ```
 
-`stim reload [ios|android]` is a recovery or explicit restart command. Use it
-after a failed first bundle load or when an error screen remains after a fix,
-not after every JavaScript edit.
+`stim reload [ios|android]` is a recovery command that reloads JavaScript in the
+live app and never restarts it. Use it when an error screen remains after a fix,
+not after every JavaScript edit. It also recovers an Android app whose first
+bundle failed; an iOS app in that state never connects to Metro, so reload
+cannot reach it.
 
 Stim needs no project initialization. Runtime state stays under `~/.stim` by
 default.

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -86,10 +86,12 @@ response; servers without capture use the build-complete marker. Run
 expected screen separately.
 
 `stim reload [ios|android]` requests a JavaScript reload in the live app on this
-workspace's owned local device. Use it after a failed first bundle load, when
-an error screen remains after a fix, or when you explicitly need an app
-restart. It is not part of the normal workflow and does not build, install,
-boot, or launch an app. The platform is optional when only one app is live.
+workspace's owned local device. Use it when an error screen remains after a fix,
+and on Android after a failed first bundle load. An iOS app whose first bundle
+failed never connects to Metro, so reload cannot reach it. It reloads
+JavaScript and never restarts the app. It is not part of the normal workflow
+and does not build, install, boot, or launch an app. The platform is optional
+when only one app is live.
 Success confirms that the request was sent; Stim does not observe completion.
 Verify the expected UI on the reported device and inspect `stim logs --errors`
 before claiming recovery.

--- a/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
+++ b/packages/stim-cli/src/__tests__/crash-diagnostics.test.ts
@@ -626,7 +626,6 @@ test('live native collection requires the current launch and device claim, not a
     deviceId: 'emulator-5556',
     metroPort: null,
     release: true,
-    deepLinkUrl: null,
     launchedAt: new Date(since).toISOString(),
   };
   let reads = 0;

--- a/packages/stim-cli/src/__tests__/engine-reload.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-reload.test.ts
@@ -1,183 +1,238 @@
+import { once } from 'node:events';
+import { createServer } from 'node:net';
 import { WebSocketServer } from 'ws';
-import { openIosDeepLink, reloadAndroidJs, reloadIosThroughMetro } from '../engine/reload.ts';
-import type { Executor } from '../exec.ts';
+import { reloadThroughMetro } from '../engine/reload.ts';
 
-function recordingExecutor() {
-  const calls: { file: string; args: string[]; timeoutMs: number | undefined }[] = [];
-  const exec = {
-    runFile(file: string, args: string[], options?: { timeoutMs?: number }) {
-      calls.push({ file, args, timeoutMs: options?.timeoutMs });
-      return '';
-    },
-  } as Executor;
-  return { calls, exec };
-}
-
-test('Android reload sends the React Native debug broadcast to the exact emulator and package', () => {
-  const { calls, exec } = recordingExecutor();
-
-  expect(reloadAndroidJs('emulator-5554', 'com.example.app', { exec })).toEqual({ ok: true });
-  expect(calls).toEqual([
-    {
-      file: 'adb',
-      args: [
-        '-s',
-        'emulator-5554',
-        'shell',
-        'am',
-        'broadcast',
-        '-a',
-        'com.example.app.RELOAD_APP_ACTION',
-        '-p',
-        'com.example.app',
-      ],
-      timeoutMs: 10_000,
-    },
-  ]);
-});
-
-test('iOS deep-link reload targets the exact simulator', () => {
-  const { calls, exec } = recordingExecutor();
-
-  expect(openIosDeepLink('U1', 'example://reload', { exec })).toEqual({ ok: true });
-  expect(calls).toEqual([
-    {
-      file: 'xcrun',
-      args: ['simctl', 'openurl', 'U1', 'example://reload'],
-      timeoutMs: 10_000,
-    },
-  ]);
-});
-
-test('Metro reload targets the sole iOS peer without reloading another platform', async () => {
+function peerServer(reply: (id: string | undefined) => unknown) {
   const messages: unknown[] = [];
   let sawReload!: () => void;
   const reloadSeen = new Promise<void>((resolve) => {
     sawReload = resolve;
   });
   const server = new WebSocketServer({ host: '127.0.0.1', port: 0, path: '/message' });
-  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const listening = new Promise<void>((resolve) => server.once('listening', resolve));
   server.on('connection', (socket) => {
     socket.on('message', (raw) => {
       const message = JSON.parse(raw.toString()) as { id?: string; method?: string };
       messages.push(message);
-      if (message.method === 'getpeers') {
-        socket.send(
-          JSON.stringify({
-            version: 2,
-            id: message.id,
-            result: {
-              'client#1': { role: 'ios' },
-              'client#2': { device: 'emulator', app: 'com.example.android' },
-            },
-          }),
-        );
-      }
+      if (message.method === 'getpeers') socket.send(JSON.stringify(reply(message.id)));
       if (message.method === 'reload') sawReload();
     });
   });
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
+  return { messages, reloadSeen, server, listening };
+}
 
+function peers(result: Record<string, unknown>) {
+  return (id: string | undefined) => ({ version: 2, id, result });
+}
+
+async function withServer<T>(harness: ReturnType<typeof peerServer>, run: (port: number) => Promise<T>): Promise<T> {
+  await harness.listening;
+  const address = harness.server.address();
+  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
   try {
-    await expect(reloadIosThroughMetro(address.port)).resolves.toEqual({ ok: true, peers: 2 });
-    await reloadSeen;
-    expect(messages).toEqual([
+    return await run(address.port);
+  } finally {
+    await new Promise<void>((resolve) => harness.server.close(() => resolve()));
+  }
+}
+
+// Both peer-metadata shapes appear here deliberately: an object from
+// @react-native-community/cli-server-api, a raw query string from @expo/cli.
+const IOS_PEER = { role: 'ios' };
+const IOS_PEER_RAW = 'role=ios';
+const ANDROID_PEER = { device: 'sdk_gphone64', app: 'com.example.android', clientid: 'c1' };
+const ANDROID_PEER_RAW = 'device=sdk_gphone64&app=com.example.android&clientid=c1';
+
+test.each([
+  ['object metadata', IOS_PEER],
+  ['raw query metadata', IOS_PEER_RAW],
+])('Metro reload targets the sole iOS peer with %s, leaving Android alone', async (_label, iosPeer) => {
+  const harness = peerServer(peers({ 'client#1': iosPeer, 'client#2': ANDROID_PEER }));
+
+  await withServer(harness, async (port) => {
+    await expect(reloadThroughMetro(port, { role: 'ios', appId: 'com.example.ios' })).resolves.toEqual({
+      ok: true,
+      peers: 2,
+      targets: 1,
+    });
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
       expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
       { version: 2, method: 'reload', target: 'client#1' },
     ]);
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
+  });
 });
 
-test('Metro reload reports that no iOS app is connected without sending a reload', async () => {
-  const messages: unknown[] = [];
-  const server = new WebSocketServer({ host: '127.0.0.1', port: 0, path: '/message' });
-  await new Promise<void>((resolve) => server.once('listening', resolve));
-  server.on('connection', (socket) => {
-    socket.on('message', (raw) => {
-      const message = JSON.parse(raw.toString()) as { id?: string; method?: string };
-      messages.push(message);
-      socket.send(JSON.stringify({ version: 2, id: message.id, result: {} }));
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
+test.each([
+  ['object metadata', ANDROID_PEER],
+  ['raw query metadata', ANDROID_PEER_RAW],
+])('Metro reload targets the Android peer by package with %s, leaving iOS alone', async (_label, androidPeer) => {
+  const harness = peerServer(peers({ 'client#1': IOS_PEER, 'client#2': androidPeer }));
 
-  try {
-    await expect(reloadIosThroughMetro(address.port)).resolves.toEqual({
-      failed: true,
-      peers: 0,
-      reason: `No iOS React Native app is connected to Metro on port ${address.port}.`,
-    });
-    expect(messages).toHaveLength(1);
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
-});
-
-test('Metro reload fails closed when CLI 20 cannot identify a connected peer', async () => {
-  const messages: unknown[] = [];
-  const server = new WebSocketServer({ host: '127.0.0.1', port: 0, path: '/message' });
-  await new Promise<void>((resolve) => server.once('listening', resolve));
-  server.on('connection', (socket) => {
-    socket.on('message', (raw) => {
-      const message = JSON.parse(raw.toString()) as { id?: string; method?: string };
-      messages.push(message);
-      if (message.method === 'getpeers') {
-        socket.send(
-          JSON.stringify({
-            version: 2,
-            id: message.id,
-            error: "TypeError: Cannot read properties of undefined (reading 'url')",
-          }),
-        );
-      }
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
-
-  try {
-    await expect(reloadIosThroughMetro(address.port)).resolves.toEqual({
-      failed: true,
-      reason: `Metro could not identify the connected iOS app on port ${address.port}.`,
-    });
-    expect(messages).toEqual([expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' })]);
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
-});
-
-test('Metro reload refuses multiple iOS peers without sending a reload', async () => {
-  const messages: unknown[] = [];
-  const server = new WebSocketServer({ host: '127.0.0.1', port: 0, path: '/message' });
-  await new Promise<void>((resolve) => server.once('listening', resolve));
-  server.on('connection', (socket) => {
-    socket.on('message', (raw) => {
-      const message = JSON.parse(raw.toString()) as { id?: string; method?: string };
-      messages.push(message);
-      socket.send(
-        JSON.stringify({
-          version: 2,
-          id: message.id,
-          result: { 'client#1': { role: 'ios' }, 'client#2': { role: 'ios' } },
-        }),
-      );
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
-
-  try {
-    await expect(reloadIosThroughMetro(address.port)).resolves.toEqual({
-      failed: true,
+  await withServer(harness, async (port) => {
+    await expect(reloadThroughMetro(port, { role: 'android', appId: 'com.example.android' })).resolves.toEqual({
+      ok: true,
       peers: 2,
-      reason: `Metro has 2 iOS apps connected on port ${address.port} and cannot identify the target app.`,
+      targets: 1,
     });
-    expect(messages).toHaveLength(1);
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload', target: 'client#2' },
+    ]);
+  });
+});
+
+test('Metro reload reports no peer when another package is connected on Android', async () => {
+  const harness = peerServer(peers({ 'client#1': 'device=sdk_gphone64&app=com.other.app&clientid=c1' }));
+
+  await withServer(harness, async (port) => {
+    const result = await reloadThroughMetro(port, { role: 'android', appId: 'com.example.android' });
+    expect(result).toMatchObject({ failed: true, noPeer: true, peers: 1 });
+    expect(result.reason).toContain(`No Android React Native app is connected to Metro on port ${port}.`);
+    expect(result.reason).toContain('1 other connected client');
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload' },
+    ]);
+  });
+});
+
+// An iOS app whose first bundle fails never opens a packager connection at all:
+// bridgeless RCTInstance resolves DevSettings only in _loadJSBundle's success
+// callback, and RCTDevSettings.initialize is what both opens the /message socket
+// and registers the reload handler. Fixed by react/react-native#58352, which has
+// landed but is not in a release yet, so every released RN still behaves this
+// way. The app is absent from getpeers rather than present-but-deaf, and that is
+// the shape Stim must turn into a UI-automation remedy.
+test('Metro reload reports no peer when the app never connected', async () => {
+  const harness = peerServer(peers({}));
+
+  await withServer(harness, async (port) => {
+    const result = await reloadThroughMetro(port, { role: 'ios', appId: 'com.example.ios' });
+    expect(result).toMatchObject({ failed: true, noPeer: true, peers: 0 });
+    expect(result.reason).toContain(`No iOS React Native app is connected to Metro on port ${port}.`);
+    expect(result.reason).toContain('Nothing at all is connected to it');
+  });
+});
+
+// @react-native-community/cli-server-api answers getpeers out of
+// `otherWs.upgradeReq.url`, a ws property removed in 3.0, so every published
+// version of the bare dev server throws instead of returning peers. Its
+// broadcast path does not touch that property, so it still reaches the app.
+test.each([
+  ['the TypeError bare Metro throws', "TypeError: Cannot read properties of undefined (reading 'url')"],
+  ['any other enumeration error', 'unknown method: getpeers'],
+])('a Metro that cannot enumerate peers is reloaded by broadcast: %s', async (_label, error) => {
+  const harness = peerServer((id) => ({ version: 2, id, error }));
+
+  await withServer(harness, async (port) => {
+    await expect(reloadThroughMetro(port, { role: 'android', appId: 'com.example.android' })).resolves.toEqual({
+      ok: true,
+      broadcast: true,
+    });
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload' },
+    ]);
+  });
+});
+
+// A workspace Metro serves one app, so two iOS peers are that app on two
+// devices. iOS peer metadata could not tell them apart anyway.
+test('every matching peer is reloaded, because they are one app on several devices', async () => {
+  const harness = peerServer(peers({ 'client#1': IOS_PEER, 'client#2': ANDROID_PEER, 'client#3': IOS_PEER_RAW }));
+
+  await withServer(harness, async (port) => {
+    await expect(reloadThroughMetro(port, { role: 'ios', appId: 'com.example.ios' })).resolves.toEqual({
+      ok: true,
+      peers: 3,
+      targets: 2,
+    });
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload', target: 'client#1' },
+      { version: 2, method: 'reload', target: 'client#3' },
+    ]);
+  });
+});
+
+// A bundle id and a package name are often the same string, so the two matchers
+// must not fall back to each other's key.
+test.each([
+  ['an Android peer for an iOS target', 'ios', 'device=sdk_gphone64&app=io.tlon.groups&clientid=c1'],
+  ['an iOS peer for an Android target', 'android', IOS_PEER_RAW],
+])('%s is never addressed as a match, only swept up by the last-resort broadcast', async (_l, role, peer) => {
+  const harness = peerServer(peers({ 'client#1': peer }));
+
+  await withServer(harness, async (port) => {
+    await expect(
+      reloadThroughMetro(port, { role: role as 'ios' | 'android', appId: 'io.tlon.groups' }),
+    ).resolves.toMatchObject({ noPeer: true, peers: 1 });
+    await harness.reloadSeen;
+    // Untargeted, so it is never claimed as this peer's reload.
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload' },
+    ]);
+  });
+});
+
+// @expo/cli stores `url.parse(req.url).query`, which is null when the connection
+// URL carries no query, and getpeers substitutes {} when the property is absent.
+test('a peer with no usable metadata is counted but never matched', async () => {
+  const harness = peerServer(peers({ 'client#1': null, 'client#2': IOS_PEER_RAW }));
+
+  await withServer(harness, async (port) => {
+    await expect(reloadThroughMetro(port, { role: 'ios', appId: 'com.example.ios' })).resolves.toEqual({
+      ok: true,
+      peers: 2,
+      targets: 1,
+    });
+    await harness.reloadSeen;
+    expect(harness.messages).toEqual([
+      expect.objectContaining({ version: 2, method: 'getpeers', target: 'server' }),
+      { version: 2, method: 'reload', target: 'client#2' },
+    ]);
+  });
+});
+
+// `unreachable` carries its own remedy -- retry the dev server, do not touch the
+// device -- so the engine has to actually produce it, not just the command fakes.
+test('a Metro that accepts the socket and never answers reports itself unreachable', async () => {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0, path: '/message' });
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
+
+  try {
+    await expect(
+      reloadThroughMetro(address.port, { role: 'ios', appId: 'com.example.ios', timeoutMs: 50 }),
+    ).resolves.toEqual({
+      failed: true,
+      unreachable: true,
+      reason: `Metro did not answer on port ${address.port}.`,
+    });
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
+});
+
+test('a refused connection reports itself unreachable rather than a missing peer', async () => {
+  const probe = createServer();
+  probe.listen(0, '127.0.0.1');
+  await once(probe, 'listening');
+  const address = probe.address();
+  if (!address || typeof address === 'string') throw new Error('expected a TCP address');
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+  const result = await reloadThroughMetro(address.port, { role: 'ios', appId: 'com.example.ios' });
+
+  expect(result).toMatchObject({ failed: true, unreachable: true });
+  expect(result.reason).toContain('Metro reload failed:');
+  expect(result.noPeer).toBeUndefined();
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -298,6 +298,16 @@ test('the rendered guide carries the warm --refresh contract, not just its sourc
   expect(options).toContain('appandflow/stim#696');
 });
 
+test('the facts topic documents every reload strategy the command can report', () => {
+  const body = renderSection('facts', 'payloads');
+  assert(body);
+  const src = readFileSync(new URL('../commands/reload.ts', import.meta.url), 'utf-8');
+  const union = src.slice(src.indexOf('strategy:'), src.indexOf(';', src.indexOf('strategy:')));
+  const values = [...union.matchAll(/'([a-z-]+)'/g)].map((m) => m[1] as string);
+  expect(values.length).toBeGreaterThan(0);
+  for (const value of values) expect(body).toContain(`"${value}"`);
+});
+
 test('the settings topic documents every supported setting key', () => {
   const body = renderTopic('settings');
   assert(body);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -951,7 +951,10 @@ describe('launch verification', () => {
     expect(errs.join('\n')).toContain('Run `stim logs --errors` again');
   });
 
-  test('a Metro build failure with a live native process recommends reload instead of another native run', async () => {
+  // The first bundle never loaded, so this app is not a Metro peer and no
+  // websocket reload reaches it. Sending the agent to `stim reload ios` here
+  // costs it two wasted round trips before it reaches the device's own button.
+  test('a Metro build failure with a live native process routes to the error screen, not a Metro reload', async () => {
     reserve();
     const { errs, exitCode } = await run(
       {},
@@ -966,7 +969,10 @@ describe('launch verification', () => {
     const text = errs.join('\n');
     expect(exitCode).toBe(1);
     expect(text).toMatch(/native app is still running/);
-    expect(text).toContain('stim reload ios');
+    expect(text).toContain("press Reload on the app's own error screen");
+    expect(text).toContain('agent-device snapshot -i --platform ios --udid');
+    expect(text).not.toContain('then run `stim reload ios`');
+    expect(text).not.toContain('agent-device metro reload --metro-port');
     expect(text).toMatch(/Do not run `stim ios` unless native inputs changed or the app process exits/);
   });
 
@@ -3500,7 +3506,6 @@ describe('re-fingerprint after the steps that rewrite fingerprinted files', () =
       deviceId: UDID,
       metroPort: 8082,
       release: false,
-      deepLinkUrl: null,
       launchedAt: expect.any(String),
     });
     expect(stderr).toContain(`unavailable after ${mutation}; the build will be installed but not cached`);
@@ -4330,7 +4335,10 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     expect(text).not.toMatch(/opened on the dev-client URL/);
   });
 
-  test('a Metro build failure on a live phone recommends Metro reload', async () => {
+  // A phone is in the same state as a simulator here: the first bundle failed,
+  // so the app never opened its packager connection and no Metro reload -- from
+  // Stim or from agent-device -- can reach it.
+  test('a Metro build failure on a live phone routes to the error screen, not a Metro reload', async () => {
     reserve();
     const { errs, exitCode } = await run(
       { device: true },
@@ -4345,8 +4353,31 @@ describe('ios --device: selecting a phone and building the device slice', () => 
     );
     const text = errs.join('\n');
     expect(exitCode).toBe(1);
+    expect(text).toContain("press Reload on the app's own error screen");
+    expect(text).toContain(`agent-device snapshot -i --platform ios --udid ${PHONE}`);
+    expect(text).not.toContain('agent-device metro reload --metro-port');
+  });
+
+  // The counterpart of the test above: this bundle loaded, so the app IS a Metro
+  // peer and a reload does reach it. A phone cannot use `stim reload`, which acts
+  // only on owned local simulators, so agent-device carries the reload instead.
+  test('a runtime error on a live phone still recommends a Metro reload', async () => {
+    reserve();
+    const { errs } = await run(
+      { device: true },
+      {
+        ...connected(),
+        verifyLaunch: async () => ({
+          verified: true,
+          processAlive: true,
+          errors: [{ src: 'metro', msg: 'ERROR [Error: root render failed]' }],
+        }),
+      },
+    );
+    const text = errs.join('\n');
+    expect(text).toMatch(/native app is still running/);
     expect(text).toContain('agent-device metro reload --metro-port 8082');
-    expect(text).not.toContain('agent-device snapshot');
+    expect(text).not.toContain("press Reload on the app's own error screen");
   });
 
   test('the collector is the launch: it carries --physical and the run reads the device pid', async () => {

--- a/packages/stim-cli/src/__tests__/reload-command.test.ts
+++ b/packages/stim-cli/src/__tests__/reload-command.test.ts
@@ -8,7 +8,6 @@ const iosLaunch: WorkspaceLaunchRecord = {
   deviceId: 'U1',
   metroPort: 8082,
   release: false,
-  deepLinkUrl: null,
   launchedAt: '2026-09-04T12:00:00.000Z',
 };
 
@@ -17,7 +16,6 @@ const androidLaunch: WorkspaceLaunchRecord = {
   deviceId: 'emulator-5554',
   metroPort: 8082,
   release: false,
-  deepLinkUrl: null,
   launchedAt: '2026-09-04T12:00:00.000Z',
 };
 
@@ -39,10 +37,7 @@ function reloadDeps(overrides: Partial<ReloadDeps> = {}): Partial<ReloadDeps> {
     iosProcess: () => 42,
     androidProcess: () => 43,
     resolveMetro: async () => ({ metro: { pid: 1, leader: 1, cwd: '/project' } }),
-    openAndroidUrl: () => ({ ok: true }),
-    openIosUrl: () => ({ ok: true }),
-    reloadAndroid: () => ({ ok: true }),
-    reloadIosMetro: async () => ({ ok: true, peers: 1 }),
+    reloadMetro: async () => ({ ok: true, peers: 1, targets: 1 }),
     ...overrides,
   };
 }
@@ -62,9 +57,40 @@ test('reload auto-selects the sole live owned app and reports its strategy', asy
       deviceName: 'stim-android',
       appId: 'com.example.android',
       metroPort: 8082,
-      strategy: 'android-broadcast',
+      strategy: 'metro-websocket',
+      targets: 1,
     },
   });
+});
+
+test('reload addresses Metro with the target platform and app', async () => {
+  const calls: unknown[] = [];
+  await runReload({
+    root: '/project',
+    platform: 'android',
+    deps: reloadDeps({
+      reloadMetro: async (port, options) => {
+        calls.push([port, options]);
+        return { ok: true, peers: 1, targets: 1 };
+      },
+    }),
+  });
+  await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async (port, options) => {
+        calls.push([port, options]);
+        return { ok: true, peers: 1, targets: 1 };
+      },
+    }),
+  });
+
+  expect(calls).toEqual([
+    [8082, { role: 'android', appId: 'com.example.android' }],
+    [8082, { role: 'ios', appId: 'com.example.ios' }],
+  ]);
 });
 
 test('reload requires a platform when both owned apps are live', async () => {
@@ -102,9 +128,9 @@ test('reload refuses release launches before issuing a reload action', async () 
     platform: 'android',
     deps: reloadDeps({
       readLaunches: () => ({ android: { ...androidLaunch, release: true, metroPort: null } }),
-      reloadAndroid: () => {
+      reloadMetro: async () => {
         called = true;
-        return { ok: true };
+        return { ok: true, peers: 1, targets: 1 };
       },
     }),
   });
@@ -123,32 +149,12 @@ test('reload refuses a launch record that no longer belongs to the configured ow
   expect(result).toMatchObject({ ok: false, error: { code: 'STIM_RELOAD_UNOWNED' } });
 });
 
-test('Expo reload resends the recorded deep link to the same device', async () => {
-  const opened: { serial: string; url: string; packageName?: string }[] = [];
-  const deepLinkUrl = 'example://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082';
+test('an app Metro cannot see gets the automation remedy, not a restart', async () => {
   const result = await runReload({
     root: '/project',
     platform: 'android',
     deps: reloadDeps({
-      readLaunches: () => ({ android: { ...androidLaunch, deepLinkUrl } }),
-      openAndroidUrl: ({ serial, url, packageName }) => {
-        opened.push({ serial, url, packageName });
-        return { ok: true };
-      },
-    }),
-  });
-
-  expect(result.ok && result.facts.strategy).toBe('deep-link');
-  expect(opened).toEqual([{ serial: 'emulator-5554', url: deepLinkUrl, packageName: 'com.example.android' }]);
-});
-
-test("bare iOS leaves startup-overlay automation to the agent's existing session", async () => {
-  const result = await runReload({
-    root: '/project',
-    platform: 'ios',
-    deps: reloadDeps({
-      readLaunches: () => ({ ios: iosLaunch }),
-      reloadIosMetro: async () => ({ failed: true, peers: 0, reason: 'No app connected.' }),
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No Android app connected.' }),
     }),
   });
 
@@ -156,22 +162,194 @@ test("bare iOS leaves startup-overlay automation to the agent's existing session
     ok: false,
     error: {
       code: 'STIM_RELOAD_FAILED',
-      message: 'No app connected.',
-      remedy: expect.stringContaining('existing automation session for com.example.ios on U1'),
+      remedy: expect.stringContaining('agent-device snapshot -i --platform android --serial emulator-5554'),
     },
   });
+});
+
+test('a no-peer reload names the first-load causes that need automation', async () => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No app connected.' }),
+    }),
+  });
+
+  const remedy = (result.ok === false ? result.error.remedy : '') ?? '';
+  expect(remedy).toContain('Stim broadcast a reload anyway');
+  expect(remedy).toContain('reconnects every 2 seconds');
+  expect(remedy).toContain('run `stim reload ios` once more');
+  expect(remedy).toContain('first bundle');
+  // Check the screen before spending a round trip on a retry.
+  expect(remedy.indexOf('check the expected UI')).toBeLessThan(remedy.indexOf('once more'));
+});
+
+// reload refuses anything that is not this workspace's owned local device, so a
+// phone never reaches this branch and its Local Network remedy does not belong here.
+test('a no-peer reload does not offer the phone-only Local Network cause', async () => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No app connected.' }),
+    }),
+  });
+
+  expect((result.ok === false ? result.error.remedy : '') ?? '').not.toContain('Local Network');
+});
+
+test('a no-peer reload on Android does not claim an iOS first-bundle cause', async () => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'android',
+    deps: reloadDeps({
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No app connected.' }),
+    }),
+  });
+
+  const remedy = (result.ok === false ? result.error.remedy : '') ?? '';
+  expect(remedy).toContain('run `stim reload android` once more');
+  expect(remedy).not.toContain('first bundle');
+});
+
+test('a no-peer reload routes to the device reload controls before a relaunch', async () => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No app connected.' }),
+    }),
+  });
+
+  const remedy = (result.ok === false ? result.error.remedy : '') ?? '';
+  expect(remedy).toContain("press the error screen's Reload button");
+  expect(remedy).toContain('open the dev menu and press Reload');
+  expect(remedy.indexOf('Reload button')).toBeLessThan(remedy.indexOf('--relaunch'));
+});
+
+// A workspace Metro serves one app, so several matching peers are that app on
+// several devices. The agent asked about one device and has to learn the others
+// reloaded too.
+test('a reload that reached several devices says so and counts them', async () => {
+  const deps = reloadDeps({ reloadMetro: async () => ({ ok: true, peers: 3, targets: 2 }) });
+  const result = await runReload({ root: '/project', platform: 'android', deps });
+
+  expect(result.ok && result.facts).toMatchObject({ strategy: 'metro-websocket', targets: 2 });
+
+  const program = new Command();
+  registerReload(program, deps);
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await program.parseAsync(['node', 'stim', 'reload', 'android']);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(lines[0]).toContain('2 devices are running this app');
+  expect(lines[0]).toContain('not only emulator-5554');
+});
+
+test('a reload that reached one device does not mention other devices', async () => {
+  const program = new Command();
+  registerReload(program, reloadDeps());
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await program.parseAsync(['node', 'stim', 'reload', 'android']);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(lines[0]).not.toContain('devices are running this app');
+});
+
+// The bare React Native dev server cannot enumerate peers, so the reload is a
+// broadcast and Stim cannot prove the named app was among the apps it reached.
+// The output has to say so, or exit 0 reads as proof this app reloaded.
+test('a broadcast reload reports its wider scope in the facts and the plain output', async () => {
+  const deps = reloadDeps({ reloadMetro: async () => ({ ok: true, broadcast: true }) });
+  const result = await runReload({ root: '/project', platform: 'android', deps });
+
+  expect(result.ok && result.facts.strategy).toBe('metro-broadcast');
+
+  const program = new Command();
+  registerReload(program, deps);
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await program.parseAsync(['node', 'stim', 'reload', 'android']);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(lines[0]).toContain('cannot name its connected apps');
+  expect(lines[0]).toContain('cannot confirm com.example.android was one');
+});
+
+test('a targeted reload does not claim the broadcast scope', async () => {
+  const program = new Command();
+  registerReload(program, reloadDeps());
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(String(line));
+  try {
+    await program.parseAsync(['node', 'stim', 'reload', 'android']);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(lines[0]).not.toContain('cannot name its connected apps');
+  expect(lines[0]).not.toContain('cannot confirm');
+});
+
+// Metro answering nothing says nothing about the app, so the agent is sent back
+// to the dev server rather than to the device's reload controls.
+test.each([
+  ['a probe timeout', 'Metro did not answer on port 8082.'],
+  ['a socket error', 'Metro reload failed: connect ECONNREFUSED'],
+])('an unreachable Metro asks for a retry, not device automation: %s', async (_label, reason) => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async () => ({ failed: true, unreachable: true, reason }),
+    }),
+  });
+
+  expect(result).toMatchObject({ ok: false, error: { code: 'STIM_RELOAD_FAILED', message: reason } });
+  const remedy = (result.ok === false ? result.error.remedy : '') ?? '';
+  expect(remedy).toContain('Run `stim reload ios` again.');
+  expect(remedy).toContain('stim doctor');
+  expect(remedy).not.toContain('agent-device');
+  expect(remedy).not.toContain('--relaunch');
+});
+
+test('a no-peer reload prints the exact agent-device commands for the iOS target', async () => {
+  const result = await runReload({
+    root: '/project',
+    platform: 'ios',
+    deps: reloadDeps({
+      readLaunches: () => ({ ios: iosLaunch }),
+      reloadMetro: async () => ({ failed: true, noPeer: true, peers: 0, reason: 'No app connected.' }),
+    }),
+  });
+
   expect(result).toMatchObject({
-    error: {
-      remedy: expect.stringContaining('agent-device snapshot -i --platform ios --udid U1'),
-    },
+    ok: false,
+    error: { code: 'STIM_RELOAD_FAILED', message: 'No app connected.' },
   });
-  expect(result).toMatchObject({
-    error: {
-      remedy: expect.stringContaining(
-        'agent-device open com.example.ios --platform ios --udid U1 --metro-port 8082 --relaunch',
-      ),
-    },
-  });
+  const remedy = (result.ok === false ? result.error.remedy : '') ?? '';
+  expect(remedy).toContain('agent-device snapshot -i --platform ios --udid U1');
+  expect(remedy).toContain('agent-device open com.example.ios --platform ios --udid U1 --metro-port 8082 --relaunch');
 });
 
 test('reload turns owned-device inspection failures into actionable errors', async () => {
@@ -221,7 +399,8 @@ test('reload --json prints exactly one parseable facts line', async () => {
     deviceName: 'stim-android',
     appId: 'com.example.android',
     metroPort: 8082,
-    strategy: 'android-broadcast',
+    strategy: 'metro-websocket',
+    targets: 1,
   });
 });
 

--- a/packages/stim-cli/src/__tests__/workspace-launch-state.test.ts
+++ b/packages/stim-cli/src/__tests__/workspace-launch-state.test.ts
@@ -31,7 +31,6 @@ function launch(appId: string, deviceId: string): WorkspaceLaunchRecord {
     deviceId,
     metroPort: 8082,
     release: false,
-    deepLinkUrl: null,
     launchedAt: '2026-09-04T12:00:00.000Z',
   };
 }
@@ -57,6 +56,19 @@ test('invalid launch entries are ignored instead of becoming reload targets', ()
   });
 
   expect(readWorkspaceLaunches(root)).toEqual({ android: launch('com.example.android', 'emulator-5554') });
+});
+
+test('a record written before deepLinkUrl was dropped is still a reload target', () => {
+  writeWorkspaceState(root, {
+    launches: {
+      android: {
+        ...launch('com.example.android', 'emulator-5554'),
+        deepLinkUrl: 'example://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082',
+      } as never,
+    },
+  });
+
+  expect(readWorkspaceLaunches(root).android).toMatchObject(launch('com.example.android', 'emulator-5554'));
 });
 
 test('stop clears launch eligibility with the supervisor record', () => {

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -573,14 +573,12 @@ export async function finishAndroidRun({
   phase('launch', `${androidPackage} ${launchTimer()}`);
 
   if (!physical && !remoteDevice) {
-    const deepLinkUrl = scheme ? androidDevClientUrl(scheme, metroPort ?? DEFAULT_METRO_PORT) : null;
     try {
       writeLaunch(root, 'android', {
         appId: androidPackage,
         deviceId: serial,
         metroPort,
         release,
-        deepLinkUrl,
         launchedAt: new Date(launchedAt).toISOString(),
       });
     } catch (error) {

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -228,10 +228,12 @@ async function verifyIosRun({
         ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
-      const reloadRemedy =
-        physical || remoteDevice
-          ? `run \`agent-device metro reload --metro-port ${metroPort}\`.`
-          : 'run `stim reload ios`.';
+      // Bridgeless RCTInstance resolves DevSettings only in _loadJSBundle's
+      // success callback, and RCTDevSettings.initialize is what opens the
+      // /message socket, so an iOS app whose first bundle failed is not a Metro
+      // peer and no websocket reload can reach it. Fixed by
+      // react/react-native#58352, which has landed but is not in a release yet.
+      const reloadRemedy = `press Reload on the app's own error screen -- run \`agent-device snapshot -i --platform ios --udid ${udid}\` in your existing automation session to reach it. Neither \`stim reload ios\` nor \`agent-device metro reload\` can: this app never connected to Metro.`;
       note(
         chalk.yellow(
           phaseLine(
@@ -436,7 +438,6 @@ function recordIosReloadTarget({
   udid,
   metroPort,
   release,
-  launched,
   launchedAt,
   note,
 }: {
@@ -448,19 +449,16 @@ function recordIosReloadTarget({
   udid: string;
   metroPort: number | null;
   release: boolean;
-  launched: ReturnType<IosDeps['launchIosApp']>;
   launchedAt: number;
   note: (line: string) => void;
 }): void {
   if (physical || remoteDevice) return;
-  const deepLinkUrl = 'url' in launched && typeof launched.url === 'string' ? launched.url : null;
   try {
     d.writeWorkspaceLaunch(root, 'ios', {
       appId: bundleId,
       deviceId: udid,
       metroPort,
       release,
-      deepLinkUrl,
       launchedAt: new Date(launchedAt).toISOString(),
     });
   } catch (error) {
@@ -744,7 +742,6 @@ export async function finishIosRun({
     udid,
     metroPort,
     release,
-    launched: launched!,
     launchedAt,
     note,
   });

--- a/packages/stim-cli/src/commands/reload.ts
+++ b/packages/stim-cli/src/commands/reload.ts
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { phaseLine } from '../command-output.ts';
 import { getProject, type ProjectRecord } from '../config.ts';
-import { androidAppProcess, iosAppProcess, openAndroidDevClientUrl } from '../engine/app-install.ts';
-import { openIosDeepLink, reloadAndroidJs, reloadIosThroughMetro } from '../engine/reload.ts';
+import { androidAppProcess, iosAppProcess } from '../engine/app-install.ts';
+import { reloadThroughMetro } from '../engine/reload.ts';
 import { resolveProjectMetro, type MetroResolution } from '../metro.ts';
 import { findProjectRoot } from '../project.ts';
 import { resolveOwnedAvdSerial, type ResolvedAvdSerial } from '../sim/android.ts';
@@ -22,7 +22,8 @@ interface ReloadFacts {
   deviceName: string;
   appId: string;
   metroPort: number;
-  strategy: 'deep-link' | 'android-broadcast' | 'metro-websocket';
+  strategy: 'metro-websocket' | 'metro-broadcast';
+  targets: number | null;
 }
 
 interface ReloadFailure {
@@ -53,10 +54,7 @@ export interface ReloadDeps {
   iosProcess: typeof iosAppProcess;
   androidProcess: typeof androidAppProcess;
   resolveMetro: (port: number, root: string) => Promise<MetroResolution>;
-  openAndroidUrl: typeof openAndroidDevClientUrl;
-  openIosUrl: typeof openIosDeepLink;
-  reloadAndroid: typeof reloadAndroidJs;
-  reloadIosMetro: typeof reloadIosThroughMetro;
+  reloadMetro: typeof reloadThroughMetro;
 }
 
 const DEFAULT_DEPS: ReloadDeps = {
@@ -68,10 +66,7 @@ const DEFAULT_DEPS: ReloadDeps = {
   iosProcess: iosAppProcess,
   androidProcess: androidAppProcess,
   resolveMetro: resolveProjectMetro,
-  openAndroidUrl: openAndroidDevClientUrl,
-  openIosUrl: openIosDeepLink,
-  reloadAndroid: reloadAndroidJs,
-  reloadIosMetro: reloadIosThroughMetro,
+  reloadMetro: reloadThroughMetro,
 };
 
 function failure(code: string, message: string, remedy: string | null): ReloadFailure {
@@ -280,55 +275,26 @@ export async function runReload({
   const stopped = processFailure(target.platform, target.record, d);
   if (stopped) return { ok: false, error: stopped };
 
-  let strategy: ReloadFacts['strategy'];
-  if (target.record.deepLinkUrl) {
-    const opened =
+  const reloaded = await d.reloadMetro(port, { role: target.platform, appId: target.record.appId });
+  if (!reloaded.ok) {
+    const stoppedAfterMetro = processFailure(target.platform, target.record, d);
+    if (stoppedAfterMetro) return { ok: false, error: stoppedAfterMetro };
+    const snapshot = `agent-device snapshot -i --platform ${target.platform} --${target.platform === 'ios' ? 'udid' : 'serial'} ${target.record.deviceId}`;
+    const relaunch = `agent-device open ${target.record.appId} --platform ${target.platform} --${target.platform === 'ios' ? 'udid' : 'serial'} ${target.record.deviceId} --metro-port ${port} --relaunch`;
+    const firstBundle =
       target.platform === 'ios'
-        ? d.openIosUrl(target.record.deviceId, target.record.deepLinkUrl)
-        : d.openAndroidUrl({
-            serial: target.record.deviceId,
-            url: target.record.deepLinkUrl,
-            packageName: target.record.appId,
-          });
-    if (!opened.ok) {
-      return {
-        ok: false,
-        error: failure(
-          'STIM_RELOAD_FAILED',
-          opened.reason ?? `Could not reopen ${target.record.deepLinkUrl}.`,
-          `Run \`stim ${target.platform}\` to re-establish the app launch.`,
-        ),
-      };
-    }
-    strategy = 'deep-link';
-  } else if (target.platform === 'android') {
-    const reloaded = d.reloadAndroid(target.record.deviceId, target.record.appId);
-    if (!reloaded.ok) {
-      return {
-        ok: false,
-        error: failure('STIM_RELOAD_FAILED', reloaded.reason ?? 'The Android reload broadcast failed.', null),
-      };
-    }
-    strategy = 'android-broadcast';
-  } else {
-    const reloaded = await d.reloadIosMetro(port);
-    if (reloaded.ok) {
-      strategy = 'metro-websocket';
-    } else {
-      const stoppedAfterMetro = processFailure(target.platform, target.record, d);
-      if (stoppedAfterMetro) return { ok: false, error: stoppedAfterMetro };
-      const snapshot = `agent-device snapshot -i --platform ios --udid ${target.record.deviceId}`;
-      const relaunch = `agent-device open ${target.record.appId} --platform ios --udid ${target.record.deviceId} --metro-port ${port} --relaunch`;
-      return {
-        ok: false,
-        error: failure(
-          'STIM_RELOAD_FAILED',
-          reloaded.reason ?? `No React Native app is connected to Metro on port ${port}.`,
-          `Continue in your existing automation session for ${target.record.appId} on ${target.record.deviceId}. Run \`${snapshot}\`, then press Reload if present. Otherwise run \`${relaunch}\` in that same session; this restarts the app and loses in-memory state. Keep your existing --session flag on these commands. Verify the expected UI afterward. Do not create another session or rerun \`stim ios\`.`,
-        ),
-      };
-    }
+        ? ' If it stays unreachable, an error in the first bundle leaves iOS without a packager connection at all, and no retry will make it a peer.'
+        : '';
+    const device = `reload from the device in your existing automation session: run \`${snapshot}\`, then press the error screen's Reload button, or open the dev menu and press Reload when no error screen is showing. Only when neither is reachable, run \`${relaunch}\`; that restarts the app and loses in-memory state. Keep your existing --session flag, verify the expected UI afterward, and do not create another session.`;
+    const remedy = reloaded.unreachable
+      ? `Metro is registered for this workspace but did not answer on port ${port}, so nothing is known about ${target.record.appId}. Run \`stim reload ${target.platform}\` again. If it keeps timing out, run \`stim doctor\` to check the dev server before touching the app.`
+      : `Metro reports no peer for ${target.record.appId} right now. Stim broadcast a reload anyway, so check the expected UI on ${target.record.deviceId} first -- it may already have recovered. If not, the app reconnects every 2 seconds, so run \`stim reload ${target.platform}\` once more.${firstBundle} Then ${device}`;
+    return {
+      ok: false,
+      error: failure('STIM_RELOAD_FAILED', reloaded.reason, remedy),
+    };
   }
+  const strategy: ReloadFacts['strategy'] = reloaded.broadcast ? 'metro-broadcast' : 'metro-websocket';
 
   return {
     ok: true,
@@ -339,6 +305,7 @@ export async function runReload({
       appId: target.record.appId,
       metroPort: port,
       strategy,
+      targets: reloaded.targets ?? null,
     },
   };
 }
@@ -395,8 +362,14 @@ export function registerReload(program: Command, deps: Partial<ReloadDeps> = {})
         console.log(JSON.stringify(result.facts));
       } else {
         const facts = result.facts;
+        const scope =
+          facts.strategy === 'metro-broadcast'
+            ? ` This Metro cannot name its connected apps, so the reload went to all of them and Stim cannot confirm ${facts.appId} was one. Check the expected UI on ${facts.deviceId}; if nothing changed, reload from the app's own error screen or dev menu.`
+            : facts.targets && facts.targets > 1
+              ? ` ${facts.targets} devices are running this app on that Metro and every one of them was reloaded, not only ${facts.deviceId}.`
+              : '';
         console.log(
-          `Reload requested for ${facts.appId} on ${facts.deviceName} (${facts.deviceId}) via ${facts.strategy}; ${facts.platform} Metro port ${facts.metroPort}. Completion is not observed; verify the expected UI and run stim logs --errors.`,
+          `Reload requested for ${facts.appId} on ${facts.deviceName} (${facts.deviceId}) via ${facts.strategy}; ${facts.platform} Metro port ${facts.metroPort}.${scope} Completion is not observed; verify the expected UI and run stim logs --errors.`,
         );
       }
     });

--- a/packages/stim-cli/src/engine/reload.ts
+++ b/packages/stim-cli/src/engine/reload.ts
@@ -1,57 +1,61 @@
 import { WebSocket } from 'ws';
-import { getExecutor, type Executor } from '../exec.ts';
 
-const TOOL_TIMEOUT_MS = 10_000;
 const METRO_TIMEOUT_MS = 2_000;
 
-export interface ReloadToolResult {
-  ok?: true;
-  failed?: true;
-  reason?: string;
-}
+type Sent = { ok: true; failed?: undefined; reason?: undefined; noPeer?: undefined; unreachable?: undefined };
+type Missed = { ok?: undefined; failed: true; reason: string; targets?: undefined; broadcast?: undefined };
 
-export interface MetroReloadResult extends ReloadToolResult {
-  peers?: number;
-}
+/**
+ * The four outcomes, spelled out so an impossible combination does not typecheck
+ * and callers cannot branch on one that never happens.
+ */
+export type MetroReloadResult =
+  /** Addressed to every peer matching the platform. */
+  | (Sent & { targets: number; peers: number; broadcast?: undefined })
+  /** Metro could not name its clients, so the reload went to all of them. */
+  | (Sent & { broadcast: true; targets?: undefined; peers?: undefined })
+  /**
+   * Metro named its clients and none matched. A broadcast went out anyway, so
+   * the app may still have reloaded; nothing here proves it did.
+   */
+  | (Missed & { noPeer: true; peers: number; unreachable?: undefined })
+  /** Metro never answered, so nothing is known about the app. */
+  | (Missed & { unreachable: true; noPeer?: undefined; peers?: undefined });
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function reloadAndroidJs(
-  serial: string,
-  packageName: string,
-  { exec = getExecutor() }: { exec?: Executor } = {},
-): ReloadToolResult {
-  try {
-    exec.runFile(
-      'adb',
-      ['-s', serial, 'shell', 'am', 'broadcast', '-a', `${packageName}.RELOAD_APP_ACTION`, '-p', packageName],
-      { timeoutMs: TOOL_TIMEOUT_MS },
-    );
-    return { ok: true };
-  } catch (error) {
-    return { failed: true, reason: `adb could not reload ${packageName} on ${serial}: ${describe(error)}` };
+export type MetroReloadRole = 'ios' | 'android';
+
+const ROLE_NAMES: Record<MetroReloadRole, string> = { ios: 'iOS', android: 'Android' };
+
+// Metro reports each peer's connection query. @expo/cli stores it unparsed
+// (`url.parse(req.url).query`, a string) while @react-native-community/cli-server-api
+// parses it into an object, so both shapes reach us.
+function peerQuery(metadata: unknown): URLSearchParams | null {
+  if (typeof metadata === 'string') return new URLSearchParams(metadata);
+  if (!metadata || typeof metadata !== 'object') return null;
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === 'string') query.set(key, value);
   }
+  return query;
 }
 
-export function openIosDeepLink(
-  udid: string,
-  url: string,
-  { exec = getExecutor() }: { exec?: Executor } = {},
-): ReloadToolResult {
-  try {
-    exec.runFile('xcrun', ['simctl', 'openurl', udid, url], { timeoutMs: TOOL_TIMEOUT_MS });
-    return { ok: true };
-  } catch (error) {
-    return { failed: true, reason: `simctl could not open ${url} on ${udid}: ${describe(error)}` };
-  }
+// Only iOS sends `role` (RCTPackagerConnection.mm), and it sends nothing else.
+// Android sends `device`, `app` and `clientid` (JSPackagerClient.kt), so its
+// package name is the only identifier available there.
+function peerMatches(query: URLSearchParams, role: MetroReloadRole, appId: string): boolean {
+  if (role === 'ios') return query.get('role')?.toLowerCase() === 'ios';
+  return query.get('app') === appId;
 }
 
-export function reloadIosThroughMetro(
+export function reloadThroughMetro(
   port: number,
-  { timeoutMs = METRO_TIMEOUT_MS }: { timeoutMs?: number } = {},
+  { role, appId, timeoutMs = METRO_TIMEOUT_MS }: { role: MetroReloadRole; appId: string; timeoutMs?: number },
 ): Promise<MetroReloadResult> {
+  const roleName = ROLE_NAMES[role];
   return new Promise((resolve) => {
     const requestId = `stim-reload-${process.pid}-${Date.now()}`;
     const socket = new WebSocket(`ws://127.0.0.1:${port}/message`);
@@ -64,7 +68,7 @@ export function reloadIosThroughMetro(
       resolve(result);
     };
     const timer = setTimeout(
-      () => finish({ failed: true, reason: `Metro did not answer on port ${port}.` }),
+      () => finish({ failed: true, unreachable: true, reason: `Metro did not answer on port ${port}.` }),
       timeoutMs,
     );
 
@@ -82,39 +86,46 @@ export function reloadIosThroughMetro(
       if (message.result && typeof message.result === 'object') {
         const entries = Object.entries(message.result);
         const peers = entries.length;
-        const iosPeers = entries.filter(([, metadata]) => {
-          if (!metadata || typeof metadata !== 'object') return false;
-          const role = (metadata as { role?: unknown }).role;
-          return typeof role === 'string' && role.toLowerCase() === 'ios';
+        const rolePeers = entries.filter(([, metadata]) => {
+          const query = peerQuery(metadata);
+          return query ? peerMatches(query, role, appId) : false;
         });
-        if (iosPeers.length === 0) {
-          finish({ failed: true, peers, reason: `No iOS React Native app is connected to Metro on port ${port}.` });
-          return;
-        }
-        if (iosPeers.length > 1) {
+        if (rolePeers.length === 0) {
+          // Matching is best-effort -- a peer can carry no query at all, or a
+          // shape these matchers do not read -- so an unmatched app may still be
+          // connected. Take the free shot with a broadcast before giving up, but
+          // report the miss: nothing here proves the app got it.
+          socket.send(JSON.stringify({ version: 2, method: 'reload' }));
+          const others =
+            peers === 0
+              ? ' Nothing at all is connected to it, so the broadcast Stim sent anyway reached nothing.'
+              : ` Metro has ${peers} other connected client${peers === 1 ? '' : 's'}, and Stim broadcast a reload to them in case one is this app unmatched.`;
           finish({
             failed: true,
+            noPeer: true,
             peers,
-            reason: `Metro has ${iosPeers.length} iOS apps connected on port ${port} and cannot identify the target app.`,
+            reason: `No ${roleName} React Native app is connected to Metro on port ${port}.${others}`,
           });
           return;
         }
-        socket.send(JSON.stringify({ version: 2, method: 'reload', target: iosPeers[0]![0] }));
-        finish({ ok: true, peers });
+        // A Stim Metro serves one app, so several matching peers are that app on
+        // several devices, not several apps. Reload each of them. iOS could not
+        // pick one anyway: its peers carry only `role`.
+        for (const [id] of rolePeers) socket.send(JSON.stringify({ version: 2, method: 'reload', target: id }));
+        finish({ ok: true, peers, targets: rolePeers.length });
         return;
       }
-      if (
-        typeof message.error === 'string' &&
-        /Cannot read properties of undefined \(reading ['"]url['"]\)/.test(message.error)
-      ) {
-        finish({
-          failed: true,
-          reason: `Metro could not identify the connected iOS app on port ${port}.`,
-        });
-        return;
-      }
-      finish({ failed: true, reason: `Metro could not enumerate connected apps on port ${port}.` });
+      // @react-native-community/cli-server-api reads `otherWs.upgradeReq.url` to
+      // answer getpeers, a property ws dropped in 3.0, so every published version
+      // of the bare dev server throws there rather than listing its clients. Its
+      // broadcast path never touches that property. Note what this costs: the
+      // throw only happens when some other client exists, so it proves a client
+      // is connected but not which, and the target app may not be among them.
+      socket.send(JSON.stringify({ version: 2, method: 'reload' }));
+      finish({ ok: true, broadcast: true });
     });
-    socket.once('error', (error) => finish({ failed: true, reason: `Metro reload failed: ${describe(error)}` }));
+    socket.once('error', (error) =>
+      finish({ failed: true, unreachable: true, reason: `Metro reload failed: ${describe(error)}` }),
+    );
   });
 }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -111,11 +111,14 @@ RULES DURING THE LOOP
   It restarts only this app's verified owned Metro, preserving devices and other
   apps' caches. See guide lifecycle for reset scope and Expo requirements.
 - Reload is not part of the normal workflow. Use stim reload on an owned local
-  simulator or emulator after a failed first bundle load, when an error screen
-  remains after the fix, or when you explicitly need an app restart. For a
-  physical device that reached Metro, use agent-device metro reload with the
-  reported port. The detected iOS Local Network first-load remedy uses UI
-  automation instead because that app never established a Metro connection.
+  simulator or emulator when an error screen remains after the fix, and on
+  Android after a failed first bundle load. It reloads JavaScript and never
+  restarts the app. An iOS app whose first bundle failed never connects to
+  Metro, so reload cannot reach it and says to use the device's own Reload
+  control. For a physical device that reached Metro, use agent-device metro
+  reload with the reported port. The detected iOS Local Network first-load
+  remedy uses UI automation instead because that app never established a Metro
+  connection.
 - A successful stim reload confirms that the request was sent, not that new
   JavaScript loaded or the screen recovered. Verify the expected UI on the
   reported device and inspect stim logs --errors before claiming recovery.

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -671,16 +671,33 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   process-probe remedy.`,
     },
     STIM_RELOAD_FAILED: {
-      summary: 'the reload failed; use Reload or the exact-app relaunch remedy',
+      summary: 'the reload failed; the remedy differs by shape -- read it before acting',
       body: () => `STIM_RELOAD_FAILED
-  The exact deep link, Android reload broadcast, or targeted Metro websocket
-  failed. If bare iOS has not connected or Metro cannot identify one iOS peer,
-  the remedy tells the agent to continue in its existing automation session on
-  this workspace's exact simulator and press Reload if present. If it is not
-  present, the printed agent-device open command relaunches that app on that
-  simulator with this workspace's Metro port. Keep the existing --session flag;
-  relaunch loses in-memory state. Verify the expected UI afterward. Stim does
-  not broadcast to unidentified peers or take over automation sessions.`,
+  The Metro websocket reload did not reach a peer Stim could identify. Two
+  shapes reach this code and the remedy differs. Read it rather than assuming.
+
+  METRO DID NOT ANSWER. The probe timed out after 2 seconds, or the socket
+  errored. Nothing is known about the app, so the remedy is to run the same
+  reload again, and to check the dev server with stim doctor if it keeps
+  timing out. Do not touch the device for this one.
+
+  METRO REPORTS NO PEER FOR THE APP. Stim broadcasts a reload anyway before
+  giving up, because matching is best-effort and an unmatched peer may still be
+  this app, so VERIFY THE UI FIRST -- the app may already have recovered. If it
+  did not, retry: a client reconnects to Metro every 2 seconds, which is also
+  this probe's timeout, so a single miss can be a reconnect window rather than
+  an app that never connected. If it stays unreachable on iOS, an error in the
+  first bundle leaves the app without a packager connection at all and no retry
+  will make it a peer. The remedy then routes the agent to the device's own
+  controls in its existing automation session: press the error screen's Reload
+  button, or open the dev menu and press Reload when no error screen is
+  showing. The printed agent-device open command is the last resort; it
+  relaunches that app on that device with this workspace's Metro port and loses
+  in-memory state. Keep the existing --session flag and verify afterward.
+
+  MORE THAN ONE MATCHING PEER IS NOT A FAILURE. A workspace Metro serves one
+  app, so several matching peers are that app on several devices. Stim reloads
+  every one of them and reports the count in the facts as targets.`,
     },
     STIM_WORKTREE_REMOVAL_IN_PROGRESS: {
       summary: 'a managed remote start found worktree remove holding the lock; wait, then rerun',

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -226,8 +226,19 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
   deviceName      the owned simulator or AVD name
   appId           the live bundle id or Android package
   metroPort       the workspace's verified Metro port
-  strategy        "deep-link" for Expo/dev-client, "android-broadcast" for
-                  bare Android, or "metro-websocket" for an identifiable bare iOS peer
+  strategy        how the reload was addressed.
+                  "metro-websocket" -- Metro named its clients and Stim
+                  addressed every peer matching this platform. A workspace
+                  Metro serves one app, so those peers are this app on however
+                  many devices are attached to that port.
+                  "metro-broadcast" -- this Metro cannot name its clients, so
+                  the reload went to all of them and Stim cannot confirm appId
+                  was among them. Verify the UI on deviceId; if it did not
+                  change, reload from the app's own error screen or dev menu
+  targets         how many peers the reload was addressed to, or null when
+                  broadcast. Greater than 1 means several devices are running
+                  this app on that Metro and all of them reloaded, not only
+                  deviceId
 
   stim doctor --json
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -86,22 +86,46 @@ and produces an app that cannot load a bundle.
 
 Repeat step 3 whenever a NATIVE input changes. A JS-only edit needs nothing --
 that is what Fast Refresh over the running dev server is for. \`stim reload\` is
-not part of the normal workflow. It is the explicit recovery path after a
-failed first bundle load, when Fast Refresh cannot clear the current screen,
-or when you explicitly need an app restart. Use \`stim reload ios\` or
-\`stim reload android\` to select a platform when both owned apps are live.
-For a physical device that reached Metro, use \`agent-device metro reload
---metro-port <reported-port>\`. The detected iOS Local Network first-load
-remedy uses agent-device UI automation because no Metro peer exists yet.
-It never builds, installs, boots, or cold-launches. It acts only on a live app
-on this workspace's owned local simulator or emulator, and refuses release
+not part of the normal workflow. It is the explicit recovery path when Fast
+Refresh cannot clear the current screen, and on Android after a failed first
+bundle load. It reloads JavaScript and never restarts the app. Use \`stim
+reload ios\` or \`stim reload android\` to select a platform when both owned
+apps are live. For a physical device that reached Metro, use \`agent-device
+metro reload --metro-port <reported-port>\`. The detected iOS Local Network
+first-load remedy uses agent-device UI automation because no Metro peer exists
+yet. It never builds, installs, boots, or cold-launches. It acts only on a live
+app on this workspace's owned local simulator or emulator, and refuses release
 builds, stopped or unowned devices, a missing or foreign Metro, and an
-ambiguous no-platform request. Expo/dev-client reloads resend the exact deep
-link recorded at launch. Bare Android sends the app-scoped React Native reload
-broadcast. Bare iOS reloads through this Metro's sole identifiable iOS peer. If
-Metro cannot identify one iOS peer, the command tells the agent to press Reload
-through its existing automation session on the exact simulator. Stim does not
-take over that stateful session.
+ambiguous no-platform request. Every reload goes over this workspace's Metro
+websocket, on both platforms. It never reopens a development-client URL,
+because that restarts the app rather than reloading its JavaScript.
+
+How the message is addressed depends on the dev server, and \`strategy\` in
+the facts reports which you got. Where Metro can name its clients, Stim
+addresses every peer matching the platform and reports \`metro-websocket\`. A
+workspace Metro serves one app, so those peers are this app on however many
+devices are attached to that port, and \`targets\` says how many were reloaded.
+The bare React Native dev server cannot name its clients at all, so Stim
+broadcasts: \`metro-broadcast\` means every app connected to that Metro
+reloaded and Stim cannot confirm \`appId\` was among them. Verify the UI on
+\`deviceId\`; if it did not change, reload from the app's own error screen or
+dev menu.
+
+When Metro reports no peer for the app, Stim broadcasts a reload anyway before
+giving up, because matching is best-effort and an unmatched peer may still be
+this app. So verify the UI first: it may already have recovered. If it did not,
+retry: a client reconnects every 2 seconds, which is also this probe's timeout,
+so a single miss can be a reconnect window rather than an app that never
+connected. If it stays unreachable on iOS, an error in the first bundle leaves
+the app without a packager connection at all, and no retry will make it a peer.
+The command then routes the agent to the device's own controls in its existing
+automation session: press the error screen's Reload button, or open the dev
+menu and press Reload when no error screen is showing, and relaunch only when
+neither is reachable. Stim does not take over that stateful session.
+
+When Metro itself does not answer within the probe's 2 seconds, nothing is
+known about the app. The command says to retry and check the dev server rather
+than sending the agent to the device.
 
 A successful reload confirms that the request was sent. It does not wait for
 new JavaScript or observe the resulting UI. Verify the expected screen or

--- a/packages/stim-cli/src/supervisor/state.ts
+++ b/packages/stim-cli/src/supervisor/state.ts
@@ -26,7 +26,6 @@ export interface WorkspaceLaunchRecord {
   deviceId: string;
   metroPort: number | null;
   release: boolean;
-  deepLinkUrl: string | null;
   launchedAt: string;
 }
 
@@ -102,7 +101,6 @@ function parseWorkspaceLaunchRecord(value: unknown): WorkspaceLaunchRecord | nul
   if (typeof record.deviceId !== 'string' || record.deviceId.length === 0) return null;
   if (record.metroPort !== null && typeof record.metroPort !== 'number') return null;
   if (typeof record.release !== 'boolean') return null;
-  if (record.deepLinkUrl !== null && typeof record.deepLinkUrl !== 'string') return null;
   if (typeof record.launchedAt !== 'string') return null;
   return record as WorkspaceLaunchRecord;
 }

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -25,9 +25,10 @@ stim stop`}
 `ios` and `android` require a running dev server for a Debug build. Release
 builds embed the JavaScript bundle and skip that requirement.
 
-`reload` is a recovery or explicit restart command. Use it after a failed first
-bundle load or when an error screen remains after a fix, not after every
-JavaScript edit.
+`reload` is a recovery command that reloads JavaScript in the live app and never
+restarts it. Use it when an error screen remains after a fix, not after every
+JavaScript edit. It also recovers an Android app whose first bundle failed; an
+iOS app in that state never connects to Metro, so reload cannot reach it.
 
 ## `doctor`
 
@@ -192,12 +193,43 @@ or emulator. It never builds, installs, boots, or cold-launches. Omit the
 platform when exactly one owned app is live; name it when both iOS and Android
 are live.
 
-Expo and dev-client apps reopen the exact project deep link recorded at launch.
-Bare Android apps receive their package-scoped React Native reload broadcast.
-Bare iOS apps reload through the workspace Metro websocket when it can identify
-one iOS peer. Otherwise the command returns instructions to continue in the
-agent's existing automation session on the exact simulator. Stim does not take
-over that stateful session.
+Every reload goes over the workspace Metro websocket, on both platforms. It never
+reopens a development-client URL, because that restarts the app rather than
+reloading its JavaScript.
+
+How the message is addressed depends on the dev server, and `strategy` reports
+which you got. Where Metro can name its clients, Stim addresses every peer
+matching the platform and reports `metro-websocket`. A workspace Metro serves one
+app, so those peers are that app on however many devices are attached to the
+port; `targets` says how many were reloaded. Android peers carry the package
+name and iOS peers carry only `role=ios`, which is enough to keep a reload on one
+platform but not to single out one iOS app among several.
+
+The bare React Native dev server cannot name its clients at all, because
+`@react-native-community/cli-server-api` answers that request out of a `ws`
+property removed in ws 3.0. There Stim broadcasts: `metro-broadcast` means every
+app on that port reloaded, and that Stim could not confirm the recorded app was
+among them. Verify the UI, and fall back to the app's own error screen or dev
+menu if nothing changed.
+
+When Metro names its clients and none match the platform, Stim still broadcasts
+before giving up, because matching is best-effort and an unmatched peer may be
+the app. It reports the miss either way, so verify the UI before acting on the
+remedy.
+
+When Metro reports no peer for the app, retry once first: a client reconnects
+every 2 seconds, which is also this probe's timeout, so a single miss can be a
+reconnect window rather than an app that never connected. If it stays
+unreachable on iOS, an error in the first bundle leaves the app without a
+packager connection at all, and no retry will make it a peer. The command then
+returns instructions to continue in the agent's existing automation session:
+press the error screen's Reload button, or open the dev menu and press Reload
+when no error screen is showing, and relaunch only when neither is reachable.
+Stim does not take over that stateful session.
+
+When Metro itself does not answer within the probe's 2 seconds, nothing is known
+about the app, so the command says to retry and check the dev server rather than
+sending the agent to the device.
 
 The command refuses release builds, stopped or unowned devices, a missing or
 foreign Metro server, and ambiguous selection. `--json` prints one object with


### PR DESCRIPTION
## Description

`stim reload android` kills any Expo dev-client app that is already running. The process dies, the reload never happens, and the command reports success because it dispatches without observing completion.

Reopening a recorded development-client URL is not a reload. It restarts the app. On Android that recreates `MainActivity`, and expo-dev-launcher asserts at that point that no React context exists yet (`DevLauncherAppLoader.kt:49`, `require(appHost.currentReactContext == null)`), so a healthy app trips a fatal activity-start failure. The assertion is still on expo's `main`: [expo/expo#35385](https://github.com/expo/expo/issues/35385) was auto-closed 77 seconds after filing for lacking a reproduction, and [expo/expo#48085](https://github.com/expo/expo/pull/48085) diagnoses this case but was closed unmerged with no maintainer review.

#363 exercised the Android dev-client path against an app handed an unreachable startup URL. No context existed there, so the assertion passed. The crash only appears on the healthy-app path, which is what agents hit after `stim start --reset-cache`.

## Solution

One transport on both platforms: the Metro `/message` websocket. The deep-link and adb-broadcast paths are removed, so three mechanisms become one and the platform branch disappears.

**Targeting, where Metro can enumerate peers.** iOS peers match on `role`, Android peers on `app`, because only iOS sends `role` (`RCTPackagerConnection.mm`, and it sends nothing else) and only Android sends `app` (`JSPackagerClient.kt`, alongside `device` and `clientid`). Every matching peer is addressed, and `targets` reports how many. A workspace Metro serves one app, so several matching peers are that app on several devices, not several apps — reloading all of them is reloading the app everywhere it is running. That matters most on iOS, where `role=ios` separates an iOS client from an Android one but cannot single out one iOS app, so an iPhone and a simulator on one port are indistinguishable and there is nothing to choose between. Targeting still buys precision over a blanket broadcast: with two iOS devices and an Android device attached, `reload ios` reloads the two iPhones and leaves Android alone.

This also fixes a latent bug in the path that already existed — Metro reports peer metadata as a parsed object under `@react-native-community/cli-server-api` and as a raw query string under `@expo/cli`, and the old code only handled the object, so the iOS peer path silently matched nothing under an Expo-hosted dev server.

**Broadcasting, where it cannot.** The bare React Native dev server cannot enumerate peers at all. `cli-server-api` answers `getpeers` out of `otherWs.upgradeReq.url`, which `ws` removed in 3.0, and its own dependency is `ws@^6`. This is not version drift: 20.2.0, the current latest, still does it, and nothing upstream tracks it. Its broadcast path does not touch that property, so a Metro that cannot enumerate gets an untargeted reload instead.

Without this, removing the adb broadcast would have left bare React Native Android with no working reload at all, since the targeted path can never find a peer there.

**What the broadcast cannot promise, and how that is reported.** `getpeers` only touches the broken property when some *other* client exists, so the throw proves a client is connected but not which one. Three cases, all confirmed against `cli-server-api@20.2.0` on its own `ws@6.2.6`:

| connected | result | reached |
| --- | --- | --- |
| nothing | `noPeer` | nothing, correctly |
| the target app | `ok, broadcast` | the target app |
| some other app | `ok, broadcast` | that app, not the target |

The third row is why `strategy` is `metro-broadcast` rather than `metro-websocket`, and why both the plain output and the `strategy` contract in `guide facts` say that the reload went to every app on the port and that Stim **cannot confirm** `appId` was among them, with the app's own error screen as the fallback. Failing closed there instead would take the second row down with it, which is the case this exists for.

**A miss also falls back to the broadcast.** Matching is best-effort — a peer can carry no query at all, or a shape these matchers do not read — so when Metro names its clients and none match, Stim still broadcasts before giving up. It reports the miss either way, because nothing there proves the app received it; the remedy just tells the agent to check the screen before spending a retry.

**Contract note.** `WorkspaceLaunchRecord.deepLinkUrl` is removed. The deep-link branch was its only reader, so it became dead state written by both launch paths on every run. Dropping it is safe for records already on disk: `parseWorkspaceLaunchRecord` validates the fields it needs and casts, so an existing record carrying the field still parses and the extra key is ignored. An older stim would reject records written by this one, which is a downgrade-only concern.

**Behavior traded away.** An app that Metro has a peer map for but no peer in cannot be reached by any websocket reload, and is no longer restarted through its dev-client URL. A missing peer is not proof the app never connected — `ReconnectingWebSocket` retries every 2 seconds, which is also this probe's own timeout — so the remedy asks for one more `stim reload` first. On Android, staying unreachable is largely theoretical: an app whose first bundle fails still receives Metro reload commands, confirmed in the test plan of [react/react-native#58352](https://github.com/react/react-native/pull/58352). On iOS the app genuinely is absent, because bridgeless `RCTInstance` resolves `DevSettings` only in `_loadJSBundle`'s success callback and `RCTDevSettings.initialize` is what both opens the `/message` socket and registers the reload handler; a failed first bundle skips both, so that cause is named only on iOS, and named as one no retry will fix. The remedy then routes to the device's own reload controls in the agent's existing automation session — the error screen's Reload button, or the dev menu — with a relaunch offered only when neither is reachable and marked as losing in-memory state. Reopening the URL was never the right answer there either, since it restarts the app for the same loss.

That same iOS fact makes `stim ios`'s own FATAL remedy wrong as of this change. It told the agent to run `stim reload ios` after a failed first bundle, which worked on `main` only because the dev-client URL restarted the app. It now routes to the error screen's Reload button instead, on simulators and phones alike — `agent-device metro reload` cannot reach that app either.

`STIM_RELOAD_FAILED` now carries two distinguishable shapes with different remedies, and the result type spells out all four outcomes so an impossible one does not typecheck. A Metro that does not answer at all says nothing about the app, so that case asks for a retry and `stim doctor` instead of sending the agent to the device.

## Test plan

Peer identification runs against a real `WebSocketServer` replaying the shapes the two dev servers actually produce, object and raw query string, for both platforms:

- iOS matches its `role` peer and leaves a simultaneously connected Android peer alone; Android matches its package peer and leaves iOS alone.
- An Android peer for a different package reports no peer rather than reloading it.
- Neither matcher falls back to the other's key when a bundle id and a package name are the same string.
- A peer whose metadata is `null`, which `@expo/cli` produces for a query-less connection URL, is counted but never matched.
- An app that never connected reports no peer, which is the shape an iOS first-bundle failure produces. Multiple matching peers refuse without sending a reload.
- A Metro that answers `getpeers` with an error is reloaded by broadcast, for the `upgradeReq` TypeError and for any other enumeration error.

The broadcast fallback is also verified against the real dependency rather than a replay. Running `@react-native-community/cli-server-api@20.2.0` on its own `ws@6.2.6`, with a client connected exactly as `JSPackagerClient.kt` connects:

```
result:      { ok: true, broadcast: true }
appReceived: [ { version: 2, method: 'reload' } ]
```

On `main` that same app receives nothing, because the adb broadcast is what reached it and `getpeers` throws.

Command behavior:

- Metro is addressed with the target platform and app id on both platforms. With the URL field gone there is no second path a reload can take, so this is the guard against the regression rather than a URL-specific assertion.
- An app Metro cannot see gets the automation remedy, not a restart. It says a broadcast went out and to check the screen first, then asks for one retry before sending the agent to the device, routes to the Reload button and dev menu ahead of `--relaunch`, and names the iOS first-bundle cause only on iOS.
- Several matching peers all reload, and both the facts and the plain output say how many devices that was. A cross-platform miss is never addressed as a match, only swept up by the last-resort broadcast.
- A Metro that does not answer, by timeout or socket error, asks for a retry and names no device command at all. Both shapes are asserted at the engine boundary against a real socket, not only through a faked result.
- `stim ios` routes a failed first bundle to the error screen rather than to any Metro reload, on the simulator and on a phone. Its counterpart still holds: a bundle that loaded and then hit a runtime error is a peer, so that case still recommends a reload.
- A broadcast reload reports `metro-broadcast` and says in the plain output that every app on that Metro reloaded; a targeted reload says neither.
- The remedy never mentions Local Network, a phone-only cause `reload` cannot reach: it refuses anything that is not this workspace's owned local simulator or emulator.
- `guide facts` names every value of `ReloadFacts['strategy']`, asserted against the source union.
- A launch record written before `deepLinkUrl` was dropped still parses and is still a reload target.
- Release, ambiguity, ownership and Metro-identity refusals still fire before any reload is attempted.

Real-device evidence from diagnosing this on an Expo SDK 57 app (`io.tlon.groups`, expo-dev-launcher 57.0.7, `emulator-5556`, Metro 8082): reopening the dev-client URL on a healthy app killed the process four times out of four, each leaving the same `App react context shouldn't be created before.` stack in `logcat -b crash`, with a focused text input present for two of them and absent for the other two. A version-2 Metro websocket reload against the same app left the process at the same pid across 30 seconds and Metro logged `Android Bundled 120ms`.

Not verified: `stim reload` from this branch driving a real device end to end. The manual websocket reload above was untargeted, so it exercised the transport but not this branch's peer identification. The iOS first-bundle-failure case is covered at the peer-identification boundary rather than on a device; reproducing it live needs an app with a deliberately broken bundle. react/react-native#58352 has landed but is not in a release yet, so every released RN still behaves this way and this path stays load-bearing.

Fixes #683
