### PR TITLE
fix: allow benchmark agent-device version probes

### DIFF
--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -315,7 +315,7 @@ log command names the exact file subsequently read. Diagnosis uses the later
 read's timestamp, not the truncated preview. A masked Android Expo pipeline can
 use a subsequent read of its exact build log as launch confirmation only when
 that output reports both build success and opening the app.
-Read-only agent-device help does not need a session. An auxiliary diagnostic
+Read-only agent-device help and `--version` do not need a session. An auxiliary diagnostic
 session must use the exact run namespace and state directory, open the assigned
 device, and close successfully before the pinned proof session opens. Its
 `auxiliarySessions` review entries name each `session` and a nonempty `assessment`.

--- a/scripts/agent-benchmark/run-guards.mjs
+++ b/scripts/agent-benchmark/run-guards.mjs
@@ -233,7 +233,7 @@ export function agentDeviceIsolationInvalidReasons(commands, expectedPrefix, tar
   const reasons = [];
   const lookup =
     /^(?:command\s+-[vV]|which|type|whence)\s+(?:[\w./-]+\s+)*agent-device(?:\s+[\w./-]+)*(?:\s+(?:\d*>|&>)\s*(?:&\d+|[\w./-]+))?$/;
-  const help = /^agent-device(?:\s+--help|\s+help(?:\s+[\w-]+)*)(?:\s+(?:\d*>|&>)\s*(?:&\d+|[\w./-]+))?$/;
+  const help = /^agent-device(?:\s+--(?:help|version)|\s+help(?:\s+[\w-]+)*)(?:\s+(?:\d*>|&>)\s*(?:&\d+|[\w./-]+))?$/;
   const deviceCommands = segments.filter(
     (command) => /(?:^|[\s(`])agent-device(?:\s|[)`]|$)/.test(command) && !lookup.test(command) && !help.test(command),
   );

--- a/scripts/agent-benchmark/run-guards.test.mjs
+++ b/scripts/agent-benchmark/run-guards.test.mjs
@@ -80,10 +80,15 @@ describe('agent-device session isolation', () => {
     }
   });
 
-  it('allows help output without letting help hide an unscoped device command', () => {
+  it('allows help and version output without hiding an unscoped device command', () => {
     expect(
       agentDeviceIsolationInvalidReasons(
-        [{ command: 'which agent-device; agent-device --help 2>&1 | head -20\nagent-device help open' }],
+        [
+          {
+            command:
+              'which agent-device 2>&1; agent-device --version 2>&1 | head -5\nagent-device --help\nagent-device help open',
+          },
+        ],
         prefix,
       ),
     ).toEqual([]);
@@ -91,6 +96,9 @@ describe('agent-device session isolation', () => {
       'agent-device help; agent-device snapshot',
       'agent-device help $(agent-device snapshot)',
       'agent-device --help `agent-device snapshot`',
+      'agent-device --version; agent-device snapshot',
+      'agent-device --version $(agent-device close)',
+      'agent-device --version --session default',
     ]) {
       expect(agentDeviceIsolationInvalidReasons([{ command }], prefix)).toContain(
         'agent-device-run-session-not-applied',


### PR DESCRIPTION
## Description

A valid readiness run was rejected because `agent-device --version` was treated as an unscoped device operation.

## Solution

Allow the literal version query alongside help and executable lookups. Device commands, extra arguments and command substitutions still require isolation. This changes only benchmark validation.

## Test plan

Replayed the retained Sonnet iOS control commands: its version probe passes, while an appended unscoped close still fails. Regression cases also cover unscoped snapshots, extra arguments and command substitutions. The original transcript, timing and media remain unchanged.

Fixes #686
