### PR TITLE
fix: accept silent benchmark session cleanup

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -221,8 +221,9 @@ overhead stays symmetric. Record each proof step as its own top-level shell comm
 an interactive shell, script, chained command, or redirected background job.
 Using a bare or mismatched agent-device state directory/session, or restarting
 its daemon inside the timed interval, invalidates the attempt. The collector
-also requires `open` and `close` output to name the exact run session; command
-shape alone is insufficient.
+and exporter require `open` output to name the exact run session. The isolated
+`close` command must exit successfully but can be silent; export also requires
+independent cleanup evidence that the campaign session inventory is empty.
 
 The agent reads `<run-udid>` or `<run-serial>` from the platform launch output.
 The explicit device identifier prevents an existing automation session from

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -610,10 +610,7 @@ function iosReadinessCommandFailure({ meta, record, proofPath, recordingPath, sc
     return 'agent-device command sequence mismatch';
   }
   const expectedSessionState = sanitizeBenchmarkText(`Session state: ${stateDir}/sessions/${session}`, []);
-  if (
-    !screenCommands[0].output.includes(expectedSessionState) ||
-    !screenCommands.at(-1).output.includes(`Closed: ${session}`)
-  ) {
+  if (!screenCommands[0].output.includes(expectedSessionState)) {
     return 'agent-device session output mismatch';
   }
   return null;

--- a/scripts/export-benchmark-viewer.test.mjs
+++ b/scripts/export-benchmark-viewer.test.mjs
@@ -1071,7 +1071,7 @@ describe('benchmark viewer export', () => {
     }
   });
 
-  it('requires isolated iOS readiness commands, recording copy, and owned cleanup', () => {
+  it.each([false, true])('requires isolated iOS readiness evidence (silent close: %s)', (silentClose) => {
     const root = mkdtempSync(join(tmpdir(), 'stim-ios-export-'));
     tempDirs.push(root);
     const runId = 'private-ios-run-id';
@@ -1108,7 +1108,7 @@ describe('benchmark viewer export', () => {
       ['copy', 9, 10, `cp ${screenshotScratch} ${proofPath}`, ''],
       ['record-stop', 11, 12, `${prefix} record stop`, `${recordingScratch}\n`],
       ['record-copy', 13, 14, `cp ${recordingScratch} ${recordingPath}`, ''],
-      ['close', 15, 16, `${prefix} close`, `Closed: ${runId}\n`],
+      ['close', 15, 16, `${prefix} close`, silentClose ? '' : `Closed: ${runId}\n`],
     ];
     writeFileSync(
       join(runDir, 'events.jsonl'),
@@ -1215,7 +1215,59 @@ describe('benchmark viewer export', () => {
     };
     writeFileSync(recordPath, JSON.stringify(record));
 
-    expect(exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof')).runs).toHaveLength(1);
+    const recordedEvents = readFileSync(eventsPath, 'utf8');
+    const payload = exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'));
+    expect(payload.runs).toHaveLength(1);
+    expect(payload.runs[0].commands.find((command) => command.id === 'close')).toMatchObject({
+      output: silentClose ? '' : 'Closed: javascript-stim\n',
+      exitCode: 0,
+      startSeconds: 14,
+      endSeconds: 15,
+    });
+    expect(readFileSync(eventsPath, 'utf8')).toBe(recordedEvents);
+
+    for (const invalidClose of [
+      { exit_code: 1 },
+      { exit_code: null },
+      { command: `env AGENT_DEVICE_STATE_DIR=${stateDir} AGENT_DEVICE_SESSION=other-session agent-device close` },
+    ]) {
+      const events = recordedEvents.trim().split('\n').map(JSON.parse);
+      const completed = events.at(-1);
+      const event = JSON.parse(completed.line);
+      Object.assign(event.item, invalidClose);
+      completed.line = JSON.stringify(event);
+      writeFileSync(eventsPath, `${events.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+      record.evidenceSha256.events = sha256(eventsPath);
+      writeFileSync(recordPath, JSON.stringify(record));
+      expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+        'no valid benchmark runs found',
+      );
+    }
+    writeFileSync(eventsPath, recordedEvents);
+    record.evidenceSha256.events = sha256(eventsPath);
+    writeFileSync(recordPath, JSON.stringify(record));
+
+    const cleanupPath = join(runDir, 'cleanup.json');
+    const cleanup = readFileSync(cleanupPath, 'utf8');
+    rmSync(cleanupPath);
+    expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+      'no valid benchmark runs found',
+    );
+    const cleanupRecord = JSON.parse(cleanup);
+    for (const missingAction of cleanupRecord.actions) {
+      writeFileSync(
+        cleanupPath,
+        JSON.stringify({
+          ...cleanupRecord,
+          actions: cleanupRecord.actions.filter((action) => action !== missingAction),
+        }),
+      );
+      expect(() => exportBenchmark(stageDir, join(root, 'benchmark.json'), join(root, 'public-proof'))).toThrow(
+        'no valid benchmark runs found',
+      );
+    }
+    writeFileSync(cleanupPath, cleanup);
+
     const sourceProofPath = join(proofDir, 'settings-source.tsx');
     writeFileSync(sourceProofPath, 'Keep saved trail maps available offline');
     record.proof = { ...record.proof, kind: 'source-edit-and-settings-screen', target: sourceProofPath };


### PR DESCRIPTION
## Description

An iOS readiness benchmark is rejected during export when its isolated `agent-device close` succeeds without output. The close-message requirement came from the [strict iOS evidence validation](https://github.com/appandflow/stim/commit/8ae44bdddcfede528c24b9448e9528df9eb206c4), but collection already accepts silent success.

## Solution

Use the successful close command and independent cleanup evidence to establish completion. Export still checks the exact isolated command sequence, run session, device, and open-session output; it no longer requires close text. Recorded output and timing remain unchanged, and the benchmark protocol documentation matches the behavior.

## Test plan

- The silent-close export regression fails before the fix and passes after it. Both silent and printed close results preserve output and timing.
- Export rejects failed or missing close exit status, a different close session, a missing cleanup file, and each missing required cleanup action.
- `pnpm test scripts/export-benchmark-viewer.test.mjs`: 46 passed.

Fixes #680
