### PR TITLE
test: reduce benchmark workflow coaching

### DIFF
--- a/docs/agent-benchmark.md
+++ b/docs/agent-benchmark.md
@@ -381,8 +381,8 @@ Inject a deterministic root-render JavaScript exception before the first app
 screen, then give each agent the same repair task. Compare first recorded activity to the
 first actionable diagnosis, commands and tokens to diagnosis, and first recorded activity to
 a repaired Settings screenshot. Run separate iOS and Android blocks. The Stim
-arm must preserve the matching `stim ios` or `stim android` launch
-output and `stim logs --errors`; control collects the equivalent Metro and
+arm uses the matching `stim ios` or `stim android` launch
+output or `stim logs --errors`; control collects the equivalent Metro and
 device logs manually, using the exact emulator serial for Android `adb`
 commands. The injected error text is unique per run so the
 collector can prove that the reported stack and repair refer to this failure.
@@ -390,7 +390,9 @@ The unique token and source location must appear in captured runtime errors;
 the earlier successful launch command does not have to print the token inline.
 When that launch response already contains the runtime error and root-layout
 context, its completion establishes diagnosis time rather than a later log
-query. The separate successful log capture remains required for validation.
+query. New dispatches accept that response as the capture itself; a separate
+log query is required only when launch output is not actionable. Older recorded
+prompts retain their original separate-capture validation contract.
 Before capture, normal guide, doctor, worktree warming, and narrowly scoped
 installed-dependency resolution are setup, not application-source inspection.
 

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -19,8 +19,8 @@ not prescribe warm/start/log commands, dependency-copy methods, background jobs,
 or a repair location. Native tasks describe the required observable label or
 identifier rather than the file and line to edit.
 
-The launch-failure task is: "The app fails on launch. Reproduce the failure
-before inspecting application source, fix it, and verify the repair."
+The launch-failure task is: "The app fails on launch. Reproduce it and capture
+the runtime error before inspecting application source, fix it, and verify the repair."
 It does not reveal the injected failure's category, token, or source location.
 
 Both arms retain the same run-scoped agent-device evidence protocol: open,

--- a/scripts/agent-benchmark/README.md
+++ b/scripts/agent-benchmark/README.md
@@ -9,6 +9,29 @@ The driver runs the iOS and Android readiness suites plus the JavaScript
 launch-failure suite described in [`../../docs/agent-benchmark.md`](../../docs/agent-benchmark.md).
 Runs are sequential. Never dispatch two cells against the same benchmark root.
 
+## Task prompts
+
+Future dispatches use the same outcome-focused task for both arms. Only the tool
+choice and owned-device allocation differ. Worktree creation remains timed;
+the source checkout has installed dependencies and reusable native outputs.
+Stim's installed skill supplies its normal product workflow. The benchmark does
+not prescribe warm/start/log commands, dependency-copy methods, background jobs,
+or a repair location. Native tasks describe the required observable label or
+identifier rather than the file and line to edit.
+
+The launch-failure task is: "The app fails on launch. Reproduce the failure
+before inspecting application source, fix it, and verify the repair."
+It does not reveal the injected failure's category, token, or source location.
+
+Both arms retain the same run-scoped agent-device evidence protocol: open,
+record, verify Settings text, screenshot, retain the media, and close. These
+commands are collection constraints, not instructions for solving the task.
+Pinned tool versions, device configuration, sandbox boundaries, and the proof
+endpoint remain controlled. A short task is not an unconstrained environment.
+
+`meta.promptPolicy` records the new policy. Earlier recordings retain their
+original validation contract and are not relabeled or rewritten by this change.
+
 After a complete campaign passes export audit, replace the canonical website
 results and retain a [timing-only campaign snapshot](../../docs/benchmark-history/README.md).
 Do not snapshot individual retries or partial campaigns.
@@ -197,8 +220,7 @@ before failing.
 Android launch-error control preparation carries dependencies and native outputs
 but leaves out the root `android/build` directory. Its generated autolinking cache
 contains absolute source-checkout paths and package checksums that survive a copy.
-The control prompt also requires excluding `android/build/generated/autolinking`
-when the agent creates its run worktree. Gradle regenerates this metadata locally;
+Gradle regenerates this metadata locally;
 `android/app/build` remains available for native output reuse. Verify the generated
 project and dependency roots belong to the run worktree before accepting a pilot.
 
@@ -232,8 +254,7 @@ validation still requires runtime error evidence before source inspection,
 the exact repair, and Settings-screen screenshot/video proof.
 
 Launch-error control can use runner-managed sessions for Metro, emulators, and
-native commands; it does not have to daemonize shell jobs. It keeps per-run logs
-for the separate completed error query and preserves the inherited Android SDK,
+native commands; it does not have to daemonize shell jobs. It preserves the inherited Android SDK,
 AVD, Gradle, and emulator-report locations so observation and cleanup use the
 same metadata as the agent.
 
@@ -242,7 +263,7 @@ scoped setup operations, including local SDK tools, managed log pipelines, and
 the assigned AVD's configuration edit. Unrecognized setup syntax is retained in
 `diagnosis.setupWarnings` for review, not automatically treated as a failed task.
 Review these commands before publication; a warning is not a safety approval.
