### PR TITLE
fix: identify source paths and wait times in warm output

### DIFF
--- a/packages/stim-cli/src/__tests__/warm-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim.test.ts
@@ -188,23 +188,27 @@ test('a refresh that gives up while copies drain leaves no claim of its own behi
   after.release();
 });
 
-test('a wait prints its holder every progress interval, in the shape build waits use', async () => {
+test('a wait attributes elapsed time to the waiter and names its holder every progress interval', async () => {
   const refresh = await acquireWarmClaim({ repositoryRoot: REPO, phase: 'refresh', sleep: never });
   const lines: string[] = [];
-  let clock = 0;
+  let clock = 120_000;
   let polls = 0;
   const copy = await acquireWarmClaim({
     repositoryRoot: REPO,
     phase: 'copy',
-    now: () => (clock += 10_000),
+    now: () => clock,
     progressMs: 30_000,
     out: (line) => lines.push(line),
     sleep: async () => {
+      clock += 10_000;
       if (++polls === 8) refresh.release();
     },
   });
-  expect(lines[0]).toMatch(/^ {2}lock {8}waiting on stim worktree warm --refresh \(pid \d+, \d+m?\d*s elapsed\)$/);
-  expect(lines.length).toBeGreaterThan(1);
+  expect(lines).toEqual([
+    `  lock        waiting 30s for stim worktree warm --refresh (pid ${process.pid})`,
+    `  lock        waiting 1m00s for stim worktree warm --refresh (pid ${process.pid})`,
+  ]);
+  expect(copy.wait.waitedMs).toBe(80_000);
   copy.release();
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
@@ -233,8 +233,8 @@ test('--refresh fast-forwards the source checkout, then copies', async () => {
   expect(result.stderr).toContain(
     `checkout    main 1 commit behind origin/main -> fast-forwarded to ${published.slice(0, 7)}`,
   );
-  expect(result.stderr).toContain('deps        no lockfile in this repository -> skipped');
-  expect(result.stderr).toContain('pods        no ios/ directory -> skipped');
+  expect(result.stderr).toContain(`deps        source ${root}: no lockfile in this repository -> skipped`);
+  expect(result.stderr).toContain(`pods        source ${root}: no ios/ directory -> skipped`);
   expect(result.stderr).toMatch(/carry {7}complete: 1 ignored entries copied/);
   expect(git(root, 'rev-parse', 'HEAD')).toBe(published);
   expect(git(target, 'branch', '--show-current')).toBe('linked');
@@ -353,44 +353,49 @@ test('worktree.defaultBranch outranks origin/HEAD, and neither resolving says wh
   expect(unknown.stderr).toContain('git remote set-head origin -a');
 });
 
-test('--refresh installs the moved lockfile at the repository root and the pods of the invoking app only', async () => {
-  write(root, 'pnpm-lock.yaml', 'lock v1\n');
-  write(root, 'apps/mobile/package.json', '{"name":"mobile"}\n');
-  write(root, 'apps/mobile/ios/Podfile', "target 'mobile'\n");
-  write(root, 'apps/mobile/ios/Podfile.lock', 'PODFILE CHECKSUM: v1\n');
-  write(root, 'apps/other/package.json', '{"name":"other"}\n');
-  write(root, 'apps/other/ios/Podfile', "target 'other'\n");
-  write(root, 'apps/other/ios/Podfile.lock', 'PODFILE CHECKSUM: v1\n');
-  commit(root, 'monorepo');
-  git(root, 'push', '-q', 'origin', 'main');
-  git(target, 'merge', '-q', '--ff-only', 'main');
-  mkdirSync(join(root, 'node_modules'), { recursive: true });
-  write(root, 'apps/mobile/ios/Pods/Manifest.lock', 'PODFILE CHECKSUM: v0\n');
-  write(root, 'apps/other/ios/Pods/Manifest.lock', 'PODFILE CHECKSUM: v0\n');
-  fallBehind({ 'pnpm-lock.yaml': 'lock v2\n' }, 'bump lockfile');
+test.each(['.', 'apps/mobile'])(
+  '--refresh names the source dependency root at %s and the invoking app for pods',
+  async (dependencyPath) => {
+    const depsRoot = join(root, dependencyPath);
+    write(depsRoot, 'pnpm-lock.yaml', 'lock v1\n');
+    write(root, 'apps/mobile/package.json', '{"name":"mobile"}\n');
+    write(root, 'apps/mobile/ios/Podfile', "target 'mobile'\n");
+    write(root, 'apps/mobile/ios/Podfile.lock', 'PODFILE CHECKSUM: v1\n');
+    write(root, 'apps/other/package.json', '{"name":"other"}\n');
+    write(root, 'apps/other/ios/Podfile', "target 'other'\n");
+    write(root, 'apps/other/ios/Podfile.lock', 'PODFILE CHECKSUM: v1\n');
+    commit(root, 'monorepo');
+    git(root, 'push', '-q', 'origin', 'main');
+    git(target, 'merge', '-q', '--ff-only', 'main');
+    mkdirSync(join(depsRoot, 'node_modules'), { recursive: true });
+    write(root, 'apps/mobile/ios/Pods/Manifest.lock', 'PODFILE CHECKSUM: v0\n');
+    write(root, 'apps/other/ios/Pods/Manifest.lock', 'PODFILE CHECKSUM: v0\n');
+    fallBehind({ [join(dependencyPath, 'pnpm-lock.yaml')]: 'lock v2\n' }, 'bump lockfile');
 
-  const real = getExecutor();
-  const spawned: { cmd: string; args: string[]; cwd: unknown }[] = [];
-  setExecutor({
-    ...real,
-    spawn(cmd: string, args: string[], opts: { cwd?: unknown }) {
-      spawned.push({ cmd, args, cwd: opts?.cwd });
-      return makeExitingChild(0);
-    },
-  });
+    const real = getExecutor();
+    const spawned: { cmd: string; args: string[]; cwd: unknown }[] = [];
+    setExecutor({
+      ...real,
+      spawn(cmd: string, args: string[], opts: { cwd?: unknown }) {
+        spawned.push({ cmd, args, cwd: opts?.cwd });
+        return makeExitingChild(0);
+      },
+    });
 
-  const result = await runWarm(join(target, 'apps', 'mobile'), '--refresh');
-  expect(result.code).toBe(0);
-  expect(spawned).toEqual([
-    { cmd: 'pnpm', args: ['install'], cwd: root },
-    { cmd: 'pod', args: ['install'], cwd: join(root, 'apps', 'mobile', 'ios') },
-  ]);
-  expect(result.stderr).toMatch(/deps {8}pnpm-lock\.yaml changed -> pnpm install \(\d+m?\d*s\)/);
-  expect(result.stderr).toMatch(
-    /pods {8}apps\/mobile: ios\/Podfile\.lock and ios\/Pods\/Manifest\.lock differ -> pod install \(\d+m?\d*s\)/,
-  );
-  expect(result.stderr).not.toMatch(/pods {8}apps\/other/);
-});
+    const result = await runWarm(join(target, 'apps', 'mobile'), '--refresh');
+    expect(result.code).toBe(0);
+    expect(spawned).toEqual([
+      { cmd: 'pnpm', args: ['install'], cwd: depsRoot },
+      { cmd: 'pod', args: ['install'], cwd: join(root, 'apps', 'mobile', 'ios') },
+    ]);
+    expect(result.stderr).toContain(`deps        source ${depsRoot}: pnpm-lock.yaml changed -> pnpm install (`);
+    expect(result.stderr).toContain(
+      `pods        source ${join(root, 'apps', 'mobile')}: ios/Podfile.lock and ios/Pods/Manifest.lock differ -> pod install (`,
+    );
+    expect(result.stderr).not.toContain(`pods        source ${join(root, 'apps', 'other')}`);
+    expect(result.stderr).not.toContain(`deps        source ${target}`);
+  },
+);
 
 test('a failed install refuses with the code the build path uses and does not copy', async () => {
   write(root, 'pnpm-lock.yaml', 'lock v1\n');
@@ -543,7 +548,9 @@ test('a retry after a failed install runs it again instead of copying a half-ins
   const retried = await runWarm(target, '--refresh');
   expect(retried.code).toBe(0);
   expect(retried.stderr).toContain('checkout    main up to date with origin/main');
-  expect(retried.stderr).toMatch(/deps {8}the last install of pnpm-lock\.yaml did not finish -> pnpm install/);
+  expect(retried.stderr).toContain(
+    `deps        source ${root}: the last install of pnpm-lock.yaml did not finish -> pnpm install`,
+  );
   expect(spawned).toEqual(['pnpm install']);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
 
@@ -551,7 +558,9 @@ test('a retry after a failed install runs it again instead of copying a half-ins
   spawned.length = 0;
   const settled = await runWarm(target, '--refresh');
   expect(settled.code).toBe(0);
-  expect(settled.stderr).toContain('deps        pnpm-lock.yaml matches the last completed install -> skipped');
+  expect(settled.stderr).toContain(
+    `deps        source ${root}: pnpm-lock.yaml matches the last completed install -> skipped`,
+  );
   expect(spawned).toEqual([]);
 });
 
@@ -614,7 +623,7 @@ test('--refresh installs at the repository root when upstream removed the app it
   const result = await runWarm(join(target, 'apps', 'mobile'), '--refresh');
   expect(result.code).toBe(0);
   expect(existsSync(join(root, 'apps', 'mobile'))).toBe(false);
-  expect(result.stderr).toMatch(/deps {8}pnpm-lock\.yaml changed -> pnpm install/);
+  expect(result.stderr).toContain(`deps        source ${root}: pnpm-lock.yaml changed -> pnpm install`);
   expect(spawned).toEqual([{ cmd: 'pnpm', cwd: root }]);
 });
 
@@ -722,7 +731,7 @@ test('a real install whose own child outlives it holds the claim until that chil
   }
   const result = await warm;
   expect(result.code).toBe(0);
-  expect(result.stderr).toMatch(/deps {8}no installed dependencies -> npm ci/);
+  expect(result.stderr).toContain(`deps        source ${root}: no installed dependencies -> npm ci`);
   expect(readFileSync(join(root, 'node_modules', 'value'), 'utf-8')).toBe('COMPLETE');
   expect(readFileSync(join(target, 'node_modules', 'value'), 'utf-8')).toBe('COMPLETE');
   expect(installLedger()).toMatchObject({ lock: 'package-lock.json', completed: true });
@@ -762,7 +771,7 @@ test('an install Stim could not record is not abandoned, and its claim outlives 
   expect(result.stderr).toMatch(
     /lock {8}could not record the install this refresh spawned \(.*\); holding the claim here until it exits/,
   );
-  expect(result.stderr).toMatch(/deps {8}pnpm-lock\.yaml changed -> pnpm install/);
+  expect(result.stderr).toContain(`deps        source ${root}: pnpm-lock.yaml changed -> pnpm install`);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
   expect(installLedger()).toMatchObject({ completed: true });
   expect(existsSync(warmClaimPath(root))).toBe(false);
@@ -805,7 +814,9 @@ test('the evidence that an install is owed is written before the fast-forward mo
   const retry = await runWarm(target, '--refresh');
   expect(retry.code).toBe(0);
   expect(retry.stderr).toContain('checkout    main up to date with origin/main');
-  expect(retry.stderr).toMatch(/deps {8}the last install of pnpm-lock\.yaml did not finish -> pnpm install/);
+  expect(retry.stderr).toContain(
+    `deps        source ${root}: the last install of pnpm-lock.yaml did not finish -> pnpm install`,
+  );
   expect(spawned).toEqual(['pnpm install']);
   expect(installLedger()).toMatchObject({ hash: sha256('lock v2\n'), completed: true });
 });
@@ -841,7 +852,9 @@ test('the ledger records the lockfile the installer read, not the one on disk wh
   });
   const second = await runWarm(target, '--refresh');
   expect(second.code).toBe(0);
-  expect(second.stderr).toMatch(/deps {8}pnpm-lock\.yaml does not match the last completed install -> pnpm install/);
+  expect(second.stderr).toContain(
+    `deps        source ${root}: pnpm-lock.yaml does not match the last completed install -> pnpm install`,
+  );
   expect(spawned).toEqual(['pnpm install']);
   expect(installLedger()).toEqual({ lock: 'pnpm-lock.yaml', hash: sha256('lock v3\n'), completed: true });
 });
@@ -922,7 +935,9 @@ test('a plain warm refuses the tree a real failed install left, and copies once 
   writeFileSync(join(root, 'succeed'), 'yes');
   const reinstalled = await runWarm(target, '--refresh');
   expect(reinstalled.code).toBe(0);
-  expect(reinstalled.stderr).toMatch(/deps {8}the last install of package-lock\.json did not finish -> npm ci/);
+  expect(reinstalled.stderr).toContain(
+    `deps        source ${root}: the last install of package-lock.json did not finish -> npm ci`,
+  );
   expect(installLedger()).toMatchObject({ lock: 'package-lock.json', completed: true });
 
   process.exitCode = 0;

--- a/packages/stim-cli/src/engine/warm-claim.ts
+++ b/packages/stim-cli/src/engine/warm-claim.ts
@@ -99,10 +99,7 @@ function asHolder(holder: ClaimHolder): WarmClaimHolder {
 }
 
 function waitingLine(holder: WarmClaimHolder, elapsedMs: number): string {
-  return phaseLine(
-    'lock',
-    `waiting on ${warmCommand(holder.phase)} (pid ${holder.pid}, ${formatElapsed(elapsedMs)} elapsed)`,
-  );
+  return phaseLine('lock', `waiting ${formatElapsed(elapsedMs)} for ${warmCommand(holder.phase)} (pid ${holder.pid})`);
 }
 
 export function warmClaimAcquiredLine(wait: WarmClaimWait): string {

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -817,8 +817,8 @@ captured"  (in metro.ndjson, bare RN)
   longer than the wait -- 60s by default, 4 minutes for the remote-session and
   EAS project locks, and ~90 minutes for the \`worktree warm\` lock, which one
   \`--refresh\` can hold for a whole dependency install. That wait prints its
-  holder every 30 seconds (\`lock        waiting on stim worktree warm
-  --refresh (pid 41233, 40s elapsed)\`) and the refusal names the same holder
+  elapsed waiting time and holder every 30 seconds (\`lock        waiting 40s
+  for stim worktree warm --refresh (pid 41233)\`) and the refusal names the same holder
   and the lock directory under ~/.stim/warm-locks.
   A lock whose owner died is taken over automatically (its recorded
   process identity is checked every poll), so this means another Stim command really

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -31,8 +31,8 @@ a seed belongs to this workflow.
   stim worktree warm --refresh
     lock        acquired
     checkout    main 3 commits behind origin/main -> fast-forwarded to 9f2c1a3
-    deps        pnpm-lock.yaml changed -> pnpm install (41s)
-    pods        apps/mobile: ios/Podfile.lock unchanged -> skipped
+    deps        source /w/main: pnpm-lock.yaml changed -> pnpm install (41s)
+    pods        source /w/main/apps/mobile: ios/Podfile.lock unchanged -> skipped
 
   # 2. The dev server, under a detached supervisor. Blocks until it is
   #    verifiably THIS project's, then hands your shell back.
@@ -342,11 +342,11 @@ result as proof instead of requiring an unrelated screenshot.`,
     checkout    janic/wip 2 commits behind origin/janic/wip -> fast-forwarded to 4b81e0c
                 not the default branch (main); worktrees seeded from this copy
                 carry janic/wip's dependencies
-    deps        pnpm-lock.yaml unchanged -> skipped
-    pods        apps/mobile: ios/Podfile.lock changed -> pod install (1m12s)
+    deps        source /w/main: pnpm-lock.yaml unchanged -> skipped
+    pods        source /w/main/apps/mobile: ios/Podfile.lock changed -> pod install (1m12s)
 
-  A wait heartbeats like a build wait, naming the holder:
-  \`lock        waiting on stim worktree warm --refresh (pid 41233, 40s elapsed)\`.
+  A wait reports how long this caller has waited and names the holder:
+  \`lock        waiting 40s for stim worktree warm --refresh (pid 41233)\`.
 
   \`start\` names the port, the supervisor mode and its pid on one line
   (\`metro       starting on port 8083 (expo-child, supervisor pid 13724)\`),
@@ -889,9 +889,9 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   Dependencies install where the lockfile is, which in a monorepo is the
   repository root, when the lockfile moved or nothing is installed. Pods run
   for the app the command was invoked from, and only that app, when its
-  ios/Podfile.lock moved or ios/Pods/Manifest.lock does not match it. Every
-  skipped step still prints its reason. A failed install refuses with
-  STIM_DEPS_FAILED and nothing is copied.
+  ios/Podfile.lock moved or ios/Pods/Manifest.lock does not match it. Each
+  completed or skipped deps and pods step names its source directory and
+  reason. A failed install refuses with STIM_DEPS_FAILED and nothing is copied.
 
   An install that did not finish is remembered, and a PLAIN warm reads that
   before it copies. The refresh records the completed install of the lockfile it

--- a/packages/stim-cli/src/worktree-refresh.ts
+++ b/packages/stim-cli/src/worktree-refresh.ts
@@ -510,6 +510,7 @@ export async function refreshMainCheckout({
     lastInstall: priorInstall,
     lockHash: consumed,
   });
+  const depsSubject = `source ${dependencies?.root ?? root}: ${deps.reason}`;
   if (deps.run && dependencies) {
     writeInstallEvidence(dependencies.root, dependencies.lock, consumed, false);
     const install = await runInstallCommand({
@@ -520,7 +521,7 @@ export async function refreshMainCheckout({
       heartbeatMs,
       onHeartbeat: emit,
     });
-    emit(stepLine('deps', deps.reason, `${dependencies.command} (${formatDuration(install.durationMs)})`));
+    emit(stepLine('deps', depsSubject, `${dependencies.command} (${formatDuration(install.durationMs)})`));
     const running = await awaitSpawnedWork(`\`${dependencies.command}\``);
     if (!install.ok) {
       return {
@@ -534,11 +535,11 @@ export async function refreshMainCheckout({
     writeInstallEvidence(dependencies.root, dependencies.lock, consumed, true);
   } else {
     if (marked) restoreInstallEvidence(marked.root, priorInstall);
-    emit(stepLine('deps', deps.reason, 'skipped'));
+    emit(stepLine('deps', depsSubject, 'skipped'));
   }
 
   const app = relative(root, appDir) || '.';
-  const where = app === '.' ? '' : `${app}: `;
+  const where = `source ${appDir}: `;
   const podState = readPodState(appDir);
   const pods = podsPlan({
     hasIos: existsSync(join(appDir, 'ios')),

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -76,7 +76,8 @@ It fetches the branch's remote, fast-forwards **whatever branch the source
 checkout has** to its `@{upstream}`, and then installs only what the new commits
 moved: the lockfile's own install command where the lockfile lives (the
 repository root in a monorepo), and `pod install` for the app you ran the
-command from. Every step prints what it did or why it skipped.
+command from. Each dependency and Pods step names its source directory and
+prints what it did or why it skipped.
 
 The flag is opt-in because it writes to a checkout you are not standing in. It
 refuses one it cannot move -- uncommitted changes to tracked files or a rebase


### PR DESCRIPTION
## Description

`worktree warm` places the caller's wait duration beside the holder's PID, making it look like the holder's elapsed time. Refresh install and skip messages also omit their source paths, so they can read as work performed in the destination worktree.

## Solution

Print `waiting 30s for stim worktree warm --refresh (pid 41233)`. Prefix dependency and Pods results with their source directory, using the actual lockfile directory for dependencies, including nested app lockfiles. Update the guide examples.

## Test plan

- The wait regression checks two progress intervals and the caller's total wait.
- Real Git fixture tests exercise installs at the repository root and a nested app root, skipped installs, and the Pods source path. All five targeted regressions fail on the old output and pass with this change; command arguments and working directories remain unchanged.

Fixes #708
