### PR TITLE
fix: let plain warm copy when its claim store is read-only

### DIFF
--- a/packages/stim-cli/src/__tests__/ownership-claim-publication.test.ts
+++ b/packages/stim-cli/src/__tests__/ownership-claim-publication.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { readClaimSet, releaseClaim, tryAcquireClaim } from '../ownership-claim.ts';
+
+const faults = vi.hoisted(() => ({
+  readOnly: '',
+  beforeRename: null as null | ((from: string, to: string) => void | (() => void)),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...fs,
+    mkdirSync: (...args: Parameters<typeof fs.mkdirSync>) => {
+      const path = String(args[0]);
+      if (!faults.readOnly || relative(faults.readOnly, path).startsWith('..')) return fs.mkdirSync(...args);
+      const options = args[1];
+      const recursive = typeof options === 'object' && options !== null && options.recursive === true;
+      if (recursive && fs.existsSync(path)) return undefined;
+      const code = recursive ? 'ENOENT' : 'EROFS';
+      throw Object.assign(new Error(`${code}: mkdir '${path}'`), { code });
+    },
+    renameSync: (...args: Parameters<typeof fs.renameSync>) => {
+      const cleanup = faults.beforeRename?.(String(args[0]), String(args[1]));
+      try {
+        return fs.renameSync(...args);
+      } finally {
+        cleanup?.();
+      }
+    },
+  };
+});
+
+let home: string;
+let root: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-claim-publication-'));
+  root = join(home, 'build.lock');
+  process.env.STIM_HOME = home;
+});
+
+afterEach(() => {
+  faults.readOnly = '';
+  faults.beforeRename = null;
+  delete process.env.STIM_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+test.each(['exclusive', 'shared'] as const)('a read-only store preserves EROFS for %s claims', (mode) => {
+  const present = join(home, 'present.lock');
+  mkdirSync(present);
+  faults.readOnly = home;
+  for (const path of [root, present]) {
+    expect(() => tryAcquireClaim({ root: path, mode })).toThrow(expect.objectContaining({ code: 'EROFS' }));
+  }
+});
+
+test.each(['exclusive', 'shared'] as const)('an ENOENT publication race retries and acquires a %s claim', (mode) => {
+  faults.beforeRename = () => {
+    faults.beforeRename = null;
+    rmSync(root, { recursive: true });
+  };
+  const attempt = tryAcquireClaim({ root, mode });
+  expect(attempt.acquired).toBeDefined();
+  expect(readClaimSet(root).live.map((holder) => holder.claimId)).toEqual([attempt.acquired!.claimId]);
+  expect(releaseClaim(attempt.acquired)).toBe(true);
+});
+
+test.each(['exclusive', 'shared'] as const)('repeated ENOENT publication races refuse %s claims', (mode) => {
+  faults.beforeRename = () => rmSync(root, { recursive: true });
+  expect(() => tryAcquireClaim({ root, mode })).toThrow(expect.objectContaining({ code: 'STIM_CLAIM_REFUSED' }));
+});
+
+test('a rename colliding with a claim that releases before the next survey still refuses after repeated races', () => {
+  faults.beforeRename = (_from, to) => {
+    mkdirSync(to);
+    writeFileSync(join(to, 'held.claim'), 'occupied');
+    return () => rmSync(to, { recursive: true });
+  };
+  expect(() => tryAcquireClaim({ root, mode: 'exclusive' })).toThrow(
+    expect.objectContaining({ code: 'STIM_CLAIM_REFUSED' }),
+  );
+  expect(existsSync(join(root, 'exclusive'))).toBe(false);
+});

--- a/packages/stim-cli/src/__tests__/ownership-claim-publication.test.ts
+++ b/packages/stim-cli/src/__tests__/ownership-claim-publication.test.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
-import { readClaimSet, releaseClaim, tryAcquireClaim } from '../ownership-claim.ts';
+import { clearFreeClaimSet, readClaimSet, releaseClaim, tryAcquireClaim } from '../ownership-claim.ts';
+import { runGc } from '../commands/gc.ts';
+import { saveConfig } from '../config.ts';
 
 const faults = vi.hoisted(() => ({
   readOnly: '',
@@ -54,6 +56,33 @@ test.each(['exclusive', 'shared'] as const)('a read-only store preserves EROFS f
   faults.readOnly = home;
   for (const path of [root, present]) {
     expect(() => tryAcquireClaim({ root: path, mode })).toThrow(expect.objectContaining({ code: 'EROFS' }));
+  }
+});
+
+test('clearing a read-only claim store reports failure without throwing', () => {
+  mkdirSync(root);
+  faults.readOnly = root;
+  expect(clearFreeClaimSet({ root })).toEqual({ status: 'failed', reason: expect.stringContaining('EROFS') });
+});
+
+test('gc reports a read-only build lock and still clears a later build slot', async () => {
+  saveConfig({ version: 2, projects: {}, repos: {} });
+  const blocked = join(home, 'build-locks', 'ios-readonly.lock');
+  const writable = join(home, 'build-slots', 'slot-0');
+  mkdirSync(blocked, { recursive: true });
+  mkdirSync(writable, { recursive: true });
+  faults.readOnly = blocked;
+  const lines: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((line) => lines.push(String(line)));
+  try {
+    await runGc({ delete: true }, { findProjectRoot: () => null });
+    expect(existsSync(blocked)).toBe(true);
+    expect(existsSync(writable)).toBe(false);
+    expect(lines.join('\n')).toContain(`Failed to clear the build lock at ${blocked}: EROFS`);
+    expect(lines.join('\n')).toContain('Cleared build slot 0');
+    expect(lines.join('\n')).toContain('1 entry could not be deleted');
+  } finally {
+    log.mockRestore();
   }
 });
 

--- a/packages/stim-cli/src/__tests__/ownership-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/ownership-claim.test.ts
@@ -7,7 +7,9 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  readlinkSync,
   rmSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -104,6 +106,31 @@ describe('exclusive claims', () => {
   test('an empty claim directory left by a crash blocks nothing', () => {
     mkdirSync(exclusiveClaimDir(root), { recursive: true });
     expect(tryAcquireClaim({ root, mode: 'exclusive' }).acquired).toBeTruthy();
+  });
+});
+
+describe('claim storage failures', () => {
+  test.each(['exclusive', 'shared'] as const)(
+    'a dangling claim-store ancestor reports ENOENT for %s claims',
+    (mode) => {
+      const home = dirname(root);
+      const link = join(home, 'dangling');
+      symlinkSync(join(home, 'missing'), link);
+      const blocked = join(link, 'build.lock');
+      try {
+        expect(() => tryAcquireClaim({ root: blocked, mode })).toThrow(expect.objectContaining({ code: 'ENOENT' }));
+      } finally {
+        rmSync(link);
+      }
+    },
+  );
+
+  test('a dangling shared-publication directory reports ENOENT without replacing it', () => {
+    mkdirSync(root);
+    const link = sharedClaimDir(root);
+    symlinkSync(join(root, 'missing'), link);
+    expect(() => tryAcquireClaim({ root, mode: 'shared' })).toThrow(expect.objectContaining({ code: 'ENOENT' }));
+    expect(readlinkSync(link)).toBe(join(root, 'missing'));
   });
 });
 

--- a/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -577,6 +578,28 @@ test('a plain warm copies without the lock when STIM_HOME cannot be written, and
   } finally {
     chmodSync(home, 0o700);
   }
+});
+
+test('a dangling STIM_HOME link permits a plain copy but refuses refresh before changing the source', async () => {
+  write(root, '.env', 'main env');
+  fallBehind({ 'package.json': '{"name":"updated-fixture"}\n' });
+  const before = git(root, 'rev-parse', 'HEAD');
+  symlinkSync(join(base, 'missing-home'), String(process.env.STIM_HOME));
+
+  const plain = await runWarm(target);
+  expect(plain.code).toBe(0);
+  expect(plain.stdout).toEqual([]);
+  expect(plain.stderr).toMatch(/lock {8}unavailable \(ENOENT:.*\); copying without it/);
+  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
+
+  rmSync(join(target, '.env'));
+  const refresh = await runWarm(target, '--refresh');
+  expect(refresh.code).toBe(1);
+  expect(refresh.stdout).toEqual([]);
+  expect(refresh.stderr).toMatch(/Could not warm this worktree: ENOENT:/);
+  expect(refresh.stderr).not.toContain('another process');
+  expect(existsSync(join(target, '.env'))).toBe(false);
+  expect(git(root, 'rev-parse', 'HEAD')).toBe(before);
 });
 
 test('a copy that waited for the lock reads the exclusions the refresh left behind, not the ones it started with', async () => {

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -917,7 +917,8 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   resolve refuses with STIM_CLAIM_REFUSED and names the removal rather than
   waiting on it or removing it.
   A plain warm that cannot record a claim at all -- an unwritable STIM_HOME, a
-  STIM_HOME that is a file, or no \`unique-pid\` build for this platform
+  STIM_HOME on a read-only mount or under a dangling symlink, a STIM_HOME that
+  is a file, or no \`unique-pid\` build for this platform
   (STIM_CLAIM_UNAVAILABLE) -- says so in one dim line and copies without it,
   exactly as it did before the lock existed, because a copy only reads.
   \`--refresh\` refuses instead, because it writes. Before that unsynchronised

--- a/packages/stim-cli/src/ownership-claim.ts
+++ b/packages/stim-cli/src/ownership-claim.ts
@@ -1,15 +1,17 @@
 import { randomUUID } from 'node:crypto';
 import {
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   renameSync,
   rmSync,
   rmdirSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { quotedPath } from './command-output.ts';
 import { captureProcessIdentity, inspectProcessIdentity, type ProcessRecord } from './process-identity.ts';
 
@@ -435,25 +437,67 @@ function selfOwner(): ClaimOwner {
   return { pid: process.pid, processToken: captured.token };
 }
 
-// A claim set is removed the instant it holds nothing, so any step of a publication can lose the
-// directory it is writing into to another process's cleanup. Those codes mean "try again", never
-// "nobody holds this".
-function contended(code: string | undefined): boolean {
+function contended(error: unknown): boolean {
+  if (error instanceof MissingClaimStoreError) return false;
+  const code = (error as NodeJS.ErrnoException)?.code;
   return code === 'EEXIST' || code === 'ENOTEMPTY' || code === 'ENOENT' || code === 'EINVAL';
+}
+
+class MissingClaimStoreError extends Error {
+  readonly code = 'ENOENT';
+}
+
+// Node recursive mkdir can hide EROFS as ENOENT: https://github.com/nodejs/node/issues/47098.
+function createClaimDir(path: string): void {
+  try {
+    mkdirSync(path, { recursive: true });
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+  }
+  const missing: string[] = [];
+  for (let level = path; ; level = dirname(level)) {
+    let entry;
+    try {
+      entry = lstatSync(level);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+      missing.push(level);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      try {
+        statSync(level);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+          throw new MissingClaimStoreError((error as Error).message, { cause: error });
+        }
+        throw error;
+      }
+    }
+    break;
+  }
+  for (const level of missing.toReversed()) {
+    try {
+      mkdirSync(level);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'EEXIST') throw error;
+    }
+  }
 }
 
 function publishExclusive(root: string, payload: string, claimId: string, label: string): string | null {
   const staging = join(root, `${STAGING_PREFIX}${claimId}`);
   const target = exclusiveClaimDir(root);
   try {
-    mkdirSync(staging, { recursive: true });
+    createClaimDir(staging);
     writeFileSync(join(staging, `${claimId}${CLAIM_SUFFIX}`), payload);
     renameSync(staging, target);
     return join(target, `${claimId}${CLAIM_SUFFIX}`);
   } catch (err) {
     rmSync(staging, { recursive: true, force: true });
     const code = (err as NodeJS.ErrnoException)?.code;
-    if (contended(code)) return null;
+    if (contended(err)) return null;
     if (code === 'ENOTDIR') refuse(root, target, label, CLAIM_PATH_NOT_A_DIRECTORY);
     throw err;
   }
@@ -463,13 +507,13 @@ function publishShared(root: string, payload: string, claimId: string): string |
   const staging = join(root, `${STAGING_PREFIX}${claimId}`);
   const target = join(sharedClaimDir(root), `${claimId}${CLAIM_SUFFIX}`);
   try {
-    mkdirSync(sharedClaimDir(root), { recursive: true });
+    createClaimDir(sharedClaimDir(root));
     writeFileSync(staging, payload);
     renameSync(staging, target);
     return target;
   } catch (err) {
     rmSync(staging, { force: true });
-    if (contended((err as NodeJS.ErrnoException)?.code)) return null;
+    if (contended(err)) return null;
     throw err;
   }
 }
@@ -489,13 +533,13 @@ export function tryAcquireClaim({ root, mode, details = {}, label = 'ownership' 
 
   for (let attempt = 0; attempt < PUBLISH_ATTEMPTS; attempt++) {
     try {
-      mkdirSync(root, { recursive: true });
+      createClaimDir(root);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code === 'EEXIST' || code === 'ENOTDIR') {
         refuse(root, root, label, CLAIM_PATH_NOT_A_DIRECTORY);
       }
-      if (contended(code)) continue;
+      if (contended(err)) continue;
       throw err;
     }
     const state = inspectClaimSet(root, { label });

--- a/packages/stim-cli/src/ownership-claim.ts
+++ b/packages/stim-cli/src/ownership-claim.ts
@@ -413,7 +413,7 @@ export function clearFreeClaimSet({ root, label = 'ownership' }: { root: string;
     attempt = tryAcquireClaim({ root, mode: 'exclusive', label });
   } catch (err) {
     if (isClaimRefusal(err) || isClaimUnavailable(err)) return { status: 'refused', reason: err.reason };
-    throw err;
+    return { status: 'failed', reason: (err as Error)?.message ?? String(err) };
   }
   if (!attempt.acquired) {
     if (attempt.pending) releaseClaim(attempt.pending);


### PR DESCRIPTION
## Description

Plain `worktree warm` refuses a copy when its claim directory is on a read-only mount or below a dangling symlink, incorrectly reporting 64 collisions with another process. Node can report `ENOENT` for recursive mkdir on a read-only filesystem ([upstream issue](https://github.com/nodejs/node/issues/47098)), which the claim treats as publication contention.

## Solution

Recover the direct filesystem error when recursive mkdir fails, and distinguish a proven dangling symlink from a directory removed during publication. Plain warm can then use its existing storage-failure fallback; `--refresh` still refuses before changing the source checkout. Unresolved claims and repeated publication races still refuse. Cleanup reports a storage failure for the affected claim and continues the sweep.

Restore the storage distinction removed by [the warm-refresh change](https://github.com/appandflow/stim/commit/97ede367fcd80b04773b575f8349f3e3dbe4133b). The degraded copy retains the race documented in #696: a refresh starting after its claim survey is not covered.

## Test plan

- Real dangling-symlink regressions failed before the fix; plain warm now copies with empty stdout, while `--refresh` leaves the source HEAD and destination unchanged.
- Real read-only APFS image, macOS/Node 22.22.1: `ENOENT` became `EROFS` for both claim modes with absent and existing claim directories.
- Real filesystem publication races recover when transient and remain `STIM_CLAIM_REFUSED` when repeated, including occupied-directory rename collisions.
- A read-only build lock reports a failed clearance; `gc --delete` keeps it, clears the next healthy build slot, and reports one failed entry.
- Required checks passed; full unit suite: 4,107 passed, 1 skipped. All 79 end-to-end tests passed.

Fixes #704

