### PR TITLE
fix: make late remote-start refusal test deterministic

### DIFF
--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -2127,10 +2127,14 @@ describe('action: an existing supervisor that is not answering', () => {
     );
     const port = 8167;
     const exec = metroExecutor({ listeners: {} });
-    const held: { server: Server | null } = { server: null };
+    let markMetroHealthy: () => void;
+    const metroHealthy = new Promise<void>((resolve) => {
+      markMetroHealthy = resolve;
+    });
     const base = exec.runQuiet.bind(exec);
     exec.runQuiet = (cmd) => {
       if (new RegExp(`lsof -nP -iTCP:${port}`).test(cmd)) return exec.listening ? '5153' : '';
+      if (/lsof -a -p 5153 -d cwd/.test(cmd)) markMetroHealthy();
       return base(cmd);
     };
     setExecutor(exec);
@@ -2144,19 +2148,22 @@ describe('action: an existing supervisor that is not answering', () => {
         startedAt: 'T',
       },
     });
-    metroListener(port).then((server) => {
-      held.server = server;
-      exec.listening = true;
-      return server;
-    });
-
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
     let result;
     try {
-      result = await runAction({ json: true, remote: true, wait: '1' });
+      const action = runAction({ json: true, remote: true, wait: '1' });
+      await vi.advanceTimersByTimeAsync(0);
+      await metroListener(port);
+      exec.listening = true;
+      await vi.advanceTimersByTimeAsync(500);
+      await metroHealthy;
+      await vi.runAllTimersAsync();
+      result = await action;
     } finally {
-      held.server?.close();
+      vi.useRealTimers();
     }
 
+    expect(result.errs.join('\n')).toMatch(/already running for this workspace; waiting for it to answer/);
     expect(result.exitCode).toBe(1);
     expect(exec.calls.spawn).toEqual([]);
     expect(JSON.parse(result.logs[0] ?? '').code).toBe('STIM_REMOTE_START_REQUIRED');

--- a/packages/stim-cli/src/__tests__/start.test.ts
+++ b/packages/stim-cli/src/__tests__/start.test.ts
@@ -2133,8 +2133,8 @@ describe('action: an existing supervisor that is not answering', () => {
     });
     const base = exec.runQuiet.bind(exec);
     exec.runQuiet = (cmd) => {
-      if (new RegExp(`lsof -nP -iTCP:${port}`).test(cmd)) return exec.listening ? '5153' : '';
-      if (/lsof -a -p 5153 -d cwd/.test(cmd)) markMetroHealthy();
+      if (new RegExp(`lsof -nP -iTCP:${port}`).test(cmd)) return exec.listening ? String(DEAD_LISTENER_PID) : '';
+      if (new RegExp(`lsof -a -p ${DEAD_LISTENER_PID} -d cwd`).test(cmd)) markMetroHealthy();
       return base(cmd);
     };
     setExecutor(exec);


### PR DESCRIPTION
## Description

The late local-supervisor test reported `STIM_METRO_TIMEOUT` on Node 22 CI instead of `STIM_REMOTE_START_REQUIRED`. Its unawaited listener competed with a one-second deadline, so scheduling could prevent it from reaching the remote-mode refusal.

## Solution

Control the test clock and await the listener after Stim enters the existing-supervisor wait. Advance the tunnel deadline only after the real HTTP health probe succeeds. The test also asserts that it took the waiting path and still requires the exact refusal code and no supervisor spawn. Production code is unchanged.

## Test plan

- 30 repeated focused runs on Node 22.22.2 passed.
- Full `pnpm test` passed.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, and `pnpm run knip` passed.

Fixes #643
