### PR TITLE
test: publish GC race readiness atomically

### DIFF
--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -2934,7 +2934,8 @@ describe('--delete against a claim taken while gc is deleting', { timeout: 60_00
         "  if (Date.now() > deadline) throw new Error('never acquired the claim');",
         '  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);',
         '}',
-        'fs.writeFileSync(acquired, JSON.stringify(got.acquired));',
+        "fs.writeFileSync(acquired + '.tmp', JSON.stringify(got.acquired));",
+        "fs.renameSync(acquired + '.tmp', acquired);",
         'waitForFile(proceed);',
       ].join('\n'),
     );


### PR DESCRIPTION
## Description

The GC race test can read its child's readiness file before the JSON write finishes, failing before it checks ownership.

## Solution

Write the complete payload to a sibling temporary file and rename it into place before the parent proceeds. The competing processes and ownership assertions stay intact. Fixes #730.

## Test plan

- A deliberately paused partial write fails with the old publication path and passes with atomic publication.
- The full unit suite passes: 4,121 tests, one skipped.
