### PR TITLE
fix: adopt a config that is missing its projects container

### DIFF
--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -362,7 +362,7 @@ test('ensureConfig creates a v2 config with a repos section', () => {
 test('adopts a hand-edited config that has no projects container', () => {
   writeFileSync(
     join(tmpHome, 'config.json'),
-    JSON.stringify({ version: 2, optimizations: { android: { compilerCache: 'auto' } } }),
+    JSON.stringify({ version: 2, repos: {}, optimizations: { android: { compilerCache: 'auto' } } }),
   );
 
   const cfg = ensureConfig();
@@ -373,6 +373,37 @@ test('adopts a hand-edited config that has no projects container', () => {
   expect(JSON.parse(readFileSync(join(tmpHome, 'config.json'), 'utf-8')).optimizations).toEqual({
     android: { compilerCache: 'auto' },
   });
+});
+
+test.each([
+  ['an array', '[]'],
+  ['a string', '"oops"'],
+  ['a number', '7'],
+])('refuses a config whose projects container is %s', (_label, shape) => {
+  writeFileSync(join(tmpHome, 'config.json'), `{ "version": 2, "projects": ${shape}, "repos": {} }`);
+
+  expect(() => ensureConfig()).toThrow(/projects that is not an object/);
+  const thrown = (() => {
+    try {
+      ensureConfig();
+      return null;
+    } catch (err) {
+      return err as { code?: string };
+    }
+  })();
+  expect(thrown?.code).toBe('STIM_CONFIG_CORRUPT');
+
+  expect(readFileSync(join(tmpHome, 'config.json'), 'utf-8')).toContain(`"projects": ${shape}`);
+});
+
+test('refuses a config whose repos container is an array', () => {
+  writeFileSync(join(tmpHome, 'config.json'), '{ "version": 2, "projects": {}, "repos": [] }');
+  expect(() => ensureConfig()).toThrow(/repos that is not an object/);
+});
+
+test('adopts a null projects container rather than refusing it', () => {
+  writeFileSync(join(tmpHome, 'config.json'), '{ "version": 2, "projects": null, "repos": {} }');
+  expect(ensureConfig().projects).toEqual({});
 });
 
 test('migrates a v1 config without touching projects', () => {

--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -359,6 +359,22 @@ test('ensureConfig creates a v2 config with a repos section', () => {
   expect(cfg.repos).toEqual({});
 });
 
+test('adopts a hand-edited config that has no projects container', () => {
+  writeFileSync(
+    join(tmpHome, 'config.json'),
+    JSON.stringify({ version: 2, optimizations: { android: { compilerCache: 'auto' } } }),
+  );
+
+  const cfg = ensureConfig();
+  expect(cfg.projects).toEqual({});
+
+  expect(() => upsertProject('/a', { metroPort: 8082 })).not.toThrow();
+  expect(getProject('/a')?.metroPort).toBe(8082);
+  expect(JSON.parse(readFileSync(join(tmpHome, 'config.json'), 'utf-8')).optimizations).toEqual({
+    android: { compilerCache: 'auto' },
+  });
+});
+
 test('migrates a v1 config without touching projects', () => {
   saveConfig(
     makeConfig({

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -478,7 +478,7 @@ export async function finishAndroidRun({
     try {
       withConfigLock(() => {
         const config = loadConfig();
-        const current = config?.projects[root]?.platforms?.android;
+        const current = config?.projects?.[root]?.platforms?.android;
         if (!config || !current || current.avdName !== device.avdName)
           throw new Error('The adopted emulator assignment changed during installation.');
         delete current.adoptionPending;

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -74,6 +74,10 @@ export function ensureConfig(): Config {
     const existing = loadConfig();
     if (existing) {
       let changed = false;
+      if (!existing.projects) {
+        existing.projects = {};
+        changed = true;
+      }
       if (!existing.repos) {
         existing.repos = {};
         changed = true;

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -35,6 +35,16 @@ export function configCorruptRepair(path: string = getConfigPath()): string {
   return `Repair the file, or move it aside to start over: mv "${path}" "${path}.broken"`;
 }
 
+function configCorrupt(reason: string, path: string = getConfigPath()): Error {
+  const corrupt = new Error(
+    `Stim config at ${path} ${reason}\n` +
+      'It holds the records of the simulators and emulators Stim owns, so it is never reset automatically.\n' +
+      configCorruptRepair(path),
+  );
+  (corrupt as Error & { code?: string }).code = 'STIM_CONFIG_CORRUPT';
+  return corrupt;
+}
+
 export function loadConfig(): Config | null {
   const p = getConfigPath();
   if (!existsSync(p)) return null;
@@ -42,14 +52,26 @@ export function loadConfig(): Config | null {
   try {
     return JSON.parse(raw) as Config;
   } catch (err) {
-    const corrupt = new Error(
-      `Stim config at ${p} is not valid JSON: ${(err as Error).message}\n` +
-        'It holds the records of the simulators and emulators Stim owns, so it is never reset automatically.\n' +
-        configCorruptRepair(p),
-    );
-    (corrupt as Error & { code?: string }).code = 'STIM_CONFIG_CORRUPT';
-    throw corrupt;
+    throw configCorrupt(`is not valid JSON: ${(err as Error).message}`, p);
   }
+}
+
+function isRecord(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * An array or scalar container swallows every write silently: `JSON.stringify` drops a string key set on
+ * an array, so the record is gone by the time the file is written. Absent is created; unusable is refused.
+ */
+function adoptContainer(cfg: Config, key: 'projects' | 'repos'): boolean {
+  const value = cfg[key] as unknown;
+  if (value === undefined || value === null) {
+    cfg[key] = {};
+    return true;
+  }
+  if (!isRecord(value)) throw configCorrupt(`has a ${key} that is not an object: ${JSON.stringify(value)}`);
+  return false;
 }
 
 export function saveConfig(config: Config): void {
@@ -74,14 +96,8 @@ export function ensureConfig(): Config {
     const existing = loadConfig();
     if (existing) {
       let changed = false;
-      if (!existing.projects) {
-        existing.projects = {};
-        changed = true;
-      }
-      if (!existing.repos) {
-        existing.repos = {};
-        changed = true;
-      }
+      if (adoptContainer(existing, 'projects')) changed = true;
+      if (adoptContainer(existing, 'repos')) changed = true;
       if (existing.version !== CONFIG_VERSION) {
         existing.version = CONFIG_VERSION;
         changed = true;

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -673,7 +673,7 @@ async function ensureOwnedAndroidDevice({
   let fresh = false;
   try {
     created = withConfigLock(() => {
-      const current = loadConfig()?.projects[projectPath]?.platforms?.android;
+      const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
       if (current?.avdName && current.avdName !== record?.avdName) {
         throw new Error(`Another Stim run assigned AVD ${current.avdName} to this workspace. Retry to use it.`);
       }


### PR DESCRIPTION
## Summary

A hand-edited `~/.stim/config.json` could crash a command with a raw `TypeError`, or — worse — accept a write that never reached disk and reported success. Closes #682.

## Changes

`ensureConfig` normalised a missing `repos` container but not a missing `projects`, so every write path went on to index `cfg.projects[projectPath]` on `undefined` and raised a bare Node `TypeError` with a stack: no `STIM_*` code, no `error` phase line, in a module that otherwise always emits a remedy.

Container shapes are now handled by their consequences rather than by falsiness:

- **Absent or `null`** is adopted as `{}` and persisted. Nothing can be lost by creating a container the file does not have.
- **An array or a scalar** is refused as `STIM_CONFIG_CORRUPT` — the code the file's other unusable states already use — and the file is left untouched. This matters because `JSON.stringify` drops a string key set on an array, so such a container accepts every write and silently discards it. `"projects": []` let `upsertProject` return the record it appeared to have stored while `getProject` read back `null` and disk kept `[]`. That is worse than the crash, because the caller has no way to know.

`loadConfig`'s corrupt-JSON error moved into a shared `configCorrupt` helper so both the unparseable file and the unusable container produce the same code, message shape, and `mv … .broken` remedy. The file is never rewritten underneath its owner in either case, which is what that message already promises.

Two callers indexed `projects` without optional chaining — `commands/android/launch.ts:481` and `engine/device.ts:676`. Both were safe only because `registerProject()` happens to run first; `engine/device.ts:711`, inside the same function, already chained. They now match.

I used `ensureConfig` rather than `loadConfig`, which #682 suggested, because it is already the normalising function: it holds the `repos` precedent, it persists the repair through `saveConfig`, and it leaves `loadConfig` a pure reader whose own callers are all optional-chained.

## Why this belongs in 1.1.0

Not a regression — 1.0.0 has it. It belongs with this release because this release increases exposure to it: the new config findings print remedies like `Remove <key> from <file>` and `Set optimizations.android.casToolchain to …`, so 1.1.0 actively sends people to hand-edit `config.json`. A container that is missing, or replaced with `[]`, is what hand-editing produces.

## How did I test?

Failing test first, using the exact config from the issue. Then each container shape, through the real module against a throwaway `STIM_HOME`:

| `projects` | before | after |
| --- | --- | --- |
| absent | `TypeError`, bare stack | adopted; `optimizations` preserved |
| `null` | adopted | adopted |
| `[]` | **`upsert ok`, `getProject` → `null`, disk keeps `[]`** | `STIM_CONFIG_CORRUPT` |
| `"oops"` | `TypeError: Cannot create property '/a' on string` | `STIM_CONFIG_CORRUPT` |
| `7` | `TypeError` | `STIM_CONFIG_CORRUPT` |

End to end through the CLI on a real Expo project, published 1.0.0 versus this build. 1.0.0:

    TypeError: Cannot read properties of undefined (reading '/…/apps/tlon-mobile')
        at upsertProject (…/dist/config-7kmtuhO2.mjs:206:9)
        at registerProject (…/dist/cli.mjs:19721:32)

Its config afterwards had gained `"repos": {}` and no `projects` — the asymmetry visible on disk. This build, same config and command:

    metro       no reservation; using 8081 (not checked)
    error       STIM_NO_DEVICE: no-such-device-xyz is not connected, and adb reports no physical device at all.
    remedy      Check the cable and `adb devices`, then retry with a serial adb lists.

Tests cover all three refusing shapes, the `null` adoption, and a fixture that carries `repos: {}` so the `projects` normalisation is asserted on its own rather than riding the pre-existing `repos` guard.

Gates: `format:check`, `lint`, `typecheck`, `knip` pass. Unit suite **4070 passed, 1 skipped**.

## Risks and impact

- Safe to rollback without consulting PR author? Yes.
- Affects important code area:
  - [x] Other: machine config normalisation.

A config that already holds object containers is unaffected. The one behaviour change for an existing user is that a malformed container now refuses where it previously crashed or silently dropped writes.

Deliberately **not** in scope, both worth their own issues: a corrupt `config.json` still prints three bare lines with no `error STIM_CONFIG_CORRUPT:` phase line unlike every other refusal (confirmed still true — routing it through the shared phase renderer changes output for every command); and `StimConfig` declares `projects`/`repos` as required while `loadConfig` does a blind `JSON.parse(raw) as Config`, so TypeScript cannot flag an unguarded index on a parsed config. That type lie is how the two unchained call sites survived review.

## Rollback plan

Revert both commits.

## Screenshots / videos

None.