-Detected source inspection before completed log capture remains a hard failure,
+Detected source inspection before completed runtime-error capture remains a hard failure,
 with every offending command in `diagnosis.violations` and the first in `commandId`.
 Version, isolation, warm ordering, device, exact repair, timing, screenshot and
 recording gates remain unchanged. This heuristic audit does not prove arbitrary
@@ -254,17 +275,17 @@ The pipeline may follow `cd <worktree> && set -o pipefail && ...`. If it ends
 with `; echo "PIPELINE_EXIT=$?"`, the captured output must contain exactly one
 `PIPELINE_EXIT=0` line: the echo's own zero exit does not prove build success.
 Retained launch-evidence rejections can be reviewed only when re-derived commands
-prove successful launch, separate error capture, repair and Settings proof.
+prove successful launch, runtime-error capture, repair and Settings proof under their recorded prompt policy.
 Ordinary commands may also append `; echo "EXIT=$?"`. The audit uses the single
 captured status line, not the echo's exit code; missing or ambiguous reports do
 not prove success. A retained warm-status rejection requires re-derived setup
 checks, including warm completion before start or build, before publication.
 
-A launch can finish before the JavaScript error reaches its log. Both arms must
-repeat standalone foreground log queries, without separate sleep or wait commands,
-until a completed query prints the error and source location before inspecting or
-editing source. An empty successful query or a redbox visible
-only through device automation does not satisfy this log-first diagnosis measure.
+A launch can finish before the JavaScript error reaches its log. For new runs,
+actionable initial launch output satisfies capture without a second log query.
+Otherwise the agent must obtain runtime error evidence before inspecting or editing
+application source; polling strategy is not prescribed. An empty successful query
+does not establish a diagnosis. Earlier runs still use their separate-capture contract.
 
 `dispatch` creates and commits the broken fixture before the timed turn, gives
 the agent the fixture checkout as its starting directory, and requires the

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -33,6 +33,7 @@ import { benchmarkFingerprint, selectBenchmarkCacheKey } from './cache-key.mjs';
 import { reconstructCommandEvidence } from './command-evidence.mjs';
 import { matchesGoldenPreparation, preparedAndroidEmulator } from './golden-state.mjs';
 import { launchCrashSetup } from './launch-crash-setup.mjs';
