### PR TITLE
fix: preserve compiler cache statistics after launch failures

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -1181,7 +1181,8 @@ describe('a cache miss', () => {
     expect(options[0]?.ccache).toBe(setup);
     assert(result.facts);
     expect(result.facts.ccache).toEqual({ status: 'reported', hits: 176, misses: 204, hitRatePercent: 46.3 });
-    expect(h.stdout.join('\n')).toMatch(/^ {2}compilation cache 176 hits \/ 204 misses \(46\.3%\)$/m);
+    expect(h.stderr).toContain(phaseLine('cache', 'compilation cache 176 hits / 204 misses (46.3%)'));
+    expect(h.stdout.join('\n')).not.toContain('compilation cache');
   });
 
   test('builds only the ABI selected for an owned emulator and scopes the cache key', async () => {
@@ -1248,7 +1249,7 @@ describe('a cache miss', () => {
     });
     const result = await h.run();
     expect(result.ok).toBe(true);
-    expect(labelled(h.stderr, 'cache')[0]).toMatch(/disk full/);
+    expect(labelled(h.stderr, 'cache')).toContainEqual(expect.stringMatching(/disk full/));
   });
 
   test('an Expo project with no android/ prebuilds first, then builds', async () => {
@@ -1711,8 +1712,9 @@ describe('the other refusals', () => {
     expect(readState().lastBuild.errorCode).toBe(PREBUILD_ERROR);
   });
 
-  test('an install failure is reported with the device in the remedy', async () => {
+  test.each([false, true])('an install failure preserves completed cache statistics (json: %s)', async (json) => {
     const h = harness({
+      json,
       install: () => ({
         failed: true,
         code: 'STIM_INSTALL_FAILED',
@@ -1725,14 +1727,31 @@ describe('the other refusals', () => {
     expect(result.error.code).toBe('STIM_INSTALL_FAILED');
     expect(result.error.remedy).toMatch(/emulator-5584/);
     expect(readState().lastBuild.errorCode).toBe('STIM_INSTALL_FAILED');
+    expect(h.stderr).toContain(phaseLine('cache', 'compilation cache 176 hits / 204 misses (46.3%)'));
+    expect(h.stdout).toHaveLength(json ? 1 : 0);
+    expect(json ? JSON.parse(h.stdout[0]!).ccache : undefined).toEqual(
+      json ? { status: 'reported', hits: 176, misses: 204, hitRatePercent: 46.3 } : undefined,
+    );
   });
 
-  test('a launch failure is reported after a successful install', async () => {
-    const h = harness({ launch: () => ({ failed: true, code: 'STIM_LAUNCH_FAILED', reason: 'am start failed' }) });
+  test('a launch failure preserves cache statistics already printed before install', async () => {
+    const h = harness({
+      json: true,
+      install: () => {
+        expect(h.stderr).toContain(phaseLine('cache', 'compilation cache 176 hits / 204 misses (46.3%)'));
+        return { ok: true };
+      },
+      launch: () => ({ failed: true, code: 'STIM_LAUNCH_FAILED', reason: 'am start failed' }),
+    });
     const result = await h.run();
     assert(result.error);
     expect(result.error.code).toBe('STIM_LAUNCH_FAILED');
     expect(readState().lastBuild.status).toBe('failed');
+    expect(h.stdout).toHaveLength(1);
+    expect(JSON.parse(h.stdout[0]!)).toMatchObject({
+      code: 'STIM_LAUNCH_FAILED',
+      ccache: { status: 'reported', hits: 176, misses: 204, hitRatePercent: 46.3 },
+    });
   });
 });
 
@@ -1756,12 +1775,20 @@ describe('a failed build', () => {
   });
 
   test('prints the extracted diagnostic and the log path, never the transcript', async () => {
-    const h = harness({ build: failingBuild, install: never('the install') });
+    const ccache = { status: 'reported' as const, hits: 176, misses: 204, hitRatePercent: 46.3 };
+    const h = harness({
+      json: true,
+      build: async () => ({ ...(await failingBuild()), ccache }),
+      install: never('the install'),
+    });
     const result = await h.run();
 
     expect(result.ok).toBe(false);
     assert(result.error);
     expect(result.error.code).toBe(BUILD_ERROR);
+    expect(h.stdout).toHaveLength(1);
+    expect(JSON.parse(h.stdout[0]!).ccache).toEqual(ccache);
+    expect(h.stderr).toContain(phaseLine('cache', 'compilation cache 176 hits / 204 misses (46.3%)'));
     expect(labelled(h.stderr, 'build')[0]).toMatch(/compiling debug with Gradle/);
     expect(labelled(h.stderr, 'build')[1]).toMatch(/FAILED after 2m41s/);
     const errors = labelled(h.stderr, 'error');
@@ -1838,7 +1865,9 @@ describe('the remote cache', () => {
     expect(result.ok).toBe(true);
     expect(h.calls.resolveRemoteBuild.length).toBe(0);
     expect(h.calls.uploadRemoteBuild.length).toBe(0);
-    expect(labelled(h.stderr, 'cache').length).toBe(0);
+    expect(labelled(h.stderr, 'cache')).toEqual([
+      phaseLine('cache', 'compilation cache 176 hits / 204 misses (46.3%)'),
+    ]);
   });
 
   test('a remote HIT is stored into the local cache and installed, without building', async () => {

--- a/packages/stim-cli/src/__tests__/engine-gradle.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-gradle.test.ts
@@ -726,7 +726,7 @@ describe('buildAndroid', () => {
     expect(beats.length).toBe(settled);
   });
 
-  test('ccache opts into the packaged PCH policy, forwards its environment, and reads fresh statistics', async () => {
+  test.each([0, 1])('keeps fresh ccache statistics on success or failure (exit: %s)', async (exitCode) => {
     makeAndroidProject();
     const statsLog = join(root, 'logs', 'ccache-stats.log');
     mkdirSync(join(root, 'logs'), { recursive: true });
@@ -749,7 +749,7 @@ describe('buildAndroid', () => {
           envs.push(opts.env as NodeJS.ProcessEnv);
           expect(existsSync(statsLog)).toBe(false);
           return fakeChild({
-            lines: ['BUILD SUCCESSFUL in 3s'],
+            code: exitCode,
             onExit: () => {
               writeFileSync(statsLog, ['# a.cpp', 'direct_cache_hit', '# b.cpp', 'cache_miss'].join('\n'));
               writeApk();
@@ -759,7 +759,7 @@ describe('buildAndroid', () => {
         onNote: (line) => notes.push(line),
       },
     );
-    expect((result as BuildAndroidResultLike).ok).toBe(true);
+    expect(Boolean(result.failed)).toBe(exitCode !== 0);
     const spawnEnv = envs[0];
     assert(spawnEnv);
     expect(spawnEnv.CMAKE_CXX_COMPILER_LAUNCHER).toBe('/opt/homebrew/bin/ccache');

--- a/packages/stim-cli/src/__tests__/engine-xcode.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-xcode.test.ts
@@ -1152,7 +1152,7 @@ describe('buildIos with a mocked executor', () => {
     await promise;
   });
 
-  test('streams and returns the Xcode compilation-cache summary', async () => {
+  test.each([0, 65])('keeps Xcode cache statistics on success or failure (exit: %s)', async (exitCode) => {
     const child = fakeChild();
     harness(tmp, { child });
     const writer = recordingWriter();
@@ -1169,7 +1169,7 @@ describe('buildIos with a mocked executor', () => {
 
     child.stdout.emit('data', 'CompilationCacheMetrics\nnote: 1394 hits / 1520 cacheable tasks (91.7%)\n');
     makeProduct(dd);
-    child.emit('close', 0, null);
+    child.emit('close', exitCode, null);
     const result = asResult(await promise);
 
     expect(result.compilationCache).toEqual({
@@ -1178,7 +1178,8 @@ describe('buildIos with a mocked executor', () => {
       cacheableTasks: 1520,
       hitRatePercent: 91.7,
     });
-    expect(notes).toEqual(['  cache       compilation cache 1394/1520 hits (91.7%)']);
+    expect(notes).toEqual([]);
+    expect(Boolean(result.failed)).toBe(exitCode !== 0);
     expect(writer.records).toContainEqual(
       expect.objectContaining({
         event: 'compilation_cache',

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -161,6 +161,14 @@ test('the lifecycle topic grids every label the output vocabulary allows, and no
   );
 });
 
+test('native-build cache fields are documented in the JSON failure contract', () => {
+  const body = renderSection('facts', 'payloads');
+  assert(body);
+  const failure = body.slice(body.indexOf('ON FAILURE'), body.indexOf('RULES'));
+  expect(failure).toContain('`ccache`');
+  expect(failure).toContain('`compilationCache`');
+});
+
 test('an unknown topic renders nothing rather than throwing', () => {
   expect(renderTopic('nope')).toBe(null);
   expect(renderSection('nope', 'anything')).toBe(null);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1233,7 +1233,9 @@ describe('the remote cache', () => {
     expect(exitCode).toBe(null);
     expect(!calls.order.includes('resolveRemote')).toBeTruthy();
     expect(!calls.order.includes('uploadRemote')).toBeTruthy();
-    expect(!/cache/.test(errs.join('\n'))).toBeTruthy();
+    expect(errs.filter((line) => /cache/.test(line))).toEqual([
+      phaseLine('cache', 'compilation cache unavailable; Xcode did not report reliable statistics'),
+    ]);
   });
 
   test('a remote HIT is stored into the local cache and installed, without building', async () => {
@@ -1919,6 +1921,7 @@ describe('pods', () => {
 describe('failure output', () => {
   test('a failed build prints the extracted diagnostics and the log path, never the transcript', async () => {
     reserve();
+    const compilationCache = { status: 'reported' as const, hits: 1394, cacheableTasks: 1520, hitRatePercent: 91.7 };
     const { errs, logs, exitCode } = await run(
       { json: true },
       {
@@ -1928,6 +1931,7 @@ describe('failure output', () => {
           durationMs: 161000,
           truncated: 3,
           exitCode: 65,
+          compilationCache,
           diagnostics: [
             { file: '/w/ios/AppDelegate.mm', line: 12, column: 4, message: "use of undeclared identifier 'foo'" },
             {
@@ -1943,6 +1947,8 @@ describe('failure output', () => {
     expect(logs.length).toBe(1);
     const payload = parseFirst(logs);
     expect(payload.code).toBe('STIM_BUILD_FAILED');
+    expect(payload.compilationCache).toEqual(compilationCache);
+    expect(errs).toContain(phaseLine('cache', 'compilation cache 1394/1520 hits (91.7%)'));
     expect(payload.message).toMatch(/xcodebuild` failed/);
     expect(payload.message).toMatch(/exit code 65/);
     expect(payload.remedy).toBeTruthy();
@@ -1962,6 +1968,7 @@ describe('failure output', () => {
     expect(logs.length).toBe(1);
     const payload = parseFirst(logs);
     expect(payload.code).toBe('STIM_NO_METRO');
+    expect(payload).not.toHaveProperty('compilationCache');
     expect(payload.message).toMatch(/no dev server/);
     expect(payload.remedy).toMatch(/stim start/);
   });
@@ -2031,11 +2038,17 @@ describe('failure output', () => {
     expect(errs.join('\n')).toMatch(/STIM_NO_DEVICE/);
   });
 
-  test('a failed install is reported with its own code and a failed record', async () => {
+  test.each([false, true])('a failed install preserves completed cache statistics (json: %s)', async (json) => {
     reserve();
-    const { errs, exitCode } = await run(
-      {},
+    const compilationCache = { status: 'reported' as const, hits: 1394, cacheableTasks: 1520, hitRatePercent: 91.7 };
+    const { errs, logs, exitCode } = await run(
+      { json },
       {
+        buildIos: async () => ({
+          appPath: join(root, 'build', 'Fixture.app'),
+          bundleId: 'com.example.app',
+          compilationCache,
+        }),
         installIosApp: () => ({ failed: true, code: 'STIM_INSTALL_FAILED', reason: 'simctl install failed' }),
       },
     );
@@ -2044,13 +2057,27 @@ describe('failure output', () => {
     const stateAfterInstall = readWorkspaceState(root);
     assert(stateAfterInstall?.lastBuild);
     expect(stateAfterInstall.lastBuild.errorCode).toBe('STIM_INSTALL_FAILED');
+    expect(errs).toContain(phaseLine('cache', 'compilation cache 1394/1520 hits (91.7%)'));
+    expect(logs).toHaveLength(json ? 1 : 0);
+    expect(json ? parseFirst(logs).compilationCache : undefined).toEqual(json ? compilationCache : undefined);
   });
 });
 
 describe('success output', () => {
   test('the phase lines stream on stderr and the final stdout block has complete agent facts', async () => {
     reserve();
-    const { logs, errs, exitCode } = await run({});
+    const compilationCache = { status: 'reported' as const, hits: 1394, cacheableTasks: 1520, hitRatePercent: 91.7 };
+    const { logs, errs, exitCode } = await run(
+      {},
+      {
+        buildIos: async () => ({
+          appPath: join(root, 'build', 'Fixture.app'),
+          bundleId: 'com.example.app',
+          durationMs: 161000,
+          compilationCache,
+        }),
+      },
+    );
     expect(exitCode).toBe(null);
     expect(logs.length).toBe(1);
     expect(logs[0]).toMatch(/^OK: com\.example\.app on stim-fixture \(BF2A\.\.\), Metro port 8082/);
@@ -2058,7 +2085,10 @@ describe('success output', () => {
     expect(logs[0]).toContain(phaseLine('app', 'com.example.app'));
     expect(logs[0]).toContain(phaseLine('metro', 'running on port 8082'));
     expect(logs[0]).toContain(phaseLine('cache', 'built'));
-    expect(logs[0]).toContain(phaseLine('compilation cache', 'unavailable; Xcode did not report reliable statistics'));
+    expect(errs.filter((line) => line.includes('compilation cache'))).toEqual([
+      phaseLine('cache', 'compilation cache 1394/1520 hits (91.7%)'),
+    ]);
+    expect(logs[0]).not.toContain('compilation cache');
     expect(logs[0]).toContain(phaseLine('logs', workspaceLogsDir(root)));
     const text = errs.join('\n');
     expect(text).toMatch(/^  device {6}stim-fixture \(BF2A\.\.\) booted \(\d+ms\)$/m);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -126,7 +126,7 @@ import { detectProviders } from '../engine/metro-reach.ts';
 import { selectFromPool } from '../engine/device-pool.ts';
 import { needsPrebuild, runPrebuild } from '../engine/prebuild.ts';
 import { buildAndroid, productFlavorRefusal, readProductFlavors } from '../engine/gradle.ts';
-import { CCACHE_NOT_RUN, CCACHE_UNAVAILABLE, resolveCcache } from '../engine/ccache.ts';
+import { CCACHE_NOT_RUN, CCACHE_UNAVAILABLE, ccacheActivityLine, resolveCcache } from '../engine/ccache.ts';
 import { resolveAndroidCas } from '../engine/android-cas.ts';
 import { swapApkBundle, resolveKeystore } from '../engine/apk-swap.ts';
 import { captureAssetManifest } from '../engine/asset-manifest.ts';
@@ -677,6 +677,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   });
   const recordRun = stats.record;
 
+  let ccacheActivity: CcacheActivity = CCACHE_NOT_RUN;
+
   const fail = (
     code: string | undefined,
     message?: string | null,
@@ -702,7 +704,15 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     if (logPath) out(phaseLine('log', logPath));
     recordRun({ failed: true, durationMs: now() - started });
     if (json) {
-      emit(JSON.stringify({ code, message, remedy: remedy ?? null, ...(lease === undefined ? {} : { lease }) }));
+      emit(
+        JSON.stringify({
+          code,
+          message,
+          remedy: remedy ?? null,
+          ...(ccacheActivity.status === 'not-run' ? {} : { ccache: ccacheActivity }),
+          ...(lease === undefined ? {} : { lease }),
+        }),
+      );
     }
     writer.close();
     return { ok: false, error: { code, message, remedy: remedy ?? null } };
@@ -1072,7 +1082,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let storeKey = '';
   let storeSources: FingerprintSource[] = [];
   let apkPath: string | null = null;
-  let ccacheActivity: CcacheActivity = CCACHE_NOT_RUN;
 
   async function resolveInitialFingerprint(): Promise<boolean> {
     const fingerprintTimer = stepTimer(now);
@@ -1430,6 +1439,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
               },
             );
             ccacheActivity = built.ccache ?? CCACHE_UNAVAILABLE;
+            phase('cache', `compilation cache ${ccacheActivityLine(ccacheActivity)}`);
             if (built.failed) {
               const diagnostics = built.diagnostics || [];
               for (const diag of diagnostics) {

--- a/packages/stim-cli/src/commands/android/result.ts
+++ b/packages/stim-cli/src/commands/android/result.ts
@@ -269,7 +269,7 @@ export function reportAndroidResult({
         phaseLine('app', androidPackage),
         phaseLine('metro', metroResult),
         phaseLine('cache', cacheResult),
-        phaseLine('compilation cache', ccacheActivityLine(ccache)),
+        ...(ccache.status === 'not-run' ? [phaseLine('compilation cache', ccacheActivityLine(ccache))] : []),
         phaseLine('logs', logsDir || 'unavailable (remote device)'),
       ].join('\n'),
     );

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -77,7 +77,11 @@ import {
   type LoadProjectProviderResult,
 } from '../engine/remote-cache.ts';
 import { createRunRecorder, statsProjectKey, type RunEstimates } from '../engine/stats.ts';
-import { COMPILATION_CACHE_NOT_RUN, COMPILATION_CACHE_UNAVAILABLE } from '../engine/xcode.ts';
+import {
+  COMPILATION_CACHE_NOT_RUN,
+  COMPILATION_CACHE_UNAVAILABLE,
+  compilationCacheActivityLine,
+} from '../engine/xcode.ts';
 import type { NdjsonWriter } from '../ndjson.ts';
 import { workspaceDir, workspaceLogsDir } from '../paths.ts';
 import { appProjectProblem } from '../project.ts';
@@ -320,6 +324,8 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   });
   const recordRun = stats.record;
 
+  let compilationCache: CompilationCacheActivity = COMPILATION_CACHE_NOT_RUN;
+
   const fail = ({ code, message, remedy = null, lines = [], logPath = null, build = null, lease }: FailArgs): null => {
     releaseLock();
     releaseSlot();
@@ -342,6 +348,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
           code,
           message: message ?? null,
           remedy: remedy ?? null,
+          ...(compilationCache.status === 'not-run' ? {} : { compilationCache }),
           ...(lease === undefined ? {} : { lease }),
         }),
       );
@@ -600,7 +607,6 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   let appPath: string | null = null;
   let bundleId: string | null = null;
   let cacheHit: CacheHitLevel = false;
-  let compilationCache: CompilationCacheActivity = COMPILATION_CACHE_NOT_RUN;
   let remote: LoadProjectProviderResult | null = null;
   let abandonedRemote = false;
   let uploadPending: Promise<RemoteUploadLike> | null = null;
@@ -1226,6 +1232,8 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
             estimateMs: estimates().coldBuildMs,
             optimizations: optimizations.ios,
           });
+          compilationCache = result.compilationCache ?? COMPILATION_CACHE_UNAVAILABLE;
+          phase('cache', `compilation cache ${compilationCacheActivityLine(compilationCache)}`);
           if (result?.failed) {
             phase('build', `FAILED after ${formatDuration(result.durationMs)}`);
             printDiagnostics(note, result);
@@ -1239,7 +1247,6 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
             });
             return false;
           }
-          compilationCache = result.compilationCache ?? COMPILATION_CACHE_UNAVAILABLE;
           stats.setBuildMs(result.durationMs ?? 0);
           phase('build', `ok (${formatDuration(result.durationMs)})`);
           appPath = result.appPath ?? null;

--- a/packages/stim-cli/src/commands/ios/result.ts
+++ b/packages/stim-cli/src/commands/ios/result.ts
@@ -304,7 +304,9 @@ export function reportIosResult({
         phaseLine('app', bundleId),
         phaseLine('metro', metroResult),
         phaseLine('cache', cacheResult),
-        phaseLine('compilation cache', compilationCacheActivityLine(compilationCache)),
+        ...(compilationCache.status === 'not-run'
+          ? [phaseLine('compilation cache', compilationCacheActivityLine(compilationCache))]
+          : []),
         phaseLine('logs', logsDir),
       ].join('\n'),
     );

--- a/packages/stim-cli/src/engine/gradle.ts
+++ b/packages/stim-cli/src/engine/gradle.ts
@@ -585,7 +585,8 @@ export async function buildAndroid(
   const transcript = window.join('\n');
   const ccacheActivity = ccache ? readCcacheActivity(ccache.statsLog) : CCACHE_UNAVAILABLE;
 
-  if (result.error) return { ...spawnFailure(result.error, project, durationMs), lastLines: tail.slice() };
+  if (result.error)
+    return { ...spawnFailure(result.error, project, durationMs), lastLines: tail.slice(), ccache: ccacheActivity };
 
   if (result.code !== 0) {
     const how = result.signal ? `signal ${result.signal}` : `exit code ${result.code}`;
@@ -598,6 +599,7 @@ export async function buildAndroid(
       truncated,
       lastLines: tail.slice(),
       durationMs,
+      ccache: ccacheActivity,
     };
   }
 
@@ -612,6 +614,7 @@ export async function buildAndroid(
       truncated: 0,
       lastLines: located.candidates.map((c) => relative(androidDir(root), c)),
       durationMs,
+      ccache: ccacheActivity,
     };
   }
   if (!located.apkPath) {
@@ -628,6 +631,7 @@ export async function buildAndroid(
       truncated: 0,
       lastLines: tail.slice(),
       durationMs,
+      ccache: ccacheActivity,
     };
   }
   const apkPath = located.apkPath;

--- a/packages/stim-cli/src/engine/xcode.ts
+++ b/packages/stim-cli/src/engine/xcode.ts
@@ -488,6 +488,7 @@ function failedResult({
   exitCode = null,
   transcriptLines = 0,
   tail = [],
+  compilationCache = COMPILATION_CACHE_UNAVAILABLE,
 }: {
   code: string;
   diagnostics: Diagnostic[];
@@ -495,6 +496,7 @@ function failedResult({
   exitCode?: number | null;
   transcriptLines?: number;
   tail?: string[];
+  compilationCache?: CompilationCacheActivity;
 }) {
   const capped = capDiagnostics(diagnostics);
   return {
@@ -506,6 +508,7 @@ function failedResult({
     exitCode,
     transcriptLines,
     tail,
+    compilationCache,
   };
 }
 
@@ -693,7 +696,6 @@ export async function buildIos({
         cacheableTasks: activity.cacheableTasks,
         hitRatePercent: activity.hitRatePercent,
       });
-      onNote(phaseLine('cache', `compilation cache ${compilationCacheActivityLine(activity)}`));
     }
   };
 
@@ -761,6 +763,7 @@ export async function buildIos({
       durationMs,
       transcriptLines: transcript.length,
       tail: tailLines(transcript),
+      compilationCache: compilationCacheActivity,
     });
   }
 
@@ -781,6 +784,7 @@ export async function buildIos({
       exitCode: outcome.code,
       transcriptLines: transcript.length,
       tail: tailLines(transcript),
+      compilationCache: compilationCacheActivity,
     });
   }
 
@@ -848,6 +852,7 @@ export async function buildIos({
       exitCode: 0,
       transcriptLines: transcript.length,
       tail: tailLines(transcript),
+      compilationCache: compilationCacheActivity,
     });
   }
 
@@ -863,6 +868,7 @@ export async function buildIos({
       exitCode: 0,
       transcriptLines: transcript.length,
       tail: tailLines(transcript),
+      compilationCache: compilationCacheActivity,
     });
   }
 

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -249,6 +249,11 @@ ON FAILURE
 
     { "code": "STIM_NO_METRO", "message": "...", "remedy": "..." }
 
+  If a native build returned before the failure, this payload also carries
+  \`ccache\` (Android) or \`compilationCache\` (iOS), with the status and
+  counters described above. This includes failed builds and later install
+  or launch failures. The field is absent when no native build returned.
+
   Branch on \`code\`, never on the message text. \`guide errors\` enumerates
   every code.
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -244,8 +244,12 @@ result as proof instead of requiring an unrelated screenshot.`,
     storage     swap        verify      version     workspace
 
   \`app\` and \`compilation cache\` join them in the stdout block a successful
-  run ends with, and nowhere else. A line states a fact; the reason a fact
-  matters lives in this guide, not in the run output. Both platforms use the
+  run ends with. When a native build runs, its compilation-cache result is
+  printed once as a \`cache\` progress line as soon as the build returns,
+  including a failed build. It survives a later install or launch failure.
+  The stdout \`compilation cache\` line is only for an artifact-cache hit
+  (compilation did not run). A line states a fact; the reason a fact matters
+  lives in this guide, not in the run output. Both platforms use the
   same words, so \`build       ok (51.8s)\` and
   \`launch      com.example.app (2s)\` read the same on iOS and Android; the
   artifact name is in the \`--json\` payload.


### PR DESCRIPTION
## Description

Android's compiler-cache counters disappear from command output when installation or launch fails. Retrying from the artifact cache then reports only that compilation did not run. Both platforms also discard available counters from JSON failures.

Fixes #644.

## Solution

Print the measurement once on stderr when the build returns, and include available counters in JSON errors from failed builds or later install/launch steps. Remove the duplicate measurement from successful stdout summaries; artifact hits retain the `not run` line.

This relaxes the [stdout-summary rule](https://github.com/appandflow/stim/commit/e759551543e7ca0b22a29f99906ac167545bcdc7) so a later failure cannot hide a completed measurement, using the existing `cache` progress label.

## Test plan

- Command regressions verify counters survive failed builds, installation and launch, appear before installation, and do not repeat on success. JSON failures remain one payload.
- Build-engine regressions preserve counters from Xcode metrics and fresh ccache logs across successful and failed exits. Guide coverage checks the JSON failure fields.
