### PR TITLE
fix: reclaim orphaned Android AVD data

### DIFF
--- a/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
+++ b/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
@@ -46,7 +46,16 @@ beforeEach(() => {
   home = realpathSync(mkdtempSync(join(tmpdir(), 'stim-orphan-avds-')));
   avdRoot = join(home, 'avd');
   mkdirSync(avdRoot);
-  const keys = ['STIM_HOME', 'HOME', 'ANDROID_HOME', 'ANDROID_SDK_ROOT', 'ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'];
+  const keys = [
+    'STIM_HOME',
+    'HOME',
+    'ANDROID_HOME',
+    'ANDROID_SDK_ROOT',
+    'ANDROID_AVD_HOME',
+    'ANDROID_SDK_HOME',
+    'ANDROID_USER_HOME',
+    'ANDROID_EMULATOR_HOME',
+  ];
   saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
   Object.assign(process.env, {
     STIM_HOME: join(home, 'stim'),
@@ -55,6 +64,8 @@ beforeEach(() => {
     ANDROID_SDK_ROOT: join(home, 'sdk'),
     ANDROID_AVD_HOME: avdRoot,
     ANDROID_SDK_HOME: home,
+    ANDROID_USER_HOME: join(home, '.android'),
+    ANDROID_EMULATOR_HOME: join(home, '.android'),
   });
   savedExitCode = process.exitCode;
   ensureConfig();
@@ -332,4 +343,42 @@ describe.skipIf(process.getuid?.() === 0)('unverifiable registrations', () => {
     expect(teardownOwnedAvd('stim-orphan', { del: true }).status).toBe('failed');
     expect(existsSync(directory)).toBe(true);
   });
+});
+
+test.each(['ANDROID_USER_HOME', 'ANDROID_EMULATOR_HOME', 'ANDROID_SDK_HOME'])(
+  'a user alias in %s protects data in another AVD root',
+  async (variable) => {
+    const directory = orphan();
+    const candidate = listOrphanedAvdDirectories()[0]!;
+    process.env[variable] = join(home, variable.toLowerCase());
+    const root =
+      variable === 'ANDROID_SDK_HOME'
+        ? join(process.env[variable]!, '.android', 'avd')
+        : join(process.env[variable]!, 'avd');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'Personal_Phone.ini'), `path=${directory}\n`);
+    listed.push('Personal_Phone');
+    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    expect(report.orphanedDevices).toEqual([]);
+    expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
+    expect(existsSync(join(directory, 'userdata.img'))).toBe(true);
+  },
+);
+
+test('a relative alias registration in a symlinked root protects its data when the absolute path is stale', async () => {
+  const root = join(home, 'real', 'avd');
+  const directory = orphan('stim-retained', root);
+  const alias = join(home, 'redirected-avds');
+  symlinkSync(root, alias);
+  process.env.ANDROID_AVD_HOME = alias;
+  const candidate = listOrphanedAvdDirectories()[0]!;
+  writeFileSync(
+    join(root, 'Personal_Phone.ini'),
+    `path=${join(home, 'missing.avd')}\npath.rel=avd/stim-retained.avd\n`,
+  );
+  listed.push('Personal_Phone');
+  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+  expect(report.orphanedDevices).toEqual([]);
+  expect(teardownOwnedAvd('stim-retained', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
+  expect(existsSync(join(directory, 'userdata.img'))).toBe(true);
 });

--- a/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
+++ b/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
@@ -1,0 +1,335 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectGcReport, runGc } from '../commands/gc.ts';
+import { ensureConfig, getProject, upsertProject } from '../config.ts';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
+import { listOrphanedAvdDirectories } from '../sim/android.ts';
+import { parkSim, readParked } from '../sim-pool.ts';
+import { teardownOwnedAvd, teardownParkedAvd } from '../teardown.ts';
+
+const race = vi.hoisted(() => ({ afterRename: null as null | ((from: string, to: string) => void) }));
+vi.mock('node:fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...fs,
+    renameSync: (...args: Parameters<typeof fs.renameSync>) => {
+      fs.renameSync(...args);
+      race.afterRename?.(String(args[0]), String(args[1]));
+    },
+  };
+});
+
+let home: string;
+let avdRoot: string;
+let saved: Record<string, string | undefined>;
+let savedExitCode: typeof process.exitCode;
+let listed: string[];
+let deleteRegistration: boolean;
+const deps = {
+  findProjectRoot: () => null,
+  precollectedEasSessionSweep: { projectScope: null, orphaned: [], notices: [], deletionSafe: true },
+};
+
+beforeEach(() => {
+  home = realpathSync(mkdtempSync(join(tmpdir(), 'stim-orphan-avds-')));
+  avdRoot = join(home, 'avd');
+  mkdirSync(avdRoot);
+  const keys = ['STIM_HOME', 'HOME', 'ANDROID_HOME', 'ANDROID_SDK_ROOT', 'ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'];
+  saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  Object.assign(process.env, {
+    STIM_HOME: join(home, 'stim'),
+    HOME: home,
+    ANDROID_HOME: join(home, 'sdk'),
+    ANDROID_SDK_ROOT: join(home, 'sdk'),
+    ANDROID_AVD_HOME: avdRoot,
+    ANDROID_SDK_HOME: home,
+  });
+  savedExitCode = process.exitCode;
+  ensureConfig();
+  listed = [];
+  deleteRegistration = false;
+  const real = getExecutor();
+  const run = (cmd: string) => {
+    if (cmd.includes('emulator -list-avds')) return listed.join('\n');
+    if (cmd === 'adb devices') return 'List of devices attached\n';
+    if (cmd.includes('delete avd')) {
+      if (deleteRegistration) {
+        const name = /-n "([^"]+)"/.exec(cmd)![1]!;
+        rmSync(join(avdRoot, `${name}.ini`));
+        listed = listed.filter((entry) => entry !== name);
+      }
+      return '';
+    }
+    throw new Error(`Unexpected command: ${cmd}`);
+  };
+  setExecutor({
+    run,
+    runQuiet: () => null,
+    runFile(file, args, options) {
+      if (file === 'du') return real.runFile(file, args, options);
+      if (file === 'xcrun') return JSON.stringify({ devices: {}, devicetypes: [] });
+      throw new Error(`Unexpected command: ${file}`);
+    },
+    runFileQuiet: () => null,
+  });
+});
+
+afterEach(() => {
+  race.afterRename = null;
+  resetExecutor();
+  vi.restoreAllMocks();
+  process.exitCode = savedExitCode;
+  for (const entry of readdirSync(avdRoot)) {
+    const blocked = join(avdRoot, entry, 'blocked');
+    if (existsSync(blocked)) chmodSync(blocked, 0o700);
+  }
+  rmSync(home, { recursive: true, force: true });
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function orphan(name = 'stim-orphan', root = avdRoot): string {
+  const directory = join(root, `${name}.avd`);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'userdata.img'), Buffer.alloc(8192, 1));
+  return directory;
+}
+
+function register(name: string, directory: string): void {
+  writeFileSync(join(avdRoot, `${name}.ini`), `path=${directory}\n`);
+  listed.push(name);
+}
+
+test('GC reports and sizes unreferenced owned data even when the emulator listing is empty', async () => {
+  const directory = orphan();
+  orphan('Personal_Phone');
+  const retained = orphan('stim-retained');
+  upsertProject(home, { platforms: { android: { avdName: 'stim-retained', owned: true } } });
+
+  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+
+  expect(report.orphanedDevices).toEqual([
+    expect.objectContaining({
+      name: 'stim-orphan',
+      bytes: expect.any(Number),
+      orphanedDirectory: expect.objectContaining({ directory }),
+    }),
+  ]);
+  expect(report.orphanedDevices[0]!.bytes).toBeGreaterThan(0);
+  expect(report.staleDeviceRecords).toEqual([]);
+  expect(existsSync(directory)).toBe(true);
+  expect(existsSync(retained)).toBe(true);
+});
+
+test('orphan sizing uses the bounded size path and tolerates its failure', async () => {
+  orphan();
+  const size = vi.fn<typeof import('../fs-util.ts').directorySize>(() => {
+    throw new Error('unreadable');
+  });
+  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, { ...deps, directorySize: size });
+  expect(size).toHaveBeenCalledWith(join(avdRoot, 'stim-orphan.avd'), { timeoutMs: 5000 });
+  expect(report.orphanedDevices).toEqual([expect.objectContaining({ name: 'stim-orphan' })]);
+  expect(report.orphanedDevices[0]!.bytes).toBeUndefined();
+});
+
+test.each(['scoped', 'no-config'])('orphan discovery preserves the %s GC sweep guard', async (guard) => {
+  const directory = orphan();
+  if (guard === 'no-config') rmSync(join(process.env.STIM_HOME!, 'config.json'));
+  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: guard === 'no-config' }, deps);
+  expect(report.orphanedDevices).toEqual([]);
+  expect(existsSync(directory)).toBe(true);
+});
+
+test('stop keeps unregistered data and delete refuses user-created names', () => {
+  const directory = orphan();
+  const personal = orphan('Personal_Phone');
+  expect(teardownOwnedAvd('stim-orphan').status).toBe('skipped');
+  expect(teardownOwnedAvd('Personal_Phone', { del: true }).kind).toBe('not-owned');
+  expect(existsSync(directory)).toBe(true);
+  expect(existsSync(personal)).toBe(true);
+});
+
+test.each(['live', 'unverifiable'])('orphan deletion refuses a %s emulator process lock', (state) => {
+  const directory = orphan();
+  writeFileSync(join(directory, 'hardware-qemu.ini.lock'), state === 'live' ? String(process.pid) : 'not-a-pid');
+  expect(teardownOwnedAvd('stim-orphan', { del: true }).status).toBe('failed');
+  expect(existsSync(directory)).toBe(true);
+});
+
+test('orphan deletion refuses a directory replaced by a symlink after survey', () => {
+  const directory = orphan();
+  const candidate = listOrphanedAvdDirectories()[0]!;
+  const outside = join(home, 'outside');
+  mkdirSync(outside);
+  writeFileSync(join(outside, 'keep'), 'mine');
+  rmSync(directory, { recursive: true });
+  symlinkSync(outside, directory);
+  expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
+  expect(readFileSync(join(outside, 'keep'), 'utf8')).toBe('mine');
+});
+
+test.each(['registration', 'workspace', 'pool'])('GC refuses an orphan that gained a %s after survey', (reference) => {
+  const directory = orphan();
+  const candidate = listOrphanedAvdDirectories()[0]!;
+  if (reference === 'registration') register('stim-orphan', directory);
+  else {
+    upsertProject(home, { platforms: { android: { avdName: 'stim-orphan', owned: true } } });
+    if (reference === 'pool')
+      parkSim({
+        platform: 'android',
+        projectPath: home,
+        max: 1,
+        record: {
+          udid: 'stim-orphan',
+          name: 'stim-orphan',
+          systemImage: 'image',
+          configuration: 'config',
+          parkedAt: new Date().toISOString(),
+        },
+      });
+  }
+  expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toMatch(/failed|skipped/);
+  expect(existsSync(directory)).toBe(true);
+});
+
+test('detachment holds the config lock and deletion cannot remove a new AVD at the original name', () => {
+  const directory = orphan();
+  race.afterRename = (from) => {
+    if (from !== directory) return;
+    expect(existsSync(join(process.env.STIM_HOME!, 'config.lock'))).toBe(true);
+    const replacement = orphan();
+    register('stim-orphan', replacement);
+    upsertProject(home, { platforms: { android: { avdName: 'stim-orphan', owned: true } } });
+  };
+  expect(teardownOwnedAvd('stim-orphan', { del: true }).status).toBe('torn-down');
+  expect(existsSync(join(directory, 'userdata.img'))).toBe(true);
+  expect(existsSync(join(avdRoot, 'stim-orphan.ini'))).toBe(true);
+  expect(getProject(home)?.platforms?.android?.avdName).toBe('stim-orphan');
+  expect(readdirSync(avdRoot).some((entry) => entry.startsWith('stim-gc-'))).toBe(false);
+});
+
+test.each(['workspace', 'pool'])(
+  'a partial SDK deletion preserves the %s record and its retry removes the leftover data',
+  (owner) => {
+    const directory = orphan();
+    register('stim-orphan', directory);
+    upsertProject(home, { platforms: { android: { avdName: 'stim-orphan', owned: true } } });
+    if (owner === 'pool')
+      parkSim({
+        platform: 'android',
+        projectPath: home,
+        max: 1,
+        record: {
+          udid: 'stim-orphan',
+          name: 'stim-orphan',
+          systemImage: 'image',
+          configuration: 'config',
+          parkedAt: new Date().toISOString(),
+        },
+      });
+    deleteRegistration = true;
+    const teardown = () =>
+      owner === 'pool'
+        ? teardownParkedAvd('stim-orphan')
+        : teardownOwnedAvd('stim-orphan', { del: true, owner: { projectPath: home } });
+    expect(teardown()).toMatchObject({ status: 'failed', reason: expect.stringContaining('data remains') });
+    expect(existsSync(directory)).toBe(true);
+    const records = () =>
+      owner === 'pool'
+        ? readParked('android').map((entry) => entry.name)
+        : [getProject(home)?.platforms?.android?.avdName];
+    expect(records()).toEqual(['stim-orphan']);
+    expect(teardown().status).toBe('torn-down');
+    expect(existsSync(directory)).toBe(false);
+    expect(records()).toEqual(owner === 'pool' ? [] : ['stim-orphan']);
+  },
+);
+
+test.skipIf(process.getuid?.() === 0)(
+  'GC keeps failed removals discoverable, continues to later devices, and reclaims them on retry',
+  async () => {
+    const blocked = orphan('stim-a-blocked');
+    mkdirSync(join(blocked, 'blocked'));
+    writeFileSync(join(blocked, 'blocked', 'data'), 'keep until removable');
+    chmodSync(join(blocked, 'blocked'), 0);
+    const removable = orphan('stim-z-removable');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+    expect(existsSync(removable)).toBe(false);
+    const leftovers = listOrphanedAvdDirectories();
+    expect(leftovers).toHaveLength(1);
+    expect(leftovers[0]!.name).toMatch(/^stim-gc-/);
+    expect(log.mock.calls.flat().join('\n')).toContain('Failed to delete android device stim-a-blocked');
+    chmodSync(join(leftovers[0]!.directory, 'blocked'), 0o700);
+    await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+    expect(listOrphanedAvdDirectories()).toEqual([]);
+  },
+);
+
+test('an unreadable or symlinked orphan prevents stale device records from being cleared', async () => {
+  const outside = join(home, 'outside');
+  mkdirSync(outside);
+  symlinkSync(outside, join(avdRoot, 'stim-linked.avd'));
+  upsertProject(home, { platforms: { android: { avdName: 'stim-linked', owned: true } } });
+  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+  expect(report.staleDeviceRecords).toEqual([]);
+  expect(report.deviceSweepNotices.join('\n')).toContain('Cannot verify AVD data');
+});
+
+test('GC reclaims orphan data after pruning its dead workspace reference', async () => {
+  const directory = orphan();
+  upsertProject(join(home, 'gone'), { platforms: { android: { avdName: 'stim-orphan', owned: true } } });
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+  expect(existsSync(directory)).toBe(false);
+  expect(log.mock.calls.flat().join('\n')).not.toContain('Failed to delete');
+});
+
+test.each(['absolute', 'relative', 'symlink'])(
+  'an alias-named registration protects its canonical %s data target during survey and deletion',
+  async (target) => {
+    const directory = orphan();
+    const candidate = listOrphanedAvdDirectories()[0]!;
+    let registration = `path=${directory}\n`;
+    if (target === 'relative') registration = 'path.rel=avd/stim-orphan.avd\n';
+    if (target === 'symlink') {
+      const alias = join(home, 'data-alias');
+      symlinkSync(directory, alias);
+      registration = `path=${alias}\n`;
+    }
+    writeFileSync(join(avdRoot, 'Personal_Phone.ini'), registration);
+    listed.push('Personal_Phone');
+    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    expect(report.orphanedDevices).toEqual([]);
+    expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
+    expect(readFileSync(join(directory, 'userdata.img')).length).toBe(8192);
+  },
+);
+
+describe.skipIf(process.getuid?.() === 0)('unverifiable registrations', () => {
+  test.each(['unreadable', 'malformed'])('an %s registration keeps unverified orphan data', async (failure) => {
+    const directory = orphan();
+    const registration = join(avdRoot, 'Personal_Phone.ini');
+    writeFileSync(registration, failure === 'malformed' ? 'avd.ini.encoding=UTF-8\n' : `path=${directory}\n`);
+    if (failure === 'unreadable') chmodSync(registration, 0);
+    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    expect(report.orphanedDevices).toEqual([]);
+    expect(report.deviceSweepNotices.join('\n')).toContain('android data sweep skipped');
+    expect(teardownOwnedAvd('stim-orphan', { del: true }).status).toBe('failed');
+    expect(existsSync(directory)).toBe(true);
+  });
+});

