### PR TITLE
test: give the large Git inventory regression a realistic timeout

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree.test.ts
@@ -314,7 +314,7 @@ test('ignored inventory and warm copying still find the target file when raw ls-
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
-});
+}, 30_000);
 
 test('removeWorktree runs git via runFile (no shell) and includes --force only when asked', () => {
   const path = '/tmp/my worktree/repo';


### PR DESCRIPTION
## Description

The ignored-inventory regression creates 6,000 files and runs real Git/copy operations, which can exceed the default five-second timeout under load.

## Solution

Give this case 30 seconds while retaining the greater-than-1MB Git output and copied-file assertions. Fixes #731.

## Test plan

- Run the real ignored-inventory regression and the full unit suite.
