### PR TITLE
fix: release cleanup claims when staging removal fails

### DIFF
--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -2717,6 +2717,32 @@ test('--delete removes the stale lock and leaves the live one alone', async () =
   expect(output).toMatch(/build lock/i);
 });
 
+test.skipIf(process.getuid?.() === 0)(
+  '--delete continues after staging cleanup fails and leaves no cleanup claim',
+  async () => {
+    saveConfig({ version: 2, projects: {}, repos: {} });
+    installExecutor();
+    const blocked = join(tmpHome, 'build-locks', 'ios-staging.lock');
+    const staging = join(blocked, '.staging-interrupted');
+    const writable = join(tmpHome, 'build-slots', 'slot-0');
+    mkdirSync(staging, { recursive: true });
+    mkdirSync(writable, { recursive: true });
+    writeFileSync(join(staging, 'partial.claim'), '{');
+    chmodSync(staging, 0);
+    try {
+      const output = await captureLog(() => sweepingGc({ delete: true }));
+      expect(output).toContain(`Failed to clear the build lock at ${blocked}: EACCES`);
+      expect(output).toContain('Cleared build slot 0');
+      expect(output).toContain('1 entry could not be deleted');
+      expect(existsSync(staging)).toBe(true);
+      expect(existsSync(writable)).toBe(false);
+      expect(readClaimSet(blocked).live).toEqual([]);
+    } finally {
+      chmodSync(staging, 0o700);
+    }
+  },
+);
+
 test('--delete keeps a lock whose holder cannot be identified, and says why', async () => {
   saveConfig({ version: 2, projects: {}, repos: {} });
   installExecutor();

--- a/packages/stim-cli/src/__tests__/ownership-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/ownership-claim.test.ts
@@ -255,6 +255,27 @@ describe('clearing a claim set that holds nothing', () => {
     expect(existsSync(root)).toBe(false);
   });
 
+  test.skipIf(process.getuid?.() === 0)(
+    'a staging deletion failure releases the cleanup claim and preserves the payload',
+    () => {
+      const staging = join(root, '.staging-interrupted');
+      const payload = join(staging, 'partial.claim');
+      mkdirSync(staging, { recursive: true });
+      writeFileSync(payload, '{');
+      chmodSync(staging, 0);
+      try {
+        expect(clearFreeClaimSet({ root })).toEqual({ status: 'failed', reason: expect.stringContaining('EACCES') });
+        expect(readClaimSet(root).live).toEqual([]);
+        expect(existsSync(staging)).toBe(true);
+      } finally {
+        chmodSync(staging, 0o700);
+      }
+      expect(readFileSync(payload, 'utf-8')).toBe('{');
+      expect(clearFreeClaimSet({ root })).toEqual({ status: 'cleared' });
+      expect(existsSync(root)).toBe(false);
+    },
+  );
+
   test('a set a live process holds is left exactly as it was', () => {
     const got = tryAcquireClaim({ root, mode: 'exclusive' });
     assert(got.acquired);

--- a/packages/stim-cli/src/ownership-claim.ts
+++ b/packages/stim-cli/src/ownership-claim.ts
@@ -419,8 +419,13 @@ export function clearFreeClaimSet({ root, label = 'ownership' }: { root: string;
     if (attempt.pending) releaseClaim(attempt.pending);
     return { status: 'held', holder: attempt.held ?? attempt.waitingFor?.[0] ?? null };
   }
-  removeAbandonedStaging(root);
-  releaseClaim(attempt.acquired);
+  try {
+    removeAbandonedStaging(root);
+  } catch (err) {
+    return { status: 'failed', reason: (err as Error)?.message ?? String(err) };
+  } finally {
+    releaseClaim(attempt.acquired);
+  }
   tidySet(root);
   const remaining = names(root);
   if (remaining === 'unreadable') return { status: 'failed', reason: 'its directory could not be read' };


### PR DESCRIPTION
## Description

A permission error while `gc --delete` removes abandoned claim staging files aborts the sweep and leaves its own exclusive claim held until the process exits.

## Solution

Report the staging error through the existing failed-clearance result and release the cleanup claim in `finally`. Undeletable staging files remain for a later retry, while other cleanup entries can still be reclaimed.

## Test plan

- Real mode-000 staging directory: failed before the fix; now reports `EACCES`, leaves no live cleanup claim, preserves the payload, and clears successfully after permissions are restored.
- `gc --delete` reports the blocked build lock, clears a later healthy build slot, and counts one failed entry.

Fixes #716