--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -24,15 +24,22 @@ const configuration = avdPoolConfiguration(8, {});
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'stim-android-pool-'));
   saved = Object.fromEntries(
-    ['STIM_HOME', 'STIM_POOL_ANDROID_PARKED_MAX', 'ANDROID_HOME', 'ANDROID_AVD_HOME', 'DISPLAY'].map((key) => [
-      key,
-      process.env[key],
-    ]),
+    [
+      'STIM_HOME',
+      'STIM_POOL_ANDROID_PARKED_MAX',
+      'ANDROID_HOME',
+      'ANDROID_AVD_HOME',
+      'ANDROID_SDK_HOME',
+      'HOME',
+      'DISPLAY',
+    ].map((key) => [key, process.env[key]]),
   );
   process.env.STIM_HOME = home;
   process.env.STIM_POOL_ANDROID_PARKED_MAX = '1';
   process.env.ANDROID_HOME = join(home, 'sdk');
   process.env.ANDROID_AVD_HOME = join(home, 'avd');
+  process.env.ANDROID_SDK_HOME = home;
+  process.env.HOME = home;
   process.env.DISPLAY = ':0';
   mkdirSync(join(home, 'sdk', ...image.split(';')), { recursive: true });
   avds = new Set();
@@ -55,7 +62,10 @@ beforeEach(() => {
     }
     if (cmd.includes('delete avd')) {
       if (failDelete) throw new Error('AVD deletion failed');
-      avds.delete(/-n "([^"]+)"/.exec(cmd)![1]!);
+      const name = /-n "([^"]+)"/.exec(cmd)![1]!;
+      avds.delete(name);
+      rmSync(join(home, 'avd', `${name}.ini`), { force: true });
+      rmSync(join(home, 'avd', `${name}.avd`), { recursive: true, force: true });
       return '';
     }
     if (cmd.includes('create avd')) {
@@ -148,15 +158,25 @@ test.each([
   expect(readParked('android').map((record) => record.name)).toEqual(['stim-source']);
 });
 
-test('a missing parked AVD loses only its pool record before a fresh device is created', async () => {
-  park();
-  avds.clear();
-  upsertProject('/adopter', {});
-  const result = await ensureOwnedDevice({ platform: 'android', projectPath: '/adopter', label: 'new', settings: {} });
-  expect(result.created).toBe(true);
-  expect(readParked('android')).toEqual([]);
-  expect(calls.some((call) => call.includes('delete avd'))).toBe(false);
-});
+test.each([false, true])(
+  'a missing parked AVD reclaims remaining data (%s) before dropping its pool record',
+  async (dataRemains) => {
+    park();
+    avds.clear();
+    rmSync(join(home, 'avd', 'stim-source.ini'));
+    if (!dataRemains) rmSync(join(home, 'avd', 'stim-source.avd'), { recursive: true });
+    upsertProject('/adopter', {});
+    const result = await ensureOwnedDevice({
+      platform: 'android',
+      projectPath: '/adopter',
+      label: 'new',
+      settings: {},
+    });
+    expect(result.created).toBe(true);
+    expect(readParked('android')).toEqual([]);
+    expect(calls.some((call) => call.includes('delete avd'))).toBe(false);
+  },
+);
 
 test('an emulator with a live process but no adb connection stays parked', async () => {
   park();

--- a/packages/stim-cli/src/__tests__/android-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/android-pool.test.ts
@@ -30,6 +30,8 @@ beforeEach(() => {
       'ANDROID_HOME',
       'ANDROID_AVD_HOME',
       'ANDROID_SDK_HOME',
+      'ANDROID_USER_HOME',
+      'ANDROID_EMULATOR_HOME',
       'HOME',
       'DISPLAY',
     ].map((key) => [key, process.env[key]]),
@@ -39,6 +41,8 @@ beforeEach(() => {
   process.env.ANDROID_HOME = join(home, 'sdk');
   process.env.ANDROID_AVD_HOME = join(home, 'avd');
   process.env.ANDROID_SDK_HOME = home;
+  process.env.ANDROID_USER_HOME = join(home, '.android');
+  process.env.ANDROID_EMULATOR_HOME = join(home, '.android');
   process.env.HOME = home;
   process.env.DISPLAY = ':0';
   mkdirSync(join(home, 'sdk', ...image.split(';')), { recursive: true });

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1210,9 +1210,13 @@ describe('ensureOwnedDevice: android', () => {
     prevAndroidAvdHome = process.env.ANDROID_AVD_HOME;
     process.env.ANDROID_HOME = androidHome;
     process.env.ANDROID_AVD_HOME = join(androidHome, 'avd');
-    prevFallbackRoots = Object.fromEntries(['HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]));
+    prevFallbackRoots = Object.fromEntries(
+      ['HOME', 'ANDROID_SDK_HOME', 'ANDROID_USER_HOME', 'ANDROID_EMULATOR_HOME'].map((key) => [key, process.env[key]]),
+    );
     process.env.HOME = androidHome;
     process.env.ANDROID_SDK_HOME = androidHome;
+    process.env.ANDROID_USER_HOME = join(androidHome, '.android');
+    process.env.ANDROID_EMULATOR_HOME = join(androidHome, '.android');
   });
 
   afterEach(() => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1200,6 +1200,7 @@ describe('ensureOwnedDevice: android', () => {
   let androidHome: string;
   let prevAndroidHome: string | undefined;
   let prevAndroidAvdHome: string | undefined;
+  let prevFallbackRoots: Record<string, string | undefined>;
 
   beforeEach(() => {
     androidHome = mkdtempSync(join(tmpdir(), 'stim-test-sdk-'));
@@ -1209,10 +1210,17 @@ describe('ensureOwnedDevice: android', () => {
     prevAndroidAvdHome = process.env.ANDROID_AVD_HOME;
     process.env.ANDROID_HOME = androidHome;
     process.env.ANDROID_AVD_HOME = join(androidHome, 'avd');
+    prevFallbackRoots = Object.fromEntries(['HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]));
+    process.env.HOME = androidHome;
+    process.env.ANDROID_SDK_HOME = androidHome;
   });
 
   afterEach(() => {
     rmSync(androidHome, { recursive: true, force: true });
+    for (const [key, value] of Object.entries(prevFallbackRoots)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     if (prevAndroidHome === undefined) delete process.env.ANDROID_HOME;
     else process.env.ANDROID_HOME = prevAndroidHome;
     if (prevAndroidAvdHome === undefined) delete process.env.ANDROID_AVD_HOME;
@@ -1262,7 +1270,14 @@ describe('ensureOwnedDevice: android', () => {
             }
             return '';
           }
-          if (/delete avd/.test(cmd)) return '';
+          if (/delete avd/.test(cmd)) {
+            const name = / -n "([^"]+)"/.exec(cmd)?.[1];
+            assert(name);
+            avds = avds.filter((entry) => entry !== name);
+            rmSync(join(process.env.ANDROID_AVD_HOME!, `${name}.ini`), { force: true });
+            rmSync(join(process.env.ANDROID_AVD_HOME!, `${name}.avd`), { recursive: true, force: true });
+            return '';
+          }
           if (cmd === 'adb devices') return 'List of devices attached\n';
           if (/emu avd name/.test(cmd)) return runningAvdName;
           if (/getprop sys\.boot_completed/.test(cmd)) return bootCompletes ? '1' : '';

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -850,9 +850,16 @@ beforeEach(() => {
   originalHome = process.env.HOME;
   fakeHome = mkdtempSync(join(tmpdir(), 'stim-fakehome-'));
   process.env.HOME = fakeHome;
-  originalAvdRoots = Object.fromEntries(['ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]));
+  originalAvdRoots = Object.fromEntries(
+    ['ANDROID_AVD_HOME', 'ANDROID_SDK_HOME', 'ANDROID_USER_HOME', 'ANDROID_EMULATOR_HOME'].map((key) => [
+      key,
+      process.env[key],
+    ]),
+  );
   process.env.ANDROID_AVD_HOME = join(fakeHome, 'avd');
   process.env.ANDROID_SDK_HOME = fakeHome;
+  process.env.ANDROID_USER_HOME = join(fakeHome, '.android');
+  process.env.ANDROID_EMULATOR_HOME = join(fakeHome, '.android');
 
   originalTmpdir = process.env.TMPDIR;
   process.env.TMPDIR = fakeHome;

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -678,6 +678,7 @@ let tmpHome: string;
 let fakeHome: string;
 let originalHome: string | undefined;
 let originalTmpdir: string | undefined;
+let originalAvdRoots: Record<string, string | undefined>;
 
 function currentConfig() {
   const cfg = loadConfig();
@@ -849,12 +850,19 @@ beforeEach(() => {
   originalHome = process.env.HOME;
   fakeHome = mkdtempSync(join(tmpdir(), 'stim-fakehome-'));
   process.env.HOME = fakeHome;
+  originalAvdRoots = Object.fromEntries(['ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]));
+  process.env.ANDROID_AVD_HOME = join(fakeHome, 'avd');
+  process.env.ANDROID_SDK_HOME = fakeHome;
 
   originalTmpdir = process.env.TMPDIR;
   process.env.TMPDIR = fakeHome;
 });
 
 afterEach(() => {
+  for (const [key, value] of Object.entries(originalAvdRoots)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   resetExecutor();
   if (originalTmpdir === undefined) delete process.env.TMPDIR;
   else process.env.TMPDIR = originalTmpdir;

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -188,6 +188,27 @@ test('ownedAvdDirectory uses AVD_HOME, SDK_HOME, then HOME precedence', () => {
   expect(ownedAvdDirectory('stim-app', { env: {}, home })).toBe(realpathSync(candidates[2]));
 });
 
+test('extra registration roots cannot override the emulator directory selected by the operational lookup', () => {
+  const sdkHome = join(tmpHome, 'sdk-home');
+  const userHome = join(tmpHome, 'user-home');
+  const emulatorHome = join(tmpHome, 'emulator-home');
+  const home = join(tmpHome, 'home');
+  const selected = join(tmpHome, 'selected.avd');
+  const extra = join(tmpHome, 'extra.avd');
+  mkdirSync(selected, { recursive: true });
+  mkdirSync(extra, { recursive: true });
+  writeAvdRoot(join(sdkHome, 'avd'), 'stim-app', `path=${selected}\n`);
+  for (const root of [join(userHome, 'avd'), join(emulatorHome, 'avd'), join(sdkHome, '.android', 'avd')]) {
+    writeAvdRoot(root, 'stim-app', `path=${extra}\n`);
+  }
+  expect(
+    ownedAvdDirectory('stim-app', {
+      env: { ANDROID_SDK_HOME: sdkHome, ANDROID_USER_HOME: userHome, ANDROID_EMULATOR_HOME: emulatorHome },
+      home,
+    }),
+  ).toBe(realpathSync(selected));
+});
+
 test('ownedAvdDirectory resolves moved, relative, and symlinked content directories', () => {
   const sdkHome = join(tmpHome, 'android-sdk-home');
   const root = join(sdkHome, 'avd');

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -14,11 +14,16 @@ let savedAvdRoots: Record<string, string | undefined>;
 beforeEach(() => {
   avdHome = mkdtempSync(join(tmpdir(), 'stim-teardown-avds-'));
   savedAvdRoots = Object.fromEntries(
-    ['HOME', 'ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]),
+    ['HOME', 'ANDROID_AVD_HOME', 'ANDROID_SDK_HOME', 'ANDROID_USER_HOME', 'ANDROID_EMULATOR_HOME'].map((key) => [
+      key,
+      process.env[key],
+    ]),
   );
   process.env.HOME = avdHome;
   process.env.ANDROID_AVD_HOME = join(avdHome, 'avd');
   process.env.ANDROID_SDK_HOME = avdHome;
+  process.env.ANDROID_USER_HOME = join(avdHome, '.android');
+  process.env.ANDROID_EMULATOR_HOME = join(avdHome, '.android');
   savedAndroidHome = process.env.ANDROID_HOME;
   savedSdkRoot = process.env.ANDROID_SDK_ROOT;
   process.env.ANDROID_HOME = join(tmpdir(), 'stim-test-no-sdk-here');

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -8,8 +8,17 @@ import { teardownOwnedIosSim, teardownOwnedAvd } from '../teardown.ts';
 
 let savedAndroidHome: string | undefined;
 let savedSdkRoot: string | undefined;
+let avdHome: string;
+let savedAvdRoots: Record<string, string | undefined>;
 
 beforeEach(() => {
+  avdHome = mkdtempSync(join(tmpdir(), 'stim-teardown-avds-'));
+  savedAvdRoots = Object.fromEntries(
+    ['HOME', 'ANDROID_AVD_HOME', 'ANDROID_SDK_HOME'].map((key) => [key, process.env[key]]),
+  );
+  process.env.HOME = avdHome;
+  process.env.ANDROID_AVD_HOME = join(avdHome, 'avd');
+  process.env.ANDROID_SDK_HOME = avdHome;
   savedAndroidHome = process.env.ANDROID_HOME;
   savedSdkRoot = process.env.ANDROID_SDK_ROOT;
   process.env.ANDROID_HOME = join(tmpdir(), 'stim-test-no-sdk-here');
@@ -17,6 +26,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const [key, value] of Object.entries(savedAvdRoots)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(avdHome, { recursive: true, force: true });
   if (savedAndroidHome === undefined) delete process.env.ANDROID_HOME;
   else process.env.ANDROID_HOME = savedAndroidHome;
   if (savedSdkRoot === undefined) delete process.env.ANDROID_SDK_ROOT;

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -13,7 +13,7 @@ import { describeDereferenced, reclaimProject } from '../reclaim.ts';
 import { SETTING_SHAPE_REMEDY } from '../settings.ts';
 import { listAllIosSims, type IosSimRecord } from '../sim/ios.ts';
 import { parkedMaxSetting, POOL_SETTING_REMEDY } from '../sim-pool.ts';
-import { listAvds, ownedAvdDirectory } from '../sim/android.ts';
+import { listAvds, listOrphanedAvdDirectories, ownedAvdDirectory } from '../sim/android.ts';
 import { declaredCachePaths, discoverCaches, projectSettingShapeErrors, sizeCaches } from '../caches.ts';
 import { withEasProjectLock } from '../engine/eas-project-lock.ts';
 import type { GcSkip, OrphanedDevice } from '../types.ts';
@@ -217,9 +217,25 @@ export async function collectGcReport(
       );
     }
 
+    let orphanedAvdDirectories: ReturnType<typeof listOrphanedAvdDirectories> = [];
+    if (avdsChecked) {
+      try {
+        orphanedAvdDirectories = listOrphanedAvdDirectories();
+      } catch (error) {
+        avdsChecked = false;
+        deviceSweepNotices.push(`android data sweep skipped: ${(error as Error).message}`);
+      }
+    }
+    avds = [...new Set([...avds, ...orphanedAvdDirectories.map((entry) => entry.name)])];
     const isMounted = (path: string) => isOnMountedVolume(path, mountedVolumes);
     orphanedDevices = withAndroidAvdSizes(
-      findOrphanedDevices({ sims, avds, config: cfg, isMounted, deadProjects }).orphaned,
+      findOrphanedDevices({ sims, avds, config: cfg, isMounted, deadProjects }).orphaned.flatMap((device) => {
+        const directories =
+          device.kind === 'android' ? orphanedAvdDirectories.filter((entry) => entry.name === device.name) : [];
+        return directories.length
+          ? directories.map((orphanedDirectory) => Object.assign({}, device, { orphanedDirectory }))
+          : [device];
+      }),
       {
         avdDirectory: deps.avdDirectory ?? ownedAvdDirectory,
         size: deps.directorySize ?? directorySize,

--- a/packages/stim-cli/src/commands/gc/devices.ts
+++ b/packages/stim-cli/src/commands/gc/devices.ts
@@ -6,7 +6,7 @@ import { plural } from '../../command-output.ts';
 import { directorySize } from '../../fs-util.ts';
 import { leaseIsExpired, listLeaseFiles, type LeaseFileEntry } from '../../engine/device-lease.ts';
 import { listAllIosSims, listIosDeviceTypes, parseRuntimeVersion, type IosSimRecord } from '../../sim/ios.ts';
-import { listAvds, ownedAvdDirectory } from '../../sim/android.ts';
+import { listAvds, ownedAvdDirectory, type OrphanedAvdDirectory } from '../../sim/android.ts';
 import { dropParked, readParked, type ParkedSim } from '../../sim-pool.ts';
 import { teardownOwnedIosSim, teardownOwnedAvd, teardownParkedIosSim, teardownParkedAvd } from '../../teardown.ts';
 import type { Config, OrphanedDevice } from '../../types.ts';
@@ -236,7 +236,9 @@ export function describeUnverifiableDevices(
   ];
 }
 
-export function withAndroidAvdSizes<T extends { kind: 'ios' | 'android'; id: string; bytes?: number }>(
+export function withAndroidAvdSizes<
+  T extends { kind: 'ios' | 'android'; id: string; bytes?: number; orphanedDirectory?: OrphanedAvdDirectory },
+>(
   devices: T[],
   {
     avdDirectory = ownedAvdDirectory,
@@ -245,7 +247,7 @@ export function withAndroidAvdSizes<T extends { kind: 'ios' | 'android'; id: str
 ): T[] {
   return devices.map((device) => {
     if (device.kind !== 'android') return device;
-    const dir = avdDirectory(device.id);
+    const dir = device.orphanedDirectory?.directory ?? avdDirectory(device.id);
     if (!dir) return device;
     try {
       const bytes = size(dir, { timeoutMs: AVD_SIZE_TIMEOUT_MS });
@@ -427,7 +429,11 @@ export function deleteProjectDevices(
     const r =
       d.kind === 'ios'
         ? teardownOwnedIosSim(d.id, { del: true, label: d.name })
-        : teardownOwnedAvd(d.name, { del: true });
+        : teardownOwnedAvd(d.name, {
+            del: true,
+            ...('project' in d ? { owner: { projectPath: d.project } } : {}),
+            ...('orphanedDirectory' in d ? { orphanedDirectory: d.orphanedDirectory } : {}),
+          });
     const what = d.kind === 'ios' ? `ios sim ${d.name} (${d.id})` : `android avd ${d.name}`;
     if (r.status === 'torn-down') {
       console.log(chalk.green(`Deleted ${what}`));

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -541,7 +541,7 @@ async function ensureOwnedAndroidDevice({
   const avdConfig = androidAvdConfigSetting(settings, settingsRoot);
   const configuration = avdPoolConfiguration(androidDataPartitionSizeGbSetting(settings), avdConfig);
   if (record?.setupIncomplete && record.avdName) {
-    const cleanup = teardownAvd(record.avdName, { del: true });
+    const cleanup = teardownAvd(record.avdName, { del: true, owner: { projectPath } });
     if (cleanup.status === 'failed' || cleanup.status === 'skipped') {
       throw new Error(
         `Owned AVD ${record.avdName} has incomplete setup and could not be deleted (${cleanup.reason || cleanup.status}). Fix the cause, then retry; Stim kept the device record for cleanup.`,
@@ -629,7 +629,8 @@ async function ensureOwnedAndroidDevice({
       if (parked.deletionClaim !== undefined) continue;
       const resolved = resolveOwnedAvdSerial(parked.name);
       if (resolved.missing) {
-        dropParked('android', parked.udid);
+        const result = teardownParkedAvd(parked.name);
+        if (result.status === 'failed') out(phaseLine('device', `kept ${parked.name}: ${result.reason}`));
         continue;
       }
       if (resolved.notOwned || resolved.serial) continue;
@@ -732,7 +733,7 @@ async function ensureOwnedAndroidDevice({
         avdConfig,
       });
     } catch (error) {
-      const cleanup = teardownAvd(created.avdName, { del: true });
+      const cleanup = teardownAvd(created.avdName, { del: true, owner: { projectPath } });
       const kept = cleanup.status === 'failed' || cleanup.status === 'skipped';
       if (!kept) clearDevice(projectPath, 'android');
       const orphan = kept

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -58,6 +58,18 @@ If a delete fails, the device's config record is KEPT and the command reports
 it. A record is what makes the device findable again, so it outlives a failed
 teardown rather than turning it into an orphan.
 
+ANDROID DATA WITHOUT A REGISTRATION
+  \`gc\` also reports stim-*.avd directories whose .ini registration is
+  gone. \`gc --delete\` rechecks the directory, emulator process locks, and
+  current workspace and pool references before removing that data. A registration
+  under any name that points at the directory protects it. User AVDs, symlinks
+  and unverifiable storage stay. The no-config and scoped-STIM_HOME
+  sweep guards apply to these directories too.
+  A partial avdmanager deletion is a failure even if the tool exits successfully.
+  The owning workspace or pool record stays for a retry. If removing orphan
+  data fails, its remaining directory is reported as stim-gc-<id>.avd on the
+  next sweep.
+
 BUILD LOCKS
   \`gc\` also reports the single-flight build locks (above): the ones whose
   builder is no longer running are debris a reboot or a kill left behind, and

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -239,6 +239,7 @@ function reclaimOwnedDevices(
     const bound = parkedMaxSetting('android');
     const r = teardownOwnedAvd(android.avdName, {
       del: true,
+      owner: { projectPath },
       ...(park && !bound.error && bound.max > 0
         ? {
             park: {

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -506,13 +506,17 @@ function avdIniPaths(root: string, ini: string): string[] {
   ].filter((candidate): candidate is string => candidate !== null);
 }
 
-export function avdStorageRoots(env: NodeJS.ProcessEnv = process.env, home: string = homedir()): string[] {
+export function avdStorageRoots(): string[] {
+  const env = process.env;
   return [
     ...new Set(
       [
         env.ANDROID_AVD_HOME,
+        env.ANDROID_EMULATOR_HOME ? join(env.ANDROID_EMULATOR_HOME, 'avd') : null,
+        env.ANDROID_USER_HOME ? join(env.ANDROID_USER_HOME, 'avd') : null,
+        env.ANDROID_SDK_HOME ? join(env.ANDROID_SDK_HOME, '.android', 'avd') : null,
         env.ANDROID_SDK_HOME ? join(env.ANDROID_SDK_HOME, 'avd') : null,
-        join(home, '.android', 'avd'),
+        join(homedir(), '.android', 'avd'),
       ].filter((value): value is string => Boolean(value)),
     ),
   ];
@@ -543,11 +547,12 @@ export function listOrphanedAvdDirectories(avdName?: string): OrphanedAvdDirecto
     names: readdirSync(root),
   }));
   const registered = new Set<string>();
-  for (const { root, names } of stores) {
+  for (const { root, canonicalRoot, names } of stores) {
     for (const name of names.filter((entry) => entry.endsWith('.ini'))) {
       const path = join(root, name);
-      const targets = avdIniPaths(root, readFileSync(path, 'utf8'));
-      if (!targets.length) throw new Error(`Cannot verify AVD registration at ${path}; its data was kept.`);
+      const ini = readFileSync(path, 'utf8');
+      const targets = new Set([...avdIniPaths(root, ini), ...avdIniPaths(canonicalRoot, ini)]);
+      if (!targets.size) throw new Error(`Cannot verify AVD registration at ${path}; its data was kept.`);
       for (const target of targets) {
         try {
           registered.add(realpathSync(target));
@@ -596,7 +601,12 @@ export function ownedAvdDirectory(
   } = {},
 ): string | null {
   if (!/^stim-[A-Za-z0-9._-]+$/.test(avdName)) return null;
-  for (const root of avdStorageRoots(env, home)) {
+  const roots = [
+    env.ANDROID_AVD_HOME,
+    env.ANDROID_SDK_HOME ? join(env.ANDROID_SDK_HOME, 'avd') : null,
+    join(home, '.android', 'avd'),
+  ];
+  for (const root of new Set(roots.filter((value): value is string => Boolean(value)))) {
     let ini: string;
     try {
       ini = readFile(join(root, `${avdName}.ini`));

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -497,6 +498,87 @@ export function parseAvdRootIni(contents: string): { path: string | null; relati
   return { path, relativePath };
 }
 
+function avdIniPaths(root: string, ini: string): string[] {
+  const parsed = parseAvdRootIni(ini);
+  return [
+    parsed.relativePath && !isAbsolute(parsed.relativePath) ? resolve(dirname(root), parsed.relativePath) : null,
+    parsed.path && isAbsolute(parsed.path) ? parsed.path : null,
+  ].filter((candidate): candidate is string => candidate !== null);
+}
+
+export function avdStorageRoots(env: NodeJS.ProcessEnv = process.env, home: string = homedir()): string[] {
+  return [
+    ...new Set(
+      [
+        env.ANDROID_AVD_HOME,
+        env.ANDROID_SDK_HOME ? join(env.ANDROID_SDK_HOME, 'avd') : null,
+        join(home, '.android', 'avd'),
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  ];
+}
+
+export interface OrphanedAvdDirectory {
+  name: string;
+  directory: string;
+  dev: number;
+  ino: number;
+}
+
+export function avdPathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+export function listOrphanedAvdDirectories(avdName?: string): OrphanedAvdDirectory[] {
+  const roots = avdStorageRoots();
+  const stores = roots.filter(avdPathExists).map((root) => ({
+    root,
+    canonicalRoot: realpathSync(root),
+    names: readdirSync(root),
+  }));
+  const registered = new Set<string>();
+  for (const { root, names } of stores) {
+    for (const name of names.filter((entry) => entry.endsWith('.ini'))) {
+      const path = join(root, name);
+      const targets = avdIniPaths(root, readFileSync(path, 'utf8'));
+      if (!targets.length) throw new Error(`Cannot verify AVD registration at ${path}; its data was kept.`);
+      for (const target of targets) {
+        try {
+          registered.add(realpathSync(target));
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error;
+        }
+      }
+    }
+  }
+  const orphaned: OrphanedAvdDirectory[] = [];
+  for (const { canonicalRoot, names: entries } of stores) {
+    const names = avdName ? [`${avdName}.avd`] : entries;
+    for (const entry of names) {
+      if (!/^stim-[A-Za-z0-9._-]+\.avd$/.test(entry)) continue;
+      const name = entry.slice(0, -4);
+      if (roots.some((candidate) => avdPathExists(join(candidate, `${name}.ini`)))) continue;
+      const directory = join(canonicalRoot, entry);
+      if (registered.has(directory) || !avdPathExists(directory)) continue;
+      const stat = lstatSync(directory);
+      if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(directory) !== directory) {
+        throw new Error(`Cannot verify AVD data at ${directory}; it was kept.`);
+      }
+      if (!orphaned.some((candidate) => candidate.directory === directory)) {
+        orphaned.push({ name, directory, dev: stat.dev, ino: stat.ino });
+      }
+    }
+  }
+  return orphaned;
+}
+
 export function ownedAvdDirectory(
   avdName: string,
   {
@@ -514,12 +596,7 @@ export function ownedAvdDirectory(
   } = {},
 ): string | null {
   if (!/^stim-[A-Za-z0-9._-]+$/.test(avdName)) return null;
-  const roots = [
-    env.ANDROID_AVD_HOME,
-    env.ANDROID_SDK_HOME ? join(env.ANDROID_SDK_HOME, 'avd') : null,
-    join(home, '.android', 'avd'),
-  ];
-  for (const root of new Set(roots.filter((value): value is string => Boolean(value)))) {
+  for (const root of avdStorageRoots(env, home)) {
     let ini: string;
     try {
       ini = readFile(join(root, `${avdName}.ini`));
@@ -528,13 +605,7 @@ export function ownedAvdDirectory(
       if (code === 'ENOENT' || code === 'ENOTDIR') continue;
       return null;
     }
-    const parsed = parseAvdRootIni(ini);
-    const candidates = [
-      parsed.relativePath && !isAbsolute(parsed.relativePath) ? resolve(dirname(root), parsed.relativePath) : null,
-      parsed.path && isAbsolute(parsed.path) ? parsed.path : null,
-    ];
-    for (const candidate of candidates) {
-      if (!candidate) continue;
+    for (const candidate of avdIniPaths(root, ini)) {
       try {
         const canonical = realpath(candidate);
         if (isDirectory(canonical)) return canonical;

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from 'node:crypto';
+import { lstatSync, renameSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { loadConfig, withConfigLock } from './config.ts';
 import {
   clearAppDataContainer,
   deleteParkedIosSim,
@@ -13,6 +17,11 @@ import {
 } from './sim/ios.ts';
 import {
   assertOwnedAvdStopped,
+  avdPathExists,
+  avdStorageRoots,
+  listOrphanedAvdDirectories,
+  ownedAvdDirectory,
+  type OrphanedAvdDirectory,
   resolveOwnedAvdSerial,
   shutdownAndroidEmulator,
   waitForAndroidEmulatorShutdown,
@@ -20,7 +29,7 @@ import {
   ownedAvdMatchesConfiguration,
   ownedAvdSystemImage,
 } from './sim/android.ts';
-import { parkSim, removeParkedAfter, type ParkedSim } from './sim-pool.ts';
+import { parkSim, readParked, removeParkedAfter, type ParkedSim } from './sim-pool.ts';
 
 export interface ParkedDevice {
   udid: string;
@@ -53,7 +62,7 @@ export interface ParkRequest {
 export function teardownParkedAvd(avdName: string): TeardownOutcome {
   try {
     const removed = removeParkedAfter('android', avdName, () => {
-      const result = teardownOwnedAvd(avdName, { del: true });
+      const result = teardownOwnedAvd(avdName, { del: true, owner: { pool: true } });
       if (result.status !== 'torn-down' && result.status !== 'missing') throw new Error(result.reason);
     });
     return removed
@@ -158,17 +167,90 @@ export function teardownOwnedIosSim(
   }
 }
 
+type AvdOwner = { projectPath: string } | { pool: true };
+
+function removeOrphanedAvdDirectory(candidate: OrphanedAvdDirectory, owner?: AvdOwner): void {
+  const detached = withConfigLock(() => {
+    const current = listOrphanedAvdDirectories(candidate.name).find((entry) => entry.directory === candidate.directory);
+    if (!current || current.name !== candidate.name || current.dev !== candidate.dev || current.ino !== candidate.ino) {
+      throw new Error(`AVD data at ${candidate.directory} changed or is registered; it was kept.`);
+    }
+    const config = loadConfig();
+    if (!config) throw new Error('Cannot verify AVD references without a Stim config; the data was kept.');
+    for (const [projectPath, project] of Object.entries(config.projects)) {
+      if (project.platforms?.android?.avdName !== candidate.name) continue;
+      if (
+        !owner ||
+        !('projectPath' in owner) ||
+        owner.projectPath !== projectPath ||
+        !project.platforms.android.owned
+      ) {
+        throw new Error(`AVD ${candidate.name} is referenced by ${projectPath}; its data was kept.`);
+      }
+    }
+    if (
+      readParked('android', { config }).some((entry) => entry.name === candidate.name) &&
+      !(owner && 'pool' in owner)
+    ) {
+      throw new Error(`AVD ${candidate.name} is in the emulator pool; its data was kept.`);
+    }
+    assertOwnedAvdStopped(candidate.name, { resolveDirectory: () => candidate.directory });
+    const destination = join(dirname(candidate.directory), `stim-gc-${randomUUID()}.avd`);
+    renameSync(candidate.directory, destination);
+    return destination;
+  });
+  const current = lstatSync(detached);
+  if (!current.isDirectory() || current.dev !== candidate.dev || current.ino !== candidate.ino) {
+    throw new Error(`Detached AVD data changed at ${detached}; it was kept.`);
+  }
+  try {
+    rmSync(detached, { recursive: true });
+  } catch (error) {
+    throw new Error(`Could not remove AVD data at ${detached}; retry gc --delete: ${(error as Error).message}`, {
+      cause: error,
+    });
+  }
+}
+
+function teardownUnregisteredAvd(
+  avdName: string,
+  del: boolean,
+  owner?: AvdOwner,
+  surveyed?: OrphanedAvdDirectory,
+): TeardownOutcome {
+  const candidates = surveyed ? [surveyed] : listOrphanedAvdDirectories(avdName);
+  if (candidates.length === 0) {
+    if (
+      avdStorageRoots().some(
+        (root) => avdPathExists(join(root, `${avdName}.ini`)) || avdPathExists(join(root, `${avdName}.avd`)),
+      )
+    )
+      throw new Error(`AVD ${avdName} is not listed but its storage remains; it was kept.`);
+    return { status: 'missing' };
+  }
+  if (!del) return { status: 'skipped', reason: 'AVD registration is missing; its data was kept.' };
+  for (const candidate of candidates) {
+    if (candidate.name !== avdName) throw new Error(`AVD data does not match ${avdName}; it was kept.`);
+    removeOrphanedAvdDirectory(candidate, owner);
+  }
+  return { status: 'torn-down', label: avdName };
+}
+
 export function teardownOwnedAvd(
   avdName: string,
   {
     del = false,
     park,
+    owner,
+    orphanedDirectory,
     waitForShutdown = waitForAndroidEmulatorShutdown,
     assertStopped = assertOwnedAvdStopped,
     resolveAvd = resolveOwnedAvdSerial,
   }: {
     del?: boolean;
     park?: ParkRequest;
+    owner?: AvdOwner;
+    orphanedDirectory?: OrphanedAvdDirectory;
     waitForShutdown?: typeof waitForAndroidEmulatorShutdown;
     assertStopped?: typeof assertOwnedAvdStopped;
     resolveAvd?: typeof resolveOwnedAvdSerial;
@@ -176,11 +258,15 @@ export function teardownOwnedAvd(
 ): TeardownOutcome {
   let parkFallback: string | undefined;
   try {
+    if (!/^stim-[A-Za-z0-9._-]+$/.test(avdName)) {
+      return { status: 'skipped', kind: 'not-owned', reason: `AVD ${avdName} is not Stim-owned by name` };
+    }
     const resolved = resolveAvd(avdName);
     if (resolved.notOwned) {
       return { status: 'skipped', kind: 'not-owned', reason: `AVD ${avdName} is not Stim-owned by name` };
     }
-    if (resolved.missing) return { status: 'missing' };
+    if (resolved.missing) return teardownUnregisteredAvd(avdName, del, owner, orphanedDirectory);
+    if (orphanedDirectory) return { status: 'skipped', reason: 'AVD registration appeared; its data was kept.' };
     const serial = resolved.serial;
     if (serial) {
       waitForShutdown(avdName, (timeoutMs) => shutdownAndroidEmulator(serial, timeoutMs));
@@ -192,7 +278,7 @@ export function teardownOwnedAvd(
       if (current.notOwned) {
         return { status: 'skipped', kind: 'not-owned', reason: `AVD ${avdName} is not Stim-owned by name` };
       }
-      if (current.missing) return { status: 'missing' };
+      if (current.missing) return teardownUnregisteredAvd(avdName, del, owner);
       if (current.serial) throw new Error(`Owned AVD ${avdName} started again before deletion.`);
       assertStopped(avdName);
       if (park && park.max > 0) {
@@ -233,7 +319,13 @@ export function teardownOwnedAvd(
           parkFallback = String((error as Error)?.message || error);
         }
       }
+      const directory = ownedAvdDirectory(avdName);
+      const paths = avdStorageRoots().map((root) => join(root, `${avdName}.ini`));
+      if (directory) paths.push(directory);
       deleteAvd(avdName);
+      const remaining = paths.filter(avdPathExists);
+      if (remaining.length)
+        throw new Error(`AVD ${avdName} was only partially deleted; data remains at ${remaining.join(', ')}.`);
     }
     return {
       status: 'torn-down',

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -189,6 +189,7 @@ export interface GcSkip {
 }
 
 export interface OrphanedDevice {
+  orphanedDirectory?: import('./sim/android.ts').OrphanedAvdDirectory;
   kind: 'ios' | 'android';
   id: string;
   name: string;


### PR DESCRIPTION
## Description

An AVD can lose its `.ini` registration while its `.avd` data survives `avdmanager delete`. Stim treated that device as missing, and GC could not find the leftover data.

## Solution

Report unregistered `stim-*.avd` directories with bounded sizing, and reclaim them through centralized teardown. A registration under any name protects its referenced data, including registrations in redirected Android homes and symlinked roots. The emulator's existing operational lookup and the GC scope guards stay unchanged. Teardown verifies the directory identity, emulator process locks, and current workspace/pool references before detaching data under the config lock. Removal runs outside that short lock and cannot remove a new device registered under the original name. A failed removal stays discoverable as `stim-gc-<id>.avd` for the next sweep.

Check that SDK deletion actually removed both registration and data. A partial deletion keeps the workspace or pool record, and its authorized teardown can finish the cleanup on retry. Stop never removes data. Pool adoption also reconciles missing registrations through teardown instead of dropping their records directly.

## Test plan

- Using Android command-line tools 19.0 with disposable AVD roots: normal deletion removed both files; a permission-blocked deletion exited successfully with `deleted with errors`, removed the `.ini`, and left data. Stim reported failure and retained the workspace record; restoring fixture permissions made the retry succeed.
- GC sized and reclaimed a real AVD after its `.ini` registration was removed. Alias registrations in default, redirected and symlinked roots protected their real AVD data; explicit `ANDROID_AVD_HOME` verified roots the installed emulator does not select. No emulator was booted.
- Regressions cover live/unverifiable process locks, replaced symlinks, alias-named registrations and new workspace/pool references, a new device at the original name after detachment, GC scope guards, bounded sizing failure, and continued cleanup/retry after a real directory permission failure.

Fixes #720
