### PR TITLE
chore: 1.1.0 — one ownership claim for long-held locks, and warm --refresh

### DIFF
--- a/docs/releases/1.1.0.md
+++ b/docs/releases/1.1.0.md
@@ -1,0 +1,89 @@
+# 1.1.0
+
+## New
+
+- `stim worktree warm --refresh` brings the source checkout up to date before copying from it: it fast-forwards that checkout to its upstream and installs when the lockfiles moved, so a warm worktree no longer inherits whatever happened to be sitting in the checkout that seeded it. It refuses a source checkout it cannot move (`STIM_MAIN_DIRTY`, `STIM_MAIN_DETACHED`, `STIM_MAIN_DIVERGED`), never switches a branch under another checkout, and warns when the checkout is not on the default branch, because every worktree seeded from there then carries that branch's dependencies. Opt-in: plain `warm` is unchanged. [97ede367f](https://github.com/appandflow/stim/commit/97ede367f)
+- One ownership-claim primitive now backs every lock held across a long operation, and `build-lock`, `build-slots` and `workspace-process-lock` were migrated onto it. Liveness comes from a process-identity record rather than a bare PID check, so a recycled PID can no longer make a dead claim look alive; a claim is built privately and renamed into place, so a half-built one is never observable; and a spawned installer is held by its process group, so a package manager's postinstall descendants keep the claim while they are still writing. A state the claim cannot resolve is refused with the path to remove, never silently reaped. [a6252b9d7](https://github.com/appandflow/stim/commit/a6252b9d7)
+- `worktree.defaultBranch` in the repository-root `.stim.json` names the default branch when `origin/HEAD` is missing or wrong. [97ede367f](https://github.com/appandflow/stim/commit/97ede367f)
+- `doctor` reports the source checkout's fitness as a seed -- uncommitted changes, a detached HEAD, a rebase or merge in progress, divergence from upstream, and a branch that is not the default one -- each naming the refusal it predicts and the git line that clears it. [6d0d16bc0](https://github.com/appandflow/stim/commit/6d0d16bc0)
+- `doctor` validates the machine config: a setting naming a path that no longer exists, a setting missing a companion it requires, a key Stim no longer reads, and a config that is not valid JSON. Previously these surfaced only when a command read them, and the error named the missing file rather than the setting that named it. [e9d520468](https://github.com/appandflow/stim/commit/e9d520468)
+- A native build's compiler-cache statistics now survive the build that failed. `--json` failure payloads carry a new `ccache` key on Android and `compilationCache` on iOS, and every native build prints a `cache` progress line, failures included. [5197ff384](https://github.com/appandflow/stim/commit/5197ff384)
+
+## Fixes
+
+- `gc --delete` could delete a build lock that was still held. It decided whether a lock was orphaned from a bare PID check, and that guard also passed for a claim record it could not parse -- so a corrupt record belonging to a running build was treated as garbage, leaving two workspaces free to compile the same app at once. It now surveys claims through the shared primitive, takes the set's own claim before removing anything, and leaves a claim it cannot resolve alone and reported. [a6252b9d7](https://github.com/appandflow/stim/commit/a6252b9d7)
+- A `STIM_HOME` the filesystem will not accept writes to no longer stops a plain `warm`. macOS reports a recursive `mkdir` against a read-only mount as `ENOENT`, which is also what a claim set another process just removed gives, so the attempts were spent as if contended and the copy refused naming a contender that was never there. Such a store is now identified as missing rather than contended, and the copy degrades the way it did before claims existed. [68d9e2fe5](https://github.com/appandflow/stim/commit/68d9e2fe5)
+- `warm` output names what it is talking about. The line reporting a wait attributed the waiter's own elapsed time to the holder's pid, and the line reporting an install named neither the tree it installed in nor the one it copied from. [aa09f4015](https://github.com/appandflow/stim/commit/aa09f4015)
+- A transient `adb shell pm clear` failure when adopting a pooled Android emulator is retried rather than failing the launch. The first launch on an emulator resumed from a snapshot could fail while its system services were still restarting, where the identical command succeeded seconds later. [3e2552ac5](https://github.com/appandflow/stim/commit/3e2552ac5)
+- A cleanup whose staging removal fails now releases the claim it took instead of keeping it. [95d2b7e3f](https://github.com/appandflow/stim/commit/95d2b7e3f)
+- `stim reload` no longer kills the app it was asked to reload. It reopened the recorded development-client URL, which restarts rather than reloads; on Android that recreates `MainActivity`, and expo-dev-launcher asserts there that no React context exists yet, so a healthy dev-client app died on every `stim reload android` while the command reported success because it dispatched without observing the result. Reload now goes through the Metro websocket on both platforms. [35c6bab80](https://github.com/appandflow/stim/commit/35c6bab80)
+- A hand-edited `config.json` no longer crashes a command with a raw `TypeError`. A missing `projects` container is adopted, the way a missing `repos` already was, and a container holding an array or a scalar is reported as `STIM_CONFIG_CORRUPT` with the file left untouched. That second shape was the quiet one: `JSON.stringify` drops a string key set on an array, so `"projects": []` let a write return the record it appeared to have stored while nothing reached disk. [2efb9db84](https://github.com/appandflow/stim/commit/2efb9db84)
+- Owned devices are now distinguished across worktrees. The default label combines the worktree directory and the app directory (`pr6460-tlon-mobile`), and an iOS name gains a suffix when two workspaces would otherwise collide, serialized under its own lock. Two worktrees of one repository used to compete for a single device named after the app directory alone. **An existing owned iOS simulator is renamed when it is next reused.** [acc1d7c29](https://github.com/appandflow/stim/commit/acc1d7c29)
+- A CAS toolchain that is missing, unreadable, or unusable no longer refuses the Android build. Stim warns, names the setting and the file it came from, and falls back to ccache where ccache is available. A stale `optimizations.android.casToolchain` pointing at a deleted directory used to fail every `stim android` instantly with `STIM_BAD_ARG`, while `doctor --platform android` reported clean. [e9d520468](https://github.com/appandflow/stim/commit/e9d520468)
+- A non-string `optimizations.android.casToolchain` no longer makes `gc` refuse. [e9d520468](https://github.com/appandflow/stim/commit/e9d520468)
+- `doctor` no longer reports the source checkout's **branch state** to people who do not use worktrees. `The source checkout is N commits behind` fired unconditionally, so working in a single checkout on a feature branch read as a problem rather than as the job. Those findings are now gated on the repository actually having a linked worktree. Findings about the source checkout's dependencies, Pods and cold build output are not gated and still appear in a single checkout. [6d0d16bc0](https://github.com/appandflow/stim/commit/6d0d16bc0)
+- Command start-up loads only the command being run. [9a23aebd7](https://github.com/appandflow/stim/commit/9a23aebd7)
+- A long run of benchmark-harness fixes: sessions no longer fail on a refusal that changed nothing, and runs pin their locale so native cache entries are reused.
+
+## Docs
+
+- `guide agent` and `guide lifecycle` name the two ways of working -- a single checkout, and the worktree workflow where the source checkout is a seed that stays clean and current -- and say which rules belong to which. Previously the worktree workflow read as the only one, and its rules about the seed looked universal. [6d0d16bc0](https://github.com/appandflow/stim/commit/6d0d16bc0)
+- Shipped text now calls the repository's primary working tree the **source checkout** rather than the **main checkout**. The old name read as _the checkout of the `main` branch_, and plenty of repositories have none -- a project whose default branch is `develop` got `The main checkout is 3 commits behind origin/develop`. No command, flag, settings key, or error code changed. [99de2b229](https://github.com/appandflow/stim/commit/99de2b229)
+
+## Migration notes
+
+- Let a running build finish before upgrading. The build lock changed shape, so a 1.0.0 build already in flight and a 1.1.0 build started after the upgrade do not see each other's record and will both compile. Running two Stim versions against one `STIM_HOME` is not a supported configuration; this is only about the moment of the upgrade, and it clears as soon as the older processes exit.
+- Output that said "main checkout" now says "source checkout". Nothing executable changed: `worktree.defaultBranch`, `worktree.exclude` and every other settings key keep their names, and `STIM_MAIN_DIRTY` / `STIM_MAIN_DETACHED` / `STIM_MAIN_DIVERGED` keep theirs. A script matching on the old phrase in human output needs updating. So does one matching on `doctor --json`, whose finding titles, details and remedies are the same renamed strings; only the field names are untouched.
+- `stim worktree warm` is unchanged without `--refresh`, with one exception: it now refuses to copy after an install that did not finish, because copying a half-installed `node_modules` into a worktree produces a broken worktree silently. `stim worktree warm --refresh` reinstalls and clears it.
+- `--refresh` needs a clean source checkout on a branch that can fast-forward. In a worktree workflow that is what keeps the checkout worth copying; if you also work in it directly, omit the flag. It is best-effort about the network: a fetch that fails is reported and the refresh continues against what is already local, and a branch with no upstream is left where it is.
+- A machine whose `optimizations.android.casToolchain` has rotted keeps building. Stim warns, names the setting and its file, and uses ccache where available; `doctor` reports the same thing so it is findable before a build rather than during one. CAS itself is unchanged, and a valid toolchain is still used.
+
+## Known limitations
+
+Recorded in [#696](https://github.com/appandflow/stim/issues/696) rather than fixed, and documented in `guide errors` and `guide lifecycle` where a user would meet them:
+
+- A plain `warm` that cannot record a claim surveys the claim set and refuses if a refresh holds it, which closes the common case but not a refresh that starts after the copy is already running. Reaching it needs one process unable to write `STIM_HOME` while another can. That survey also only treats an unreadable `.claim` file as a blocker, so a refresh whose `exclusive/` directory itself cannot be read is not seen.
+- A process-group id carries no identity, so a recycled one reads as alive. It holds a claim too long; it never frees a live writer.
+- An installer descendant that never exits makes `--refresh` wait, then refuse after five minutes naming the process group and the command to end it, keeping the claim.
+- `STIM_HOME` or its `warm-locks` directory existing as a plain _file_ refuses with a remedy that names a path one level too deep.
+
+## QA
+
+Cut with the expedited preflight plus the full `caches` matrix, at the release owner's direction. `RELEASE.md` section 3 excludes a stable version from the expedited lane and asks for every applicable row on a minor release, so this is a disclosed deviation from the documented gate rather than a completion of it. What it does not omit any more is the cache evidence.
+
+Why the cache rows specifically: this release migrates the single-flight build lock, the build-slot semaphore and the workspace process lock onto one primitive, and `RELEASE.md` names the `caches` row as the required evidence for "build, cache, fingerprint, Pods, Metro, single-flight, or `gc` behaviour". A lock change without that row is the one thing this release could not claim.
+
+Run on the version commit:
+
+- `pnpm install --frozen-lockfile`, `release:prep --check` (5 packages at 1.1.0, 7 `workspace:` ranges), `build`, `--version`, `--help`, `guide agent`, and the tarball inspection.
+- `format:check`, `lint`, `typecheck`, `knip`, `test`, `test:e2e`.
+- `node test/e2e/native/run-cache-e2e.mjs --framework expo --platform ios` -- **7 pass, 1 skip, 0 fail, 0 missing** in 327s. The skip is `gradle-cache`, which is Android-only.
+- `node test/e2e/native/run-cache-e2e.mjs --framework expo --platform android` -- **6 pass, 2 skip, 0 fail, 0 missing** in 363s. The skips are `xcode-cas` and `pods-reuse`, both iOS-only.
+
+Every check passes on the platform where it applies, on real compiles in throwaway workspaces.
+
+**Both rows were run on `0bbdead9c`, the candidate before the final five commits** -- `aa09f4015`, `3e2552ac5`, `68d9e2fe5`, `95d2b7e3f` and `e22636dd0`, which are the four fixes listed above plus a docs change. They were not re-run against the tagged tree, at the release owner's direction. Three of the four touch code the suite exercises: the claim store's error classification, `warm` output wording, and Android pool adoption. What covers them instead is the unit and e2e suites, which did run on the tagged tree and include the tests those commits shipped with, plus exact-release-commit CI.
+
+The evidence that bears directly on the lock migration is `single-flight`, on both platforms, with two workspaces racing one uncached fingerprint.
+
+iOS, through xcodebuild:
+
+    wt3: cacheHit="local" waitedForBuild={"pid":37959,"ms":67452} durationMs=85630
+    wt4: cacheHit=false   waitedForBuild=null                    durationMs=85659
+    both racers computed the same key: b75c50589e37f1b49ff92feca64e128fc05852b2-debug-sim
+
+Android, through Gradle:
+
+    wt3: cacheHit="local" waitedForBuild={"pid":67582,"ms":23053} durationMs=67306
+    wt4: cacheHit=false   waitedForBuild=null                    durationMs=63857
+    build  waited 23.1s for .../e2e-cache-4's build -> installed from cache
+
+One workspace compiled and the other waited on the claim and installed what it stored, on each platform. The surrounding checks cover the rest of what the migration touches: `gradle-cache` proves `--build-cache` reached the real argv with 651 new entries and 89 `FROM-CACHE` tasks in the second worktree; `xcode-cas` proves all five compilation-cache settings reached the real argv with 69% of the cold compile's CAS files reused by a never-compiled workspace; `pods-reuse` proves a carried, matching `Pods` skips `pod install` outright rather than merely running it quickly; and `zero-config` proves the source checkout was porcelain-clean afterwards with all four worktrees removed without `--force`.
+
+`gc-view` reports every cache with a size and calls none of them garbage on both platforms. It does **not** reach `gc --delete`, so the repaired deletion guard -- the fix in this release that previously decided deletions from a bare PID check -- has unit coverage only.
+
+Omitted: the pre-tag native `loop` rows and the manual field-test matrix in `RELEASE.md` section 3.
+
+Retained after push: exact-release-commit CI, including its format, lint, build, typecheck, knip, unit, cross-platform e2e, and published-runtime jobs.
+
+Three things the next person running this suite should know, each of which currently fails late rather than up front ([#702](https://github.com/appandflow/stim/issues/702)). It needs `ANDROID_HOME` for the Android row, or the run spends 37s inside a Gradle build before reporting `SDK location not found`. It needs `LANG`/`LC_ALL` set to a UTF-8 locale, or `pod install` fails inside the iOS row on a unicode normalization error. And it needs no orphaned `.avd` directory for the AVD names it will claim, a state that is invisible to `emulator -list-avds` and therefore to Stim's own check ([#710](https://github.com/appandflow/stim/issues/710)). The suite's own exit status is trustworthy: it exits 1 on a failed check, a missing check, and a fatal, including one raised by its own cleanup.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/cache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Cache provider contract and tier coordination for Stim.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared internal cache and runtime primitives for Stim packages.",
   "license": "MIT",
   "repository": {

--- a/packages/expo-build-cache/package.json
+++ b/packages/expo-build-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/expo-build-cache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Local Expo build cache provider: installs a cached .app/.apk instead of compiling when no native input changed.",
   "license": "MIT",
   "repository": {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stim-cli/metro",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Metro integration for Stim: shared transforms across worktrees and structured logs.",
   "license": "MIT",
   "repository": {

--- a/packages/stim-cli/package.json
+++ b/packages/stim-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stim",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Stim: fast, isolated React Native environments for coding agents",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

Bumps the five packages to 1.1.0 and adds `docs/releases/1.1.0.md`. No code changes.

## Changes

`docs/releases/1.1.0.md` carries the changelog, the migration notes, the known limitations, and a QA section stating what was run and what was not.

Headline contents of the release: one ownership-claim primitive behind every long-held lock, with `build-lock`, `build-slots` and `workspace-process-lock` migrated onto it; `stim worktree warm --refresh`; `doctor` reporting the source checkout's fitness as a seed and validating the machine config; a CAS toolchain that has rotted now warning and falling back rather than refusing the build; and "main checkout" renamed to "source checkout" in shipped text.

One genuine bug fix in shipped behaviour worth calling out: `gc --delete` could delete a build lock that was still held, because it decided from a bare PID check whose guard also passed for a claim record it could not parse.

## How did I test?

Short preflight on the bumped candidate: `install --frozen-lockfile`, `release:prep --check` (5 packages at 1.1.0, 7 `workspace:` ranges), `build`, `--version` → `1.1.0`, `--help`, `guide agent`.

Tarball inspection, which the expedited lane keeps mandatory: all five pack at 1.1.0, **zero** unsubstituted `workspace:` ranges, a README in each, and the `stim` tarball carries `dist/cli.mjs`, `skill/SKILL.md` and all the shims.

Local gates: `format:check`, `lint`, `typecheck`, `knip`, `test` (130 files, 4064 passed, 1 skipped), `test:e2e` (79 passed).

`caches` e2e, iOS: **7 pass, 1 skip, 0 fail, 0 missing** in 311s. The `single-flight` row is the evidence this release needs, on real compiles of one fingerprint key -- one workspace compiled, the other waited 62s on the claim and installed the artifact it stored.

`caches` e2e, Android: **attempted twice, no evidence collected**, recorded in the notes as an omission with its reasoning rather than as a pass. Both failures are harness fragility, filed as #702.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes, before the tag. After publishing, no -- npm is the constraint, not this commit.)
- Affects important code area:
  - [x] Other: a version bump and release notes only; the behaviour shipped here landed in #681, #690, #661, #679 and #700.

Two things a reviewer should weigh rather than take on trust. The QA basis is the expedited preflight plus the iOS `caches` row, which is a deviation from `RELEASE.md` section 3's full lane, recorded in the notes. And the cache suite **exits 0 when it fails** (#701) -- the first iOS run reported `ok: false` with all eight checks missing and still exited 0, so the summary JSON is the only trustworthy signal.

## Rollback plan

Before the tag: close this PR, or revert the commit. Nothing is published until the tag exists.

After the tag: the published version cannot be withdrawn cleanly, so recovery is a follow-up patch release. That is why the tag is deliberately not part of this PR.

## Screenshots / videos

None.