### PR TITLE
fix: point long waits to the relevant workflow guide

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -2193,7 +2193,9 @@ describe('single-flight builds', () => {
     assert(result.facts);
     expect(result.facts.cacheHit).toBe('local');
     expect(result.facts.waitedForBuild).toEqual({ pid: 41233, ms: 761000 });
-    expect(h.stderr.join('\n')).toMatch(/waited 12m41s for \/w\/app-999's build -> installed from cache/);
+    expect(h.stderr.join('\n')).toMatch(
+      /waited 12m41s for \/w\/app-999's build -> installed from cache -- stim guide lifecycle concurrency/,
+    );
   });
 
   test('a run that did not wait reports waitedForBuild: null', async () => {
@@ -2213,7 +2215,7 @@ describe('single-flight builds', () => {
     });
     await h.run();
     const err = h.stderr.join('\n');
-    expect(err).toMatch(/\/w\/app-999 is already building/);
+    expect(err).toMatch(/\/w\/app-999 is already building[^\n]+ -- stim guide lifecycle concurrency/);
     expect(err).toMatch(/waiting on \/w\/app-999 \(pid 41233, 4m elapsed\)/);
     expect(h.stdout.length).toBe(1);
   });

--- a/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-lock.test.ts
@@ -346,7 +346,7 @@ describe('waitForBuild', () => {
     expect(lines.length >= 5).toBeTruthy();
     expect(lines.length < 20).toBeTruthy();
     expect(lines[0]).toMatch(
-      /^build\s+waiting on \/other\/worktree \(pid \d+, .+ elapsed\) -- tail \/other\/build\.ndjson$/,
+      /^build\s+waiting on \/other\/worktree \(pid \d+, .+ elapsed\) -- tail \/other\/build\.ndjson -- stim guide lifecycle concurrency$/,
     );
   });
 
@@ -381,7 +381,7 @@ describe('waitingLine', () => {
       logFile: '/w/app-412/.stim/logs/build-ios.ndjson',
     });
     expect(line).toBe(
-      'build       waiting on /w/app-412 (pid 41233, 8m00s elapsed) -- tail /w/app-412/.stim/logs/build-ios.ndjson',
+      'build       waiting on /w/app-412 (pid 41233, 8m00s elapsed) -- tail /w/app-412/.stim/logs/build-ios.ndjson -- stim guide lifecycle concurrency',
     );
   });
 

