### PR TITLE
fix: distinguish owned devices across worktrees

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -17,6 +17,8 @@ import { allConsolePortsAndSerials, getProject, setDevice, upsertProject } from 
 import type { DeviceRecord } from '../types.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
 import { parkSim, readParked } from '../sim-pool.ts';
+import { workspaceId } from '../paths.ts';
+import { ownedSimName } from '../sim/ios.ts';
 import { makeAdbDevices, makeChildProcess, makeConfig, makeExitingChild, makeIosSim } from './_factories.ts';
 
 type SimEntry = {
@@ -619,7 +621,88 @@ function iosExecutor(devices: SimEntry[]) {
 }
 
 describe('ensureOwnedDevice: ios', () => {
-  test('adopts a matching parked simulator and resets it inside the deferred boot', async () => {
+  test('concurrent allocations disambiguate names after truncation and preserve the suffix on reuse', async () => {
+    const roots = [projectDir(), projectDir()];
+    const label = 'same-worktree-name-'.repeat(5);
+    const { exec } = iosExecutor([]);
+    let nextUdid = 0;
+    setExecutor({
+      ...exec,
+      run(cmd: string) {
+        if (cmd.includes('simctl create')) return `CREATED-${++nextUdid}`;
+        return exec.run(cmd);
+      },
+    });
+    try {
+      const devices = await Promise.all(
+        roots.map((root) =>
+          ensureOwnedDevice({
+            platform: 'ios',
+            projectPath: root,
+            label,
+            settings: {},
+          }),
+        ),
+      );
+      await Promise.all(devices.map((device) => device.booting?.done));
+      expect(devices[0]?.deviceName).toBe(ownedSimName(label, { model: 'iPhone 17 Pro', runtime: '26.2' }));
+      expect(devices[1]?.deviceName).not.toBe(devices[0]?.deviceName);
+      expect(devices[1]?.deviceName).toContain(` ${workspaceId(roots[1]!)}`);
+      for (const device of devices) expect(device.deviceName!.length).toBeLessThanOrEqual(60);
+      const listed = devices.map((device) => ({
+        udid: device.deviceUdid!,
+        name: device.deviceName!,
+        state: 'Booted',
+        isAvailable: true,
+        deviceTypeIdentifier: TYPE_17_PRO.identifier,
+      }));
+      const reuse = iosExecutor(listed);
+      setExecutor(reuse.exec);
+      const second = await ensureOwnedDevice({
+        platform: 'ios',
+        projectPath: roots[1]!,
+        project: getProject(roots[1]!),
+        label,
+        settings: {},
+      });
+      expect(second.deviceName).toBe(devices[1]?.deviceName);
+      expect(reuse.files.some((call) => call.includes('rename'))).toBe(false);
+    } finally {
+      for (const root of roots) rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each(['unavailable', 'parked'])('creation avoids a name held by a %s simulator', async (source) => {
+    const root = projectDir();
+    const name = 'stim-app (iPhone 17 Pro 26.2)';
+    try {
+      if (source === 'parked')
+        parkSim({
+          platform: 'ios',
+          projectPath: root,
+          max: 1,
+          record: {
+            udid: 'OTHER',
+            name,
+            deviceTypeIdentifier: TYPE_16.identifier,
+            runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+            parkedAt: '2026-09-01T10:00:00.000Z',
+            simslimManaged: false,
+          },
+        });
+      const { exec } = iosExecutor(
+        source === 'unavailable' ? [{ udid: 'OTHER', name, state: 'Shutdown', isAvailable: false }] : [],
+      );
+      setExecutor(exec);
+      const device = await ensureOwnedDevice({ platform: 'ios', projectPath: root, label: 'app', settings: {} });
+      await device.booting?.done;
+      expect(device.deviceName).toBe(`${name} ${workspaceId(root)}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each([false, true])('adopts and resets a matching parked simulator (name collision: %s)', async (collision) => {
     const root = projectDir();
     process.env.STIM_POOL_IOS_PARKED_MAX = '3';
     try {
@@ -637,7 +720,7 @@ describe('ensureOwnedDevice: ios', () => {
           cacheKey: 'fingerprint-debug-sim',
         },
       });
-      const { run, files, exec } = iosExecutor([
+      const devices = [
         {
           udid: 'U1',
           name: 'stim-parked (iPhone 17 Pro 26.2) u1',
@@ -645,7 +728,17 @@ describe('ensureOwnedDevice: ios', () => {
           isAvailable: true,
           deviceTypeIdentifier: TYPE_17_PRO.identifier,
         },
-      ]);
+      ];
+      if (collision)
+        devices.push({
+          udid: 'OTHER',
+          name: 'stim-app (iPhone 17 Pro 26.2)',
+          state: 'Booted',
+          isAvailable: true,
+          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+        });
+      const name = `stim-app (iPhone 17 Pro 26.2)${collision ? ` ${workspaceId(root)}` : ''}`;
+      const { run, files, exec } = iosExecutor(devices);
       setExecutor(exec);
       const device = await ensureOwnedDevice({
         platform: 'ios',
@@ -656,14 +749,14 @@ describe('ensureOwnedDevice: ios', () => {
       });
       expect(device).toMatchObject({
         deviceUdid: 'U1',
-        deviceName: 'stim-app (iPhone 17 Pro 26.2)',
+        deviceName: name,
         adopted: true,
         adoptionPending: true,
         parkedCacheKey: 'fingerprint-debug-sim',
       });
       expect(readParked('ios')).toEqual([]);
       expect(run).toContain('xcrun simctl boot U1');
-      expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', 'stim-app (iPhone 17 Pro 26.2)']);
+      expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', name]);
       expect(files.some((call) => call.includes('privacy'))).toBe(false);
       await device.booting?.done;
       expect(files).toContainEqual(['xcrun', 'simctl', 'privacy', 'U1', 'reset', 'all']);

--- a/packages/stim-cli/src/__tests__/project.test.ts
+++ b/packages/stim-cli/src/__tests__/project.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve, join } from 'path';
 import {
@@ -10,12 +10,44 @@ import {
   detectAndroidPackage,
   resolveRegisteredProject,
   projectShortcut,
+  ownedDeviceLabel,
 } from '../project.ts';
 import { upsertProject, getProject } from '../config.ts';
+import { getExecutor } from '../exec.ts';
 
 const FIXTURES = resolve(import.meta.dirname, 'fixtures');
 const EXPO_PROJ = join(FIXTURES, 'sample-expo-project');
 const BARE_PROJ = join(FIXTURES, 'sample-bare-project');
+
+test('owned device labels distinguish worktrees and apps, collapse equal basenames, and resolve symlinks', () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'stim-labels-')));
+  const main = join(tmp, 'My.App');
+  const worktree = join(tmp, 'pr6460');
+  const git = (cwd: string, ...args: string[]) => getExecutor().runFile('git', ['-C', cwd, ...args]);
+  try {
+    mkdirSync(main);
+    git(main, 'init');
+    git(main, 'config', 'commit.gpgsign', 'false');
+    git(main, '-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '--allow-empty', '-m', 'init');
+    git(main, 'worktree', 'add', '-b', 'review', worktree);
+    const app = join(worktree, 'apps', 'tlon-mobile');
+    const otherApp = join(worktree, 'apps', 'tlon-desktop');
+    const mainApp = join(main, 'apps', 'tlon-mobile');
+    for (const root of [app, otherApp, mainApp]) mkdirSync(root, { recursive: true });
+    const alias = join(tmp, 'alias');
+    symlinkSync(app, alias);
+    expect(ownedDeviceLabel(main)).toBe('My.App');
+    expect(ownedDeviceLabel(app)).toBe('pr6460-tlon-mobile');
+    expect(ownedDeviceLabel(otherApp)).toBe('pr6460-tlon-desktop');
+    expect(ownedDeviceLabel(mainApp)).toBe('My.App-tlon-mobile');
+    expect(ownedDeviceLabel(alias)).toBe(ownedDeviceLabel(app));
+    const standalone = join(tmp, '@Standalone App');
+    mkdirSync(standalone);
+    expect(ownedDeviceLabel(standalone)).toBe('@Standalone App');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
 
 test('findProjectRoot walks up from cwd to find package.json', () => {
   const nested = join(EXPO_PROJ, 'src');

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -967,7 +967,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         project,
         projectPath: root,
         settingsRoot,
-        label,
         settings,
         flags: { systemImage },
         note: out,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -566,7 +566,6 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         project: proj,
         projectPath: root,
         settingsRoot: root,
-        label,
         settings,
         flags: { deviceType, runtime },
         note,

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -1,9 +1,12 @@
 import chalk from 'chalk';
 import { randomUUID } from 'node:crypto';
 import { phaseLine } from '../command-output.ts';
+import { ownedDeviceLabel } from '../project.ts';
+import { workspaceId } from '../paths.ts';
 import {
   allConsolePortsAndSerials,
   clearDevice,
+  getConfigDir,
   loadConfig,
   releaseAndroidConsolePort,
   saveConfig,
@@ -54,6 +57,7 @@ import {
 import { androidAvdConfigSetting, androidDataPartitionSizeGbSetting, iosSimSlimProfileSetting } from '../settings.ts';
 import { teardownOwnedAvd, teardownParkedAvd, teardownParkedIosSim } from '../teardown.ts';
 import { reconcileSimSlim } from './simslim.ts';
+import { withWorkspaceProcessLock } from './workspace-process-lock.ts';
 
 export interface OwnedDeviceRecord {
   deviceUdid?: string;
@@ -138,7 +142,7 @@ export async function ensureOwnedDevice({
   project,
   projectPath,
   settingsRoot = projectPath,
-  label,
+  label = ownedDeviceLabel(projectPath),
   settings,
   flags = {},
   note = () => {},
@@ -153,7 +157,7 @@ export async function ensureOwnedDevice({
   project?: ProjectRecord | null;
   projectPath: string;
   settingsRoot?: string;
-  label: string;
+  label?: string;
   settings: DeviceSettings;
   flags?: DeviceFlags;
   note?: Notify;
@@ -239,7 +243,7 @@ async function ensureOwnedIosDevice({
           model: deviceTypes.find((d) => d.identifier === sim.deviceTypeIdentifier)?.name ?? null,
           runtime: parseRuntimeVersion(sim.runtime),
         };
-        const name = renameToOwnedName(sim, label, model);
+        const name = await withIosDeviceNameLock(() => renameToOwnedName(sim, label, model, projectPath));
         const updated = {
           deviceUdid: sim.udid,
           owned: true,
@@ -294,7 +298,10 @@ async function ensureOwnedIosDevice({
     runtime: flags.runtime || settings.ios?.runtime,
   });
 
-  const adopted = parkedMaxSetting('ios').max > 0 ? takeParkedIosSim({ projectPath, label, choice, out }) : null;
+  const adopted =
+    parkedMaxSetting('ios').max > 0
+      ? await withIosDeviceNameLock(() => takeParkedIosSim({ projectPath, label, choice, out }))
+      : null;
   if (adopted) {
     out(chalk.dim(phaseLine('device', `booting ${adopted.deviceName} (${adopted.deviceUdid})`)));
     const booting = startIosBoot(adopted.deviceUdid, async () => {
@@ -310,13 +317,13 @@ async function ensureOwnedIosDevice({
     return { ...adopted, booting, deviceType: choice.deviceType, runtime: choice.runtime };
   }
 
-  const created = createOwnedIosSim(
-    label,
-    { deviceType: flags.deviceType || settings.ios?.deviceType, runtime: flags.runtime || settings.ios?.runtime },
-    choice,
-  );
+  const created = await withIosDeviceNameLock(() => {
+    const suffix = ownedIosNameSuffix(label, { model: choice.deviceType, runtime: choice.runtime }, projectPath);
+    const result = createOwnedIosSim(label, { suffix }, choice);
+    setDevice(projectPath, 'ios', { deviceUdid: result.udid, owned: true, deviceName: result.name });
+    return result;
+  });
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
-  setDevice(projectPath, 'ios', newRecord);
   const booting = startIosBoot(created.udid, () =>
     configureOwnedIosSim({
       record: newRecord,
@@ -335,8 +342,32 @@ async function ensureOwnedIosDevice({
   };
 }
 
-function renameToOwnedName(sim: SimRecord, label: string, model: SimModel): string {
-  const wanted = ownedSimName(label, model);
+function withIosDeviceNameLock<T>(fn: () => T): Promise<T> {
+  return withWorkspaceProcessLock(getConfigDir(), 'ios-device-names', async () => fn(), { external: true });
+}
+
+function ownedIosNameSuffix(label: string, model: SimModel, projectPath: string, udid?: string): string {
+  const names = new Set(
+    listAllIosSims({ includeUnavailable: true })
+      .filter((sim) => sim.udid !== udid)
+      .map((sim) => sim.name),
+  );
+  for (const project of Object.values(loadConfig()?.projects ?? {})) {
+    const record = project.platforms?.ios;
+    if (record?.deviceUdid !== udid && record?.deviceName) names.add(record.deviceName);
+  }
+  for (const parked of readParked('ios')) {
+    if (parked.udid !== udid) names.add(parked.name);
+  }
+  let suffix = '';
+  for (let attempt = 0; names.has(ownedSimName(label, model, suffix)); attempt++) {
+    suffix = ` ${workspaceId(projectPath)}${attempt ? `-${attempt}` : ''}`;
+  }
+  return suffix;
+}
+
+function renameToOwnedName(sim: SimRecord, label: string, model: SimModel, projectPath: string): string {
+  const wanted = ownedSimName(label, model, ownedIosNameSuffix(label, model, projectPath, sim.udid));
   if (sim.name === wanted) return wanted;
   try {
     renameIosSim(sim.udid, wanted);
@@ -371,7 +402,6 @@ function takeParkedIosSim({
   });
   if (candidates.length === 0) return null;
   const listed = new Map(listAllIosSims({ includeUnavailable: true }).map((sim) => [sim.udid, sim]));
-  const name = ownedSimName(label, { model: choice.deviceType, runtime: choice.runtime });
   for (const parked of candidates) {
     const sim = listed.get(parked.udid);
     if (!sim || !sim.available) {
@@ -406,6 +436,8 @@ function takeParkedIosSim({
       );
       continue;
     }
+    const model = { model: choice.deviceType, runtime: choice.runtime };
+    const name = ownedSimName(label, model, ownedIosNameSuffix(label, model, projectPath, parked.udid));
     const device = {
       deviceUdid: parked.udid,
       owned: true,

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -259,7 +259,13 @@ RULES
   - Never assume "booted" is your simulator. Other agents have theirs booted
     too.
   - Every device Stim creates or boots is one Stim created, named
-    stim-<label> (<model> <runtime>) on iOS. The exceptions are
+    stim-<label> (<model> <runtime>) on iOS. New local device labels combine
+    the git worktree directory and app directory names, e.g.
+    pr6460-tlon-mobile. Equal names collapse to one; outside git, the app
+    directory name is used. An iOS name collision adds the workspace ID
+    after the model and runtime, preserving it when the label is truncated.
+    Existing owned iOS simulators are renamed on reuse. Android keeps
+    existing and adopted AVD names. The exceptions are
     \`android --device\` and
     \`ios --device\`, which use a connected physical device Stim never
     creates, boots, or deletes.`,

--- a/packages/stim-cli/src/project.ts
+++ b/packages/stim-cli/src/project.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
 import { createRequire } from 'module';
-import { join, dirname, resolve } from 'path';
+import { basename, join, dirname, resolve } from 'path';
 import { type ProjectRecord, loadConfig, findEnclosingWorktreeRoot, getProject } from './config.ts';
+import { repoRoot } from './worktree.ts';
 
 interface PackageJson {
   scripts?: Record<string, unknown>;
@@ -56,6 +57,15 @@ export function projectShortcut(path: string, proj: ProjectRecord | null | undef
     return `${rootLabel}/${base}`;
   }
   return path.split('/').pop() || path;
+}
+
+export function ownedDeviceLabel(projectPath: string): string {
+  const app = realpathSync(projectPath);
+  const root = repoRoot(app);
+  const appLabel = basename(app);
+  if (!root) return appLabel;
+  const worktreeLabel = basename(realpathSync(root));
+  return worktreeLabel === appLabel ? appLabel : `${worktreeLabel}-${appLabel}`;
 }
 
 export function resolveRegisteredProject(arg?: string | null): ResolveResult {

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -319,9 +319,9 @@ function fitSimName(label: string, { model, runtime }: SimModel, suffix = '', pr
   return `stim-${shortLabel} (${shortModel} ${version})${suffix}`;
 }
 
-export function ownedSimName(label: string, model: SimModel = { model: null, runtime: null }): string {
+export function ownedSimName(label: string, model: SimModel = { model: null, runtime: null }, suffix = ''): string {
   const clean = sanitizeDeviceLabel(label);
-  return fitSimName(clean.startsWith('stim-') ? clean.slice('stim-'.length) : clean, model);
+  return fitSimName(clean.startsWith('stim-') ? clean.slice('stim-'.length) : clean, model, suffix);
 }
 
 export function parkedSimName(udid: string, model: SimModel): string {
@@ -357,10 +357,10 @@ export function resolveIosCreation({
 
 export function createOwnedIosSim(
   label: string,
-  { deviceType, runtime }: { deviceType?: string; runtime?: string } = {},
+  { deviceType, runtime, suffix = '' }: { deviceType?: string; runtime?: string; suffix?: string } = {},
   choice: IosCreationChoice = resolveIosCreation({ deviceType, runtime }),
 ): { udid: string; name: string; deviceType: string | null; runtime: string | null } {
-  const name = ownedSimName(label, { model: choice.deviceType, runtime: choice.runtime });
+  const name = ownedSimName(label, { model: choice.deviceType, runtime: choice.runtime }, suffix);
   const udid = getExecutor().run(`xcrun simctl create "${name}" "${choice.deviceTypeId}" "${choice.runtimeId}"`).trim();
   return { udid, name, deviceType: choice.deviceType, runtime: choice.runtime };
 }


### PR DESCRIPTION
## Description

Worktrees of the same app currently get identical iOS simulator names, making name-based device selection ambiguous. Local device labels now combine the worktree and app directory names:

```text
pr6460/apps/tlon-mobile            -> stim-pr6460-tlon-mobile (iPhone 17 26.5)
login-button-test/apps/tlon-mobile -> stim-login-button-test-tlon-mobile (iPhone 17 26.5)
myapp/                            -> stim-myapp (iPhone 17 26.5)
```

## Solution

Basenames keep their existing casing and punctuation (`My.App` stays `My.App`). If the formatted iOS name still collides, append the workspace ID after the model and runtime so truncation cannot remove it. Creation, reuse, and parked adoption share the existing process-held lock to prevent concurrent name assignments. Booting remains outside that lock. New Android AVDs use the same readable labels; existing and adopted AVD names stay unchanged.

## Test plan

- Regression coverage uses real git worktrees and a symlink; checks separate apps, equal basenames, and directories outside git. Device tests cover concurrent allocations, truncation, unavailable and parked names, adoption, and reuse.
- Real `simctl` on iOS 26.5 verified the three names above and a 60-character rename retaining the workspace ID. Calls had 30-second timeouts; all three disposable simulators were deleted through Stim teardown, without booting or building an app.

Fixes #684.
