### PR TITLE
fix: recover transient Android adoption cleanup failures

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -471,7 +471,7 @@ test('an invalid Android pool bound refuses before device creation and emits one
 describe('adopted Android installs', () => {
   afterEach(() => resetExecutor());
 
-  test.each(['same', 'different', 'signature', 'downgrade', 'cleanup-failed', 'install-failed'] as const)(
+  test.each(['same', 'different', 'signature', 'downgrade', 'cleanup-failed', 'error', 'install-failed'] as const)(
     'cleanup precedes install and only matching APK bytes skip installation: %s',
     async (mode) => {
       const apkPath = fakeApk();
@@ -493,7 +493,13 @@ describe('adopted Android installs', () => {
             const cmd = [file, ...args].join(' ');
             commands.push(cmd);
             if (args.includes('list')) return 'package:com.example.app\npackage:com.example.other';
-            if (args.includes('clear')) return mode === 'cleanup-failed' ? 'Failed' : 'Success';
+            if (args.includes('clear')) {
+              if (mode === 'error')
+                throw Object.assign(new Error('adb command failed'), {
+                  stdout: 'SecurityException: permission denied',
+                });
+              return mode === 'cleanup-failed' ? 'Failed' : 'Success';
+            }
             if (args.includes('uninstall')) return 'Success';
             if (args.includes('path')) return 'package:/data/app/base.apk';
             if (args.includes('sha256sum'))
@@ -511,18 +517,22 @@ describe('adopted Android installs', () => {
       );
       const h = harness({ ensureDevice: async () => device, resolveCached: () => apkPath, install: installAndroidApp });
       const result = await h.run();
-      const failed = mode === 'cleanup-failed' || mode === 'install-failed';
+      const cleanupFailed = mode === 'cleanup-failed' || mode === 'error';
+      const failed = cleanupFailed || mode === 'install-failed';
+      expect(result.error?.message?.includes('SecurityException: permission denied')).toBe(
+        mode === 'error' ? true : failed ? false : undefined,
+      );
       expect(result.ok).toBe(!failed);
       expect(result.error?.message?.includes('Could not clean com.example.app')).toBe(
-        mode === 'cleanup-failed' ? true : mode === 'install-failed' ? false : undefined,
+        mode === 'cleanup-failed' ? true : failed ? false : undefined,
       );
       expect(h.calls.launch.length).toBe(failed ? 0 : 1);
       const clear = commands.indexOf('adb -s emulator-5584 shell pm clear com.example.app');
       const hash = commands.indexOf('adb -s emulator-5584 shell pm path com.example.app');
       expect(clear).toBeGreaterThanOrEqual(0);
-      expect(hash > clear).toBe(mode !== 'cleanup-failed');
+      expect(hash > clear).toBe(!cleanupFailed);
       const conflict = mode === 'signature' || mode === 'downgrade';
-      expect(installs).toBe(mode === 'same' || mode === 'cleanup-failed' ? 0 : conflict ? 2 : 1);
+      expect(installs).toBe(mode === 'same' || cleanupFailed ? 0 : conflict ? 2 : 1);
       expect(commands.includes('adb -s emulator-5584 uninstall com.example.app')).toBe(conflict);
       expect(h.stderr.some((line) => line.includes('already has this build'))).toBe(mode === 'same');
       expect(loadConfig()?.projects[root]?.platforms?.android?.adoptionPending).toBe(failed ? true : undefined);

--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -46,6 +47,7 @@ beforeEach(() => {
     if (cmd === 'adb devices') return `List of devices attached\n${running ? 'emulator-5554\tdevice\n' : ''}`;
     if (cmd.includes('emu avd name')) return `${running}\nOK`;
     if (cmd.includes('getprop sys.boot_completed')) return '1';
+    if (cmd.includes('getprop ')) return '';
     if (cmd.includes('shell sync')) return '';
     if (cmd.includes('emu kill')) {
       running = null;
@@ -270,17 +272,18 @@ test('GC protects parked emulators from the orphan sweep and keeps an unverifiab
   expect(readParked('android')).toHaveLength(1);
 });
 
-test('adoption clears the retained app and uninstalls other third-party apps, with a failed clear refusing reuse', () => {
+test('adoption clears the retained app and uninstalls other third-party apps, with a failed clear refusing reuse', async () => {
   makeAvd('stim-source');
   running = 'stim-source';
-  resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+  await resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
   expect(calls).toContain('adb -s emulator-5554 shell pm clear com.example.app');
   expect(calls).toContain('adb -s emulator-5554 uninstall com.example.other');
   expect(calls).not.toContain('adb -s emulator-5554 uninstall com.example.app');
+  expect(calls.some((cmd) => cmd.includes('getprop '))).toBe(false);
   cleanupResult = 'Failed';
-  expect(() => resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).toThrow('Could not clean');
+  await expect(resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).rejects.toThrow('Could not clean');
   packageOutput = 'Error: package manager unavailable';
-  expect(() => resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).toThrow(
+  await expect(resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).rejects.toThrow(
     'Could not read installed apps',
   );
 });
@@ -294,4 +297,143 @@ test('an AVD whose configured disk size changed is evicted rather than adopted',
   expect(result.created).toBe(true);
   expect(avds.has('stim-source')).toBe(false);
   expect(readParked('android')).toEqual([]);
+});
+
+describe('adoption transport recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    makeAvd('stim-source');
+    running = 'stim-source';
+  });
+  afterEach(() => vi.useRealTimers());
+
+  test.each(['list', 'clear', 'uninstall'])(
+    're-lists packages after a transient %s failure and waits only on failure',
+    async (operation) => {
+      const exec = getExecutor();
+      let failed = false;
+      setExecutor({
+        ...exec,
+        runFile(file, args = [], options) {
+          if (!failed && args.includes(operation)) {
+            failed = true;
+            if (operation === 'uninstall') packageOutput = 'package:com.example.app';
+            throw Object.assign(new Error('adb command failed'), { stderr: 'error: closed' });
+          }
+          return exec.runFile(file, args, options);
+        },
+      });
+      const cleanup = resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+      await vi.runAllTimersAsync();
+      await cleanup;
+      expect(failed).toBe(true);
+      expect(calls).toContain('adb -s emulator-5554 shell pm clear com.example.app');
+      expect(calls.some((cmd) => cmd.includes('getprop sys.boot_completed'))).toBe(true);
+      expect(calls.includes('adb -s emulator-5554 uninstall com.example.other')).toBe(operation !== 'uninstall');
+    },
+  );
+
+  test('stops before destructive retry when another AVD takes the serial', async () => {
+    const exec = getExecutor();
+    setExecutor({
+      ...exec,
+      runFile() {
+        running = 'stim-replacement';
+        throw Object.assign(new Error('adb command failed'), { stderr: 'adb: device offline' });
+      },
+    });
+    const cleanup = resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+    await Promise.all([expect(cleanup).rejects.toThrow('no longer running'), vi.runAllTimersAsync()]);
+    expect(calls.some((cmd) => cmd.includes('pm clear') || cmd.includes('uninstall'))).toBe(false);
+  });
+
+  test('retries an unavailable identity without touching the device until its identity returns', async () => {
+    const exec = getExecutor();
+    let names = 0;
+    setExecutor({
+      ...exec,
+      runQuiet(cmd, options) {
+        if (cmd.includes('emu avd name') && names++ === 0) return null;
+        return exec.runQuiet(cmd, options);
+      },
+    });
+    const cleanup = resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+    expect(calls.some((cmd) => cmd.includes('pm clear'))).toBe(false);
+    await vi.runAllTimersAsync();
+    await cleanup;
+    expect(calls).toContain('adb -s emulator-5554 shell pm clear com.example.app');
+  });
+
+  test.each(['adb: device offline', 'error: closed'])(
+    'bounds repeated %s failures and retains child diagnostics',
+    async (stderr) => {
+      const exec = getExecutor();
+      let attempts = 0;
+      setExecutor({
+        ...exec,
+        runFile() {
+          attempts++;
+          throw Object.assign(new Error('adb command failed'), { stderr });
+        },
+      });
+      const cleanup = resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+      await Promise.all([expect(cleanup).rejects.toThrow(stderr), vi.runAllTimersAsync()]);
+      expect(attempts).toBeGreaterThan(1);
+      expect(attempts).toBeLessThanOrEqual(31);
+    },
+  );
+
+  test('reports an unrelated command failure without waiting or retrying', async () => {
+    const exec = getExecutor();
+    setExecutor({
+      ...exec,
+      runFile() {
+        throw Object.assign(new Error('adb command failed'), { stdout: 'SecurityException: permission denied' });
+      },
+    });
+    await expect(resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app')).rejects.toThrow(
+      'SecurityException: permission denied',
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+test('adoption recovery gives ownership and readiness probes the remaining timeout budget', async () => {
+  vi.useFakeTimers();
+  try {
+    makeAvd('stim-source');
+    running = 'stim-source';
+    const exec = getExecutor();
+    const timeouts: number[] = [];
+    let failed = false;
+    setExecutor({
+      ...exec,
+      run(cmd, options) {
+        expect(options?.timeoutMs).toBeGreaterThan(0);
+        timeouts.push(options!.timeoutMs!);
+        return exec.run(cmd, options);
+      },
+      runQuiet(cmd, options) {
+        expect(options?.timeoutMs).toBeGreaterThan(0);
+        timeouts.push(options!.timeoutMs!);
+        return exec.runQuiet(cmd, options);
+      },
+      runFile(file, args, options) {
+        expect(options?.timeoutMs).toBeGreaterThan(0);
+        if (!failed) {
+          failed = true;
+          throw new Error('error: closed');
+        }
+        expect(options!.timeoutMs!).toBeLessThan(30000);
+        return exec.runFile(file, args, options);
+      },
+    });
+    const cleanup = resetAdoptedAvd('stim-source', 'emulator-5554', 'com.example.app');
+    await vi.runAllTimersAsync();
+    await cleanup;
+    expect(timeouts.every((value) => value <= 30000)).toBe(true);
+    expect(timeouts.at(-1)).toBeLessThan(30000);
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -442,7 +442,7 @@ export async function finishAndroidRun({
         'Retry once the APK applicationId can be read.',
       );
     try {
-      resetAdoptedAvd(device.avdName, serial, androidPackage);
+      await resetAdoptedAvd(device.avdName, serial, androidPackage);
     } catch (error) {
       return fail(
         LAUNCH_FAILED,

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -469,8 +469,10 @@ result as proof instead of requiring an unrelated screenshot.`,
 
   Android cleanup happens AFTER boot, before install or launch: \`adb shell
   pm clear\` clears the adopting app's data while retaining its APK, and
-  other third-party apps are uninstalled. Failed cleanup blocks launch and
-  remains pending for a retry. The installed APK's SHA-256 must match the
+  other third-party apps are uninstalled. If ADB goes offline or closes the
+  connection, Stim waits for boot readiness and retries cleanup for up to 30
+  seconds, verifying the same owned AVD before each destructive command.
+  Failed cleanup blocks launch and remains pending for a retry. The installed APK's SHA-256 must match the
   requested artifact before Stim skips installation; a package name or cache
   key alone is insufficient, including for release builds with swapped JS.
   If the retained APK has a conflicting signer or version, adoption uninstalls

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -300,8 +300,8 @@ export function listAvds({ timeoutMs }: { timeoutMs?: number } = {}): string[] {
   return parseAvdList(getExecutor().run(`${androidTool('emulator')} -list-avds`, { timeoutMs }));
 }
 
-export function listAdbDevices(): AdbDevices {
-  return parseAdbDevices(getExecutor().run(`${androidTool('adb')} devices`));
+export function listAdbDevices({ timeoutMs }: { timeoutMs?: number } = {}): AdbDevices {
+  return parseAdbDevices(getExecutor().run(`${androidTool('adb')} devices`, { timeoutMs }));
 }
 
 const ADB_PROP_TIMEOUT_MS = 5000;
@@ -645,28 +645,62 @@ export function ownedAvdMatchesConfiguration(avdName: string, configuration: str
   );
 }
 
-export function resetAdoptedAvd(avdName: string, serial: string, keepPackage: string): void {
+export async function resetAdoptedAvd(avdName: string, serial: string, keepPackage: string): Promise<void> {
+  const exec = getExecutor();
+  let recoveryDeadline: number | undefined;
+  let firstFailure: string | undefined;
+  let unavailableTarget = false;
+  const commandTimeout = (timeoutMs: number) =>
+    recoveryDeadline === undefined ? timeoutMs : Math.max(1, Math.min(timeoutMs, recoveryDeadline - Date.now()));
   const assertTarget = () => {
-    const resolved = resolveOwnedAvdSerial(avdName);
+    const resolved = resolveOwnedAvdSerial(avdName, { timeoutMs: commandTimeout(30000) });
+    unavailableTarget = Boolean(resolved.notRunning);
     if (resolved.serial !== serial) throw new Error(`AVD ${avdName} is no longer running on ${serial}.`);
   };
-  assertTarget();
-  const exec = getExecutor();
-  const output = exec.runFile('adb', ['-s', serial, 'shell', 'pm', 'list', 'packages', '-3'], { timeoutMs: 30000 });
-  const packages = output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const match = /^package:([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)$/.exec(line);
-      if (!match) throw new Error(`Could not read installed apps on ${avdName}: ${line}`);
-      return match[1]!;
-    });
-  for (const packageName of packages) {
-    assertTarget();
-    const args = packageName === keepPackage ? ['shell', 'pm', 'clear', packageName] : ['uninstall', packageName];
-    const result = exec.runFile('adb', ['-s', serial, ...args], { timeoutMs: 120000 });
-    if (result.trim() !== 'Success') throw new Error(`Could not clean ${packageName} on ${avdName}: ${result.trim()}`);
+  for (;;) {
+    unavailableTarget = false;
+    try {
+      assertTarget();
+      const output = exec.runFile('adb', ['-s', serial, 'shell', 'pm', 'list', 'packages', '-3'], {
+        timeoutMs: commandTimeout(30000),
+      });
+      const packages = output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const match = /^package:([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)$/.exec(line);
+          if (!match) throw new Error(`Could not read installed apps on ${avdName}: ${line}`);
+          return match[1]!;
+        });
+      for (const packageName of packages) {
+        assertTarget();
+        const args = packageName === keepPackage ? ['shell', 'pm', 'clear', packageName] : ['uninstall', packageName];
+        const result = exec.runFile('adb', ['-s', serial, ...args], { timeoutMs: commandTimeout(120000) });
+        if (result.trim() !== 'Success')
+          throw new Error(`Could not clean ${packageName} on ${avdName}: ${result.trim()}`);
+      }
+      return;
+    } catch (error) {
+      const failed = error as Error & { stderr?: unknown; stdout?: unknown };
+      const detail = [failed?.message || String(error), failed?.stderr, failed?.stdout]
+        .filter(Boolean)
+        .map(String)
+        .join('\n');
+      firstFailure ??= detail;
+      const diagnostic = detail === firstFailure ? detail : `${firstFailure}\nRecovery failed: ${detail}`;
+      const transient = /(?:^|\n)(?:adb: )?(?:error: )?(?:device offline|closed)\s*(?:$|\n)/i.test(detail);
+      recoveryDeadline ??= Date.now() + 30000;
+      if ((!unavailableTarget && !transient) || Date.now() >= recoveryDeadline)
+        throw new Error(diagnostic, { cause: error });
+      const delayMs = Math.min(1000, recoveryDeadline - Date.now());
+      await new Promise((done) => setTimeout(done, delayMs));
+      const ready = await waitForBoot(serial, recoveryDeadline - Date.now(), { commandTimeoutMs: 5000 });
+      if (!ready.ok)
+        throw new Error(`${diagnostic}\nEmulator did not recover: ${JSON.stringify(ready.diagnostic)}`, {
+          cause: error,
+        });
+    }
   }
 }
 
@@ -747,37 +781,50 @@ export function emulatorFailureRemedy(lines: string[]): string {
 // for most of a boot: adb answers "device offline" or "device not found" until
 // the emulator has registered. Null is "not booted yet", so it reads as an
 // empty string and the poll continues.
-function getprop(exec: Executor, serial: string, prop: string): string {
-  const out = exec.runQuiet(`${androidTool('adb')} -s ${serial} shell getprop ${prop}`);
+function getprop(exec: Executor, serial: string, prop: string, timeoutMs?: number): string {
+  const out = exec.runQuiet(`${androidTool('adb')} -s ${serial} shell getprop ${prop}`, { timeoutMs });
   return typeof out === 'string' ? out.trim() : '';
 }
 
 export async function waitForBoot(
   serial: string,
   timeoutMs = 60000,
-  { aborted = () => false, pollMs = 1000 }: { aborted?: () => boolean; pollMs?: number } = {},
+  {
+    aborted = () => false,
+    pollMs = 1000,
+    commandTimeoutMs,
+  }: { aborted?: () => boolean; pollMs?: number; commandTimeoutMs?: number } = {},
 ): Promise<BootResult> {
   const exec = getExecutor();
   const start = Date.now();
   let exited = false;
+  const probeTimeout = () =>
+    commandTimeoutMs === undefined
+      ? undefined
+      : Math.max(1, Math.min(commandTimeoutMs, timeoutMs - (Date.now() - start)));
   while (Date.now() - start < timeoutMs) {
-    if (getprop(exec, serial, 'sys.boot_completed') === '1') return { ok: true };
-    if (getprop(exec, serial, 'dev.bootcomplete') === '1') return { ok: true };
+    if (getprop(exec, serial, 'sys.boot_completed', probeTimeout()) === '1') return { ok: true };
+    if (getprop(exec, serial, 'dev.bootcomplete', probeTimeout()) === '1') return { ok: true };
     if (aborted()) {
       exited = true;
       break;
     }
-    await new Promise((r) => setTimeout(r, pollMs));
+    await new Promise((r) =>
+      setTimeout(
+        r,
+        commandTimeoutMs === undefined ? pollMs : Math.min(pollMs, Math.max(0, timeoutMs - (Date.now() - start))),
+      ),
+    );
   }
-  const devicesOut = exec.runQuiet(`${androidTool('adb')} devices`);
+  const devicesOut = exec.runQuiet(`${androidTool('adb')} devices`, { timeoutMs: probeTimeout() });
   return {
     ok: false,
     ...(exited ? { exited: true as const } : {}),
     diagnostic: {
       devices: typeof devicesOut === 'string' ? devicesOut.trim() : '',
-      sysBoot: getprop(exec, serial, 'sys.boot_completed'),
-      devBoot: getprop(exec, serial, 'dev.bootcomplete'),
-      bootAnim: getprop(exec, serial, 'init.svc.bootanim'),
+      sysBoot: getprop(exec, serial, 'sys.boot_completed', probeTimeout()),
+      devBoot: getprop(exec, serial, 'dev.bootcomplete', probeTimeout()),
+      bootAnim: getprop(exec, serial, 'init.svc.bootanim', probeTimeout()),
     },
   };
 }
@@ -910,21 +957,25 @@ export function waitForAndroidEmulatorShutdown(
   }
 }
 
-export function getAvdNameForSerial(serial: string): string | null {
-  const out = getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} emu avd name`);
+export function getAvdNameForSerial(serial: string, { timeoutMs }: { timeoutMs?: number } = {}): string | null {
+  const out = getExecutor().runQuiet(`${androidTool('adb')} -s ${serial} emu avd name`, { timeoutMs });
   if (!out) return null;
   return out.split('\n')[0]?.trim() || null;
 }
 
-export function resolveOwnedAvdSerial(avdName: string): ResolvedAvdSerial {
-  if (!listAvds().includes(avdName)) return { missing: true };
+export function resolveOwnedAvdSerial(avdName: string, { timeoutMs }: { timeoutMs?: number } = {}): ResolvedAvdSerial {
+  const started = Date.now();
+  const remaining = () => ({
+    timeoutMs: timeoutMs === undefined ? undefined : Math.max(1, timeoutMs - (Date.now() - started)),
+  });
+  if (!listAvds(remaining()).includes(avdName)) return { missing: true };
   if (!avdName?.startsWith('stim-')) return { notOwned: true };
-  const adb = listAdbDevices();
+  const adb = listAdbDevices(remaining());
   const candidates = [
     ...adb.emulators,
     ...adb.unhealthy.filter((entry) => entry.kind === 'emulator' && entry.consolePort !== undefined),
   ];
-  const match = candidates.find((e) => getAvdNameForSerial(e.serial) === avdName);
+  const match = candidates.find((e) => getAvdNameForSerial(e.serial, remaining()) === avdName);
   if (match) return { serial: match.serial };
   return { notRunning: true };
 }

--- a/test/e2e/native/run-android-pool-e2e.mjs
+++ b/test/e2e/native/run-android-pool-e2e.mjs
@@ -70,7 +70,7 @@ async function deviceFor(index) {
   owned.add(device.avdName);
   const ready = performance.now();
   const serial = `emulator-${device.consolePort}`;
-  if (device.adopted) resetAdoptedAvd(device.avdName, serial, packageName);
+  if (device.adopted) await resetAdoptedAvd(device.avdName, serial, packageName);
   const cleaned = performance.now();
   const installed = installAndroidApp({ serial, apkPath, packageName });
   assert(installed.ok, JSON.stringify(installed));


### PR DESCRIPTION
## Description

Adopting a parked Android emulator can fail with `adb: device offline` or `error: closed` while listing or clearing apps, even when retrying later succeeds. The original snapshot failure's cause remains unknown; this change covers recovery during adoption cleanup, not later install or launch failures.

## Solution

Retry cleanup within a 30-second recovery budget, including its ownership and boot-readiness probes. Each attempt reads the installed packages again and verifies the same owned AVD before clearing or uninstalling an app. Successful cleanup adds no wait; other errors still block launch, leave adoption pending, and preserve the child-process diagnostics.

## Test plan

- Regression cases cover interrupted package listing, clearing, and uninstalling; an unavailable or replaced AVD; exhausted recovery; and a permanent cleanup error that preserves diagnostics and prevents launch.
- On Emulator 35.6.11/API 36, a guest reboot induced a real `adb: device offline`; cleanup recovered in 19.2 seconds, cleared retained-app data, and removed another third-party app. Normal cleanup took 244 ms. The disposable AVD was removed afterward.

Fixes #639
