### PR TITLE
fix: create Android emulators with a sharp phone display

### DIFF
--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -96,7 +96,7 @@ function makeAvd(name: string): void {
   writeFileSync(join(home, 'avd', `${name}.ini`), `path=${directory}\n`);
   writeFileSync(
     join(directory, 'config.ini'),
-    `image.sysdir.1=${image.split(';').join('/')}\ndisk.dataPartition.size=8589934592\n`,
+    `image.sysdir.1=${image.split(';').join('/')}\ndisk.dataPartition.size=8589934592\nhw.device.name=pixel_6\n`,
   );
 }
 
@@ -132,6 +132,7 @@ test('a new workspace adopts a compatible stopped AVD and retains cleanup state 
 
 test.each([
   { systemImage: image.replace('android-36', 'android-35') },
+  { configuration: '[["disk.dataPartition.size","8589934592"]]' },
   { configuration: avdPoolConfiguration(10, {}) },
   { configuration: avdPoolConfiguration(8, { 'hw.ramSize': '4096' }) },
 ])('an incompatible parked AVD stays parked and its name cannot be recovered by creation: %j', async (overrides) => {

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -101,7 +101,10 @@ KEYS STIM READS
                         -- the sdkmanager package id the owned AVD is created
                         from. The \`--system-image\` flag overrides this per
                         invocation, and an id this SDK has not installed is
-                        STIM_BAD_ARG with the installed ids printed
+                        STIM_BAD_ARG with the installed ids printed.
+                        New AVDs use the Pixel 6 hardware profile (1080x2400,
+                        420 dpi). Existing AVDs keep their display settings;
+                        parked AVDs from the old generic profile are not adopted.
   android.dataPartitionSizeGb
                         whole GiB for a newly created owned AVD's data
                         partition. Defaults to 8; accepts 6 through 16384.

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -24,6 +24,7 @@ export interface SystemImage {
 }
 
 const ANDROID_ABIS = new Set(['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64']);
+const DEFAULT_AVD_DEVICE = 'pixel_6';
 
 interface AdbEmulatorEntry {
   serial: string;
@@ -205,7 +206,9 @@ export function createOwnedAvd(
     );
   }
   const avdName = ownedAvdName(label);
-  getExecutor().run(`echo no | ${androidTool('avdmanager')} create avd -n "${avdName}" -k "${pick.pkg}"`);
+  getExecutor().run(
+    `echo no | ${androidTool('avdmanager')} create avd -n "${avdName}" -k "${pick.pkg}" --device "${DEFAULT_AVD_DEVICE}"`,
+  );
   return { avdName, systemImage: pick.pkg };
 }
 
@@ -622,6 +625,7 @@ export function avdPoolConfiguration(dataPartitionSizeGb: number, avdConfig: Rec
   return JSON.stringify(
     Object.entries({
       ...avdConfig,
+      'hw.device.name': DEFAULT_AVD_DEVICE,
       'disk.dataPartition.size': String(androidDataPartitionSizeBytes(dataPartitionSizeGb)),
     }).toSorted(([a], [b]) => a.localeCompare(b)),
   );

--- a/test/e2e/native/run-android-pool-e2e.mjs
+++ b/test/e2e/native/run-android-pool-e2e.mjs
@@ -70,6 +70,10 @@ async function deviceFor(index) {
   owned.add(device.avdName);
   const ready = performance.now();
   const serial = `emulator-${device.consolePort}`;
+  const displaySize = exec.runFile('adb', ['-s', serial, 'shell', 'wm', 'size']);
+  const displayDensity = exec.runFile('adb', ['-s', serial, 'shell', 'wm', 'density']);
+  assert.match(displaySize, /^Physical size: 1080x2400\s*$/);
+  assert.match(displayDensity, /^Physical density: 420\s*$/);
   if (device.adopted) await resetAdoptedAvd(device.avdName, serial, packageName);
   const cleaned = performance.now();
   const installed = installAndroidApp({ serial, apkPath, packageName });
@@ -79,6 +83,8 @@ async function deviceFor(index) {
     name: device.avdName,
     systemImage: device.systemImage,
     adopted: Boolean(device.adopted),
+    displaySize,
+    displayDensity,
     prepareMs: Math.round(ready - started),
     cleanupMs: Math.round(cleaned - ready),
     installMs: Math.round(finished - cleaned),

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -90,6 +90,10 @@ project's own `metro.config.js` calls `sharedCacheStores()` from
 
 ### Android AVD overrides
 
+New owned AVDs use the Pixel 6 hardware profile (1080 × 2400 pixels at 420 dpi).
+Existing AVDs keep their display settings. Parked AVDs created with the old generic
+profile are not adopted by new workspaces.
+
 `android.avdConfigFile` reads an Android `config.ini` file. `android.avdConfig`
 provides the same safe keys as JSON. Stim applies these values only when it
 creates a new owned AVD. It never rewrites an existing AVD or changes generated


### PR DESCRIPTION
## Description

New Android emulators render at 320 x 640 because Stim does not select a hardware profile. Enlarging the window makes text and UI blurry.

Fixes #724.

## Solution

Create AVDs with the Pixel 6 profile (1080 x 2400, 420 dpi) and include the profile in pool compatibility. Older generic AVDs stay out of new workspaces; existing workspace devices and their data are preserved. Obsolete parked devices remain eligible for normal eviction and GC.

## Test plan

- Ran the native Android pool smoke test against a debug APK on macOS/Apple Silicon. Both fresh and recycled AVDs reported `Physical size: 1080x2400` and `Physical density: 420`; APK reuse, app-data cleanup, and final AVD deletion passed.
- The legacy-pool regression failed before the fix and passes with it.

Stock Android Settings on empty test devices, with the same installed system image:

| Before: generic, 320 × 640 / 160 dpi | After: Pixel 6, 1080 × 2400 / 420 dpi |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/20cc02e1-9862-4317-bd42-02051902eecd" width="320" /> | <img src="https://github.com/user-attachments/assets/545a4bc2-d10c-42be-a5fc-693316319e9d" width="320" /> |