--- a/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-build-slots.test.ts
@@ -105,6 +105,27 @@ describe('releaseBuildSlot', () => {
 });
 
 describe('acquireBuildSlot', () => {
+  test('a queued build keeps its progress cadence and points to concurrency guidance', async () => {
+    const held = tryAcquireBuildSlot({ max: 1 });
+    assert(held);
+    let clock = 0;
+    const lines: string[] = [];
+    const acquired = await acquireBuildSlot({
+      max: 1,
+      now: () => clock,
+      out: (line) => lines.push(line),
+      sleep: async () => {
+        clock += 10000;
+        if (clock === 90000) releaseBuildSlot(held);
+      },
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines.every((line) => line.endsWith(' -- stim guide lifecycle concurrency'))).toBe(true);
+    expect(lines[0]).toContain('30s elapsed');
+    expect(lines[1]).toContain('1m00s elapsed');
+    releaseBuildSlot(acquired);
+  });
+
   test('unlimited (max 0) acquires immediately without a slot on disk', async () => {
     const got = await acquireBuildSlot({ max: 0 });
     expect(got.unlimited).toBe(true);

--- a/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
@@ -263,6 +263,7 @@ describe('waiting for a device another workspace holds', () => {
     const result = await acquire(h, { waitSeconds: 61 });
     assert(result.status === 'refused');
     expect(h.warnings).toHaveLength(3);
+    expect(h.warnings.every((line) => line.endsWith(' -- stim guide lifecycle lease'))).toBe(true);
     expect(h.warnings[0]).toMatch(new RegExp(`waiting for ${OTHER} to release Test Phone \\(${UDID}\\)`));
     expect(h.warnings[0]).toMatch(/its lease runs until \d\d:\d\d:\d\d \(\d+m\d\ds from now\)/);
     expect(h.slept.slice(0, 1)).toEqual([DEVICE_WAIT_POLL_MS]);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1638,7 +1638,9 @@ describe('single-flight builds', () => {
     const facts = parseFirst(logs);
     expect(facts.cacheHit).toBe('local');
     expect(facts.waitedForBuild).toEqual({ pid: 41233, ms: 761000 });
-    expect(stderr).toMatch(/waited 12m41s for \/w\/app-999's build -> installed from cache/);
+    expect(stderr).toMatch(
+      /waited 12m41s for \/w\/app-999's build -> installed from cache -- stim guide lifecycle concurrency/,
+    );
   });
 
   test('a run that did not wait reports waitedForBuild: null', async () => {
@@ -1658,6 +1660,7 @@ describe('single-flight builds', () => {
     );
     expect(stderr).toMatch(/\/w\/app-999/);
     expect(stderr).toMatch(/41233/);
+    expect(stderr).toMatch(/is already building[^\n]+ -- stim guide lifecycle concurrency/);
     expect(stderr).toMatch(/build-ios\.ndjson/);
   });
 

--- a/packages/stim-cli/src/__tests__/warm-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim.test.ts
@@ -205,8 +205,8 @@ test('a wait attributes elapsed time to the waiter and names its holder every pr
     },
   });
   expect(lines).toEqual([
-    `  lock        waiting 30s for stim worktree warm --refresh (pid ${process.pid})`,
-    `  lock        waiting 1m00s for stim worktree warm --refresh (pid ${process.pid})`,
+    `  lock        waiting 30s for stim worktree warm --refresh (pid ${process.pid}) -- stim guide lifecycle options`,
+    `  lock        waiting 1m00s for stim worktree warm --refresh (pid ${process.pid}) -- stim guide lifecycle options`,
   ]);
   expect(copy.wait.waitedMs).toBe(80_000);
   copy.release();
@@ -215,7 +215,7 @@ test('a wait attributes elapsed time to the waiter and names its holder every pr
 test('the acquired line reports a wait only when there was one', () => {
   expect(warmClaimAcquiredLine({ waitedMs: 0, holder: null })).toBe(`  ${'lock'.padEnd(11)} acquired`);
   expect(warmClaimAcquiredLine({ waitedMs: 12_000, holder: { pid: 41233, phase: 'refresh' } })).toBe(
-    `  ${'lock'.padEnd(11)} acquired (waited 12s for stim worktree warm --refresh pid 41233)`,
+    `  ${'lock'.padEnd(11)} acquired (waited 12s for stim worktree warm --refresh pid 41233) -- stim guide lifecycle options`,
   );
 });
 

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1287,7 +1287,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
           phase(
             'build',
             `${who} is already building ${shortHash(hash)} (pid ${holder.pid})` +
-              `${holder.logFile ? ` -- tail ${holder.logFile}` : ''}`,
+              `${holder.logFile ? ` -- tail ${holder.logFile}` : ''} -- stim guide lifecycle concurrency`,
           );
 
           let waited: WaitForBuildResult | null = null;
@@ -1326,7 +1326,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
             apkPath = waited.hit ?? null;
             record.cacheHit = 'local';
             waitedForBuild = { pid: holder.pid, ms: waited.waitedMs };
-            phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+            phase(
+              'build',
+              `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache -- stim guide lifecycle concurrency`,
+            );
           } else if (waited?.lockReleased) {
             failedHolder = undefined;
             releasedWait = { facts: { pid: holder.pid, ms: waited.waitedMs }, who };
@@ -1462,7 +1465,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
                     waitedForBuild = releasedWait.facts;
                     phase(
                       'build',
-                      `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache`,
+                      `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache -- stim guide lifecycle concurrency`,
                     );
                   }
                 }

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -941,7 +941,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         phase(
           'build',
           `${who} is already building ${shortHash(fingerprint)} (pid ${held.pid})` +
-            `${held.logFile ? ` -- tail ${held.logFile}` : ''}`,
+            `${held.logFile ? ` -- tail ${held.logFile}` : ''} -- stim guide lifecycle concurrency`,
         );
 
         let waited: WaitForBuildResult | null = null;
@@ -985,7 +985,10 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
           appPath = waited.hit ?? null;
           cacheHit = 'local';
           waitedForBuild = { pid: held.pid, ms: waited.waitedMs };
-          phase('build', `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache`);
+          phase(
+            'build',
+            `waited ${formatDuration(waited.waitedMs)} for ${who}'s build -> installed from cache -- stim guide lifecycle concurrency`,
+          );
         } else if (waited?.lockReleased) {
           failedHolder = undefined;
           releasedWait = { facts: { pid: held.pid, ms: waited.waitedMs }, who };
@@ -1236,7 +1239,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
                   waitedForBuild = releasedWait.facts;
                   phase(
                     'build',
-                    `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache`,
+                    `waited ${formatDuration(waitedForBuild.ms)} for ${releasedWait.who}'s build -> installed from cache -- stim guide lifecycle concurrency`,
                   );
                 }
               }

--- a/packages/stim-cli/src/engine/build-lock.ts
+++ b/packages/stim-cli/src/engine/build-lock.ts
@@ -206,7 +206,7 @@ export function listBuildLocks(): BuildLockInfo[] {
 export function waitingLine({ projectRoot, pid, elapsedMs, logFile }: WaitingLineArgs): string {
   const where = projectRoot || 'another workspace';
   const tail = logFile ? ` -- tail ${logFile}` : '';
-  return `${'build'.padEnd(11)} waiting on ${where} (pid ${pid ?? '?'}, ${formatElapsed(elapsedMs)} elapsed)${tail}`;
+  return `${'build'.padEnd(11)} waiting on ${where} (pid ${pid ?? '?'}, ${formatElapsed(elapsedMs)} elapsed)${tail} -- stim guide lifecycle concurrency`;
 }
 
 export function takeoverLine({

--- a/packages/stim-cli/src/engine/build-slots.ts
+++ b/packages/stim-cli/src/engine/build-slots.ts
@@ -141,7 +141,7 @@ export function tryAcquireBuildSlot({
 }
 
 export function slotWaitingLine({ max, elapsedMs }: { max: number; elapsedMs: number }): string {
-  return `${'build'.padEnd(11)} waiting for a build slot (all ${max} in use, ${formatElapsed(elapsedMs)} elapsed)`;
+  return `${'build'.padEnd(11)} waiting for a build slot (all ${max} in use, ${formatElapsed(elapsedMs)} elapsed) -- stim guide lifecycle concurrency`;
 }
 
 export async function acquireBuildSlot({

--- a/packages/stim-cli/src/engine/device-lease-run.ts
+++ b/packages/stim-cli/src/engine/device-lease-run.ts
@@ -79,7 +79,7 @@ function facts(lease: DeviceLease): LeaseFacts {
 function waitingLine(lease: DeviceLease, now: number): string {
   return (
     `waiting for ${lease.holder} to release ${describeDevice(lease)}; ` +
-    `its lease runs until ${leaseExpiryText(lease.expiresAt, now)}`
+    `its lease runs until ${leaseExpiryText(lease.expiresAt, now)} -- stim guide lifecycle lease`
   );
 }
 

--- a/packages/stim-cli/src/engine/warm-claim.ts
+++ b/packages/stim-cli/src/engine/warm-claim.ts
@@ -99,14 +99,17 @@ function asHolder(holder: ClaimHolder): WarmClaimHolder {
 }
 
 function waitingLine(holder: WarmClaimHolder, elapsedMs: number): string {
-  return phaseLine('lock', `waiting ${formatElapsed(elapsedMs)} for ${warmCommand(holder.phase)} (pid ${holder.pid})`);
+  return phaseLine(
+    'lock',
+    `waiting ${formatElapsed(elapsedMs)} for ${warmCommand(holder.phase)} (pid ${holder.pid}) -- stim guide lifecycle options`,
+  );
 }
 
 export function warmClaimAcquiredLine(wait: WarmClaimWait): string {
   if (!wait.holder || wait.waitedMs <= 0) return phaseLine('lock', 'acquired');
   return phaseLine(
     'lock',
-    `acquired (waited ${formatElapsed(wait.waitedMs)} for ${warmCommand(wait.holder.phase)} pid ${wait.holder.pid})`,
+    `acquired (waited ${formatElapsed(wait.waitedMs)} for ${warmCommand(wait.holder.phase)} pid ${wait.holder.pid}) -- stim guide lifecycle options`,
   );
 }
 
@@ -179,7 +182,7 @@ export function warmClaimBlockedRefusal(blocker: WarmClaimBlocker): string {
 function installerWaitingLine(pid: number, elapsedMs: number): string {
   return phaseLine(
     'lock',
-    `waiting on the install this refresh spawned (pid ${pid}, ${formatElapsed(elapsedMs)} elapsed)`,
+    `waiting on the install this refresh spawned (pid ${pid}, ${formatElapsed(elapsedMs)} elapsed) -- stim guide lifecycle options`,
   );
 }
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -324,7 +324,7 @@ result as proof instead of requiring an unrelated screenshot.`,
     build       still compiling (4m00s, usually ~3m10s)
     build       still compiling (1m00s)
     pods        still installing (1m30s of ~1m40s)
-    build       waiting on /w/app-411 (pid 41233, 1m30s elapsed)
+    build       waiting on /w/app-411 (pid 41233, 1m30s elapsed) -- stim guide lifecycle concurrency
 
   The \`~\` value is an estimate, never a countdown; the third line is a
   project with no record to estimate from yet. \`guide facts stats\` says where
@@ -340,7 +340,7 @@ result as proof instead of requiring an unrelated screenshot.`,
   step, before those. A plain warm prints the \`lock\` line only when its copy
   actually waited for another warm:
 
-    lock        acquired (waited 12s for stim worktree warm --refresh pid 41233)
+    lock        acquired (waited 12s for stim worktree warm --refresh pid 41233) -- stim guide lifecycle options
     checkout    janic/wip 2 commits behind origin/janic/wip -> fast-forwarded to 4b81e0c
                 not the default branch (main); worktrees seeded from this copy
                 carry janic/wip's dependencies
@@ -348,7 +348,7 @@ result as proof instead of requiring an unrelated screenshot.`,
     pods        source /w/main/apps/mobile: ios/Podfile.lock changed -> pod install (1m12s)
 
   A wait reports how long this caller has waited and names the holder:
-  \`lock        waiting 40s for stim worktree warm --refresh (pid 41233)\`.
+  \`lock        waiting 40s for stim worktree warm --refresh (pid 41233) -- stim guide lifecycle options\`.
 
   \`start\` names the port, the supervisor mode and its pid on one line
   (\`metro       starting on port 8083 (expo-child, supervisor pid 13724)\`),
@@ -777,9 +777,9 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   <fingerprint, platform> (a directory under ~/.stim/build-locks). Exactly
   one workspace compiles; the others print
 
-    build       /w/app-412 is already building a3f9b1.. (pid 41233) -- tail ...
-    build       waiting on /w/app-412 (pid 41233, 4m elapsed) -- tail ...
-    build       waited 12m41s for /w/app-412's build -> installed from cache
+    build       /w/app-412 is already building a3f9b1.. (pid 41233) -- tail ... -- stim guide lifecycle concurrency
+    build       waiting on /w/app-412 (pid 41233, 4m elapsed) -- tail ... -- stim guide lifecycle concurrency
+    build       waited 12m41s for /w/app-412's build -> installed from cache -- stim guide lifecycle concurrency
 
   and install the artifact the builder stored. They report cacheHit: "local"
   plus waitedForBuild: { pid, ms }.


### PR DESCRIPTION
## Description

Long wait phase lines provide no route to the guidance that explains the wait, so agents can miss the existing workflow instructions.

## Solution

Add short guide pointers to shared-build and build-slot waits, cache completion after waiting, warm coordination, and physical device lease waits. The pointers use the existing progress lines and their cadence; immediate warm-claim acquisition stays concise.

## Test plan

- Output regressions cover the guide routes, unchanged progress cadence and holder details, immediate warm acquisition, and one JSON payload during a shared build wait.
- Ran the built CLI with `guide lifecycle concurrency`, `guide lifecycle options`, and `guide lifecycle lease`; all three routes resolved successfully.

Fixes #722
