### PR TITLE
docs: rename the main checkout to the source checkout

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -172,7 +172,7 @@ node test/e2e/native/run-cache-e2e.mjs --framework bare --platform android
 # skip the single-flight race (saves one cold compile; that check reports SKIP)
 node test/e2e/native/run-cache-e2e.mjs --framework expo --platform ios --skip-race
 
-# warm-cache parity: use a previously built disposable main checkout with matching Pods
+# warm-cache parity: use a previously built disposable source checkout with matching Pods
 node test/e2e/native/run-cache-e2e.mjs --framework expo --platform ios \
   --app-dir /tmp/my-app-fixture --summary /tmp/cache-summary.json
 

--- a/docs/field-test-protocol.md
+++ b/docs/field-test-protocol.md
@@ -88,11 +88,11 @@ cold worktree hits on its first lookup; a bare repo commits `ios/` and
 Before testing caching across worktrees, choose a commit that already contains
 the representative identifiers and native inputs. For a throwaway fixture,
 prepare and commit those inputs before declaring the baseline. Never prebuild
-or commit in a user's main checkout. Otherwise the fixture manufactures a
+or commit in a user's source checkout. Otherwise the fixture manufactures a
 transition that few users see, and the result reads as a product bug. Test the
 cold/warm split deliberately only when it is the behavior under test.
 
-For warm-cache parity, use a disposable main checkout that has completed a
+For warm-cache parity, use a disposable source checkout that has completed a
 normal native build for the tested platform and configuration, and record that
 build and its clean tracked baseline before warming linked worktrees.
 Dependency installation and native setup alone can leave first-build generated
@@ -101,7 +101,7 @@ suite's `--home`, whose dedicated caches must start empty.
 
 ## Safety rules (non-negotiable)
 
-- NEVER modify the target repo's main checkout. Worktrees only.
+- NEVER modify the target repo's source checkout. Worktrees only.
 - NEVER run `gc --delete`, `gc --delete --cache all`, or
   `gc --delete --cache <name>` without the user's explicit approval in this
   session. Bare `gc` (report) is always fine.

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -103,17 +103,17 @@ stim worktree warm
 ```
 
 If a harness already created the linked worktree, run only `stim worktree warm`
-there. Warm copies missing ignored state from main, including eligible `.env`
-and local configuration files. Existing entries are preserved; existing
-ignored directories such as `node_modules` are skipped whole.
+there. Warm copies missing ignored state from the source checkout, including
+eligible `.env` and local configuration files. Existing entries are preserved;
+existing ignored directories such as `node_modules` are skipped whole.
 
-`stim worktree warm --refresh` brings the main checkout up to date first: it
+`stim worktree warm --refresh` brings the source checkout up to date first: it
 fetches, fast-forwards whatever branch is checked out there, and installs what
-the new commits moved before copying. It refuses a main checkout it cannot move
-(uncommitted tracked changes, a rebase or merge in progress, a detached HEAD, a
-diverged branch) and never switches branches. One lock per repository keeps a
-copy from reading a `node_modules` a refresh is rewriting; plain warms still run
-side by side. A plain warm also refuses (`STIM_DEPS_INCOMPLETE`) when the last
+the new commits moved before copying. It refuses a source checkout it cannot
+move (uncommitted tracked changes, a rebase or merge in progress, a detached
+HEAD, a diverged branch) and never switches branches. One lock per repository
+keeps a copy from reading a `node_modules` a refresh is rewriting; plain warms
+still run side by side. A plain warm also refuses (`STIM_DEPS_INCOMPLETE`) when the last
 install of the lockfile on disk did not finish, instead of copying a partial
 `node_modules`; `stim worktree warm --refresh` reinstalls it.
 

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -72,9 +72,9 @@ test('checkMainCheckout reports missing dependencies, Pods, and native output', 
 
     const findings = checkMainCheckout(project, { brokenPods: [], upstream: null });
     expect(findings.map((finding) => finding.title)).toEqual([
-      'The main checkout has no installed dependencies',
-      'The main checkout CocoaPods state is missing',
-      'The main checkout has no iOS warm build output',
+      'The source checkout has no installed dependencies',
+      'The source checkout CocoaPods state is missing',
+      'The source checkout has no iOS warm build output',
     ]);
     expect(findings[0]?.fix).toMatch(/npm ci/);
     expect(findings[1]?.fix).toMatch(/pod install/);
@@ -121,9 +121,9 @@ test('checkMainCheckout says nothing about the seed when the repository has no l
 
     git('git worktree add -q --detach ../linked');
     expect(checkMainCheckout(main, { platform: 'ios' }).map((entry) => entry.title)).toEqual([
-      'The main checkout is 1 commit behind origin/main',
-      'The main checkout has 1 uncommitted tracked change',
-      'The main checkout is on feature, not the default branch main',
+      'The source checkout is 1 commit behind origin/main',
+      'The source checkout has 1 uncommitted tracked change',
+      'The source checkout is on feature, not the default branch main',
     ]);
 
     rmSync(join(base, 'linked'), { recursive: true, force: true });
@@ -145,7 +145,7 @@ test('an interrupted rebase is named instead of the dirty and detached remedies 
     git('git worktree add -q -b task ../linked');
 
     const findings = checkMainCheckout(main, { platform: 'ios' });
-    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has a rebase in progress']);
+    expect(findings.map((entry) => entry.title)).toEqual(['The source checkout has a rebase in progress']);
     expect(findings[0]?.fix).toBe(`Finish it, or run \`git -C '${main}' rebase --abort\`.`);
   } finally {
     rmSync(base, { recursive: true, force: true });
@@ -164,7 +164,7 @@ test('a tag sharing the branch name does not turn the branch into an ambiguous r
   }
 });
 
