### PR TITLE
fix: tolerate unavailable iPhones in the live probe test

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -698,6 +698,7 @@ describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as b
     if (!connected) return;
     const executor = getExecutor();
     let failure = '';
+    let timedOut = false;
     let probedUdid: string | undefined;
     const pid = iosDeviceProcess(
       { udid: connected.udid, appName: 'NoSuchAppStimWouldEverBuild' },
@@ -709,8 +710,9 @@ describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as b
             try {
               return executor.runFile(file, args, options);
             } catch (error) {
-              const failed = error as Error & { stderr?: unknown; stdout?: unknown };
+              const failed = error as Error & { stderr?: unknown; stdout?: unknown; code?: unknown };
               failure = [failed.message, failed.stderr, failed.stdout].filter(Boolean).join('\n');
+              timedOut = failed.code === 'ETIMEDOUT';
               throw error;
             }
           },
@@ -719,6 +721,7 @@ describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as b
     );
     expect(probedUdid).toBe(connected.udid);
     if (pid === undefined) {
+      if (timedOut) throw new Error(`devicectl process probe timed out\n${failure}`);
       const unavailable =
         /^ERROR: A connection to this device could not be established\. \(com\.apple\.dt\.CoreDeviceError error 4000 \(0xFA0\)\)$/m.test(
           failure,

--- a/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-ios-device.test.ts
@@ -696,7 +696,39 @@ describe('listIosDevices against a real devicectl', { skip: LIVE as unknown as b
     resetExecutor();
     const [connected] = listIosDevices();
     if (!connected) return;
-    const pid = iosDeviceProcess({ udid: connected.udid, appName: 'NoSuchAppStimWouldEverBuild' });
+    const executor = getExecutor();
+    let failure = '';
+    let probedUdid: string | undefined;
+    const pid = iosDeviceProcess(
+      { udid: connected.udid, appName: 'NoSuchAppStimWouldEverBuild' },
+      {
+        exec: {
+          ...executor,
+          runFile(file, args, options) {
+            probedUdid = args?.[args.indexOf('--device') + 1];
+            try {
+              return executor.runFile(file, args, options);
+            } catch (error) {
+              const failed = error as Error & { stderr?: unknown; stdout?: unknown };
+              failure = [failed.message, failed.stderr, failed.stdout].filter(Boolean).join('\n');
+              throw error;
+            }
+          },
+        },
+      },
+    );
+    expect(probedUdid).toBe(connected.udid);
+    if (pid === undefined) {
+      const unavailable =
+        /^ERROR: A connection to this device could not be established\. \(com\.apple\.dt\.CoreDeviceError error 4000 \(0xFA0\)\)$/m.test(
+          failure,
+        ) ||
+        /^ERROR: CoreDeviceService was unable to locate a device matching the requested device identifier\. \(DeviceIdentifier: [^\r\n)]+\) \(com\.apple\.dt\.CoreDeviceError error 1011 \(0x3F3\)\)$/m.test(
+          failure,
+        );
+      if (iosLaunchRefusalKind(failure) !== null || unavailable) return;
+      throw new Error(failure || 'The probe failed without a devicectl error');
+    }
     expect(pid).toBe(null);
   }, 120_000);
 });


### PR DESCRIPTION
## Description

`devicectl` lists remembered iPhones that are currently unavailable. The live process-probe test treats those devices, or a locked phone, as a broken probe and fails `pnpm test`.

## Solution

Accept existing classified launch refusals and the exact CoreDevice message/code pairs observed here: 4000 for an unavailable connection and 1011 for a device that cannot be found. Verify that the command receives the selected UDID before accepting any refusal. Unknown errors, child-process timeouts, and missing output still fail; production code and command arguments are unchanged.

## Test plan

- `pnpm test packages/stim-cli/src/__tests__/engine-ios-device.test.ts`: 50 passed with real `devicectl` enabled and an isolated `TMPDIR`.
- Full `pnpm test`: 124 files passed, 3,892 tests passed, 1 skipped.
- A temporary executable fixture covered successful probes, recognized refusals on stdout/stderr, malformed errors, timeouts, missing output, and incorrect arguments or UDIDs.
- `pnpm run format:check`, `pnpm run lint`, `pnpm run build`, `pnpm run typecheck`, `pnpm run knip`, and `pnpm run test:runtime` passed.

Fixes #631
