### PR TITLE
feat: warm Metro during native builds

### DIFF
--- a/packages/stim-cli/shim/bundle-response.cjs
+++ b/packages/stim-cli/shim/bundle-response.cjs
@@ -4,6 +4,11 @@ const { randomUUID } = require('node:crypto');
 
 function bundleResponseMiddleware(write) {
   return (req, res, next) => {
+    if (req.method === 'GET' && req.url === '/_stim/metro-warmup') {
+      res.end('ready');
+      return;
+    }
+    if (req.headers['x-stim-metro-warmup'] === '1') return next();
     let url;
     try {
       url = new URL(req.url, 'http://localhost');

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -289,6 +289,7 @@ function harness(overrides = {}) {
       calls.metro.push([port, path]);
       return { metro: { pid: 41233, leader: 41233, cwd: root } };
     },
+    warmMetro: async () => {},
     fingerprint: async (path: string) => {
       calls.fingerprint.push(path);
       return { hash: FINGERPRINT, sources: [] };
@@ -752,6 +753,9 @@ describe('explicit remote backend behavior', () => {
         webPreviewUrl: () => null,
       }),
       resolveEasBin: () => ({ file: '/bin/eas', args: [] }),
+      warmMetro: async () => {
+        order.push('warmMetro');
+      },
       fingerprint: async () => {
         order.push('fingerprint');
         return { hash: FINGERPRINT, sources: [] };
@@ -759,12 +763,13 @@ describe('explicit remote backend behavior', () => {
     });
 
     expect((await h.run()).ok).toBe(true);
-    expect(order.slice(0, 6)).toEqual([
+    expect(order.slice(0, 7)).toEqual([
       'localMetro',
       'resolveBackend',
       'publicMetro',
       'ensureDevice',
       'ensureDeviceBooted',
+      'warmMetro',
       'fingerprint',
     ]);
   });
@@ -804,6 +809,7 @@ describe('explicit remote backend behavior', () => {
         webPreviewUrl: () => null,
       }),
       resolveEasBin: () => ({ file: '/bin/eas', args: [] }),
+      warmMetro: never('prefetch before public Metro verifies'),
       fingerprint: never('fingerprint'),
     });
 
@@ -5418,4 +5424,33 @@ test('CAS Release builds skip legacy providers that cannot key compiler identity
     if (previous === undefined) delete process.env.STIM_ANDROID_CAS_TOOLCHAIN;
     else process.env.STIM_ANDROID_CAS_TOOLCHAIN = previous;
   }
+});
+
+describe('Metro prefetch', () => {
+  test('starts before native work without waiting for the bundle', async () => {
+    let warming = false;
+    const h = harness({
+      warmMetro: (args: unknown) => {
+        expect(args).toEqual({ port: 8082, platform: 'android', isExpo: false, appId: 'com.example.app' });
+        warming = true;
+        return new Promise(() => {});
+      },
+      fingerprint: async () => {
+        expect(warming).toBe(true);
+        return { hash: FINGERPRINT, sources: [] };
+      },
+    });
+    expect((await h.run()).ok).toBe(true);
+    expect(h.calls.verify[0]).toMatchObject({ requireBundleResponse: true });
+  });
+
+  test.each([{ variant: 'release' }, { metroCheck: false }, { resolveMetro: async () => ({ missing: true }) }])(
+    'skips prefetch when Metro is skipped or refused: %j',
+    async (options) => {
+      const warmMetro = vi.fn<() => Promise<void>>(async () => {});
+      const h = harness({ ...options, warmMetro });
+      await h.run();
+      expect(warmMetro).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5427,21 +5427,35 @@ test('CAS Release builds skip legacy providers that cannot key compiler identity
 });
 
 describe('Metro prefetch', () => {
-  test('starts before native work without waiting for the bundle', async () => {
-    let warming = false;
-    const h = harness({
-      warmMetro: (args: unknown) => {
-        expect(args).toEqual({ port: 8082, platform: 'android', isExpo: false, appId: 'com.example.app' });
-        warming = true;
-        return new Promise(() => {});
-      },
-      fingerprint: async () => {
-        expect(warming).toBe(true);
-        return { hash: FINGERPRINT, sources: [] };
-      },
-    });
+  test.each([null, '/custom.bundle?platform=android&dev=true'])(
+    'starts before native work without waiting for the bundle: %s',
+    async (bundleUrl) => {
+      let warming = false;
+      const h = harness({
+        resolveSettingsFor: () =>
+          bundleUrl ? { metro: { warmupUrl: { android: bundleUrl, ios: '/other.bundle?platform=ios' } } } : {},
+        warmMetro: (args: unknown) => {
+          expect(args).toEqual({ port: 8082, platform: 'android', isExpo: false, appId: 'com.example.app', bundleUrl });
+          warming = true;
+          return new Promise(() => {});
+        },
+        fingerprint: async () => {
+          expect(warming).toBe(true);
+          return { hash: FINGERPRINT, sources: [] };
+        },
+      });
+      expect((await h.run()).ok).toBe(true);
+      expect(h.calls.verify[0]).toMatchObject({ requireBundleResponse: true });
+    },
+  );
+
+  test('disabling warmup still verifies Metro and completes the native run', async () => {
+    const warmMetro = vi.fn<() => Promise<void>>(async () => {});
+    const h = harness({ warmMetro, resolveSettingsFor: () => ({ optimizations: { metroWarmup: false } }) });
     expect((await h.run()).ok).toBe(true);
-    expect(h.calls.verify[0]).toMatchObject({ requireBundleResponse: true });
+    expect(warmMetro).not.toHaveBeenCalled();
+    expect(h.calls.metro).toHaveLength(1);
+    expect(h.calls.verify).toHaveLength(1);
   });
 
   test.each([{ variant: 'release' }, { metroCheck: false }, { resolveMetro: async () => ({ missing: true }) }])(

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -1256,11 +1256,21 @@ test('runDoctor reports a wrong-typed setting as a finding rather than refusing'
   process.env.STIM_HOME = home;
   try {
     writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
-    writeFileSync(join(project, '.stim.json'), JSON.stringify({ ios: { configuration: {} }, caches: 42 }));
+    writeFileSync(
+      join(project, '.stim.json'),
+      JSON.stringify({
+        ios: { configuration: {} },
+        caches: 42,
+        optimizations: { metroWarmup: 'false' },
+        metro: { warmupUrl: { ios: '/index.bundle?platform=android' } },
+      }),
+    );
     const findings = runDoctor(project, { concurrency: { maxBuilds: 0, maxDevices: 0 } });
     const shapeFindings = findings.filter((finding) => /wrong type/i.test(finding.title));
     expect(shapeFindings.map((finding) => finding.detail)).toEqual([
+      'Invalid optimizations.metroWarmup setting "false". Expected true or false.',
       'Invalid ios.configuration setting {}. Expected a string.',
+      'Invalid metro.warmupUrl.ios setting "/index.bundle?platform=android". Expected an HTTP(S) URL or /path ending in .bundle with a matching platform query and no fragment.',
       'Invalid caches setting 42. Expected an array of strings.',
     ]);
     for (const finding of shapeFindings) {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -2525,3 +2525,55 @@ describe('skipping an install the device already holds', () => {
     expect(exec.calls).toContainEqual(['xcrun', 'simctl', 'install', 'U1', appPath]);
   });
 });
+
+describe('launch verification after Metro prefetch', () => {
+  test.each(['bare', 'expo'])('a late %s prefetch completion is not app activity', async (mode) => {
+    const clock = fakeClock();
+    const result = await verifyLaunch({
+      requireBundleResponse: true,
+      platform: 'ios',
+      since: 1000,
+      readRecords: () => [
+        {
+          ts: 1500,
+          src: 'metro',
+          platform: 'ios',
+          event: mode === 'bare' ? 'bundle_build_done' : 'expo_stdout',
+          msg: 'iOS Bundled 500ms index.js',
+        },
+      ],
+      readDeviceRecords: () => [],
+      readClientRecords: () => [],
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 2000,
+    });
+    expect(result.verified).toBe(false);
+    expect(result.requested).not.toBe(true);
+  });
+
+  test.each(['bundle_response_finished', 'bundle_response_failed'])('uses the app response: %s', async (event) => {
+    const clock = fakeClock();
+    const records: NdjsonRecord[] = [
+      { ts: 1000, src: 'metro', platform: 'ios', event: 'bundle_response_started', requestId: 'app' },
+      { ts: 1200, src: 'metro', platform: 'ios', event: 'bundling_error', level: 'error', msg: 'prefetch error' },
+      { ts: 1300, src: 'metro', platform: 'ios', event: 'bundle_build_done' },
+      { ts: 1500, src: 'metro', platform: 'ios', event, requestId: 'app' },
+    ];
+    const result = await verifyLaunch({
+      requireBundleResponse: true,
+      platform: 'ios',
+      since: 1000,
+      readRecords: () => records.filter((r) => Number(r.ts) <= clock.now()),
+      readDeviceRecords: () => [],
+      readClientRecords: () => [],
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 2000,
+      stabilityMs: 0,
+    });
+    expect(result.verified).toBe(event === 'bundle_response_finished');
+    expect(result.record?.event).toBe(event);
+    expect(Boolean(result.fatal)).toBe(event === 'bundle_response_failed');
+  });
+});

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -313,7 +313,7 @@ test('the settings topic documents every supported setting key', () => {
   assert(body);
   const src = readFileSync(new URL('../settings.ts', import.meta.url), 'utf-8');
   const table = src.slice(src.indexOf('const SETTING_SHAPES'), src.indexOf('};', src.indexOf('const SETTING_SHAPES')));
-  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z]+',$/gm)]
+  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z-]+',$/gm)]
     .map((match) => match[1])
     .filter((key): key is string => key !== undefined);
   expect(known.length).toBeGreaterThan(0);

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -215,6 +215,9 @@ function harness(overrides: LooseDeps = {}) {
       record('resolveProjectMetro', { port, path });
       return { metro: { pid: 1, leader: 1, cwd: root } };
     },
+    warmMetro: async (args) => {
+      record('warmMetro', args);
+    },
     fingerprintProject: async (path) => {
       record('fingerprintProject', path);
       return { hash: FINGERPRINT, sources: [] };
@@ -724,6 +727,43 @@ describe('the boot this run performed', () => {
     );
     expect(exitCode).toBe(null);
     expect(errs.join('\n')).toMatch(/booted \(8s\)/);
+  });
+});
+
+describe('Metro prefetch', () => {
+  test('starts before native work without waiting for the bundle', async () => {
+    reserve();
+    let warming = false;
+    const { exitCode, calls } = await run(
+      {},
+      {
+        warmMetro: (args) => {
+          expect(args).toEqual({ port: 8082, platform: 'ios', isExpo: false, appId: 'com.example.app' });
+          warming = true;
+          return new Promise(() => {});
+        },
+        fingerprintProject: async () => {
+          expect(warming).toBe(true);
+          return { hash: FINGERPRINT, sources: [] };
+        },
+      },
+    );
+    expect(exitCode).toBe(null);
+    expect(calls.args.verifyLaunch).toMatchObject({ requireBundleResponse: true });
+  });
+
+  test.each([{ configuration: 'Release' }, { metroCheck: false }])('skips prefetch for %j', async (opts) => {
+    reserve();
+    const warmMetro = vi.fn<() => Promise<void>>(async () => {});
+    await run(opts, { warmMetro });
+    expect(warmMetro).not.toHaveBeenCalled();
+  });
+
+  test('does not prefetch a server that fails ownership verification', async () => {
+    reserve();
+    const warmMetro = vi.fn<() => Promise<void>>(async () => {});
+    await run({}, { warmMetro, resolveProjectMetro: async () => ({ missing: true }) });
+    expect(warmMetro).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -731,25 +731,46 @@ describe('the boot this run performed', () => {
 });
 
 describe('Metro prefetch', () => {
-  test('starts before native work without waiting for the bundle', async () => {
+  test.each([null, '/custom.bundle?platform=ios&dev=true'])(
+    'starts before native work without waiting for the bundle: %s',
+    async (bundleUrl) => {
+      reserve();
+      let warming = false;
+      const { exitCode, calls } = await run(
+        {},
+        {
+          resolveSettings: () =>
+            bundleUrl ? { metro: { warmupUrl: { ios: bundleUrl, android: '/other.bundle?platform=android' } } } : {},
+          warmMetro: (args) => {
+            expect(args).toEqual({ port: 8082, platform: 'ios', isExpo: false, appId: 'com.example.app', bundleUrl });
+            warming = true;
+            return new Promise(() => {});
+          },
+          fingerprintProject: async () => {
+            expect(warming).toBe(true);
+            return { hash: FINGERPRINT, sources: [] };
+          },
+        },
+      );
+      expect(exitCode).toBe(null);
+      expect(calls.args.verifyLaunch).toMatchObject({ requireBundleResponse: true });
+    },
+  );
+
+  test('disabling warmup still verifies Metro and completes the native run', async () => {
     reserve();
-    let warming = false;
+    const warmMetro = vi.fn<() => Promise<void>>(async () => {});
     const { exitCode, calls } = await run(
       {},
       {
-        warmMetro: (args) => {
-          expect(args).toEqual({ port: 8082, platform: 'ios', isExpo: false, appId: 'com.example.app' });
-          warming = true;
-          return new Promise(() => {});
-        },
-        fingerprintProject: async () => {
-          expect(warming).toBe(true);
-          return { hash: FINGERPRINT, sources: [] };
-        },
+        warmMetro,
+        resolveSettings: () => ({ optimizations: { metroWarmup: false } }),
       },
     );
     expect(exitCode).toBe(null);
-    expect(calls.args.verifyLaunch).toMatchObject({ requireBundleResponse: true });
+    expect(warmMetro).not.toHaveBeenCalled();
+    expect(calls.order).toContain('resolveProjectMetro');
+    expect(calls.order).toContain('verifyLaunch');
   });
 
   test.each([{ configuration: 'Release' }, { metroCheck: false }])('skips prefetch for %j', async (opts) => {

--- a/packages/stim-cli/src/__tests__/metro-warmup.test.ts
+++ b/packages/stim-cli/src/__tests__/metro-warmup.test.ts
@@ -1,0 +1,152 @@
+import { once } from 'node:events';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { spawn } from 'node:child_process';
+import { warmMetro } from '../engine/metro-warmup.ts';
+import { bundleResponseMiddleware } from '../../shim/bundle-response.cjs';
+
+let server: Server;
+afterEach(async () => {
+  vi.useRealTimers();
+  server?.closeAllConnections();
+  if (server?.listening) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function listen(handler: (req: IncomingMessage, res: ServerResponse) => void) {
+  const observer = bundleResponseMiddleware(() => {});
+  server = createServer((req, res) => observer(req, res, () => handler(req, res)));
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return (server.address() as AddressInfo).port;
+}
+
+test.each(['ios', 'android'] as const)(
+  'prefetches the bare %s bundle without app-response evidence',
+  async (platform) => {
+    const records: Record<string, unknown>[] = [];
+    const requests: string[] = [];
+    const observe = bundleResponseMiddleware((record) => records.push(record));
+    const port = await listen((req, res) =>
+      observe(req, res, () => {
+        requests.push(`${req.method} ${req.url}`);
+        res.end();
+      }),
+    );
+    await warmMetro({ port, platform, isExpo: false, appId: 'com.example.app' });
+    const requested = new URL(requests[0]!.slice(4), 'http://localhost');
+    expect(requests[0]).toMatch(/^GET /);
+    expect(requested.pathname).toBe('/index.bundle');
+    expect(Object.fromEntries(requested.searchParams)).toEqual({
+      platform,
+      dev: 'true',
+      lazy: 'true',
+      minify: 'false',
+      ...(platform === 'ios' ? { inlineSourceMap: 'false' } : {}),
+      modulesOnly: 'false',
+      runModule: 'true',
+      excludeSource: 'true',
+      sourcePaths: 'url-server',
+      app: 'com.example.app',
+    });
+    expect(records).toEqual([]);
+  },
+);
+
+test('uses Expo manifest entry/options on the verified local port', async () => {
+  const requests: string[] = [];
+  const port = await listen((req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    expect(req.headers['expo-platform']).toBe('android');
+    res.end(
+      req.url === '/'
+        ? JSON.stringify({
+            launchAsset: {
+              url: 'https://public.example/node_modules/expo-router/entry.bundle?platform=android&dev=true&lazy=true&transform.engine=hermes',
+            },
+          })
+        : '',
+    );
+  });
+  await warmMetro({ port, platform: 'android', isExpo: true });
+  expect(requests).toEqual([
+    'GET /',
+    'GET /node_modules/expo-router/entry.bundle?platform=android&dev=true&lazy=true&transform.engine=hermes',
+  ]);
+});
+
+test.each(['invalid JSON', '{}', 'null'])('a missing Expo bundle URL skips prefetch: %s', async (body) => {
+  const methods: string[] = [];
+  const port = await listen((req, res) => {
+    methods.push(req.method!);
+    res.end(body);
+  });
+  await warmMetro({ port, platform: 'ios', isExpo: true });
+  expect(methods).toEqual(['GET']);
+});
+
+test.each([500, 302])('HTTP %s is best effort and does not follow a redirect', async (status) => {
+  let requests = 0;
+  const port = await listen((_req, res) => {
+    requests++;
+    res.writeHead(status, { location: 'http://example.invalid/bundle' });
+    res.end();
+  });
+  await warmMetro({ port, platform: 'ios', isExpo: true });
+  expect(requests).toBe(1);
+});
+
+test('bounds a stalled request without rejecting', async () => {
+  const port = await listen(() => {});
+  vi.useFakeTimers();
+  const incoming = new Promise<void>((resolve) =>
+    server.on('request', (req) => {
+      if (req.url?.startsWith('/index.bundle')) resolve();
+    }),
+  );
+  const warming = warmMetro({ port, platform: 'ios', isExpo: false });
+  await incoming;
+  await vi.advanceTimersByTimeAsync(60_000);
+  await expect(warming).resolves.toBeUndefined();
+});
+
+test('a pending warmup does not keep the command alive', async () => {
+  const port = await listen(() => {});
+  const incoming = new Promise<void>((resolve) =>
+    server.on('request', (req) => {
+      if (req.url?.startsWith('/index.bundle')) resolve();
+    }),
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `
+    import { warmMetro } from ${JSON.stringify(new URL('../engine/metro-warmup.ts', import.meta.url).href)};
+    void warmMetro({ port: ${port}, platform: 'ios', isExpo: false });
+    setTimeout(() => {}, 100);
+  `,
+    ],
+    { stdio: 'pipe' },
+  );
+  const exited = once(child, 'exit');
+  try {
+    await incoming;
+    expect(await exited).toEqual([0, null]);
+  } finally {
+    if (child.exitCode === null) child.kill();
+  }
+});
+
+test('an older or external Metro without prefetch isolation is left alone', async () => {
+  const requests: string[] = [];
+  server = createServer((req, res) => {
+    requests.push(req.url!);
+    res.statusCode = 404;
+    res.end();
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  await warmMetro({ port: (server.address() as AddressInfo).port, platform: 'ios', isExpo: false });
+  expect(requests).toEqual(['/_stim/metro-warmup']);
+});

--- a/packages/stim-cli/src/__tests__/metro-warmup.test.ts
+++ b/packages/stim-cli/src/__tests__/metro-warmup.test.ts
@@ -74,6 +74,31 @@ test('uses Expo manifest entry/options on the verified local port', async () => 
   ]);
 });
 
+test.each([
+  { isExpo: false, platform: 'ios', origin: '' },
+  { isExpo: false, platform: 'android', origin: 'http://device.example:8081' },
+  { isExpo: true, platform: 'ios', origin: 'https://public.example' },
+  { isExpo: true, platform: 'android', origin: '' },
+] as const)(
+  'a custom $platform URL overrides bundle discovery for Expo=$isExpo',
+  async ({ isExpo, platform, origin }) => {
+    const path = `/src/native.bundle?platform=${platform}&dev=true&lazy=false&transform.custom=a%2Fb&custom=one&custom=two`;
+    const requests: string[] = [];
+    const records: Record<string, unknown>[] = [];
+    const observe = bundleResponseMiddleware((record) => records.push(record));
+    const port = await listen((req, res) =>
+      observe(req, res, () => {
+        requests.push(req.url!);
+        expect(req.headers.host).toBe(`127.0.0.1:${port}`);
+        res.end('bundle');
+      }),
+    );
+    await warmMetro({ port, platform, isExpo, bundleUrl: `${origin}${path}`, appId: 'not-added-to-override' });
+    expect(requests).toEqual([path]);
+    expect(records).toEqual([]);
+  },
+);
+
 test.each(['invalid JSON', '{}', 'null'])('a missing Expo bundle URL skips prefetch: %s', async (body) => {
   const methods: string[] = [];
   const port = await listen((req, res) => {

--- a/packages/stim-cli/src/__tests__/optimizations.test.ts
+++ b/packages/stim-cli/src/__tests__/optimizations.test.ts
@@ -130,7 +130,7 @@ test.each(['ios', 'android'] as const)(
     expect(
       optimizationBuildProfile(
         platform,
-        resolveOptimizations({ optimizations: { remoteBuildCache: false, buildCache: false } }, {}),
+        resolveOptimizations({ optimizations: { remoteBuildCache: false, buildCache: false, metroWarmup: false } }, {}),
       ),
     ).toBeUndefined();
   },

--- a/packages/stim-cli/src/__tests__/settings.test.ts
+++ b/packages/stim-cli/src/__tests__/settings.test.ts
@@ -404,6 +404,17 @@ const SHAPE_CASES: Record<string, { valid: unknown; invalid: unknown; expected: 
   'metro.tunnel': { valid: 'ngrok', invalid: {}, expected: 'a string' },
   'metro.ngrokUrl': { valid: 'https://a.ngrok.app', invalid: {}, expected: 'a string' },
   'metro.publicUrl': { valid: 'https://metro.example', invalid: false, expected: 'a string' },
+  'metro.warmupUrl': { valid: {}, invalid: '/index.bundle', expected: 'an object' },
+  'metro.warmupUrl.ios': {
+    valid: '/custom.bundle?platform=ios&dev=true',
+    invalid: false,
+    expected: 'an HTTP(S) URL or /path ending in .bundle with a matching platform query and no fragment',
+  },
+  'metro.warmupUrl.android': {
+    valid: 'https://metro.example/custom.bundle?platform=android&dev=true',
+    invalid: false,
+    expected: 'an HTTP(S) URL or /path ending in .bundle with a matching platform query and no fragment',
+  },
   'worktree.exclude': { valid: ['node_modules'], invalid: ['ok', 7], expected: 'an array of strings' },
   'worktree.defaultBranch': { valid: 'main', invalid: ['main'], expected: 'a string' },
   'cache.provider': { valid: './cache.cjs', invalid: {}, expected: 'a string' },
@@ -414,7 +425,7 @@ const SHAPE_CASES: Record<string, { valid: unknown; invalid: unknown; expected: 
 test('every known setting has a shape, and a wrong-typed value is one refusal naming the key and the shape', () => {
   const src = readFileSync(new URL('../settings.ts', import.meta.url), 'utf-8');
   const table = src.slice(src.indexOf('const SETTING_SHAPES'), src.indexOf('};', src.indexOf('const SETTING_SHAPES')));
-  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z]+',$/gm)]
+  const known = [...table.matchAll(/^\s*'?([A-Za-z0-9.]+)'?: '[a-z-]+',$/gm)]
     .map((match) => match[1])
     .filter((key): key is string => key !== undefined);
   expect(known.length).toBeGreaterThan(0);
@@ -440,6 +451,24 @@ test('settingShapeErrors reports one line per bad key and ignores absent keys', 
     'Invalid ios.configuration setting {}. Expected a string.',
     'Invalid android.keystore setting 5. Expected a string path.',
   ]);
+});
+
+test.each([
+  '',
+  'custom.bundle?platform=ios',
+  '//metro.example/custom.bundle?platform=ios',
+  'file:///custom.bundle?platform=ios',
+  'http://[invalid/custom.bundle?platform=ios',
+  '/status?platform=ios',
+  '/custom.bundle',
+  '/custom.bundle?platform=android',
+  '/custom.bundle?platform=ios#fragment',
+  '/custom.bundle?platform=ios&custom=unescaped value',
+  '/custom\\entry.bundle?platform=ios',
+])('a malformed or wrong-platform warmup URL is refused: %s', (value) => {
+  const errors = settingShapeErrors({ metro: { warmupUrl: { ios: value } } });
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('metro.warmupUrl.ios');
 });
 
 test('unknownSettingKeys tolerates empty and malformed input', () => {
@@ -732,9 +761,14 @@ test('machine optimization defaults merge with committed, repository and project
   expect(resolveOptimizations(resolveSettings({}), {}).android.pch).toBe('on');
 });
 
-test('a repository can enable the shared Metro store over a machine opt-out', () => {
-  saveConfig({ version: 2, projects: {}, repos: {}, optimizations: { metroSharedCache: false } });
+test('a repository can enable Metro optimizations over a machine opt-out', () => {
+  saveConfig({ version: 2, projects: {}, repos: {}, optimizations: { metroSharedCache: false, metroWarmup: false } });
   expect(resolveMetroSharedCache(resolveSettings({}))).toBe(false);
-  writeFileSync(join(tmpHome, '.stim.json'), JSON.stringify({ optimizations: { metroSharedCache: true } }));
+  expect(resolveOptimizations(resolveSettings({}), {}).metroWarmup).toBe(false);
+  writeFileSync(
+    join(tmpHome, '.stim.json'),
+    JSON.stringify({ optimizations: { metroSharedCache: true, metroWarmup: true } }),
+  );
   expect(resolveMetroSharedCache(resolveSettings({ repoRoot: tmpHome }))).toBe(true);
+  expect(resolveOptimizations(resolveSettings({ repoRoot: tmpHome }), {}).metroWarmup).toBe(true);
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -85,6 +85,7 @@ import { claimFailure } from '../ownership-claim.ts';
 import { acquireBuildSlot, releaseBuildSlot, type BuildSlotHandle } from '../engine/build-slots.ts';
 import { createNdjsonWriter } from '../ndjson.ts';
 import { pidExists, resolveProjectMetro } from '../metro.ts';
+import { warmMetro } from '../engine/metro-warmup.ts';
 import {
   ensureWorkspaceStorageSafely,
   resolveMetroWithRetry,
@@ -355,6 +356,7 @@ interface RunAndroidOptions {
   ensureDevice?: typeof ensureOwnedDevice;
   ensureDeviceBooted?: typeof ensureBooted;
   resolveMetro?: typeof resolveProjectMetro;
+  warmMetro?: typeof warmMetro;
   resolveMetroRetrying?: typeof resolveMetroWithRetry;
   readState?: typeof readWorkspaceState;
   pidAlive?: typeof pidExists;
@@ -434,6 +436,7 @@ function resolveRunAndroidOptions(
     listSystemImages = listInstalledSystemImages,
     ensureDeviceBooted = ensureBooted,
     resolveMetro = resolveProjectMetro,
+    warmMetro: prewarmMetro = warmMetro,
     resolveMetroRetrying = resolveMetroWithRetry,
     readState = readWorkspaceState,
     pidAlive = pidExists,
@@ -512,6 +515,7 @@ function resolveRunAndroidOptions(
     listSystemImages,
     ensureDeviceBooted,
     resolveMetro,
+    prewarmMetro,
     resolveMetroRetrying,
     readState,
     pidAlive,
@@ -592,6 +596,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     listSystemImages,
     ensureDeviceBooted,
     resolveMetro,
+    prewarmMetro,
     resolveMetroRetrying,
     readState,
     pidAlive,
@@ -1186,6 +1191,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   }
 
   const runFromFingerprint = async (): Promise<RunAndroidResult> => {
+    if (metroCheck && metroPort !== null)
+      void prewarmMetro({ port: metroPort, platform: 'android', isExpo, appId: androidPackage });
     if (!(await resolveInitialFingerprint())) return phaseFailure!;
 
     let remote: LoadProjectProviderResult | null = null;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -37,6 +37,7 @@ import {
   androidAvdConfigSettingError,
   androidDataPartitionSizeGbSettingError,
   cacheProviderSettingError,
+  metroWarmupUrlSetting,
   publicUrlSetting,
   remoteAndroidSetting,
   remoteDeviceSettingError,
@@ -1191,8 +1192,14 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   }
 
   const runFromFingerprint = async (): Promise<RunAndroidResult> => {
-    if (metroCheck && metroPort !== null)
-      void prewarmMetro({ port: metroPort, platform: 'android', isExpo, appId: androidPackage });
+    if (metroCheck && metroPort !== null && optimizations.metroWarmup)
+      void prewarmMetro({
+        port: metroPort,
+        platform: 'android',
+        isExpo,
+        appId: androidPackage,
+        bundleUrl: metroWarmupUrlSetting(settings, 'android'),
+      });
     if (!(await resolveInitialFingerprint())) return phaseFailure!;
 
     let remote: LoadProjectProviderResult | null = null;

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -152,6 +152,7 @@ async function verifyAndroidRun({
 
   const verification: VerifyLaunchResultLike = metroCheck
     ? await verifyLaunched({
+        requireBundleResponse: true,
         onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -27,6 +27,7 @@ import {
   iosSigningIdentitySettingError,
   iosSigningIdentitySha1Setting,
   iosSigningIdentitySha1SettingError,
+  metroWarmupUrlSetting,
   publicUrlSetting,
   remoteDeviceSettingError,
   remoteIosSetting,
@@ -684,8 +685,14 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         return false;
       }
     }
-    if (!release && metroCheck)
-      void d.warmMetro({ port: metroPort as number, platform: 'ios', isExpo, appId: proj?.bundleId });
+    if (!release && metroCheck && optimizations.metroWarmup)
+      void d.warmMetro({
+        port: metroPort as number,
+        platform: 'ios',
+        isExpo,
+        appId: proj?.bundleId,
+        bundleUrl: metroWarmupUrlSetting(settings, 'ios'),
+      });
     return true;
   }
 

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -684,6 +684,8 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
         return false;
       }
     }
+    if (!release && metroCheck)
+      void d.warmMetro({ port: metroPort as number, platform: 'ios', isExpo, appId: proj?.bundleId });
     return true;
   }
 

--- a/packages/stim-cli/src/commands/ios/dependencies.ts
+++ b/packages/stim-cli/src/commands/ios/dependencies.ts
@@ -55,6 +55,7 @@ import { detectBundleId, detectIsExpo, findProjectRoot, projectShortcut } from '
 import { resolveCacheProviderConfig, resolveSettings } from '../../settings.ts';
 import { readWorkspaceState, writeWorkspaceLaunch, writeWorkspaceState } from '../../supervisor/state.ts';
 import { gitCommonDir, repoRoot } from '../../worktree.ts';
+import { warmMetro } from '../../engine/metro-warmup.ts';
 import { resolveMetroWithRetry, ensureWorkspaceStorageSafely } from '../native-runtime.ts';
 import { devClientScheme } from '../dev-client.ts';
 import { stopPreviousCollector, replaceCollector } from './collector.ts';
@@ -82,6 +83,7 @@ export interface IosDeps {
   ensureBooted: typeof ensureBooted;
   resolveProjectMetro: typeof resolveProjectMetro;
   resolveMetroWithRetry: typeof resolveMetroWithRetry;
+  warmMetro: typeof warmMetro;
   readWorkspaceState: typeof readWorkspaceState;
   pidExists: typeof pidExists;
   getConcurrencyLimits: typeof getConcurrencyLimits;
@@ -163,6 +165,7 @@ export const DEFAULT_DEPS: IosDeps = {
   detectProviders,
   resolveProjectMetro,
   resolveMetroWithRetry,
+  warmMetro,
   readWorkspaceState,
   pidExists,
   getConcurrencyLimits,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -175,6 +175,7 @@ async function verifyIosRun({
 
   const verification: VerifyLaunchResultLike = metroCheck
     ? await d.verifyLaunch({
+        requireBundleResponse: true,
         onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -826,6 +826,7 @@ export async function verifyLaunch({
   metroPort = null,
   platform = null,
   mode = null,
+  requireBundleResponse,
   timeoutMs = VERIFY_TIMEOUT_MS,
   stabilityMs = STABILITY_WINDOW_MS,
   pollMs = VERIFY_POLL_MS,
@@ -843,6 +844,7 @@ export async function verifyLaunch({
   metroPort?: number | string | null;
   platform?: 'ios' | 'android' | null;
   mode?: string | null;
+  requireBundleResponse?: boolean;
   timeoutMs?: number;
   stabilityMs?: number;
   pollMs?: number;
@@ -870,6 +872,9 @@ export async function verifyLaunch({
   let nextCrashCheck = startedAt + 1000;
   while (true) {
     const metroRecords = read().filter((record) => after(record, since));
+    const bundleRecords = metroRecords.filter(
+      (record) => !requireBundleResponse || String(record.event).startsWith('bundle_response_'),
+    );
     const deviceRecords = readDevice().filter((record) => after(record, since));
     const clientRecords = readClient().filter((record) => after(record, since));
     if (now() >= nextCrashCheck) {
@@ -885,7 +890,7 @@ export async function verifyLaunch({
       if (crash) return crash;
     }
     if (deliveryId === null) {
-      const request = metroRecords.find(
+      const request = bundleRecords.find(
         (record) =>
           record.event === 'bundle_response_started' &&
           typeof record.requestId === 'string' &&
@@ -897,7 +902,7 @@ export async function verifyLaunch({
         stabilityDeadline = null;
       }
     }
-    for (const record of metroRecords) {
+    for (const record of bundleRecords) {
       if (isBundleProof(record, since, platform)) activity = record;
       const completed =
         deliveryId === null
@@ -958,7 +963,7 @@ export async function verifyLaunch({
           Number(record.ts) <= readinessDeadline &&
           appReadinessSignal(record, platform) === 'ready',
       );
-    const bundleErrors = metroRecords.filter(
+    const bundleErrors = bundleRecords.filter(
       (record) =>
         isFatalLaunchError(record, platform) ||
         (deliveryId !== null &&

--- a/packages/stim-cli/src/engine/metro-warmup.ts
+++ b/packages/stim-cli/src/engine/metro-warmup.ts
@@ -1,0 +1,77 @@
+import { request } from 'node:http';
+
+const WARMUP_TIMEOUT_MS = 60_000;
+
+async function requestLocal(url: URL, platform: string, prefetch: boolean): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = request(url, {
+      headers: {
+        accept: 'application/json',
+        'expo-platform': platform,
+        ...(prefetch ? { 'x-stim-metro-warmup': '1' } : {}),
+      },
+    });
+    const timer = setTimeout(() => req.destroy(), WARMUP_TIMEOUT_MS);
+    timer.unref();
+    req.on('socket', (socket) => socket.unref());
+    req.on('error', () => resolve(null));
+    req.on('close', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+    req.on('response', (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        if (!prefetch) body += chunk;
+      });
+      res.on('error', () => resolve(null));
+      res.on('end', () => resolve(res.statusCode === 200 ? body : null));
+    });
+    req.end();
+  });
+}
+
+export async function warmMetro({
+  port,
+  platform,
+  isExpo,
+  appId,
+}: {
+  port: number;
+  platform: 'ios' | 'android';
+  isExpo: boolean;
+  appId?: string | null;
+}): Promise<void> {
+  try {
+    const origin = `http://127.0.0.1:${port}`;
+    const supported = await requestLocal(new URL('/_stim/metro-warmup', origin), platform, false);
+    if (supported !== 'ready') return;
+    // React Native entry-point and dev-menu overrides are runtime inputs; bare prefetch uses template defaults.
+    let url = new URL('/index.bundle', origin);
+    url.search = new URLSearchParams({
+      platform,
+      dev: 'true',
+      lazy: 'true',
+      minify: 'false',
+      ...(platform === 'ios' ? { inlineSourceMap: 'false' } : {}),
+      modulesOnly: 'false',
+      runModule: 'true',
+      excludeSource: 'true',
+      sourcePaths: 'url-server',
+      ...(appId ? { app: appId } : {}),
+    }).toString();
+    if (isExpo) {
+      const body = await requestLocal(new URL(origin), platform, false);
+      if (body === null) return;
+      const manifest = JSON.parse(body);
+      const bundleUrl = manifest.launchAsset?.url ?? manifest.bundleUrl;
+      if (typeof bundleUrl !== 'string') return;
+      const bundle = new URL(bundleUrl);
+      url = new URL(origin);
+      url.pathname = bundle.pathname;
+      url.search = bundle.search;
+    }
+    await requestLocal(url, platform, true);
+  } catch {}
+}

--- a/packages/stim-cli/src/engine/metro-warmup.ts
+++ b/packages/stim-cli/src/engine/metro-warmup.ts
@@ -37,18 +37,20 @@ export async function warmMetro({
   platform,
   isExpo,
   appId,
+  bundleUrl,
 }: {
   port: number;
   platform: 'ios' | 'android';
   isExpo: boolean;
   appId?: string | null;
+  bundleUrl?: string | null;
 }): Promise<void> {
   try {
     const origin = `http://127.0.0.1:${port}`;
     const supported = await requestLocal(new URL('/_stim/metro-warmup', origin), platform, false);
     if (supported !== 'ready') return;
     // React Native entry-point and dev-menu overrides are runtime inputs; bare prefetch uses template defaults.
-    let url = new URL('/index.bundle', origin);
+    const url = new URL('/index.bundle', origin);
     url.search = new URLSearchParams({
       platform,
       dev: 'true',
@@ -61,14 +63,15 @@ export async function warmMetro({
       sourcePaths: 'url-server',
       ...(appId ? { app: appId } : {}),
     }).toString();
-    if (isExpo) {
+    if (!bundleUrl && isExpo) {
       const body = await requestLocal(new URL(origin), platform, false);
       if (body === null) return;
       const manifest = JSON.parse(body);
-      const bundleUrl = manifest.launchAsset?.url ?? manifest.bundleUrl;
+      bundleUrl = manifest.launchAsset?.url ?? manifest.bundleUrl;
       if (typeof bundleUrl !== 'string') return;
-      const bundle = new URL(bundleUrl);
-      url = new URL(origin);
+    }
+    if (bundleUrl) {
+      const bundle = new URL(bundleUrl, origin);
       url.pathname = bundle.pathname;
       url.search = bundle.search;
     }

--- a/packages/stim-cli/src/guide/metro.ts
+++ b/packages/stim-cli/src/guide/metro.ts
@@ -26,7 +26,15 @@ BUNDLE WARMUP
   platform's development bundle while native work continues. Expo supplies the
   entry point and bundle options through its manifest; bare React Native uses
   the standard index entry and development bundle options, including lazy loading.
-  Custom native entry points or dev-menu bundle options are not discovered.
+  Warmup is enabled by default. Set optimizations.metroWarmup=false to disable
+  it on the next ios/android command, using the machine or project settings.
+  For custom entry points or bundle options, set metro.warmupUrl.ios and/or
+  metro.warmupUrl.android to the app's complete bundle URL or /path?query.
+  Stim keeps the path and query and uses the verified local Metro port.
+  Overrides replace discovery and receive no additional query defaults.
+  doctor validates configured URLs, including their platform; it does not
+  infer or auto-fix runtime native entry points or dev-menu bundle options.
+  See \`guide settings\` for configuration examples.
   Each request times out after 60 seconds and does not keep the command alive.
   Warmup failures do not fail the native build.
   Release builds and \`--no-metro-check\` skip warmup. Servers without Stim's

--- a/packages/stim-cli/src/guide/metro.ts
+++ b/packages/stim-cli/src/guide/metro.ts
@@ -21,6 +21,22 @@ Plain \`stim start\` is local and does not create a public tunnel. Remote intent
 comes from \`start --remote\`, \`ios.remote\`, or \`android.remote\`. The
 \`metro.tunnel\` setting selects the provider after remote intent exists.
 
+BUNDLE WARMUP
+  After verifying Metro, \`stim ios\` and \`stim android\` prefetch the
+  platform's development bundle while native work continues. Expo supplies the
+  entry point and bundle options through its manifest; bare React Native uses
+  the standard index entry and development bundle options, including lazy loading.
+  Custom native entry points or dev-menu bundle options are not discovered.
+  Each request times out after 60 seconds and does not keep the command alive.
+  Warmup failures do not fail the native build.
+  Release builds and \`--no-metro-check\` skip warmup. Servers without Stim's
+  prefetch-aware response observer also skip it; restart an older supervisor
+  with the current CLI to enable warmup.
+
+  Prefetch completion is not launch proof. Development launch verification
+  waits for the app's own bundle response. With a bundler started outside Stim,
+  device logs may prove a request, but bundle completion may stay unverified.
+
 REMOTE DEVICE BACKENDS
   Metro exposure and device selection are separate:
 

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -181,6 +181,25 @@ ${ANDROID_AVD_CONFIG_HELP.map((line) => `                          ${line}`).joi
                         did not create it, so a Metro request through it is
                         still gated the same way a managed tunnel's is. Set it
                         before Expo start so the manifest advertises it.
+  metro.warmupUrl       optional object with per-platform bundle URLs:
+  metro.warmupUrl.ios
+  metro.warmupUrl.android
+                        an HTTP(S) URL or a /path ending in .bundle, with the
+                        full query the app uses, including a matching platform.
+                        Unset uses Expo's manifest or bare React Native defaults.
+                        Stim preserves the path and query but always requests
+                        this workspace's verified local Metro port; a supplied
+                        host and port are ignored. No defaults are added to an
+                        override. This only configures prefetch, not the app.
+                        For example, in .stim.json:
+                        { "metro": { "warmupUrl": {
+                          "ios": "/src/main.bundle?platform=ios&dev=true&lazy=true"
+                        } } }
+                        Use the app's complete request for custom options.
+                        URLs must encode spaces and omit fragments. doctor
+                        validates the shape and platform but cannot discover
+                        runtime entry-point or dev-menu overrides or auto-fix
+                        them. See \`guide metro\` for warmup behavior.
   worktree.exclude      ignored-path skip list for worktree warm. Settings
                         come from the source checkout's repository-root
                         .stim.json. A nonempty .worktreeexclude in the source
@@ -331,6 +350,7 @@ key inherits the next layer. Changes apply on the next build or Metro restart.
       "remoteBuildCache": true,
       "releaseBundleSwap": true,
       "metroSharedCache": true,
+      "metroWarmup": true,
       "ios": {
         "compilationCache": true,
         "swiftCompilationCache": false,
@@ -362,6 +382,11 @@ The example shows the defaults. Full setting names and behavior:
     false stops Stim appending its shared Metro store on both dev servers.
     Project-configured stores remain the project's choice. Replace the removed
     machine setting caches.injectMetroStore=false with this setting set false.
+  optimizations.metroWarmup
+    true by default. false skips background development bundle requests during
+    ios/android, including any metro.warmupUrl override. Metro verification and
+    native builds still run. Applies on the next ios/android command; no Metro
+    restart is needed.
   optimizations.ios.compilationCache
     controls Xcode compilation caching (Xcode 26+).
   optimizations.ios.swiftCompilationCache

--- a/packages/stim-cli/src/optimizations.ts
+++ b/packages/stim-cli/src/optimizations.ts
@@ -8,6 +8,7 @@ export const OPTIMIZATION_SHAPES = {
   'optimizations.remoteBuildCache': 'boolean',
   'optimizations.releaseBundleSwap': 'boolean',
   'optimizations.metroSharedCache': 'boolean',
+  'optimizations.metroWarmup': 'boolean',
   'optimizations.ios': 'object',
   'optimizations.ios.compilationCache': 'boolean',
   'optimizations.ios.swiftCompilationCache': 'boolean',
@@ -25,6 +26,7 @@ export interface Optimizations {
   remoteBuildCache: boolean;
   releaseBundleSwap: boolean;
   metroSharedCache: boolean;
+  metroWarmup: boolean;
   ios: { compilationCache: boolean; swiftCompilationCache: boolean; prefixMapping: boolean };
   android: {
     compilerCache: 'ccache' | 'cas' | 'none';
@@ -115,6 +117,7 @@ export function resolveOptimizations(
     remoteBuildCache: optimizationBoolean(settings, 'remoteBuildCache'),
     releaseBundleSwap: optimizationBoolean(settings, 'releaseBundleSwap'),
     metroSharedCache: optimizationBoolean(settings, 'metroSharedCache'),
+    metroWarmup: optimizationBoolean(settings, 'metroWarmup'),
     ios: {
       compilationCache: optimizationBoolean(settings, 'ios.compilationCache'),
       swiftCompilationCache: optimizationBoolean(settings, 'ios.swiftCompilationCache', false),

--- a/packages/stim-cli/src/settings.ts
+++ b/packages/stim-cli/src/settings.ts
@@ -32,11 +32,11 @@ export function mergeSettingsLayers(layers: Array<SettingsObject | null | undefi
   return out;
 }
 
-type SettingShape = 'string' | 'path' | 'strings' | 'number' | 'object' | 'boolean';
+type SettingShape = 'string' | 'path' | 'strings' | 'number' | 'object' | 'boolean' | 'bundle-url';
 
 interface SettingShapeRule {
   expected: string;
-  accepts: (value: unknown) => boolean;
+  accepts: (value: unknown, key: string) => boolean;
 }
 
 const SETTING_SHAPE_RULES: Record<SettingShape, SettingShapeRule> = {
@@ -49,6 +49,18 @@ const SETTING_SHAPE_RULES: Record<SettingShape, SettingShapeRule> = {
   },
   number: { expected: 'a number', accepts: (value) => typeof value === 'number' },
   object: { expected: 'an object', accepts: isPlainObject },
+  'bundle-url': {
+    expected: 'an HTTP(S) URL or /path ending in .bundle with a matching platform query and no fragment',
+    accepts: (value, key) => {
+      if (typeof value !== 'string' || !/^(https?:\/\/|\/(?!\/))/.test(value) || /[\s\\#]/.test(value)) return false;
+      try {
+        const url = new URL(value, 'http://localhost');
+        return /\.bundle\/*$/.test(url.pathname) && url.searchParams.get('platform') === key.split('.').at(-1);
+      } catch {
+        return false;
+      }
+    },
+  },
 };
 
 const SETTING_SHAPES: Record<string, SettingShape> = {
@@ -72,6 +84,9 @@ const SETTING_SHAPES: Record<string, SettingShape> = {
   'metro.tunnel': 'string',
   'metro.ngrokUrl': 'string',
   'metro.publicUrl': 'string',
+  'metro.warmupUrl': 'object',
+  'metro.warmupUrl.ios': 'bundle-url',
+  'metro.warmupUrl.android': 'bundle-url',
   'worktree.exclude': 'strings',
   'worktree.defaultBranch': 'string',
   'cache.provider': 'string',
@@ -105,7 +120,7 @@ export function settingShapeErrors(settings: unknown): string[] {
     const value = settingValueAt(settings, path);
     if (value === undefined) continue;
     const rule = SETTING_SHAPE_RULES[shape];
-    if (rule.accepts(value)) continue;
+    if (rule.accepts(value, path)) continue;
     errors.push(`Invalid ${path} setting ${JSON.stringify(value)}. Expected ${rule.expected}.`);
   }
   return errors;
@@ -446,7 +461,11 @@ export function unknownSettingKeys(settings: unknown, prefix = ''): string[] {
   const unknown: string[] = [];
   for (const [key, value] of Object.entries(settings)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    if (KNOWN_SETTINGS.has(path) && ![...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`))) continue;
+    if (
+      KNOWN_SETTINGS.has(path) &&
+      (!isPlainObject(value) || ![...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`)))
+    )
+      continue;
     if (isPlainObject(value) && [...KNOWN_SETTINGS].some((k) => k.startsWith(`${path}.`))) {
       unknown.push(...unknownSettingKeys(value, path));
       continue;
@@ -660,6 +679,11 @@ export function publicUrlSetting(settings: SettingsObject): string | null {
   if (typeof block !== 'object' || block === null) return null;
   const url = (block as { publicUrl?: unknown }).publicUrl;
   return typeof url === 'string' && url.trim() ? url : null;
+}
+
+export function metroWarmupUrlSetting(settings: SettingsObject, platform: 'ios' | 'android'): string | null {
+  const value = settingValueAt(settings, `metro.warmupUrl.${platform}`);
+  return typeof value === 'string' ? value : null;
 }
 
 export function ngrokUrlSetting(settings: SettingsObject): string | null {


### PR DESCRIPTION
## Description

Development builds leave Metro idle until the app launches. `stim ios` and `stim android` now prefetch the platform bundle while native work runs.

## Solution

A background GET requests the bundle and discards the response. Expo supplies the URL through its manifest. Bare React Native uses the standard `index` development options, including `lazy=true` ([iOS](https://github.com/facebook/react-native/blob/95cffbff2e071e278987c7d7cd51fbc970dd5622/packages/react-native/React/Base/RCTBundleURLProvider.mm#L467), [Android](https://github.com/facebook/react-native/blob/95cffbff2e071e278987c7d7cd51fbc970dd5622/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt#L292)).

Warmup defaults to enabled. Set `optimizations.metroWarmup: false` in machine or project settings to disable it. For custom native entry points or bundle options, `metro.warmupUrl.ios` and `metro.warmupUrl.android` accept the app's complete HTTP(S) URL or `/path?query`. An override replaces discovery and receives no additional defaults; Stim preserves its path and query but uses this workspace's verified local Metro origin. `doctor` validates these settings and their platform query. It cannot infer or auto-fix native runtime entry points or dev-menu overrides.

Requests time out after 60 seconds without keeping the command alive. Release builds and `--no-metro-check` skip prefetch.

Launch verification requires the app's own bundle response, so a late prefetch cannot report a successful launch. A capability check skips servers that cannot distinguish prefetch from app traffic. Externally started servers without response records may leave launches unverified.

## Test plan

- Regression coverage checks build/warmup overlap, default-on behavior and opt-out precedence, skip paths, request timeout and process exit, Expo URL selection, custom URL preservation and local-origin isolation, doctor validation, and launch evidence.
- Real bare Metro 0.84.5 and Expo 57 fixtures, including Expo Router: prefetched iOS and Android, then issued app-style GETs. All returned the app bundle with `X-Metro-Files-Changed-Count: 0`; only the app-style GETs emitted bundle-response records.
- Custom entry and query options were also checked against real bare Metro and Expo Router on both platforms; subsequent GETs returned the fixture code with zero changed files.
- Formatting, lint, typecheck, and build passed. Unit suite: 4,162 passed, one skipped. End-to-end suite: 79 passed. Fresh correctness review found no actionable issues.

Fixes #721