-test('seed findings are reported from inside a linked worktree, about the main checkout', () => {
+test('seed findings are reported from inside a linked worktree, about the source checkout', () => {
   const { base, main, git } = seedRepo('stim-doctor-from-worktree-');
   try {
     writeFileSync(join(main, 'README.md'), 'edited\n');
@@ -173,13 +173,13 @@ test('seed findings are reported from inside a linked worktree, about the main c
     writeFileSync(join(main, 'second.txt'), 'tracked\n');
     git('git add second.txt');
     expect(checkMainCheckout(join(base, 'linked'), { platform: 'ios' }).map((entry) => entry.title)).toEqual([
-      'The main checkout has 2 uncommitted tracked changes',
+      'The source checkout has 2 uncommitted tracked changes',
     ]);
     git('git rm -q --cached second.txt');
     rmSync(join(main, 'second.txt'));
 
     const findings = checkMainCheckout(join(base, 'linked'), { platform: 'ios' });
-    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has 1 uncommitted tracked change']);
+    expect(findings.map((entry) => entry.title)).toEqual(['The source checkout has 1 uncommitted tracked change']);
     expect(findings[0]?.level).toBe('note');
     expect(findings[0]?.detail).toContain('stim worktree warm --refresh');
     expect(findings[0]?.detail).toContain('README.md');
@@ -189,14 +189,14 @@ test('seed findings are reported from inside a linked worktree, about the main c
   }
 });
 
-test('a detached main checkout is reported, and nothing compares its missing branch to the default', () => {
+test('a detached source checkout is reported, and nothing compares its missing branch to the default', () => {
   const { base, main, git } = seedRepo('stim-doctor-detached-');
   try {
     git('git checkout -q --detach HEAD~1');
     git('git worktree add -q -b task ../linked');
 
     const findings = checkMainCheckout(main, { platform: 'ios' });
-    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has a detached HEAD']);
+    expect(findings.map((entry) => entry.title)).toEqual(['The source checkout has a detached HEAD']);
     expect(findings[0]?.detail).toContain('there is no branch to fast-forward');
     expect(findings[0]?.fix).toBe(`Run \`git -C '${main}' checkout <branch>\`.`);
   } finally {
@@ -204,7 +204,7 @@ test('a detached main checkout is reported, and nothing compares its missing bra
   }
 });
 
-test('a main checkout that is ahead of and behind its upstream is reported as diverged', () => {
+test('a source checkout that is ahead of and behind its upstream is reported as diverged', () => {
   const { base, main, git } = seedRepo('stim-doctor-diverged-');
   try {
     git('git checkout -q -B main HEAD~1');
@@ -212,7 +212,7 @@ test('a main checkout that is ahead of and behind its upstream is reported as di
     git('git worktree add -q -b task ../linked');
 
     const findings = checkMainCheckout(main, { platform: 'ios' });
-    expect(findings.map((entry) => entry.title)).toEqual(['The main checkout has diverged from origin/main']);
+    expect(findings.map((entry) => entry.title)).toEqual(['The source checkout has diverged from origin/main']);
     expect(findings[0]?.detail).toContain('main is 1 ahead of and 1 behind origin/main');
     expect(findings[0]?.detail).toContain('refuses rather than merging or resetting');
     expect(findings[0]?.fix).toBe('Rebase or merge main onto origin/main yourself.');
@@ -230,7 +230,7 @@ test('worktree.defaultBranch outranks origin/HEAD, and neither resolving stays s
     writeFileSync(join(main, '.stim.json'), JSON.stringify({ worktree: { defaultBranch: 'release' } }));
     const configured = checkMainCheckout(main, { platform: 'ios' });
     expect(configured.map((entry) => entry.title)).toEqual([
-      'The main checkout is on main, not the default branch release',
+      'The source checkout is on main, not the default branch release',
     ]);
     expect(configured[0]?.detail).toContain("carries main's dependencies");
     expect(configured[0]?.fix).toContain(`git -C '${main}' checkout release`);
@@ -320,12 +320,12 @@ test('checkMainCheckout filters native warm state and CocoaPods by platform', ()
 
     const ios = checkMainCheckout(project, { platform: 'ios', brokenPods: [], upstream: null });
     expect(ios.map((finding) => finding.title)).toEqual([
-      'The main checkout CocoaPods state is missing',
-      'The main checkout has no iOS warm build output',
+      'The source checkout CocoaPods state is missing',
+      'The source checkout has no iOS warm build output',
     ]);
 
     const android = checkMainCheckout(project, { platform: 'android', brokenPods: [], upstream: null });
-    expect(android.map((finding) => finding.title)).toEqual(['The main checkout has no Android warm build output']);
+    expect(android.map((finding) => finding.title)).toEqual(['The source checkout has no Android warm build output']);
   } finally {
     rmSync(project, { recursive: true, force: true });
   }
@@ -436,7 +436,7 @@ test('checkMainCheckout recognizes non-npm dependency installs', () => {
   }
 });
 
-test('checkMainCheckout reads warm state from the Git main checkout', () => {
+test('checkMainCheckout reads warm state from the repository source checkout', () => {
   resetExecutor();
   const base = mkdtempSync(join(tmpdir(), 'stim-doctor-main-worktree-'));
   const repo = join(base, 'repo');

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -279,7 +279,7 @@ test('the errors topic documents both codes the ownership-claim primitive raises
 test('the rendered guide carries the warm --refresh contract, not just its source', () => {
   const options = renderSection('lifecycle', 'options');
   assert(options);
-  expect(options).toMatch(/--refresh.*WRITES TO THE MAIN CHECKOUT/s);
+  expect(options).toMatch(/--refresh.*WRITES TO THE SOURCE CHECKOUT/s);
   expect(options).toContain('never switches branches');
   expect(options).toContain('keyed on the repository root');
   expect(options).toMatch(/worktree warm {4}--refresh/);

--- a/packages/stim-cli/src/__tests__/stats.test.ts
+++ b/packages/stim-cli/src/__tests__/stats.test.ts
@@ -309,7 +309,7 @@ describe('the stats file', () => {
     expect(existsSync(join(tmpHome, 'config.json'))).toBe(false);
   });
 
-  test('the project key is the app path in the main working tree, canonical', () => {
+  test('the project key is the app path in the source checkout, canonical', () => {
     const repo = realpathSync(mkdtempSync(join(tmpdir(), 'stim-repo-')));
     const worktree = join(repo, 'worktrees', 'agent-1');
 

--- a/packages/stim-cli/src/__tests__/warm-claim-unavailable.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim-unavailable.test.ts
@@ -125,7 +125,7 @@ test('a plain warm with no claim of its own refuses while a refresh holds this r
   expect(result.stderr).toMatch(
     /lock {8}unavailable \(.*\); stim worktree warm --refresh \(pid \d+\) holds this repository/,
   );
-  expect(result.stderr).toContain('Refusing to copy from a main checkout a refresh is rewriting');
+  expect(result.stderr).toContain('Refusing to copy from a source checkout a refresh is rewriting');
   expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
   expect(existsSync(join(target, '.env'))).toBe(false);
   expect(existsSync(claim)).toBe(true);

--- a/packages/stim-cli/src/__tests__/warm-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim.test.ts
@@ -356,7 +356,7 @@ test('a copy with no claim of its own reads what it would overlap before it copi
   expect(warmClaimBlockedLine('EACCES: permission denied', blocker!)).toMatch(
     /^ {2}lock {8}unavailable \(EACCES: permission denied\); stim worktree warm --refresh \(pid \d+\) holds this repository$/,
   );
-  expect(warmClaimBlockedRefusal(blocker!)).toContain('Refusing to copy from a main checkout a refresh is rewriting');
+  expect(warmClaimBlockedRefusal(blocker!)).toContain('Refusing to copy from a source checkout a refresh is rewriting');
   refresh.release();
 
   plantClaim(warmClaimPath(REPO), 'exclusive', goneClaimOwner(), { claimId: 'dead-refresh' });

--- a/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
@@ -224,7 +224,7 @@ test('the refresh decisions read off the state without touching git', () => {
   });
 });
 
-test('--refresh fast-forwards the main checkout, then copies', async () => {
+test('--refresh fast-forwards the source checkout, then copies', async () => {
   const published = fallBehind({ 'src/new.ts': 'upstream work\n' });
   write(root, '.env', 'main env');
   const result = await runWarm(target, '--refresh');
@@ -250,7 +250,7 @@ test('--refresh reports a fetch it could not run and continues with the local st
   expect(result.stderr).toMatch(/checkout {4}main 1 commit behind origin\/main -> fast-forwarded to/);
 });
 
-test('--refresh refuses a diverged main checkout without merging or resetting it', async () => {
+test('--refresh refuses a diverged source checkout without merging or resetting it', async () => {
   fallBehind({ 'src/new.ts': 'upstream work\n' });
   write(root, 'src/local.ts', 'local work\n');
   commit(root, 'local');
@@ -263,7 +263,7 @@ test('--refresh refuses a diverged main checkout without merging or resetting it
   expect(result.stderr).not.toMatch(/carry {7}complete/);
 });
 
-test('--refresh refuses a dirty main checkout and names the path, but a plain warm still copies it', async () => {
+test('--refresh refuses a dirty source checkout and names the path, but a plain warm still copies it', async () => {
   write(root, 'package.json', '{"name":"edited-in-main"}\n');
   write(root, '.env', 'main env');
   const refused = await runWarm(target, '--refresh');
@@ -283,7 +283,7 @@ test('--refresh refuses a dirty main checkout and names the path, but a plain wa
   expect(readFileSync(join(root, 'package.json'), 'utf-8')).toBe('{"name":"edited-in-main"}\n');
 });
 
-test('--refresh refuses a main checkout with a merge in progress', async () => {
+test('--refresh refuses a source checkout with a merge in progress', async () => {
   git(root, 'checkout', '-qb', 'other');
   write(root, 'package.json', '{"name":"other-side"}\n');
   commit(root, 'other side');
@@ -300,7 +300,7 @@ test('--refresh refuses a main checkout with a merge in progress', async () => {
   expect(existsSync(join(root, '.git', 'MERGE_HEAD'))).toBe(true);
 });
 
-test('--refresh refuses a detached main checkout and an untracked file is not a reason to refuse', async () => {
+test('--refresh refuses a detached source checkout and an untracked file is not a reason to refuse', async () => {
   write(root, 'untracked.txt', 'not a reason\n');
   git(root, 'checkout', '-q', '--detach');
   const result = await runWarm(target, '--refresh');
@@ -324,7 +324,7 @@ test('--refresh leaves a branch with no upstream where it is', async () => {
   expect(git(root, 'rev-parse', 'HEAD')).toBe(head);
 });
 
-test('--refresh warns when the main checkout is not on the default branch, and stays quiet when it is', async () => {
+test('--refresh warns when the source checkout is not on the default branch, and stays quiet when it is', async () => {
   const onDefault = await runWarm(target, '--refresh');
   expect(onDefault.stderr).not.toMatch(/default branch/);
 
@@ -618,7 +618,7 @@ test('--refresh installs at the repository root when upstream removed the app it
   expect(spawned).toEqual([{ cmd: 'pnpm', cwd: root }]);
 });
 
-test('--refresh refuses a main checkout whose only change is staged, with the working file back at HEAD', async () => {
+test('--refresh refuses a source checkout whose only change is staged, with the working file back at HEAD', async () => {
   write(root, 'package.json', '{"name":"staged"}\n');
   git(root, 'add', 'package.json');
   write(root, 'package.json', '{"name":"refresh-fixture"}\n');

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -339,7 +339,7 @@ afterEach(() => {
   delete process.env.STIM_HOME;
 });
 
-test('action: on the main checkout, reclaims the environment with the owned device deleted and the tree untouched', async () => {
+test('action: on the source checkout, reclaims the environment with the owned device deleted and the tree untouched', async () => {
   upsertProject(mainDir, {
     metroPort: 8081,
     platforms: { ios: { deviceUdid: 'U9', owned: true, deviceName: 'stim-main' } },
@@ -373,10 +373,10 @@ test('action: on the main checkout, reclaims the environment with the owned devi
   expect(existsSync(workspaceDir(mainDir))).toBe(false);
   expect(readFileSync(join(mainDir, 'keep.txt'), 'utf-8')).toBe('source file');
   expect(![...exec.calls.run, ...exec.calls.runQuiet].some((c) => /worktree remove/.test(c))).toBeTruthy();
-  expect(errs.join('\n')).toMatch(/working tree stays \(it is the main checkout\)/);
+  expect(errs.join('\n')).toMatch(/working tree stays \(it is the source checkout\)/);
 });
 
-test('action: a dirty main checkout still reclaims, without a refusal and without mentioning the dirt', async () => {
+test('action: a dirty source checkout still reclaims, without a refusal and without mentioning the dirt', async () => {
   upsertProject(mainDir, { metroPort: 8084 });
   writeFileSync(join(mainDir, 'uncommitted.txt'), 'not yet committed');
   const exec = makeExecutor({
@@ -406,7 +406,7 @@ test('action: a dirty main checkout still reclaims, without a refusal and withou
   expect(text).toMatch(/working tree stays/);
 });
 
-test('action: --force changes nothing on the main checkout -- reclaim only, tree stays', async () => {
+test('action: --force changes nothing on the source checkout -- reclaim only, tree stays', async () => {
   upsertProject(mainDir, { metroPort: 8085 });
   writeFileSync(join(mainDir, 'keep.txt'), 'source file');
   const exec = makeExecutor({
@@ -432,7 +432,7 @@ test('action: --force changes nothing on the main checkout -- reclaim only, tree
   expect(errs.join('\n')).toMatch(/working tree stays/);
 });
 
-test('action: a failed device teardown on the main checkout keeps the record and exits 1', async () => {
+test('action: a failed device teardown on the source checkout keeps the record and exits 1', async () => {
   upsertProject(mainDir, {
     metroPort: 8086,
     platforms: { ios: { deviceUdid: 'U7', owned: true, deviceName: 'stim-held' } },
@@ -464,7 +464,7 @@ test('action: a failed device teardown on the main checkout keeps the record and
   expect(errs.join('\n')).toMatch(/still tracks/);
 });
 
-test('action: a tunnel verification failure on the main checkout retains its state directory', async () => {
+test('action: a tunnel verification failure on the source checkout retains its state directory', async () => {
   const child = liveUnrelatedProcess();
   upsertProject(mainDir, { label: 'main' });
   writeManagedTunnel(mainDir, child.pid!);
@@ -494,7 +494,7 @@ test('action: a tunnel verification failure on the main checkout retains its sta
   await expect(withManagedTunnelLock(mainDir, async () => true)).resolves.toBe(true);
 });
 
-test('action: main-checkout artifact deletion blocks a concurrent replacement tunnel start', async () => {
+test('action: source-checkout artifact deletion blocks a concurrent replacement tunnel start', async () => {
   upsertProject(mainDir, { label: 'main' });
   ensureWorkspaceStorage(mainDir);
   writeFileSync(workspaceStateFile(mainDir), '{}');
@@ -1347,7 +1347,7 @@ test('action: the dirty-tree remedy names the real worktree, not a placeholder',
   expect(text).toMatch(new RegExp(`git -C ${wtDir} clean -fd`));
 });
 
-test('against a real repo: remove on the main checkout reclaims the environment and leaves the repo intact', async () => {
+test('against a real repo: remove on the source checkout reclaims the environment and leaves the repo intact', async () => {
   resetExecutor();
   const base = canon(mkdtempSync(join(tmpdir(), 'stim-test-remove-main-')));
   const repo = join(base, 'repo');
@@ -1382,7 +1382,7 @@ test('against a real repo: remove on the main checkout reclaims the environment 
     expect(execSync('git rev-parse --is-inside-work-tree', { cwd: repo, encoding: 'utf-8' }).trim()).toBe('true');
     expect(existsSync(join(repo, '.stim'))).toBe(true);
     expect(getProject(repo)).toBe(null);
-    expect(errs.join('\n')).toMatch(/working tree stays \(it is the main checkout\)/);
+    expect(errs.join('\n')).toMatch(/working tree stays \(it is the source checkout\)/);
   } finally {
     console.error = originalError;
     console.log = originalLog;

--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -213,19 +213,19 @@ test('warm identifies canonical main and linked roots from a symlinked subdirect
   expect(warmWorktreePaths(join(alias, 'ios'))).toEqual({ root, target, common: join(root, '.git') });
 });
 
-test('warm rejects the main checkout and non-repositories without changing them', async () => {
+test('warm rejects the source checkout and non-repositories without changing them', async () => {
   write(root, '.env', 'source env');
   const main = await runWarm(root);
   expect(main.code).toBe(1);
   expect(main.stdout).toEqual([]);
-  expect(main.stderr).toMatch(/linked worktree, not the main checkout/);
+  expect(main.stderr).toMatch(/linked worktree, not the source checkout/);
   process.exitCode = 0;
   const outside = await runWarm(base);
   expect(outside.code).toBe(1);
   expect(outside.stderr).toMatch(/Not a git repository/);
 });
 
-test('warm refuses an unregistered target, missing main checkout, or mismatched Git common directory', () => {
+test('warm refuses an unregistered target, missing source checkout, or mismatched Git common directory', () => {
   const real = getExecutor();
   for (const kind of ['unregistered', 'missing main', 'different common']) {
     setExecutor({

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -56,7 +56,7 @@ export function doctorSuccessLines(platform: DoctorPlatform | undefined, stim: S
     ...stimVersionLines(stim),
     '',
     'Project',
-    phaseLine('project', 'main checkout, dependencies, local upstream'),
+    phaseLine('project', 'source checkout, dependencies, local upstream'),
     phaseLine('settings', 'every Stim setting type'),
   ];
 
@@ -161,7 +161,7 @@ export default function doctorCommand(
   program
     .command('doctor')
     .description(
-      'Inspect the main checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed; --platform filters native findings.',
+      'Inspect the source checkout and report project state that can make native worktrees slow or invalid. Read-only unless --fix is passed; --platform filters native findings.',
     )
     .option('--json', 'print the findings as JSON')
     .option(
@@ -244,7 +244,7 @@ export default function doctorCommand(
 
       console.log(
         chalk.dim(
-          `\n${findings.length} finding(s). Fix relevant "costs time" findings before copying the main checkout into a native worktree.`,
+          `\n${findings.length} finding(s). Fix relevant "costs time" findings before copying the source checkout into a native worktree.`,
         ),
       );
     });

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -118,10 +118,10 @@ function mainCheckoutAppDir(root: string, target: string): string {
 export function registerWarm(worktree: Command): void {
   worktree
     .command('warm')
-    .description('Copy missing ignored paths from the main checkout into the current linked worktree.')
+    .description('Copy missing ignored paths from the source checkout into the current linked worktree.')
     .option(
       '--refresh',
-      'Before copying, fast-forward the main checkout to its upstream and install what the new commits moved.',
+      'Before copying, fast-forward the source checkout to its upstream and install what the new commits moved.',
     )
     .action(async (opts: { refresh?: boolean }) => {
       try {
@@ -675,7 +675,7 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
       const branch = pending.worktreeBranch;
       const mainRoot = pending.worktreeMainRoot;
       if (!existsSync(mainRoot)) {
-        console.error(chalk.red(`Cannot finish branch cleanup for ${path}: main worktree ${mainRoot} is missing.`));
+        console.error(chalk.red(`Cannot finish branch cleanup for ${path}: source checkout ${mainRoot} is missing.`));
         console.error(chalk.dim(`Delete ${branch} from the repository, then run \`stim gc --delete\`.`));
         process.exitCode = 1;
         return;
@@ -741,9 +741,9 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
   }
   if (isMainWorkingTree(entry.path)) {
     if (entry.path !== path) {
-      console.error(chalk.dim(`${path} is inside the main checkout ${entry.path}; reclaiming its environment.`));
+      console.error(chalk.dim(`${path} is inside the source checkout ${entry.path}; reclaiming its environment.`));
     }
-    await reclaimEnvironment(entry.path, 'it is the main checkout');
+    await reclaimEnvironment(entry.path, 'it is the source checkout');
     return;
   }
   if (entry.path !== path) {
@@ -805,7 +805,7 @@ async function runRemove(target: string | undefined, opts: RemoveOptions = {}): 
         }
         upsertProject(path, { worktreeRemovalComplete: true, worktreePendingBranchSha: approvedBranchSha });
         if (!branchDeleteCwd) {
-          console.error(chalk.yellow(phaseLine('branch', `kept ${branch} (Stim could not find the main worktree)`)));
+          console.error(chalk.yellow(phaseLine('branch', `kept ${branch} (Stim could not find the source checkout)`)));
           console.error(chalk.dim(`  Retry with: stim worktree remove ${path}`));
           process.exitCode = 1;
           finish();
@@ -848,7 +848,7 @@ export function registerRemove(worktree: Command): void {
   worktree
     .command('remove [target]')
     .description(
-      'Remove a worktree, its unused Stim-created branch, build artifacts, owned devices, and Metro port. Defaults to the current workspace. On the main checkout it reclaims the environment only and leaves the tree in place.',
+      'Remove a worktree, its unused Stim-created branch, build artifacts, owned devices, and Metro port. Defaults to the current workspace. On the source checkout it reclaims the environment only and leaves the tree in place.',
     )
     .option('--force', 'remove even when the worktree holds uncommitted or unpushed work')
     .action(runRemove);

--- a/packages/stim-cli/src/doctor-storage.ts
+++ b/packages/stim-cli/src/doctor-storage.ts
@@ -39,7 +39,7 @@ export function checkStorageLayout(
     check(
       'Worktree copy',
       [source, target],
-      'Keep the main checkout and linked worktree on the same volume to share file blocks when warming.',
+      'Keep the source checkout and linked worktree on the same volume to share file blocks when warming.',
     );
     const cache = sharedBuildCache();
     check('Cached app/APK staging', [cache, stagingRoot(join(cache, 'artifact.app'))], temporaryFix);

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -232,9 +232,9 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        `The main checkout is ${plural(upstream.behind, 'commit')} behind ${upstream.name}`,
+        `The source checkout is ${plural(upstream.behind, 'commit')} behind ${upstream.name}`,
         'The count uses the locally known upstream ref. A fetch can reveal additional commits. A later rebase or merge can change native inputs and invalidate work done from the older base.',
-        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the main checkout, or \`git -C ${quotedRoot} fetch --prune\` and inspect the branch yourself.`,
+        `Run \`stim worktree warm --refresh\` from a linked worktree to fetch and fast-forward the source checkout, or \`git -C ${quotedRoot} fetch --prune\` and inspect the branch yourself.`,
       ),
     );
   }
@@ -245,8 +245,8 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        `The main checkout has a ${operation} in progress`,
-        '`stim worktree warm --refresh` refuses a main checkout it cannot move, and the branch stays where the interrupted operation left it.',
+        `The source checkout has a ${operation} in progress`,
+        '`stim worktree warm --refresh` refuses a source checkout it cannot move, and the branch stays where the interrupted operation left it.',
         `Finish it, or run \`git -C ${quotedRoot} ${operation} --abort\`.`,
       ),
     );
@@ -258,8 +258,8 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        `The main checkout has ${plural(dirty.length, 'uncommitted tracked change')}`,
-        `\`stim worktree warm --refresh\` refuses a main checkout it cannot move, so the seed stays where it is until this is cleared. First: ${dirty[0]}.`,
+        `The source checkout has ${plural(dirty.length, 'uncommitted tracked change')}`,
+        `\`stim worktree warm --refresh\` refuses a source checkout it cannot move, so the seed stays where it is until this is cleared. First: ${dirty[0]}.`,
         `Commit them, or run \`git -C ${quotedRoot} stash push -u -m warm-refresh\`.`,
       ),
     );
@@ -270,7 +270,7 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        'The main checkout has a detached HEAD',
+        'The source checkout has a detached HEAD',
         '`stim worktree warm --refresh` refuses: there is no branch to fast-forward.',
         `Run \`git -C ${quotedRoot} checkout <branch>\`.`,
       ),
@@ -282,7 +282,7 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        `The main checkout has diverged from ${upstream.name}`,
+        `The source checkout has diverged from ${upstream.name}`,
         `${branch} is ${upstream.ahead} ahead of and ${upstream.behind} behind ${upstream.name}, so it cannot fast-forward. \`stim worktree warm --refresh\` refuses rather than merging or resetting.`,
         `Rebase or merge ${branch} onto ${upstream.name} yourself.`,
       ),
@@ -294,7 +294,7 @@ function seedFindings(mainRoot: string, upstream: UpstreamState | null): Finding
     findings.push(
       finding(
         'note',
-        `The main checkout is on ${branch}, not the default branch ${defaultBranch}`,
+        `The source checkout is on ${branch}, not the default branch ${defaultBranch}`,
         `Every worktree warmed from here carries ${branch}'s dependencies. \`stim worktree warm --refresh\` warns and continues; it never switches a branch under another checkout.`,
         `Run \`git -C ${quotedRoot} checkout ${defaultBranch}\`.`,
       ),
@@ -331,7 +331,7 @@ export function checkMainCheckout(
       findings.push(
         finding(
           'cost',
-          'The main checkout has no installed dependencies',
+          'The source checkout has no installed dependencies',
           `A worktree cannot carry dependencies from ${dependencies.root}, so its first build must install them from scratch.`,
           `Run \`${installCommand}\` before creating native worktrees, or let \`stim worktree warm --refresh\` run it from a linked worktree.`,
         ),
@@ -342,7 +342,7 @@ export function checkMainCheckout(
         findings.push(
           finding(
             'cost',
-            'The main checkout dependency tree is stale',
+            'The source checkout dependency tree is stale',
             `npm reports that ${dependencies.root}/node_modules does not match the project dependency graph. Copying it makes each worktree start from the same invalid state.`,
             `Run \`${installCommand}\` before creating native worktrees, or let \`stim worktree warm --refresh\` run it from a linked worktree.`,
           ),
@@ -370,7 +370,7 @@ export function checkMainCheckout(
       findings.push(
         finding(
           'cost',
-          `The main checkout CocoaPods state is ${podsState}`,
+          `The source checkout CocoaPods state is ${podsState}`,
           `ios/Pods cannot be reused safely because its Manifest.lock ${podsState === 'missing' ? 'is absent' : 'does not match ios/Podfile.lock'}.`,
           `Run \`${podCommand}\` before creating native worktrees, or let \`stim worktree warm --refresh\` run it from a linked worktree.`,
         ),
@@ -384,7 +384,7 @@ export function checkMainCheckout(
       findings.push(
         finding(
           'cost',
-          'The main checkout CocoaPods state has broken links',
+          'The source checkout CocoaPods state has broken links',
           `${broken.length} symlink${broken.length === 1 ? '' : 's'} under ios/Pods point to missing files. Worktrees copy these broken links and can fail during compilation. First: ${broken[0]}.`,
           `Run \`${podCommand}\` before creating native worktrees.`,
         ),
@@ -405,8 +405,8 @@ export function checkMainCheckout(
     findings.push(
       finding(
         'note',
-        `The main checkout has no ${coldPlatforms.join(' or ')} warm build output`,
-        'The shared Stim artifact or compilation cache can still be warm. Building the main checkout once gives later native worktrees the strongest warm starting point.',
+        `The source checkout has no ${coldPlatforms.join(' or ')} warm build output`,
+        'The shared Stim artifact or compilation cache can still be warm. Building the source checkout once gives later native worktrees the strongest warm starting point.',
         `When more native worktrees are expected, run \`stim start\`, \`stim ${coldPlatforms[0] === 'iOS' ? 'ios' : 'android'}\`, and \`stim stop\` from ${mainRoot}.`,
       ),
     );

--- a/packages/stim-cli/src/engine/warm-claim.ts
+++ b/packages/stim-cli/src/engine/warm-claim.ts
@@ -169,7 +169,7 @@ export function warmClaimBlockedLine(reason: string, blocker: WarmClaimBlocker):
 export function warmClaimBlockedRefusal(blocker: WarmClaimBlocker): string {
   if (blocker.kind === 'refresh') {
     return (
-      'Refusing to copy from a main checkout a refresh is rewriting, even without a claim of its own. ' +
+      'Refusing to copy from a source checkout a refresh is rewriting, even without a claim of its own. ' +
       'Wait for that refresh to finish, then run warm again.'
     );
   }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -11,14 +11,14 @@ TWO WORKFLOWS
 
 SINGLE CHECKOUT: work in place, on whatever branch the task needs, in one
 directory. start, ios, android, logs, stop, and never a linked worktree. That
-directory is your workspace, and no rule below about keeping the main checkout
+directory is your workspace, and no rule below about keeping the source checkout
 fit as a seed applies to it.
 
 WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
 branch, and every task gets a linked worktree warmed from it. In this workflow
-the main checkout is infrastructure, not a workspace: you edit, build, and run
+the source checkout is infrastructure, not a workspace: you edit, build, and run
 in the worktree, and you keep the seed fit to copy. Every rule below about the
-main checkout's fitness as a seed belongs to this workflow.
+source checkout's fitness as a seed belongs to this workflow.
 
 Doctor reports that fitness -- how far behind the seed is, uncommitted tracked
 changes, an interrupted rebase or merge, a detached HEAD, a diverged branch, a
@@ -32,11 +32,11 @@ Work in the current checkout by default. When the task needs another branch or
 an isolated environment, take the worktree workflow: create a linked worktree
 with Git and warm its ignored state. If a harness already created this linked
 worktree, run stim worktree warm here instead of creating another one. It
-copies missing ignored paths from the main checkout, including eligible .env
+copies missing ignored paths from the source checkout, including eligible .env
 and local configuration files. It preserves the branch, tracked files, and
 every existing destination entry; existing ignored directories are skipped
-whole, not filled in. Add --refresh to fast-forward the main checkout and
-install what moved there before the copy; it refuses a main checkout with local
+whole, not filled in. Add --refresh to fast-forward the source checkout and
+install what moved there before the copy; it refuses a source checkout with local
 work and never switches branches. Read guide lifecycle options for exclusions
 and incomplete-copy remedies.
 
@@ -50,7 +50,7 @@ it finishes; concurrent files can be overwritten or removed.
 If warm fails or reports incomplete, resolve the reported failure first.
 
 Before native worktree work, run doctor for the platform in scope. It checks
-the main checkout from a linked worktree. Fix relevant findings and inspect the
+the source checkout from a linked worktree. Fix relevant findings and inspect the
 upstream gap; in the single-checkout workflow those seed findings do not
 appear. It also prints the running CLI version and the stim installation
 resolved from PATH. If that resolved installation is older than another one,
@@ -102,7 +102,7 @@ RULES DURING THE LOOP
   and doctor reports it as a finding.
 - Put runtime .stim.json beside that app's package.json. Monorepo apps do not
   inherit a repository-root runtime file. Keep repository-wide worktree-copy
-  rules at the main checkout root; see guide settings for the two scopes.
+  rules at the source checkout root; see guide settings for the two scopes.
 - Run start before a debug ios or android build. If it returns STIM_NO_METRO,
   run stim start and retry.
 - Run ios or android again after a native input changes. A JavaScript-only

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -37,15 +37,16 @@ to stats.json.corrupt-<unix ms> and starts a new one.`,
   branches stay. A branch with an existing Stim ownership record is deleted
   only when it has no unique commits.
 
-ON THE MAIN CHECKOUT
-  git cannot remove the main working tree, and deleting the source tree is not
-  what anyone meant -- so there, and only there, \`worktree remove\` reclaims
-  the ENVIRONMENT and nothing else: the owned devices are parked or deleted, the Metro
-  port freed, the registry entries (including nested monorepo app dirs)
-  dropped, and the global workspace directory deleted. The tree itself is never touched, which
-  is also why the dirty-tree and unpushed guards do not apply on that path.
+ON THE SOURCE CHECKOUT
+  git cannot remove a repository's main working tree, and deleting the source
+  checkout is not what anyone meant -- so there, and only there,
+  \`worktree remove\` reclaims the ENVIRONMENT and nothing else: the owned
+  devices are parked or deleted, the Metro port freed, the registry entries
+  (including nested monorepo app dirs) dropped, and the global workspace
+  directory deleted. The tree itself is never touched, which is also why the
+  dirty-tree and unpushed guards do not apply on that path.
   It ends with:
-    Reclaimed the environment; the working tree stays (it is the main checkout).
+    Reclaimed the environment; the working tree stays (it is the source checkout).
   A registered project directory that is not a git repo at all gets the same
   environment reclaim -- there is nothing else remove could mean there.
 

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -81,10 +81,10 @@ code, never on the message.`,
   or the environment. When that lands inside the project, Stim says so in a dim
   note naming which of the two set it; Gemfile.lock is never edited either way.
   \`worktree warm --refresh\` reports the same code for the install it runs in
-  the MAIN CHECKOUT -- the lockfile's own command (\`pnpm install\`,
+  the SOURCE CHECKOUT -- the lockfile's own command (\`pnpm install\`,
   \`yarn install\`, \`bun install\`, \`npm ci\`) or that same pod ladder. The
   message names the command, quotes its last lines, and nothing is copied: fix
-  the main checkout, then warm again.`,
+  the source checkout, then warm again.`,
     },
     STIM_BUILD_FAILED: {
       summary: 'xcodebuild or gradle failed; the two Android APK refusals; a damaged compilation-cache object',
@@ -238,7 +238,7 @@ code, never on the message.`,
   module for this platform is present, then run the command again. Nothing was
   built, installed or removed.
   \`worktree warm --refresh\` refuses for the same reason, because it writes to
-  the main checkout. Plain \`worktree warm\` does NOT: it prints one dim
+  the source checkout. Plain \`worktree warm\` does NOT: it prints one dim
   \`lock        unavailable (...)\` line and copies unsynchronised. A copy only
   reads, so running it with no claim is what it did before the lock existed,
   while refusing it would break a warm that works today -- an unwritable
@@ -867,30 +867,31 @@ not on any remote"  (worktree remove)
   uncommitted and untracked files permanently.`,
     },
     STIM_MAIN_DIRTY: {
-      summary: 'warm --refresh will not move a main checkout with local work or an operation in progress',
+      summary: 'warm --refresh will not move a source checkout with local work or an operation in progress',
       body: () => `STIM_MAIN_DIRTY
-  \`worktree warm --refresh\` writes to the MAIN CHECKOUT, and it refuses one
+  \`worktree warm --refresh\` writes to the SOURCE CHECKOUT, and it refuses one
   it cannot move: tracked files with uncommitted changes (the refusal names
   them), or a rebase or merge in progress. Untracked files are not a reason to
   refuse -- but git itself refuses a fast-forward that would overwrite one, and
   that reports this code too, quoting git. The remedy is the exact line that
-  clears it: commit, \`git -C <main> stash push -u -m warm-refresh\`, or
-  \`git -C <main> rebase --abort\`. Nothing was installed or copied.
-  Plain \`stim worktree warm\` does not care: it copies from a dirty main
-  checkout exactly as it always has.`,
+  clears it: commit, \`git -C <source-checkout> stash push -u -m warm-refresh\`,
+  or \`git -C <source-checkout> rebase --abort\`. Nothing was installed or
+  copied. Plain \`stim worktree warm\` does not care: it copies from a dirty
+  source checkout exactly as it always has.`,
     },
     STIM_MAIN_DETACHED: {
       summary: 'warm --refresh needs a branch to fast-forward, not a detached HEAD',
       body: () => `STIM_MAIN_DETACHED
-  The main checkout's HEAD is detached, so there is no branch to fast-forward
-  and no upstream to fast-forward it to. Run \`git -C <main> checkout <branch>\`
-  and warm again. \`--refresh\` never picks a branch for you; a checkout whose
-  job is to seed worktrees should sit on a branch someone chose.`,
+  The source checkout's HEAD is detached, so there is no branch to fast-forward
+  and no upstream to fast-forward it to. Run
+  \`git -C <source-checkout> checkout <branch>\` and warm again. \`--refresh\`
+  never picks a branch for you; a checkout whose job is to seed worktrees
+  should sit on a branch someone chose.`,
     },
     STIM_MAIN_DIVERGED: {
-      summary: 'the main checkout is both ahead of and behind its upstream; warm --refresh will not merge',
+      summary: 'the source checkout is both ahead of and behind its upstream; warm --refresh will not merge',
       body: () => `STIM_MAIN_DIVERGED
-  The main checkout's branch has commits its upstream does not, AND its
+  The source checkout's branch has commits its upstream does not, AND its
   upstream has commits it does not. A fast-forward is impossible, and
   \`--refresh\` will not merge or reset someone else's checkout to make one:
   that decision is yours. Rebase or merge it yourself, then warm again. The
@@ -899,7 +900,7 @@ not on any remote"  (worktree remove)
     STIM_DEPS_INCOMPLETE: {
       summary: 'the last install recorded for the lockfile on disk now did not finish, so warm will not copy it',
       body: () => `STIM_DEPS_INCOMPLETE
-  \`worktree warm\` refuses to copy dependencies the main checkout never
+  \`worktree warm\` refuses to copy dependencies the source checkout never
   finished installing. \`--refresh\` records a COMPLETED install of the lockfile
   it read under ~/.stim/warm-installs; an install that failed, or whose process
   was killed, leaves that record saying unfinished. A plain warm reads it after
@@ -922,7 +923,7 @@ not on any remote"  (worktree remove)
       body: () => `"Could not warm this worktree: EACCES: permission denied, mkdir
 '<home>/warm-locks/<name>.lock'"  (worktree warm --refresh)
   A STIM_HOME that \`--refresh\` cannot write. The refusal itself is right -- it
-  writes to the main checkout, so it will not run without a claim -- but it
+  writes to the source checkout, so it will not run without a claim -- but it
   carries no \`failed: <CODE>\` line, because EACCES is not a Stim code, and no
   fix line. Make STIM_HOME writable, or set STIM_HOME to somewhere writable,
   then run it again. A plain warm degrades in this state rather than refusing.
@@ -949,9 +950,9 @@ changes nothing  (worktree warm --refresh)
   with empty stdout.
 
 "carry       carried <dir>/Pods does not match the <dir>/Podfile.lock on disk here"
-  Warm copied ignored Pods from main, but their Manifest.lock differs from
-  the tracked Podfile.lock in this worktree. Warm does not change tracked
-  files. Run the printed pod-install command before building directly.
+  Warm copied ignored Pods from the source checkout, but their Manifest.lock
+  differs from the tracked Podfile.lock in this worktree. Warm does not change
+  tracked files. Run the printed pod-install command before building directly.
   \`stim ios\` detects a mismatch and runs \`pod install\` for you.
 
 "carry       carried <dir>/Pods but there is no <dir>/Podfile.lock"
@@ -959,15 +960,15 @@ changes nothing  (worktree warm --refresh)
   pod-install command before building.
 
 "carry       carried dependencies may be stale: they do not match ..."
-  Main's lockfile differs from this branch's lockfile. Run the printed
-  package-manager command before building. A carry whose lockfile matches is
-  silent; the warning means a real difference.
+  The source checkout's lockfile differs from this branch's lockfile. Run the
+  printed package-manager command before building. A carry whose lockfile
+  matches is silent; the warning means a real difference.
 
-  If main has no dependencies to copy, use this project's package manager to
-  install them. Warm does not install dependencies or prove the app is ready,
-  unless \`--refresh\` installed them in the MAIN CHECKOUT first; even then the
-  copy can still carry a lockfile this branch does not have, which is exactly
-  what these carry warnings report.`,
+  If the source checkout has no dependencies to copy, use this project's
+  package manager to install them. Warm does not install dependencies or prove
+  the app is ready, unless \`--refresh\` installed them in the SOURCE CHECKOUT
+  first; even then the copy can still carry a lockfile this branch does not
+  have, which is exactly what these carry warnings report.`,
     },
     environment: {
       summary: 'npx registry E401/E404, the Node floor, no free Metro port, the reservation race',

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -387,7 +387,7 @@ RULES
 HOW A RUN IS COUNTED (\`stats\`)
   Every \`ios\` or \`android\` invocation that got as far as computing a
   cache key is one run, in this project's bucket and in the machine-wide one.
-  The project key is the app's path IN THE MAIN WORKING TREE, so every
+  The project key is the app's path IN THE SOURCE CHECKOUT, so every
   worktree of a repository pools into one bucket and two apps in a monorepo
   do not. A run that ends through an error or an uncaught exception counts
   only as \`failed\`; \`launched: "unverified"\` or \`"bundling"\` is a

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -9,11 +9,11 @@ Two workflows share steps 2 through 6.
 
 SINGLE CHECKOUT: work in place, on a branch, in one directory. There is no
 step 1, and step 7 reclaims the environment without deleting the tree, which
-stays because it is the main checkout. That directory is your workspace, and
-no rule here about keeping the main checkout fit as a seed applies to it.
+stays because it is the source checkout. That directory is your workspace, and
+no rule here about keeping the source checkout fit as a seed applies to it.
 
 WORKTREE: the checkout you cloned is a seed. It stays clean and on the default
-branch so every worktree warmed from it starts current. Here the main checkout
+branch so every worktree warmed from it starts current. Here the source checkout
 is infrastructure, not a workspace, and every rule below about its fitness as
 a seed belongs to this workflow.
 
@@ -23,10 +23,11 @@ a seed belongs to this workflow.
   cd ../app-412
   stim worktree warm
 
-  # Warm copies missing ignored state from main; it does not install dependencies.
+  # Warm copies missing ignored state from the source checkout; it does not
+  # install dependencies.
   # In a monorepo, enter the app directory before starting the dev server.
 
-  # Optional: bring the MAIN CHECKOUT up to date first, then copy that.
+  # Optional: bring the SOURCE CHECKOUT up to date first, then copy that.
   stim worktree warm --refresh
     lock        acquired
     checkout    main 3 commits behind origin/main -> fast-forwarded to 9f2c1a3
@@ -346,12 +347,12 @@ result as proof instead of requiring an unrelated screenshot.`,
   Removal works with any linked worktree, whether warmed or not, and does not
   require a Stim registry entry. Git-created branches are kept. An existing
   Stim ownership record permits deleting a branch only when it has no unique
-  commits; otherwise the command reports why it kept it. On the main checkout,
+  commits; otherwise the command reports why it kept it. On the source checkout,
   \`worktree remove\` reclaims only the
   environment -- the same \`device\`, \`lease\` and \`workspace\` lines, ending
   with a sentence instead of a \`removed\` line, because the checkout itself
   is never touched: \`Reclaimed the environment; the working tree stays (it
-  is the main checkout).\`
+  is the source checkout).\`
 
   A GAP BETWEEN HEARTBEATS IS NOT A HANG. Stim runs device tools
   synchronously, so a long \`simctl\`, \`adb\` or copy call holds the timer
@@ -461,10 +462,10 @@ result as proof instead of requiring an unrelated screenshot.`,
       summary:
         'optional cache warm-up, build optimizations, fingerprints, .fingerprintignore, install unchanged, runtime state',
       body: () => `OPTIONAL CACHE WARM-UP FOR REPEATED NATIVE WORK
-  When several native worktrees are coming, build the main checkout once to
+  When several native worktrees are coming, build the source checkout once to
   seed the shared caches before warming the linked worktrees. Skip this extra
   build for one-off or JavaScript-only work. For local simulator or emulator
-  work, run these commands in the main checkout's app directory:
+  work, run these commands in the source checkout's app directory:
 
     stim doctor --platform ios        # or: --platform android
     stim start
@@ -833,15 +834,15 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   not in a flag here.
 
   \`stim worktree warm\` takes one flag, \`--refresh\`. Run it anywhere inside
-  the current linked worktree to copy missing ignored entries from its main
+  the current linked worktree to copy missing ignored entries from its source
   checkout, regardless of either branch's HEAD. Both roots must be registered
-  worktrees of the same Git repository; the main checkout
-  must be available. Running it in the main checkout refuses.
+  worktrees of the same Git repository; the source checkout must be available.
+  Running it in the source checkout refuses.
 
-  \`--refresh\` WRITES TO THE MAIN CHECKOUT before the copy, which is why it
+  \`--refresh\` WRITES TO THE SOURCE CHECKOUT before the copy, which is why it
   is opt-in: it fetches, fast-forwards whatever branch is checked out there to
   its \`@{upstream}\`, and installs what the new commits moved. It refuses a
-  main checkout it cannot move -- uncommitted changes to tracked files or a
+  source checkout it cannot move -- uncommitted changes to tracked files or a
   rebase or merge in progress (STIM_MAIN_DIRTY), a detached HEAD
   (STIM_MAIN_DETACHED), or a branch that is both ahead and behind
   (STIM_MAIN_DIVERGED) -- and each refusal names the git line that clears it.
@@ -908,7 +909,7 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   overwritten or removed.
 
   Warm copies installed dependencies, Pods, native output, and other ignored
-  paths eligible under the main checkout's Git ignore rules, including .env
+  paths eligible under the source checkout's Git ignore rules, including .env
   and local configuration. The source's nonempty
   .worktreeexclude replaces its resolved worktree.exclude setting. Nested
   registered worktrees, .DerivedData, and android/build/generated/autolinking
@@ -917,14 +918,15 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   overlapping a nested destination worktree or below a symlink ancestor.
 
   Warm copies directly into the destination, without intermediate staging.
-  Keep main and the linked worktree on the same volume to retain copy-on-write
-  cloning where supported. Cross-volume copies require full file data; doctor
-  reports that cost. STIM_TMPDIR and machine tempDir do not affect warming.
+  Keep the source checkout and the linked worktree on the same volume to
+  retain copy-on-write cloning where supported. Cross-volume copies require
+  full file data; doctor reports that cost. STIM_TMPDIR and machine tempDir do
+  not affect warming.
 
   Existing entries, including dangling symlinks, stay untouched. An existing
   ignored directory such as node_modules is skipped WHOLE; missing children are not
   filled in. Warm does not copy tracked changes, switch branches, or build,
-  and it installs dependencies only under \`--refresh\`, in the main checkout. stdout stays empty; stderr reports copied, kept,
+  and it installs dependencies only under \`--refresh\`, in the source checkout. stdout stays empty; stderr reports copied, kept,
   and failed entry counts. A copy failure exits 1 and reports incomplete;
   files copied before a failure remain. Inspect the named failed entry
   before retrying: a partially copied directory will be kept on the retry.

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -21,7 +21,7 @@ their precedence. Move root runtime settings into each relevant app when
 upgrading; relative profile/config/provider paths resolve from the app directory.
 
 Worktree copying is repository-wide: worktree warm reads worktree.exclude and
-worktree.defaultBranch from the main checkout's root .stim.json, not from
+worktree.defaultBranch from the source checkout's root .stim.json, not from
 individual apps. Keep those rules at the repository root; runtime files and
 worktree-copy policy are separate scopes.
 
@@ -182,14 +182,14 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         still gated the same way a managed tunnel's is. Set it
                         before Expo start so the manifest advertises it.
   worktree.exclude      ignored-path skip list for worktree warm. Settings
-                        come from the main checkout's repository-root .stim.json.
-                        A nonempty
-                        .worktreeexclude in main replaces this setting.
-                        Registered nested Git worktrees are always skipped.
+                        come from the source checkout's repository-root
+                        .stim.json. A nonempty .worktreeexclude in the source
+                        checkout replaces this setting. Registered nested Git
+                        worktrees are always skipped.
   worktree.defaultBranch
-                        the branch the main checkout is expected to sit on,
+                        the branch the source checkout is expected to sit on,
                         read only by \`worktree warm --refresh\`, which WARNS
-                        (and continues) when the main checkout is on another
+                        (and continues) when the source checkout is on another
                         branch, because the copy then carries that branch's
                         dependencies. Unset, the branch
                         \`git symbolic-ref --short refs/remotes/origin/HEAD\`

--- a/packages/stim-cli/src/worktree-refresh.ts
+++ b/packages/stim-cli/src/worktree-refresh.ts
@@ -165,7 +165,7 @@ export function depsPlan({
 }
 
 /**
- * Why a copy must not read the main checkout's dependencies: the install recorded for the lockfile as it
+ * Why a copy must not read the source checkout's dependencies: the install recorded for the lockfile as it
  * stands now did not finish, so what is installed there is partial. A record of any other lockfile says
  * nothing about this one, and no record at all is the state of every repository before its first refresh.
  */
@@ -180,7 +180,7 @@ export function incompleteInstallRefusal(root: string, appDir: string): RefreshF
     code: 'STIM_DEPS_INCOMPLETE',
     message: `Refusing to copy from ${dependencies.root}: the last install of ${dependencies.lock} there did not finish, so its dependencies are partial.`,
     lines: [],
-    remedy: `Run \`stim worktree warm --refresh\` to install them in the main checkout -- it reinstalls rather than skipping, because no completed install of this ${dependencies.lock} is recorded -- then warm again.`,
+    remedy: `Run \`stim worktree warm --refresh\` to install them in the source checkout -- it reinstalls rather than skipping, because no completed install of this ${dependencies.lock} is recorded -- then warm again.`,
   };
 }
 
@@ -484,7 +484,7 @@ export async function refreshMainCheckout({
         code: 'STIM_MAIN_DIRTY',
         message: `Refusing to refresh ${root}: git could not fast-forward ${branch} to ${plan.upstream}.`,
         lines: merged.lines,
-        remedy: 'Clear what git reports in the main checkout, then run warm again.',
+        remedy: 'Clear what git reports in the source checkout, then run warm again.',
       };
     }
     head = resolveFullRef(root, 'HEAD') ?? before;

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -46,12 +46,12 @@ export function warmWorktreePaths(cwd: string): { root: string; target: string; 
   if (!currentRoot) throw new Error('Not a git repository.');
   const target = realpathSync(currentRoot);
   if (isMainWorkingTree(target)) {
-    throw new Error('Run stim worktree warm from a linked worktree, not the main checkout.');
+    throw new Error('Run stim worktree warm from a linked worktree, not the source checkout.');
   }
   const entries = listWorktrees(target);
   const current = entries.find((entry) => canonicalPath(entry.path) === target);
   const main = entries.find((entry) => isMainWorkingTree(entry.path));
-  if (!current || !main) throw new Error('Could not identify the linked worktree and its main checkout.');
+  if (!current || !main) throw new Error('Could not identify the linked worktree and its source checkout.');
   const root = realpathSync(main.path);
   const sourceRoot = repoRoot(root);
   const sourceCommon = gitCommonDir(root);
@@ -64,7 +64,7 @@ export function warmWorktreePaths(cwd: string): { root: string; target: string; 
     !targetCommon ||
     realpathSync(sourceCommon) !== realpathSync(targetCommon)
   ) {
-    throw new Error('Could not verify that the main checkout belongs to this linked worktree.');
+    throw new Error('Could not verify that the source checkout belongs to this linked worktree.');
   }
   return { root, target, common: realpathSync(targetCommon) };
 }

--- a/test/e2e/cache-flow.e2e.js
+++ b/test/e2e/cache-flow.e2e.js
@@ -222,7 +222,7 @@ test('worktree remove refuses a dirty tree, then removes a clean one and retains
   assert.ok(!Object.keys(projects).some((p) => p.includes('-worktrees')), 'no stray worktree entries remain');
 
   const list = execFileSync('git', ['-C', ctx.repo, 'worktree', 'list'], { encoding: 'utf-8' });
-  assert.ok(!list.includes(ctx.wt1) && !list.includes(ctx.wt2), `only the main checkout remains:\n${list}`);
+  assert.ok(!list.includes(ctx.wt1) && !list.includes(ctx.wt2), `only the source checkout remains:\n${list}`);
   for (const name of ['e2e-wt1', 'e2e-wt2']) {
     const branch = spawnSync('git', ['-C', ctx.repo, 'show-ref', '--verify', '--quiet', `refs/heads/worktree-${name}`]);
     assert.equal(branch.status, 0, `Git-created worktree-${name} branch is retained`);

--- a/test/e2e/native-cleanup.e2e.js
+++ b/test/e2e/native-cleanup.e2e.js
@@ -278,7 +278,7 @@ test('native cleanup preserves registry, checkout, worktree and GC checks', asyn
   const f = fixture(t);
   for (const [field, text, message] of [
     ['status', f.cwd, /status still lists a removed workspace/],
-    ['porcelain', ' M tracked-file', /main checkout is dirty/],
+    ['porcelain', ' M tracked-file', /source checkout is dirty/],
     ['worktrees', `worktree ${f.cwd}\n`, /a worktree registration survived/],
     ['gc', f.cwd, /gc reports one of our workspaces as orphaned/],
   ]) {

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -174,7 +174,7 @@ export function assertMatchingPods(appDir) {
   const lock = join(appDir, 'ios', 'Podfile.lock');
   const manifest = join(appDir, 'ios', 'Pods', 'Manifest.lock');
   const remedy =
-    "Prepare matching Pods in the main checkout before the cache suite: for Expo, run `npx --no-install expo prebuild --platform ios`; for bare React Native, run the project's normal pod install.";
+    "Prepare matching Pods in the source checkout before the cache suite: for Expo, run `npx --no-install expo prebuild --platform ios`; for bare React Native, run the project's normal pod install.";
   assert(
     existsSync(lock) && existsSync(manifest),
     `Pods reuse requires Podfile.lock and Pods/Manifest.lock at ${appDir}. ${remedy}`,
@@ -317,7 +317,7 @@ export async function verifyCleanup({ h, cleanup, appDir, created }) {
   h.log('(3) status is clean of our workspaces');
 
   const porcelain = h.sh('git', ['-C', appDir, 'status', '--porcelain']).stdout.trim();
-  assert(porcelain === '', `main checkout is dirty after the run:\n${porcelain}`);
+  assert(porcelain === '', `source checkout is dirty after the run:\n${porcelain}`);
   const wl = h.sh('git', ['-C', appDir, 'worktree', 'list', '--porcelain']).stdout;
   const registered = new Set(
     wl
@@ -326,7 +326,7 @@ export async function verifyCleanup({ h, cleanup, appDir, created }) {
       .map((line) => line.slice('worktree '.length)),
   );
   assert(!created.some((path) => registered.has(resolve(path))), `a worktree registration survived:\n${wl}`);
-  h.log('(4) main checkout byte-clean, no worktrees linger');
+  h.log('(4) source checkout byte-clean, no worktrees linger');
 
   const gc = h.cli(['gc'], { allowFail: true });
   assert(!created.some((p) => gc.stdout.includes(p)), 'gc reports one of our workspaces as orphaned');

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -694,13 +694,13 @@ async function main() {
 
     const after = snapshotRepo(appDir);
     c.ev(
-      `main checkout after the run: porcelain ${after.porcelain === '' ? 'CLEAN' : JSON.stringify(after.porcelain)}`,
+      `source checkout after the run: porcelain ${after.porcelain === '' ? 'CLEAN' : JSON.stringify(after.porcelain)}`,
     );
-    assert(after.porcelain === baseline.porcelain, `the main checkout is not as we found it:\n${after.porcelain}`);
+    assert(after.porcelain === baseline.porcelain, `the source checkout is not as we found it:\n${after.porcelain}`);
     c.ev(
       `.gitignore ${after.gitignore === baseline.gitignore ? 'byte-identical to the baseline' : 'CHANGED'} (${after.gitignore.length} bytes)`,
     );
-    assert(after.gitignore === baseline.gitignore, "the main checkout's .gitignore was left modified");
+    assert(after.gitignore === baseline.gitignore, "the source checkout's .gitignore was left modified");
     for (const wt of created) assert(!existsSync(wt), `worktree directory survived removal: ${wt}`);
     c.ev(`all ${created.length} worktree directories are gone, each removed without --force`);
     return c.pass('runtime state stayed outside the repository and removal restored fixture changes');

--- a/test/e2e/storage-volumes.e2e.js
+++ b/test/e2e/storage-volumes.e2e.js
@@ -93,7 +93,7 @@ test(
       const warmFinding = findings.find((finding) => finding.title === 'Worktree copy crosses filesystems');
       assert.ok(warmFinding);
       assert.match(warmFinding.detail, /cannot share file blocks across volumes/);
-      assert.match(warmFinding.fix, /main checkout and linked worktree on the same volume/);
+      assert.match(warmFinding.fix, /source checkout and linked worktree on the same volume/);
     } finally {
       resetExecutor();
       for (const [key, value] of Object.entries(previous)) {

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -50,14 +50,14 @@ Provider and build-profile restrictions still apply; see
 [build optimizations](./build-optimizations.md#compare-compiler-settings).
 This caches app artifacts; ccache and Clang CAS use separate compiler caches.
 
-## Keep the main checkout warm
+## Keep the source checkout warm
 
-Run `stim doctor` before native worktree work. It checks whether the main
+Run `stim doctor` before native worktree work. It checks whether the source
 checkout has current dependencies and CocoaPods state. On a checkout without
 installed dependencies, it also checks whether a fresh worktree produces the
 same native fingerprint.
 
-When several native tasks are coming, build the main checkout once:
+When several native tasks are coming, build the source checkout once:
 
 <StimTabs
 code={`stim start
@@ -66,9 +66,9 @@ stim stop`}
 />
 
 Later worktrees can reuse that cache entry. In an existing linked worktree,
-`stim worktree warm` copies missing ignored state from main without replacing
-existing entries. This includes installed dependencies, Pods, and native
-output. See [worktree isolation](./worktrees.md) for its full scope.
+`stim worktree warm` copies missing ignored state from the source checkout
+without replacing existing entries. This includes installed dependencies, Pods,
+and native output. See [worktree isolation](./worktrees.md) for its full scope.
 
 ## Inspect and clean caches
 

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -35,9 +35,9 @@ JavaScript edit.
 stim doctor [--platform <ios|android>] [--json] [--fix]
 ```
 
-Inspects the main checkout. It reports missing or stale dependencies, CocoaPods
-state, cache conflicts, device capacity, remote session problems, and a linked
-native library whose Git metadata enters the fingerprint. On a
+Inspects the source checkout. It reports missing or stale dependencies,
+CocoaPods state, cache conflicts, device capacity, remote session problems, and
+a linked native library whose Git metadata enters the fingerprint. On a
 checkout without installed dependencies, it also reports fingerprint
 differences against a fresh worktree. The check is read-only unless `--fix` is
 passed.
@@ -311,22 +311,22 @@ moment, minus its own duration, floored at zero.
 stim worktree warm [--refresh]
 ```
 
-Copies missing ignored entries from the repository's main checkout into the
-current linked worktree. It accepts a current subdirectory. The main checkout
-must be available in the same Git repository; running warm in the main checkout
-refuses.
+Copies missing ignored entries from the repository's source checkout into the
+current linked worktree. It accepts a current subdirectory. The source checkout
+must be available in the same Git repository; running warm in the source
+checkout refuses.
 
-`--refresh` updates the main checkout before the copy: it fetches, fast-forwards
-whatever branch is checked out there, and installs dependencies or Pods when the
-new commits moved a lockfile, when nothing is installed, or when `ios/Pods` does
-not match `ios/Podfile.lock`. See
-[worktree isolation](./worktrees.md#refresh-the-main-checkout-first).
+`--refresh` updates the source checkout before the copy: it fetches,
+fast-forwards whatever branch is checked out there, and installs dependencies or
+Pods when the new commits moved a lockfile, when nothing is installed, or when
+`ios/Pods` does not match `ios/Podfile.lock`. See
+[worktree isolation](./worktrees.md#refresh-the-source-checkout-first).
 
 The branch, tracked files, and existing destination entries stay untouched.
 Existing directories, including `node_modules`, are skipped whole. Eligible
-ignored `.env` and local configuration files are included. The main checkout's
-nonempty `.worktreeexclude` replaces its resolved `worktree.exclude` setting.
-See [worktree isolation](./worktrees.md) for exclusions.
+ignored `.env` and local configuration files are included. The source
+checkout's nonempty `.worktreeexclude` replaces its resolved `worktree.exclude`
+setting. See [worktree isolation](./worktrees.md) for exclusions.
 
 Wait for warm to finish before any other process writes to the destination.
 Concurrent writes are unsafe: files created after the initial existence check
@@ -348,8 +348,8 @@ Reclaims the target environment, build output, port, and owned device. It then
 removes any linked worktree when safe, warmed or not, without requiring a
 Stim registry entry. Git-created branches stay. An existing Stim ownership
 record permits deleting a branch only when it has no unique commits. On the
-main checkout it only reclaims the environment. `--force` permits removal with
-uncommitted, untracked, or unpushed work.
+source checkout it only reclaims the environment. `--force` permits removal
+with uncommitted, untracked, or unpushed work.
 
 ## `gc`
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -46,7 +46,7 @@ wrapper.
 The agent normally runs:
 
 <StimTabs
-code={`stim doctor           # inspect the main checkout and warm-state gaps
+code={`stim doctor           # inspect the source checkout and warm-state gaps
 stim start            # start this workspace's dev server
 stim ios              # build or restore, install, launch, and verify
 stim logs --errors    # check for errors in the captured logs
@@ -134,13 +134,14 @@ stim worktree remove`}
 />
 
 If a harness already created the linked worktree, skip Git creation and run
-`stim worktree warm` there. Warm copies missing ignored state from main,
-including dependencies, native output, and eligible `.env` and local config.
-Existing entries stay untouched. See [worktree isolation](./worktrees.md) for
-exclusions and cleanup; removal works whether or not the worktree was warmed.
+`stim worktree warm` there. Warm copies missing ignored state from the source
+checkout, including dependencies, native output, and eligible `.env` and local
+config. Existing entries stay untouched. See
+[worktree isolation](./worktrees.md) for exclusions and cleanup; removal works
+whether or not the worktree was warmed.
 
 The worktree gets a separate port and device. It can still use native and Metro
-cache entries created by the main checkout or another worktree.
+cache entries created by the source checkout or another worktree.
 
 ## What success means
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -61,19 +61,19 @@ Explicit machine project/repository overrides keep their existing precedence.
 | `metro.ngrokUrl`              | Existing ngrok URL                                                   |
 | `metro.publicUrl`             | Existing public Metro URL                                            |
 | `worktree.exclude`            | Ignored paths skipped by `worktree warm`                             |
-| `worktree.defaultBranch`      | Branch `worktree warm --refresh` expects the main checkout on        |
+| `worktree.defaultBranch`      | Branch `worktree warm --refresh` expects the source checkout on      |
 | `cache.provider`              | Optional second-tier cache provider module                           |
 | `cache.options`               | Options passed to that provider                                      |
 | `caches`                      | Additional cache paths reported by `gc`                              |
 | `optimizations`               | [Build optimization switches and defaults](./build-optimizations.md) |
 
-`worktree warm` reads repository-wide copy settings from the main checkout's
+`worktree warm` reads repository-wide copy settings from the source checkout's
 root `.stim.json`, not individual app files. Keep `worktree.exclude` and
 `worktree.defaultBranch` there. `worktree.defaultBranch` is read only by
-`worktree warm --refresh`, which warns when the main checkout sits on another
-branch; unset, it uses the branch `origin/HEAD` names. A nonempty
-`.worktreeexclude` in main replaces its resolved `worktree.exclude` setting;
-an empty or absent file uses the setting.
+`worktree warm --refresh`, which warns when the source checkout sits on
+another branch; unset, it uses the branch `origin/HEAD` names. A nonempty
+`.worktreeexclude` in the source checkout replaces its resolved
+`worktree.exclude` setting; an empty or absent file uses the setting.
 
 Do not put secrets in a committed `.stim.json`. Keep secrets in ignored files
 and carry those files into a worktree.

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -26,14 +26,14 @@ If a harness already created the linked worktree, skip Git creation and run
 
 ## Warm ignored state
 
-Warm uses the repository's main checkout as its source, regardless of either
-branch's `HEAD`. The main checkout must still be available. It copies missing
+Warm copies from the repository's source checkout, regardless of either
+branch's `HEAD`. That checkout must still be available. It copies missing
 ignored entries, including installed dependencies, Pods, native build output,
 `.env`, and local configuration files. APFS clones keep copies space-efficient
 where supported; a normal byte copy is used when cloning is unavailable.
-Copies go directly to the destination with no intermediate staging. Keep main
-and the linked worktree on the same volume to benefit from CoW; `STIM_TMPDIR`
-and `tempDir` do not affect warming.
+Copies go directly to the destination with no intermediate staging. Keep the
+source checkout and the linked worktree on the same volume to benefit from CoW;
+`STIM_TMPDIR` and `tempDir` do not affect warming.
 
 Warm preserves the current branch, tracked files, and every existing
 destination entry, including dangling symlinks. An existing ignored directory
@@ -51,8 +51,8 @@ Stim excludes:
 - Any `.DerivedData` directory.
 - `android/build/generated/autolinking`, including in nested apps, so Gradle
   regenerates paths for the new checkout.
-- Paths matched by main's nonempty `.worktreeexclude`, or its resolved
-  `worktree.exclude` setting when that file is absent or empty.
+- Paths matched by the source checkout's nonempty `.worktreeexclude`, or its
+  resolved `worktree.exclude` setting when that file is absent or empty.
 - Destination paths that overlap a registered nested worktree or have symlink
   ancestors.
 
@@ -61,18 +61,18 @@ lockfile remedies. A failure exits 1; files already copied remain. Inspect
 the named failure before retrying, because a partially copied directory is
 kept on retry. A completed copy does not prove dependencies are installed or
 match the current branch. Install missing dependencies with the project's
-package manager when main has none to copy.
+package manager when the source checkout has none to copy.
 
-## Refresh the main checkout first
+## Refresh the source checkout first
 
-Every worktree is a copy of the main checkout, so a stale main checkout seeds
-stale worktrees. `stim worktree warm --refresh` updates it before the copy:
+Every worktree is a copy of the source checkout, so a stale one seeds stale
+worktrees. `stim worktree warm --refresh` updates it before the copy:
 
 <StimTabs
 code={`stim worktree warm --refresh`}
 />
 
-It fetches the branch's remote, fast-forwards **whatever branch the main
+It fetches the branch's remote, fast-forwards **whatever branch the source
 checkout has** to its `@{upstream}`, and then installs only what the new commits
 moved: the lockfile's own install command where the lockfile lives (the
 repository root in a monorepo), and `pod install` for the app you ran the
@@ -85,8 +85,8 @@ or merge in progress (`STIM_MAIN_DIRTY`), a detached `HEAD`
 (`STIM_MAIN_DIVERGED`) -- and names the git command that clears it. Untracked
 files are not a reason to refuse, a branch with no upstream is left alone, and a
 fetch that fails is reported as a fact while the run continues on local state.
-It never switches branches, merges, or resets. When the main checkout is not on
-the default branch it warns and continues, because the copy then carries that
+It never switches branches, merges, or resets. When the source checkout is not
+on the default branch it warns and continues, because the copy then carries that
 branch's dependencies; set `worktree.defaultBranch` in the repository-root
 `.stim.json` when `origin/HEAD` is missing or wrong.
 
@@ -94,7 +94,7 @@ An install that fails is remembered, and a plain warm reads that before it
 copies. The refresh records the install it completed for the lockfile it read;
 when the last install of the lockfile as it stands now did not finish, a plain
 warm refuses with `STIM_DEPS_INCOMPLETE` and copies nothing, because the
-dependencies in the main checkout are partial and only the refresh's own
+dependencies in the source checkout are partial and only the refresh's own
 terminal ever said so. Run `stim worktree warm --refresh`, which reinstalls for
 the same reason. A record of a different lockfile does not block a copy, and a
 repository with no record copies exactly as it did before.
@@ -137,5 +137,5 @@ It refuses uncommitted, untracked, or unpushed work unless you pass `--force`.
 Git-created branches stay. An existing Stim ownership record permits deleting
 a branch only when it has no unique commits.
 
-On the main checkout, `worktree remove` only reclaims the Stim environment. It
-does not remove the source directory.
+On the source checkout, `worktree remove` only reclaims the Stim environment.
+It does not remove that checkout.


### PR DESCRIPTION
## Description

Stim called the repository's primary working tree the "main checkout" in its
shipped text: doctor finding titles and fixes, `guide agent`/`lifecycle`/
`settings`/`cleanup`/`errors`, `worktree warm` and `worktree remove` output and
refusals, command descriptions, the CLI README, and the website docs. The term
reads as *the checkout of the `main` branch*, which plenty of repositories do
not have -- in a repository whose default branch is `develop`, "The main
checkout is 3 commits behind origin/develop" invites exactly the wrong
question. Two stragglers ("main working tree", "main worktree") described the
same thing in two more ways.

This renames that term to "source checkout" everywhere Stim says it: no
collision with a branch name, and it says what the checkout is for -- the one
`worktree warm` copies from and `doctor` inspects. In-scope occurrences go from
152 to 3 deliberate keeps (below).

No behavior change. No command, flag, or settings key is renamed:
`worktree.defaultBranch`, `worktree.exclude`, `worktreeDir` and every other key
keep their names, as do the `STIM_MAIN_DIRTY`, `STIM_MAIN_DETACHED` and
`STIM_MAIN_DIVERGED` error codes, which are a code-defined contract. No
identifier is renamed: `checkMainCheckout`, `refreshMainCheckout`,
`mainCheckoutProjectRoot`, `isMainWorkingTree` and `mainRoot` are untouched, so
the diff stays a text review.

## Solution

Most sites are a phrase substitution. The rest needed judgment:

- **Sentences reworded rather than substituted.** `worktrees.md` said "Warm uses
  the repository's main checkout as its source" -- "source checkout as its
  source" reads badly, so it is now "Warm copies from the repository's source
  checkout", with the following sentence as "That checkout must still be
  available". "a stale main checkout seeds stale worktrees" became "a stale one
  seeds stale worktrees" to avoid saying the term twice in one sentence.
  "It does not remove the source directory" became "It does not remove that
  checkout", since "source directory" now collides with the new name.
- **Bare "main" that now needs qualifying.** Several places said "copies missing
  ignored state from main", "Keep main and the linked worktree on the same
  volume", "`.worktreeexclude` in main", "Main's lockfile differs", "if main has
  no dependencies to copy", "whatever branch the main checkout has". Each now
  names the source checkout, because "main" alone reads as the branch.
- **Remedy placeholder.** `guide errors` used `git -C <main> ...` in the
  STIM_MAIN_DIRTY and STIM_MAIN_DETACHED remedies; it is now
  `git -C <source-checkout> ...` so the placeholder does not reintroduce the
  ambiguity the rename removes.
- **Anchor.** The `worktrees.md` heading "Refresh the main checkout first"
  became "Refresh the source checkout first", and the one link to its anchor in
  `commands.md` was updated with it.
- **Wrapping.** Hard-wrapped guide prose, the README and the docs were
  re-wrapped where the two extra characters left ragged or over-long lines; one
  settings table cell lost two padding spaces to keep the column aligned.

Three sites keep "main" because they are git's concept, not Stim's role for it:

- `doctor.ts`: the comment "Git lists the main working tree before all linked
  worktrees" describes `git worktree list` output order.
- `guide cleanup`: "git cannot remove a repository's main working tree, and
  deleting the source checkout is not what anyone meant" -- the first clause is
  git's own refusal, the second is Stim's term.
- `worktree-refresh.test.ts`: `git -C /w/main checkout <branch>` is a fixture
  path plus the `git checkout` subcommand, not the phrase.

Historical records are left alone: release notes under `docs/releases/`, design
specs and plans, the agent-benchmark docs and the recorded benchmark runs in
`website/src/data/benchmarks/*.json` (which contain verbatim transcripts of
older guide output), and `scripts/agent-benchmark/driver.mjs`, whose
`main-checkout-dirty` marker appears in those recorded results. The two live
internal process docs that use the term as Stim's own (`docs/e2e-and-ci.md`,
`docs/field-test-protocol.md`) are updated, so no live document disagrees with
the CLI.

## Test plan

From the repository root, outside the shell sandbox:

- `pnpm format:check` -- clean (488 files).
- `pnpm lint` -- clean.
- `pnpm build` then `pnpm typecheck` -- clean.
- `pnpm knip` -- clean.
- `pnpm test` -- 129 files, 4011 passed, 1 skipped. Includes the doctor-finding
  title assertions, the `worktree remove` "(it is the source checkout)" output
  assertions, the warm refusal assertions, and the guide contract test that
  pins `--refresh WRITES TO THE SOURCE CHECKOUT`.
- `pnpm test:e2e` -- 79 passed, 0 failed.
- Rendered the changed guide text from the built CLI (`guide cleanup gc`,
  `guide errors STIM_MAIN_DIRTY`, `guide errors carry`, `guide lifecycle
  options`) and read the re-wrapped paragraphs in their terminal form.

Closes #654
