### PR TITLE
test: check native prerequisites before setup and isolate run names

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -94,6 +94,14 @@ The fixture-creation commands are version-sensitive; each is overridable with an
 env var (`STIM_E2E_BARE_INIT`, `STIM_E2E_EXPO_INIT`) so a runner can adjust
 them without touching assertion logic.
 
+Native runners check their environment before preparing the fixture. Android
+requires `ANDROID_HOME` or `ANDROID_SDK_ROOT` pointing to an existing SDK
+directory, even when the app has `android/local.properties`. iOS requires a
+UTF-8 locale; set `LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8` when needed.
+The cache runner performs these checks before seeding its disposable Gradle
+home. Worktree names include a digest of the run directory, so separate runs
+use different device names and do not recover a previous run's AVD by name.
+
 ### The simulator pool suite
 
 `test/e2e/native/run-pool-e2e.mjs` runs on iOS. With a pool bound of one, it

--- a/test/e2e/native-preflight.e2e.js
+++ b/test/e2e/native-preflight.e2e.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { createHarness, preflight } from './native/harness.mjs';
+
+function scratch(t) {
+  const root = mkdtempSync(join(tmpdir(), 'stim-native-preflight-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function harness(env) {
+  const tools = [];
+  return {
+    env,
+    tools,
+    cli: () => ({ code: 0, stdout: 'test-version', stderr: '' }),
+    log() {},
+    requireTool: (file) => tools.push(file),
+  };
+}
+
+test('native Android preflight refuses missing or invalid SDK paths before checking tools', (t) => {
+  const root = scratch(t);
+  for (const env of [{}, { ANDROID_HOME: join(root, 'missing') }]) {
+    const h = harness(env);
+    assert.throws(() => preflight(h, 'android'), /Android SDK/);
+    assert.deepEqual(h.tools, []);
+  }
+  const file = join(root, 'not-a-directory');
+  writeFileSync(file, 'file');
+  assert.throws(() => preflight(harness({ ANDROID_HOME: file }), 'android'), /SDK directory/);
+});
+
+test('native Android preflight accepts either explicit SDK environment variable', (t) => {
+  const root = scratch(t);
+  for (const key of ['ANDROID_HOME', 'ANDROID_SDK_ROOT']) {
+    const h = harness({ [key]: root });
+    preflight(h, 'android');
+    assert.deepEqual(h.tools, ['adb']);
+  }
+});
+
+test('native iOS preflight rejects an ASCII locale before any Xcode or fixture work', (t) => {
+  const root = scratch(t);
+  const env = { ...process.env, STIM_HOME: join(root, 'home'), LANG: 'C', LC_ALL: 'C' };
+  const h = createHarness({ env, cliPath: '', label: 'locale' });
+  h.cli = () => ({ code: 0, stdout: 'test-version', stderr: '' });
+  h.requireTool = () => assert.fail('tool preparation must not start');
+  assert.throws(() => preflight(h, 'ios'), /require a UTF-8 locale.*LANG=.*LC_ALL=/);
+});
+
+test('cache runner rejects a missing Android SDK before cloning or sweeping Gradle homes', (t) => {
+  const root = scratch(t);
+  const gradle = join(root, 'gradle');
+  const residue = join(root, '.stim-e2e-gradle-unrelated');
+  const temp = join(root, 'tmp');
+  mkdirSync(gradle);
+  mkdirSync(residue);
+  mkdirSync(temp);
+  writeFileSync(join(residue, 'owner.pid'), '999999999');
+  writeFileSync(join(residue, 'keep'), 'unrelated');
+  const summary = join(root, 'summary.json');
+  const env = { ...process.env, PATH: '', GRADLE_USER_HOME: gradle, TMPDIR: temp, STIM_HOME: join(root, 'home') };
+  delete env.ANDROID_HOME;
+  delete env.ANDROID_SDK_ROOT;
+  const result = spawnSync(
+    process.execPath,
+    ['test/e2e/native/run-cache-e2e.mjs', '--framework', 'expo', '--platform', 'android', '--summary', summary],
+    { env, encoding: 'utf-8', timeout: 10_000 },
+  );
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /require ANDROID_HOME or ANDROID_SDK_ROOT/);
+  assert.equal(readFileSync(join(residue, 'keep'), 'utf-8'), 'unrelated');
+  assert.deepEqual(
+    readdirSync(root).filter((name) => name.startsWith('.stim-e2e-gradle-')),
+    ['.stim-e2e-gradle-unrelated'],
+  );
+  const report = JSON.parse(readFileSync(summary, 'utf-8'));
+  assert.equal(report.ok, false);
+  assert.equal(report.counts.missing, 8);
+  assert.doesNotMatch(result.stderr, /creating expo fixture|gradle home seed:/);
+});

--- a/test/e2e/native-worktrees.e2e.js
+++ b/test/e2e/native-worktrees.e2e.js
@@ -12,7 +12,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import test from 'node:test';
 import {
   assertMatchingPods,
@@ -64,7 +64,7 @@ test('native worktree creation uses real detached Git paths and records them bef
     return { code: 0, stdout: '', stderr: '' };
   };
   const path = createWarmWorktree({ ...f, name: 'native [one]' });
-  assert.equal(path, join(f.workDir, 'native [one]'));
+  assert.equal(dirname(path), f.workDir);
   assert.equal(warmCalls, 1);
   assert.equal(git(f.sourceDir, 'show-ref', '--heads'), before);
   assert.equal(git(f.sourceDir, 'status', '--porcelain'), '');
@@ -76,7 +76,8 @@ test('a failed native warm keeps its created worktree recorded for diagnostics a
   const f = repoFixture(t);
   f.h.cli = () => ({ code: 1, stdout: '', stderr: 'copy failed' });
   assert.throws(() => createWarmWorktree({ ...f, name: 'failed-warm' }), /warming .* failed: copy failed/);
-  assert.deepEqual(f.created, [join(f.workDir, 'failed-warm')]);
+  assert.equal(f.created.length, 1);
+  assert.equal(dirname(f.created[0]), f.workDir);
   assert.equal(existsSync(f.created[0]), true);
   assert.equal(git(f.sourceDir, 'branch', '--list'), '* main');
   git(f.sourceDir, 'worktree', 'remove', f.created[0]);
@@ -107,12 +108,30 @@ test('native worktrees from a symlinked parent use the same paths as logs and Gi
 
 test('failed Git creation does not warm or claim an existing path', (t) => {
   const f = repoFixture(t);
-  const path = join(f.workDir, 'occupied');
-  writeFileSync(path, 'keep');
+  let path;
+  const sh = f.h.sh;
+  f.h.sh = (file, argv, opts) => {
+    path = argv[5];
+    writeFileSync(path, 'keep');
+    return sh(file, argv, opts);
+  };
   f.h.cli = () => assert.fail('warm must not run after a failed git add');
   assert.throws(() => createWarmWorktree({ ...f, name: 'occupied' }), /git worktree add failed/);
   assert.deepEqual(f.created, []);
   assert.equal(readFileSync(path, 'utf-8'), 'keep');
+});
+
+test('separate native runs cannot claim the same device name for their first worktree', (t) => {
+  const f = repoFixture(t);
+  const anotherRun = join(f.workDir, 'another run');
+  mkdirSync(anotherRun);
+  f.h.cli = () => ({ code: 0, stdout: '', stderr: '' });
+  const first = createWarmWorktree({ ...f, name: 'e2e-cache-1' });
+  const second = createWarmWorktree({ ...f, workDir: anotherRun, name: 'e2e-cache-1' });
+  assert.notEqual(basename(first), basename(second));
+  assert.deepEqual(f.created, [first, second]);
+  git(f.sourceDir, 'worktree', 'remove', second);
+  git(f.sourceDir, 'worktree', 'remove', first);
 });
 
 test('Pods reuse requires both lockfiles and an exact match', (t) => {

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -58,10 +58,18 @@ export function preflight(h, platform) {
   assert(v.code === 0, `stim CLI does not run: ${v.stderr}`);
   h.log(`stim ${v.stdout.trim()}`);
   if (platform === 'ios') {
+    const locale = h.sh('locale', ['charmap'], { allowFail: true });
+    assert(
+      locale.code === 0 && /^utf-?8$/i.test(locale.stdout.trim()),
+      'Native iOS tests require a UTF-8 locale for CocoaPods. Set LANG=en_US.UTF-8 and LC_ALL=en_US.UTF-8 before running the suite.',
+    );
     if (process.platform !== 'darwin') h.die('ios variant requires macOS + Xcode; this is not a macOS host.', 2);
     h.requireTool('xcrun', ['--version']);
     h.requireTool('xcodebuild', ['-version']);
   } else {
+    const sdk = h.env.ANDROID_HOME || h.env.ANDROID_SDK_ROOT;
+    assert(sdk, 'Native Android tests require ANDROID_HOME or ANDROID_SDK_ROOT pointing to the Android SDK.');
+    assert(existsSync(sdk) && statSync(sdk).isDirectory(), `Android SDK directory does not exist: ${sdk}`);
     h.requireTool('adb', ['version']);
   }
   return v.stdout.trim();
@@ -157,7 +165,8 @@ export function createFixture({ framework, platform, workDir, h }) {
 }
 
 export function createWarmWorktree({ h, sourceDir, workDir, name, created }) {
-  const requestedPath = join(workDir, name);
+  const runId = createHash('sha256').update(realpathSync(workDir)).digest('hex').slice(0, 12);
+  const requestedPath = join(workDir, `${name}-${runId}`);
   const added = h.sh('git', ['-C', sourceDir, 'worktree', 'add', '--detach', requestedPath, 'HEAD'], {
     allowFail: true,
   });

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -74,23 +74,12 @@ const ENV = {
   STIM_POOL_ANDROID_PARKED_MAX: '0',
 };
 process.env.STIM_HOME = HOME_DIR;
-// Android runs get a throwaway gradle home so build-cache-1 starts empty and
-// storing stays measurable (#136). Clones, not symlinks: gradle resolves real
-// paths when it assembles script classpaths, so a symlinked modules-2 breaks
-// buildscript compilation. Created BESIDE the real home so the clones stay
-// same-volume copy-on-write.
-const GRADLE_USER_HOME =
-  PLATFORM === 'android' && !args.dryRun
-    ? seedGradleUserHome(process.env.GRADLE_USER_HOME || join(homedir(), '.gradle'))
-    : process.env.GRADLE_USER_HOME || join(homedir(), '.gradle');
-if (PLATFORM === 'android' && !args.dryRun) {
-  ENV.GRADLE_USER_HOME = GRADLE_USER_HOME;
-  process.env.GRADLE_USER_HOME = GRADLE_USER_HOME;
-}
-const GRADLE_CACHE_DIR = join(GRADLE_USER_HOME, 'caches', 'build-cache-1');
-const GRADLE_HOME_IS_THROWAWAY = PLATFORM === 'android' && !args.dryRun;
+let GRADLE_USER_HOME = process.env.GRADLE_USER_HOME || join(homedir(), '.gradle');
+let GRADLE_CACHE_DIR = join(GRADLE_USER_HOME, 'caches', 'build-cache-1');
+let GRADLE_HOME_IS_THROWAWAY = false;
 
 function seedGradleUserHome(source) {
+  // Gradle resolves script classpath symlinks, so dependency caches are cloned into the disposable home.
   const base = existsSync(source) ? dirname(realpathSync(source)) : tmpdir();
   // A crashed run cannot clean its own home; sweep predecessors only when
   // their recorded owner pid is provably dead.
@@ -221,6 +210,15 @@ function skipCheck(id, reason) {
 
 async function main() {
   preflight(h, PLATFORM);
+
+  if (PLATFORM === 'android') {
+    GRADLE_USER_HOME = seedGradleUserHome(GRADLE_USER_HOME);
+    GRADLE_HOME_IS_THROWAWAY = true;
+    ENV.GRADLE_USER_HOME = GRADLE_USER_HOME;
+    process.env.GRADLE_USER_HOME = GRADLE_USER_HOME;
+    GRADLE_CACHE_DIR = join(GRADLE_USER_HOME, 'caches', 'build-cache-1');
+    log(`gradle build cache=${GRADLE_CACHE_DIR}`);
+  }
 
   const appDir = args.appDir
     ? resolve(args.appDir)
@@ -1012,7 +1010,7 @@ function plan() {
   log(`build cache=${BUILD_CACHE_ROOT} (forced; any inherited STIM_BUILD_CACHE is ignored)`);
   log(`metro cache=${METRO_CACHE_ROOT} (forced; any inherited STIM_METRO_CACHE is ignored)`);
   log(`temp dir=${CACHE_TMP_DIR} (forced so Metro's default store cannot hide shared-store writes)`);
-  log(PLATFORM === 'ios' ? `xcode CAS=${CAS_DIR}` : `gradle build cache=${GRADLE_CACHE_DIR}`);
+  log(PLATFORM === 'ios' ? `xcode CAS=${CAS_DIR}` : `Gradle dependency seed=${GRADLE_USER_HOME}`);
   log(`race build cache=${RACE_CACHE_ROOT}`);
   log(
     args.appDir


### PR DESCRIPTION
## Description

Native QA can spend time preparing a fixture before discovering a missing Android SDK or an incompatible CocoaPods locale. Repeated worktree names also make a new run recover an earlier run's AVD.

## Solution

Check SDK environment paths and the iOS UTF-8 locale before fixture preparation or Gradle-home seeding. Add a digest of the run directory to native worktree names so separate runs get different device names.

Addresses these harness problems from #702. Interrupted Gradle cleanup and production orphan-AVD handling remain separate work.

## Test plan

- Four regression cases fail against the old harness, covering missing prerequisites, setup ordering, and repeated worktree names.
- All 84 end-to-end checks pass, including real Git worktree operations, locale inspection, and a cache-runner subprocess that refuses before modifying Gradle homes.
- A full native build has not been rerun for this change.