+import { benchmarkTaskPrompt } from './task-prompt.mjs';
 import { collectedNativeCompatibility, probeNativeCompatibility, verifyNativeCompatibility } from './native-compat.mjs';
 import {
   androidApplicationLabelFromBadging,
@@ -972,63 +973,47 @@ function prepareLaunchCrashFixture(arm, runId, environment, platform) {
 
 function promptFor(arm, variant, runId, runDir, crash = null, requestedPlatform = 'ios') {
   const platform = checkedPlatform(requestedPlatform);
-  const controlDeviceName = platform === 'ios' ? `Trailhead ${runId}` : `Trailhead_${runId}`;
-  const stimPath = join(worktreeParent, `bench-${runId}`);
-  const quotedStimPath = `'${stimPath.replaceAll("'", "'\\''")}'`;
-  const stimSource = variant === launchCrashVariant ? crash.fixtureCheckout : main;
-  const worktree =
-    arm === 'stim'
-      ? `In ${stimSource}, run exactly \`git worktree add -b worktree-bench/${runId} ${quotedStimPath} HEAD\`. Then change into ${stimPath}, run \`stim guide agent\`, and follow the guide before using other Stim commands. Run \`stim worktree warm\` and wait for its successful exit before running start or a platform command. Work only in that checkout. `
-      : variant === launchCrashVariant
-        ? `In ${crash.fixtureCheckout}, create a git worktree for branch bench/${runId} at ${join(worktreeParent, runId)} from the current fixture HEAD and carry installed dependencies and native outputs from the fixture checkout. Then work only in that run worktree. Name the new ${platform === 'ios' ? 'simulator' : 'AVD'} exactly ${JSON.stringify(controlDeviceName)}. `
-        : `In ${main}, create a git worktree for branch bench/${runId} at ${join(worktreeParent, runId)} and carry installed dependencies and native outputs from the main checkout. Then work only in that worktree. Name the new ${platform === 'ios' ? 'simulator' : 'AVD'} exactly ${JSON.stringify(controlDeviceName)} so the coordinator can prove ownership and clean it safely. `;
-  const screenshot = join(runDir, 'proof', 'settings.png');
-  const screenshotScratch = join('/tmp', `${runId}-settings.png`);
-  const recording = join(runDir, 'proof', 'session.mp4');
-  const recordingScratch = join('/tmp', `${runId}-session.mp4`);
-  const expected = settingsProofText(variant);
-  const agentDevicePrefix = `env AGENT_DEVICE_STATE_DIR=${agentDeviceState} AGENT_DEVICE_SESSION=${runId} agent-device`;
-  const targetDescription = platform === 'ios' ? 'simulator UDID' : 'emulator serial';
-  const targetFlag = platform === 'ios' ? '--udid' : '--serial';
-  const deviceProof = ` After the app launches, you MUST use the agent-device skill and CLI. Codex does not forward the coordinator's agent-device environment into shell tools, so every agent-device command below includes the required prefix. Never run a bare \`agent-device\` command. Read the exact run ${targetDescription} from the launch output. Handle any Expo onboarding shown and navigate to the Settings tab using semantic refs or labels between steps 2 and 3 below. Do not stop or restart the agent-device daemon; report a failure if the isolated session refuses to open. The explicit state and session assignments and device identifier prevent cross-run ownership.`;
-  const proofProtocol = `\n\nFINAL PROOF PROTOCOL: The proof directory already exists. For each numbered shell command below, send the displayed line alone as the entire Bash \`command\` string. Do not prepend \`mkdir\`, append \`ls\`, combine it with another command, use redirection, or wrap it in a script or interactive shell. Replace only the angle-bracketed value in step 1.\n\n1. \`${agentDevicePrefix} open com.appandflow.trailhead --foreground --platform ${platform} ${targetFlag} <run ${targetDescription}>\`\n2. \`${agentDevicePrefix} record start ${recordingScratch} --scope device --quality high --hide-touches\`\n3. \`${agentDevicePrefix} wait text ${JSON.stringify(expected)}\`\n4. \`${agentDevicePrefix} screenshot ${screenshotScratch}\`\n5. \`cp ${screenshotScratch} ${screenshot}\`\n6. \`${agentDevicePrefix} record stop\`\n7. \`cp ${recordingScratch} ${recording}\`\n8. \`${agentDevicePrefix} close\`\n\nDo not claim completion before all eight commands succeed in order, the wait finds the expected text, recording stop reports the saved video, and the copied screenshot and recording exist.`;
-  const commandCompletion =
-    'The runner starts in the source checkout because creating your isolated run worktree is part of the timed task. After creating it, use that run worktree as the working directory of subsequent shell calls. If the shell tool has a workdir/cwd parameter, set it explicitly instead of repeating cd prefixes. A cd in one shell call may not persist to the next; when no working-directory parameter is available, keep the explicit cd where needed. Do not change the standalone proof commands below. For shell-tool calls, preserve the full result, including exit status and any running session handle. In a code wrapper around exec_command or write_stdin, print the complete result with text(result), not only result.output. A completed code wrapper or empty output does not mean its shell process finished. For finite commands, if the shell result contains a session_id, poll that session with write_stdin until an exit_code is returned before issuing dependent commands; do not replace polling with another copy of the command. Long-lived Metro/emulator sessions stay running: wait for their readiness evidence, not their exit, before using them. For explicitly detached shell processes, retain separate PID/log monitoring. Finish dependency copying before starting Metro or native commands; do not install dependencies inside the timed run.';
-  const suffix = ` ${commandCompletion} Stay in this turn until the Settings screenshot is saved; do not stop to await a background notification. Do not use subagents. Work only in the fixture checkout, run worktree, and the current run's proof, temporary, runtime, and tool-state paths. Coordinator configuration, golden caches, other worktrees, and other runs' file contents are protected by the runner filesystem policy. Parent directory listings are permitted; do not try to bypass a denied read or use another process or service to access protected files. Report the run worktree and screenshot paths, then stop; the coordinator will verify and clean up.${proofProtocol}`;
-  if (variant === launchCrashVariant) {
-    const launch = launchCrashSetup({ arm, platform, systemImage: pins.ANDROID_SYSTEM_IMAGE }).instructions;
-    return (
-      worktree +
-      'The app has a deterministic JavaScript failure during its initial root render. Diagnose and repair that launch failure without making unrelated product changes. ' +
-      launch +
-      deviceProof +
-      suffix
-    );
-  }
-  if (variant === 'javascript') {
-    const edit =
-      'change the Settings offline-map subtitle from "Keep map tiles for saved trails on device" to "Keep saved trail maps available offline". ';
-    const launch = platformLaunchInstructions(arm, platform, runId, true);
-    return worktree + edit + launch + deviceProof + suffix;
-  }
-  const edit =
+  const source = variant === launchCrashVariant ? crash.fixtureCheckout : main;
+  const worktree = join(worktreeParent, arm === 'stim' ? `bench-${runId}` : runId);
+  const branch = arm === 'stim' ? `worktree-bench/${runId}` : `bench/${runId}`;
+  const deviceName = platform === 'ios' ? `Trailhead ${runId}` : `Trailhead_${runId}`;
+  const device =
     platform === 'ios'
-      ? `edit ios/Trailhead/AppDelegate.swift so that immediately after the existing window assignment it sets the window accessibilityIdentifier to "Trailhead ${runId}". `
-      : `edit android/app/src/main/res/values/strings.xml so the app_name string is exactly "Trailhead ${runId}". `;
-  const launch = platformLaunchInstructions(arm, platform, runId, false);
-  return worktree + edit + launch + deviceProof + suffix;
-}
-
-function platformLaunchInstructions(arm, platform, runId, startMetro) {
-  if (arm === 'stim') {
-    return platform === 'ios'
-      ? 'Use the Stim skill and only the pinned published command available on PATH as exactly `stim` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run the iOS app on the prepared parked iPhone 17 simulator running iOS 26.5; Stim must report that it adopted the simulator. Leave Metro running until the screenshot is saved.'
-      : `Use the Stim skill and only the pinned published command available on PATH as exactly \`stim\` (never through npx or an absolute path). Keep the inherited STIM_HOME unchanged. Run \`stim start\`, then run \`stim android --system-image ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)}\`. Use the prepared parked emulator; Stim must report that it adopted it. Leave Metro and the changed app running until the screenshot is saved.`;
-  }
-  if (platform === 'android') {
-    return `Use only the project's local Expo and Android SDK tooling; do not use Stim. Create a new AVD named exactly ${JSON.stringify(`Trailhead_${runId}`)} from ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)} using avdmanager's default hardware profile, matching Stim; do not use an existing emulator. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim's default 8 GiB data partition. Boot it with the emulator's default Quick Boot policy, matching Stim; the fresh AVD cold-boots because no snapshot exists. Wait for Android boot completion. ${startMetro ? 'Start Metro and verify it is ready. ' : ''}Build, install, and launch only the default Debug variant; do not use a Release variant. Wait for the native build/install/launch to finish successfully, then immediately perform the agent-device proof without ending the turn. Leave the emulator${startMetro ? ', Metro,' : ''} and app running. `;
-  }
-  return `Run the iOS app with the project's local Expo and Apple tooling on a new iPhone 17 simulator running iOS 26.5; do not use an existing simulator. ${startMetro ? 'Start Metro and verify it is ready. ' : ''}Wait for the native build/install/launch to finish successfully, then immediately perform the agent-device proof without ending the turn. Leave the changed app running. Do not use Stim.`;
+      ? `an isolated iPhone 17 simulator with iOS 26.5${arm === 'control' ? `, newly created and named ${JSON.stringify(deviceName)}` : ''}`
+      : `an isolated arm64 Android emulator using ${JSON.stringify(pins.ANDROID_SYSTEM_IMAGE)}${arm === 'control' ? `, newly created and named ${JSON.stringify(deviceName)}, with the default hardware profile and an 8 GiB data partition` : ''}`;
+  const prefix = `env AGENT_DEVICE_STATE_DIR=${agentDeviceState} AGENT_DEVICE_SESSION=${runId} agent-device`;
+  const screenshot = join('/tmp', `${runId}-settings.png`);
+  const recording = join('/tmp', `${runId}-session.mp4`);
+  const target = platform === 'ios' ? '--udid <run simulator UDID>' : '--serial <run emulator serial>';
+  const proof =
+    `Use this run-scoped agent-device prefix: ` +
+    '\n' +
+    prefix +
+    '\n' +
+    `The common evidence protocol below records the same endpoint for both arms. Run each proof command separately; navigate to Settings between recording start and the text check.\n\n` +
+    [
+      `${prefix} open com.appandflow.trailhead --foreground --platform ${platform} ${target}`,
+      `${prefix} record start ${recording} --scope device --quality high --hide-touches`,
+      `${prefix} wait text ${JSON.stringify(settingsProofText(variant))}`,
+      `${prefix} screenshot ${screenshot}`,
+      `cp ${screenshot} ${join(runDir, 'proof', 'settings.png')}`,
+      `${prefix} record stop`,
+      `cp ${recording} ${join(runDir, 'proof', 'session.mp4')}`,
+      `${prefix} close`,
+    ]
+      .map((command, index) => `${index + 1}. \`${command}\``)
+      .join('\n');
+  return benchmarkTaskPrompt({
+    arm,
+    platform,
+    variant,
+    source,
+    worktree,
+    branch,
+    marker: `Trailhead ${runId}`,
+    device,
+    proof,
+  });
 }
 
 function runnerForModel(model) {
@@ -1457,6 +1442,7 @@ async function dispatch(model, arm, variant, stage = 'pilot', requestedPlatform 
   const dispatchAt = new Date().toISOString();
   const meta = {
     schemaVersion: 1,
+    promptPolicy: 'minimal-v1',
     locale: benchmarkLocale,
     runId,
     stage,
@@ -2238,6 +2224,7 @@ function collect(runDir) {
   const diagnosis =
     meta.variant === launchCrashVariant
       ? launchCrashDiagnosis(commandAudit.commands, {
+          initialLaunchCapture: meta.promptPolicy === 'minimal-v1',
           dispatchAt: meta.dispatchAt,
           token: meta.crash.token,
           arm: meta.arm,
@@ -2753,18 +2740,13 @@ function selftestAgentDeviceIsolation() {
     `cp ${recordingScratch} ${recording}`,
     agentDeviceCommand(meta, 'close'),
   ];
-  if (
-    !prompt.includes('The proof directory already exists') ||
-    !prompt.includes('alone as the entire Bash `command` string') ||
-    proofCommands.some((proofCommand, index) => !prompt.includes(`${index + 1}. \`${proofCommand}\``))
-  ) {
+  if (proofCommands.some((proofCommand, index) => !prompt.includes(`${index + 1}. \`${proofCommand}\``))) {
     throw new Error('proof command boundaries are not explicit and ordered');
   }
   if (
     !androidPrompt.includes(
       `1. \`${agentDeviceCommand(meta, 'open com.appandflow.trailhead --foreground --platform android --serial <run emulator serial>')}\``,
-    ) ||
-    !androidPrompt.includes('alone as the entire Bash `command` string')
+    )
   ) {
     throw new Error('Android proof command boundaries are not explicit');
   }
@@ -2782,20 +2764,21 @@ function selftestLaunchCrash() {
   const prompt = promptFor('stim', launchCrashVariant, runId, state, crash);
   for (const platform of ['ios', 'android']) {
     const instructions = promptFor('stim', launchCrashVariant, runId, state, crash, platform);
-    const guide = instructions.indexOf('`stim guide agent`');
-    const warm = instructions.indexOf('`stim worktree warm`');
-    if (guide < 0 || warm < guide) throw new Error(`${platform} prompt must load the guide before warm`);
-    if (promptFor('control', launchCrashVariant, runId, state, crash, platform).includes('`stim guide agent`')) {
+    if (!instructions.includes('Use Stim and its installed skill.'))
+      throw new Error(`${platform} prompt must identify the available Stim skill`);
+    if (
+      promptFor('control', launchCrashVariant, runId, state, crash, platform).includes(
+        'Use Stim and its installed skill.',
+      )
+    ) {
       throw new Error(`${platform} control must not load the Stim guide`);
     }
   }
   for (const required of [
-    `git worktree add -b worktree-bench/${runId}`,
-    'stim worktree warm',
-    'Before inspecting source or git diff',
-    'stim logs --errors',
-    'Make the smallest repair',
-    'demonstrate the repaired Settings screen on the same adopted simulator',
+    `worktree-bench/${runId}`,
+    'The app fails on launch.',
+    'Reproduce the failure before inspecting application source',
+    'Settings screenshot',
   ]) {
     if (!prompt.includes(required)) {
       throw new Error(`launch-crash prompt is missing: ${required}`);
@@ -2837,10 +2820,9 @@ function selftestAndroid() {
   const runId = 'android-selftest';
   const prompt = promptFor('stim', 'native', runId, state, null, 'android');
   for (const required of [
-    `git worktree add -b worktree-bench/${runId}`,
-    'stim worktree warm',
-    'android/app/src/main/res/values/strings.xml',
-    'stim android --system-image',
+    `worktree-bench/${runId}`,
+    'Android application label',
+    pins.ANDROID_SYSTEM_IMAGE,
     '--platform android --serial <run emulator serial>',
     'record start',
     'record stop',

--- a/scripts/agent-benchmark/driver.mjs
+++ b/scripts/agent-benchmark/driver.mjs
@@ -2777,7 +2777,7 @@ function selftestLaunchCrash() {
   for (const required of [
     `worktree-bench/${runId}`,
     'The app fails on launch.',
-    'Reproduce the failure before inspecting application source',
+    'capture the runtime error before inspecting application source',
     'Settings screenshot',
   ]) {
     if (!prompt.includes(required)) {

--- a/scripts/agent-benchmark/launch-crash-setup.mjs
+++ b/scripts/agent-benchmark/launch-crash-setup.mjs
@@ -10,27 +10,5 @@ export function launchCrashSetup({ platform, arm, systemImage }) {
     platform === 'ios'
       ? ['node_modules', 'ios/Pods', 'ios/build']
       : ['node_modules', 'android/.gradle', 'android/.cxx', 'android/app/build', 'android/local.properties'];
-  const platformCommand = platform === 'ios' ? 'stim ios' : `stim android --system-image '${systemImage}'`;
-  const device = platform === 'ios' ? 'adopted simulator' : 'owned emulator';
-  const stim = `Use the Stim skill and only the pinned command available on PATH as exactly \`stim\`. Keep the inherited STIM_HOME unchanged. Before inspecting source or git diff, run \`stim start\` and then \`${platformCommand}\` so the benchmark observes the failure. Preserve that launch output, then immediately run \`stim logs --errors\` as its own command. Diagnose the launch failure from those results. Only after the diagnostic commands may you inspect and edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${device}. Leave Metro and the app running until screenshot proof is complete. Do not use npx, an absolute Stim path, raw Expo launch commands, or stop Stim.`;
-  const controlDevice =
-    platform === 'ios'
-      ? 'Create a new iPhone 17 simulator running iOS 26.5 with the exact required name; do not substitute another device type or runtime and do not use an existing simulator.'
-      : `Keep the inherited ANDROID_AVD_HOME, ANDROID_HOME, GRADLE_USER_HOME, and ANDROID_EMU_CRASH_REPORTING_DATABASE unchanged. Create a new AVD there with the exact required name from ${JSON.stringify(systemImage)} using avdmanager's default hardware profile, matching Stim. Set disk.dataPartition.size=8589934592 in its config.ini, matching Stim. Boot this new emulator with default Quick Boot policy and wait for Android boot completion; do not use an existing emulator. Use its exact serial for Expo launch and every adb command. Build only the default Debug variant and arm64-v8a architecture. Use adb reverse for the app's Metro port before launch.`;
-  const tooling = platform === 'ios' ? 'Apple' : 'Android SDK';
-  const logs = platform === 'ios' ? 'simulator-log' : '`adb -s <run serial> logcat -d`';
-  const portableCopy =
-    platform === 'android'
-      ? ' When carrying native outputs, exclude android/build/generated/autolinking from the copy. It caches absolute paths to the source checkout; let Gradle regenerate it in the new worktree before building.'
-      : '';
-  const control = `Use the project's local Expo and ${tooling} tooling and do not use Stim.${portableCopy} ${controlDevice} Before inspecting source or git diff, start Metro and run the initial native build/install/launch. Keep Metro and any emulator process alive in runner-managed shell sessions or supported background tasks; a shell background job is not required. Save Metro and native output to per-run logs under /tmp. Poll finite copy/build commands to completion before dependent commands. For long-lived servers, preserve the running session and wait for readiness instead of waiting for exit or stopping it. Once the app has launched and failed, run a separate foreground \`tail\`, \`rg\`, or ${logs} command that completes and prints the crash token and source location. Only after that explicit error-capture command completes may you inspect or edit source. Make the smallest repair and demonstrate the repaired Settings screen on the same ${platform === 'ios' ? 'simulator' : 'emulator'}. Leave Metro and the app running until screenshot proof is complete. Do not rely on streamed output from a command that is still running as diagnosis evidence.`;
-  const pipelineRule =
-    ' For any build/launch pipeline ending in tee, enable set -o pipefail in that same shell command before the pipeline so its exit status proves the launch succeeded, not just the log writer.';
-  const evidenceGate =
-    'Do not inspect or edit source until a completed foreground log command prints the launch error and its source location. If the first log query is empty, repeat standalone foreground log queries without separate sleep or wait commands until the error and source location appear. A successful launch, a zero exit code, or an error visible only in a device snapshot does not satisfy this log-capture requirement.';
-  return {
-    ignoredPaths,
-    deviceKind,
-    instructions: `${arm === 'stim' ? stim : control + pipelineRule} ${evidenceGate}`,
-  };
+  return { ignoredPaths, deviceKind };
 }

--- a/scripts/agent-benchmark/launch-crash-setup.test.mjs
+++ b/scripts/agent-benchmark/launch-crash-setup.test.mjs
@@ -6,30 +6,12 @@ import { launchCrashSetup } from './launch-crash-setup.mjs';
 
 const systemImage = 'system-images;android-36;google_apis_playstore_ps16k;arm64-v8a';
 
-it('selects Android fixture inputs and owned-device launch instructions for both arms', () => {
-  for (const arm of ['stim', 'control']) {
-    const setup = launchCrashSetup({ platform: 'android', arm, systemImage });
-    expect(setup.deviceKind).toBe('AVD');
-    expect(setup.instructions).toContain(systemImage);
-    expect(setup.instructions).not.toContain('stim ios');
-    expect(setup.instructions).not.toContain('simulator');
-  }
-  expect(launchCrashSetup({ platform: 'android', arm: 'control', systemImage }).instructions).toContain(
-    'inherited ANDROID_AVD_HOME',
-  );
+it('selects only reusable iOS fixture inputs', () => {
   expect(launchCrashSetup({ platform: 'ios', arm: 'control' }).ignoredPaths).toEqual([
     'node_modules',
     'ios/Pods',
     'ios/build',
   ]);
-});
-
-it.each(['ios', 'android'])('keeps managed control servers alive through %s proof', (platform) => {
-  const { instructions } = launchCrashSetup({ platform, arm: 'control', systemImage });
-  expect(instructions).toContain('runner-managed shell sessions');
-  expect(instructions).toContain('wait for readiness instead of waiting for exit or stopping it');
-  expect(instructions).not.toContain('Do not use a long-running foreground shell command');
-  expect(instructions).toContain('explicit error-capture command completes');
 });
 
 it('carries reusable Android outputs without importing a sibling autolinking cache', () => {

--- a/scripts/agent-benchmark/task-prompt.mjs
+++ b/scripts/agent-benchmark/task-prompt.mjs
@@ -1,0 +1,18 @@
+export function benchmarkTaskPrompt({ arm, platform, variant, source, worktree, branch, marker, device, proof }) {
+  const task =
+    variant === 'launch-crash'
+      ? 'The app fails on launch. Reproduce the failure before inspecting application source, fix it, and verify the repair.'
+      : variant === 'javascript'
+        ? 'Change the Settings offline-map subtitle from "Keep map tiles for saved trails on device" to "Keep saved trail maps available offline".'
+        : platform === 'ios'
+          ? `Set the main iOS window accessibility identifier to ${JSON.stringify(marker)}.`
+          : `Change the Android application label to ${JSON.stringify(marker)}.`;
+  return [
+    `Create an isolated git worktree from ${source} at ${worktree} on branch ${branch}, and work there. Installed dependencies and native outputs are available in the source checkout.`,
+    task,
+    arm === 'stim' ? 'Use Stim and its installed skill.' : "Use the project's standard tooling. Do not use Stim.",
+    `Run the Debug app on ${device}. Use only the device assigned to this run.`,
+    'Verify the result in the app with agent-device, handle any onboarding, and save a Settings screenshot and simulator recording. Keep the app running until proof is saved. Make no unrelated changes.',
+    `Run constraints: preserve the supplied environment and tool versions; do not access other runs or use subagents. ${proof}`,
+  ].join('\n\n');
+}

--- a/scripts/agent-benchmark/task-prompt.mjs
+++ b/scripts/agent-benchmark/task-prompt.mjs
@@ -1,7 +1,7 @@
 export function benchmarkTaskPrompt({ arm, platform, variant, source, worktree, branch, marker, device, proof }) {
   const task =
     variant === 'launch-crash'
-      ? 'The app fails on launch. Reproduce the failure before inspecting application source, fix it, and verify the repair.'
+      ? 'The app fails on launch. Reproduce it and capture the runtime error before inspecting application source, fix it, and verify the repair.'
       : variant === 'javascript'
         ? 'Change the Settings offline-map subtitle from "Keep map tiles for saved trails on device" to "Keep saved trail maps available offline".'
         : platform === 'ios'
@@ -13,6 +13,6 @@ export function benchmarkTaskPrompt({ arm, platform, variant, source, worktree, 
     arm === 'stim' ? 'Use Stim and its installed skill.' : "Use the project's standard tooling. Do not use Stim.",
     `Run the Debug app on ${device}. Use only the device assigned to this run.`,
     'Verify the result in the app with agent-device, handle any onboarding, and save a Settings screenshot and simulator recording. Keep the app running until proof is saved. Make no unrelated changes.',
-    `Run constraints: preserve the supplied environment and tool versions; do not access other runs or use subagents. ${proof}`,
+    `Run constraints: preserve the supplied environment and tool versions; do not install dependencies, access other runs, or use subagents. ${proof}`,
   ].join('\n\n');
 }

--- a/scripts/agent-benchmark/task-prompt.test.mjs
+++ b/scripts/agent-benchmark/task-prompt.test.mjs
@@ -1,0 +1,36 @@
+import { expect, it } from 'vitest';
+import { benchmarkTaskPrompt } from './task-prompt.mjs';
+
+const input = {
+  platform: 'ios',
+  source: '/fixture',
+  worktree: '/run',
+  branch: 'bench/run',
+  marker: 'Trailhead test',
+  device: 'the assigned device',
+  proof: 'Save evidence in /proof.',
+};
+
+it.each(['javascript', 'native', 'launch-crash'])(
+  'gives both arms the same %s task, constraints and evidence requirements',
+  (variant) => {
+    const stim = benchmarkTaskPrompt({ ...input, variant, arm: 'stim' });
+    const control = benchmarkTaskPrompt({ ...input, variant, arm: 'control' });
+    expect(stim.replace('Use Stim and its installed skill.', '')).toBe(
+      control.replace("Use the project's standard tooling. Do not use Stim.", ''),
+    );
+    expect(stim).not.toMatch(
+      /stim (?:start|ios|android|logs|worktree)|rsync|cp -|nohup|pipefail|session_id|RootLayout|_layout\.tsx|deterministic|initial root/,
+    );
+    expect(stim).toContain('/run');
+    expect(stim).toContain('/proof');
+  },
+);
+
+it('specifies native outcomes without giving source locations or code edits', () => {
+  const ios = benchmarkTaskPrompt({ ...input, variant: 'native', arm: 'control' });
+  const android = benchmarkTaskPrompt({ ...input, platform: 'android', variant: 'native', arm: 'control' });
+  expect(ios).toContain('window accessibility identifier to "Trailhead test"');
+  expect(android).toContain('application label to "Trailhead test"');
+  expect(ios + android).not.toMatch(/AppDelegate|strings\.xml|window assignment/);
+});

--- a/scripts/export-benchmark-viewer.mjs
+++ b/scripts/export-benchmark-viewer.mjs
@@ -967,6 +967,7 @@ function validateLaunchCrashRecord(runDir, record, meta, rederive = false, revie
     .match(/STIM_BENCH_LAUNCH_CRASH_[0-9A-F]{12}/)?.[0];
   if (!token) return reject('crash token missing');
   const diagnosis = launchCrashDiagnosis(commands, {
+    initialLaunchCapture: meta.promptPolicy === 'minimal-v1',
     dispatchAt: meta.dispatchAt,
     token,
     arm: record.arm,

--- a/scripts/launch-crash-benchmark.mjs
+++ b/scripts/launch-crash-benchmark.mjs
@@ -389,7 +389,16 @@ function allowedBeforeErrorCapture(command, arm, platform, setup = {}) {
 
 export function launchCrashDiagnosis(
   commands,
-  { dispatchAt, token, arm = 'stim', platform = 'ios', activities = [], setup = {}, reviewedDiagnostics = [] },
+  {
+    dispatchAt,
+    token,
+    arm = 'stim',
+    platform = 'ios',
+    activities = [],
+    setup = {},
+    reviewedDiagnostics = [],
+    initialLaunchCapture = false,
+  },
 ) {
   const ordered = orderedCommands(commands);
   const sourceMarkers = ['app/_layout.tsx', 'RootLayout'];
@@ -401,7 +410,12 @@ export function launchCrashDiagnosis(
   if (initialLaunchIndex === -1) {
     return { valid: false, reason: 'launch-crash-initial-launch-evidence-missing' };
   }
-  const errorCaptureIndex = ordered.findIndex(
+  const initialLaunch = ordered[initialLaunchIndex];
+  const launchOutput = String(initialLaunch.output ?? '');
+  const launchIsActionable =
+    launchOutput.split('\n').some((line) => line.includes(token) && /\b(?:Error|Exception)\b/.test(line)) &&
+    sourceMarkers.some((marker) => launchOutput.includes(marker));
+  let errorCaptureIndex = ordered.findIndex(
     (command, index) =>
       index > initialLaunchIndex &&
       successful(command) &&
@@ -434,6 +448,14 @@ export function launchCrashDiagnosis(
       typeof command.output === 'string' &&
       command.output.includes(token),
   );
+  if (
+    initialLaunchCapture &&
+    launchIsActionable &&
+    (errorCaptureIndex === -1 ||
+      timestamp(initialLaunch, 'endedAt') <= timestamp(ordered[errorCaptureIndex], 'endedAt'))
+  ) {
+    errorCaptureIndex = initialLaunchIndex;
+  }
   if (errorCaptureIndex === -1) {
     return { valid: false, reason: 'launch-crash-error-capture-missing' };
   }
@@ -480,11 +502,6 @@ export function launchCrashDiagnosis(
           command.output.includes(token) &&
           sourceMarkers.some((marker) => command.output.includes(marker)),
       );
-  const initialLaunch = ordered[initialLaunchIndex];
-  const launchOutput = String(initialLaunch.output ?? '');
-  const launchIsActionable =
-    launchOutput.split('\n').some((line) => line.includes(token) && /\b(?:Error|Exception)\b/.test(line)) &&
-    sourceMarkers.some((marker) => launchOutput.includes(marker));
   if (
     launchIsActionable &&
     (index === -1 || timestamp(initialLaunch, 'endedAt') <= timestamp(ordered[index], 'endedAt'))

--- a/scripts/launch-crash-benchmark.test.mjs
+++ b/scripts/launch-crash-benchmark.test.mjs
@@ -17,7 +17,7 @@ describe('launch crash benchmark', () => {
     ['control', 'ios', 'npx expo run:ios', 'tail -40 /tmp/metro.log'],
     ['control', 'android', 'npx expo run:android', 'adb -s emulator-5554 logcat -d'],
   ])(
-    'times actionable initial launch output for %s/%s without waiving log capture',
+    'accepts actionable initial launch output for %s/%s without a redundant log query',
     (arm, platform, command, logCommand) => {
       const token = launchCrashToken('initial-diagnosis');
       const launch = {
@@ -36,16 +36,21 @@ describe('launch crash benchmark', () => {
         endedAt: '2026-09-04T12:00:15Z',
         output: `${token}\nRootLayout (app/_layout.tsx:27:18)`,
       };
-      const options = { dispatchAt: '2026-09-04T12:00:00Z', token, arm, platform };
+      const options = { dispatchAt: '2026-09-04T12:00:00Z', token, arm, platform, initialLaunchCapture: true };
       expect(launchCrashDiagnosis([launch, logs], options)).toMatchObject({
         valid: true,
         commandId: 'launch',
-        errorCaptureCommandId: 'logs',
+        errorCaptureCommandId: 'launch',
         observedAt: launch.endedAt,
         dispatchToDiagnosisSeconds: 10,
         commandCount: 1,
       });
-      expect(launchCrashDiagnosis([launch], options)).toEqual({
+      expect(launchCrashDiagnosis([launch], options)).toMatchObject({
+        valid: true,
+        errorCaptureCommandId: 'launch',
+        dispatchToDiagnosisSeconds: 10,
+      });
+      expect(launchCrashDiagnosis([launch], { ...options, initialLaunchCapture: false })).toEqual({
         valid: false,
         reason: 'launch-crash-error-capture-missing',
       });
@@ -64,7 +69,7 @@ describe('launch crash benchmark', () => {
           launchCrashDiagnosis([{ ...wrap(launch), output: `${launch.output}\n${label}=1\n` }, wrap(logs)], options),
         ).toMatchObject({ valid: false });
       }
-      expect(launchCrashDiagnosis([launch, { ...logs, exitCode: 1 }], options).valid).toBe(false);
+      expect(launchCrashDiagnosis([launch, { ...logs, exitCode: 1 }], options).valid).toBe(true);
       for (const output of [`${token} RootLayout`, `ERROR [Error: ${token}]`, 'ERROR unrelated\nRootLayout']) {
         expect(launchCrashDiagnosis([{ ...launch, output }, logs], options)).toMatchObject({
           commandId: 'logs',


### PR DESCRIPTION
## Description

Future benchmark runs should test how agents solve the task, not how closely they follow our launch recipe. The current prompts reveal the crash category/location and prescribe warm, start, log polling and dependency-copy steps.

Fixes #705.

## Solution

Give both arms the same outcome-focused task, with only tool choice and owned-device allocation differing. Keep worktree setup timed and leave normal Stim usage to its installed skill. The shared screenshot/recording protocol remains explicit for collection.

No published data or timings change: recorded prompt policy keeps old runs on their original audit contract. New runs accept an actionable initial launch response instead of forcing another log query, replacing the [deliberate separate-capture gate](https://github.com/appandflow/stim/commit/14ac4ea4ffc695af3b45573829fc50a28a07f5f5).

## Test plan

- Exercise both arms on iOS/Android with actionable launch output, missing context, failed launch status, and earlier separate runtime logs; confirm only genuine runtime evidence allows source inspection.
- Run driver prompt/isolation/Android self-tests and compare generated task text across arms. No model runs were dispatched; the next campaign needs a pilot under the shortened instructions.
