### PR TITLE
fix: recognize grouped benchmark iOS relaunches

### DIFF
--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -44,6 +44,23 @@ function completedStepCommand(command, arm) {
   return /[&|]\s*$/.test(body) ? '' : (shellCommandSegments(body).at(-1) ?? '');
 }
 
+function iosRelaunchGroup(command, output) {
+  const binding = /^([A-Za-z_]\w*)=([A-Fa-f0-9-]{36});\s*([\s\S]+)$/.exec(command);
+  if (!binding) return false;
+  const device = `\\$${binding[1]}(?![A-Za-z0-9_])`;
+  const group = new RegExp(
+    `^\\{\\s*xcrun simctl terminate ${device} ([\\w.]+) 2>/dev/null;\\s*` +
+      `xcrun simctl launch ${device} \\1 && sleep \\d+ && ` +
+      `xcrun simctl openurl ${device} "[^"$\x60\\\\\\n]+" && echo "([A-Z_]+)";\\s*\\}\\s*$`,
+  ).exec(binding[3]);
+  if (!group) return false;
+  const lines = String(output ?? '').split('\n');
+  return (
+    lines.some((line) => new RegExp(`^${group[1].replaceAll('.', '\\.')}: \\d+$`).test(line)) &&
+    lines.includes(group[2])
+  );
+}
+
 function successfulLaunch(command, arm, platform) {
   if (!successful(command)) return false;
   const value = shellCommand(command.command);
@@ -75,8 +92,9 @@ function successfulLaunch(command, arm, platform) {
   const group = /^\{\s*([\s\S]*?);\s*\}$/.exec(launch);
   const launches = group ? shellCommandSegments(group[1]) : [launch];
   return (
-    launches.length > 0 &&
-    launches.every((entry) => launchCommand(entry, arm, platform) && !/[;&\n$`]/.test(entry)) &&
+    ((arm === 'control' && platform === 'ios' && iosRelaunchGroup(launch, command.output)) ||
+      (launches.length > 0 &&
+        launches.every((entry) => launchCommand(entry, arm, platform) && !/[;&\n$`]/.test(entry)))) &&
     filters.length > 0 &&
     filters.every((filter) => /^(?:tee(?: -a)? [\w/.-]+|(?:tail|head) -(?:\d+|n \d+))\s*$/.test(filter))
   );

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -371,6 +371,33 @@ done`;
         valid: false,
         reason: 'launch-crash-initial-launch-evidence-missing',
       });
+    const relaunch = {
+      ...launch,
+      command:
+        'set -o pipefail; UDID=EA54D648-50C7-4ACC-9A69-52A07CF05B95; { xcrun simctl terminate $UDID com.appandflow.trailhead 2>/dev/null; xcrun simctl launch $UDID com.appandflow.trailhead && sleep 3 && xcrun simctl openurl $UDID "trailhead://app" && echo "LAUNCH_OK"; } 2>&1 | tee -a /tmp/native.log; echo "PIPELINE_EXIT=$?"',
+      output: 'com.appandflow.trailhead: 82652\nLAUNCH_OK\nPIPELINE_EXIT=0',
+    };
+    expect(launchCrashDiagnosis([relaunch, logs], { ...options, platform: 'ios' })).toMatchObject({
+      valid: true,
+      initialLaunchCommandId: 'launch',
+      commandId: 'logs',
+    });
+    for (const changed of [
+      { command: relaunch.command.replace('&& sleep', '; sleep') },
+      { command: relaunch.command.replace('&& echo', '; echo') },
+      { command: relaunch.command.replace('launch $UDID', 'launch $OTHER') },
+      { command: relaunch.command.replace('openurl $UDID', 'openurl $OTHER') },
+      { command: relaunch.command.replace('EA54D648-50C7-4ACC-9A69-52A07CF05B95', '$(cat /tmp/udid)') },
+      { command: relaunch.command.replace('trailhead://app', 'trailhead://$(cat /tmp/value)') },
+      { command: relaunch.command.replace('set -o pipefail', 'set +o pipefail') },
+      { output: 'com.appandflow.trailhead: 82652\nLAUNCH_OK\nPIPELINE_EXIT=1' },
+      { output: 'LAUNCH_OK\nPIPELINE_EXIT=0' },
+      { output: 'other.app: 82652\nLAUNCH_OK\nPIPELINE_EXIT=0' },
+    ])
+      expect(launchCrashDiagnosis([{ ...relaunch, ...changed }, logs], { ...options, platform: 'ios' })).toMatchObject({
+        valid: false,
+        reason: 'launch-crash-initial-launch-evidence-missing',
+      });
     const forwardedLaunch = {
       ...launch,
       command:


### PR DESCRIPTION
## Description

The crash benchmark rejected a successful control run because its simulator relaunch used a shell group with a literal UDID binding.

## Solution

Recognize the narrow terminate -> launch -> sleep -> openurl -> marker sequence. Launch and later steps must use success chaining, the same device/app, pipefail and successful status; output must include the app PID and marker. This changes benchmark analysis only.

## Test plan

Replayed the retained Opus iOS control commands: the successful relaunch is recognized, while the preceding Expo command remains failed. Regression cases reject masked failures, substitutions, mismatched devices and marker-only output.

Fixes #697
