### PR TITLE
fix: remove scoped GC test bypass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,9 @@ can continue. `stop` shuts down devices; it never deletes them.
 
 Set `STIM_HOME` to a temporary directory in every test that reads or writes
 global state. Delete the directory and environment variable after each test.
+This redirects Stim state, not machine-global simulators or emulators. Never
+bypass the scoped GC guard for real-tool validation. Clean up only exact devices
+created by that validation, using centralized teardown and retained fixture records.
 
 ### 6. Compare canonical paths
 

--- a/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
+++ b/packages/stim-cli/src/__tests__/android-orphan-gc.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { collectGcReport, runGc } from '../commands/gc.ts';
+import * as gcDevices from '../commands/gc/devices.ts';
 import { ensureConfig, getProject, upsertProject } from '../config.ts';
 import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
 import { listOrphanedAvdDirectories } from '../sim/android.ts';
@@ -131,7 +132,8 @@ test('GC reports and sizes unreferenced owned data even when the emulator listin
   const retained = orphan('stim-retained');
   upsertProject(home, { platforms: { android: { avdName: 'stim-retained', owned: true } } });
 
-  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  const report = await collectGcReport({}, deps);
 
   expect(report.orphanedDevices).toEqual([
     expect.objectContaining({
@@ -151,7 +153,8 @@ test('orphan sizing uses the bounded size path and tolerates its failure', async
   const size = vi.fn<typeof import('../fs-util.ts').directorySize>(() => {
     throw new Error('unreadable');
   });
-  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, { ...deps, directorySize: size });
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  const report = await collectGcReport({}, { ...deps, directorySize: size });
   expect(size).toHaveBeenCalledWith(join(avdRoot, 'stim-orphan.avd'), { timeoutMs: 5000 });
   expect(report.orphanedDevices).toEqual([expect.objectContaining({ name: 'stim-orphan' })]);
   expect(report.orphanedDevices[0]!.bytes).toBeUndefined();
@@ -160,7 +163,7 @@ test('orphan sizing uses the bounded size path and tolerates its failure', async
 test.each(['scoped', 'no-config'])('orphan discovery preserves the %s GC sweep guard', async (guard) => {
   const directory = orphan();
   if (guard === 'no-config') rmSync(join(process.env.STIM_HOME!, 'config.json'));
-  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: guard === 'no-config' }, deps);
+  const report = await collectGcReport({}, deps);
   expect(report.orphanedDevices).toEqual([]);
   expect(existsSync(directory)).toBe(true);
 });
@@ -279,14 +282,15 @@ test.skipIf(process.getuid?.() === 0)(
     chmodSync(join(blocked, 'blocked'), 0);
     const removable = orphan('stim-z-removable');
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+    vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+    await runGc({ delete: true }, deps);
     expect(existsSync(removable)).toBe(false);
     const leftovers = listOrphanedAvdDirectories();
     expect(leftovers).toHaveLength(1);
     expect(leftovers[0]!.name).toMatch(/^stim-gc-/);
     expect(log.mock.calls.flat().join('\n')).toContain('Failed to delete android device stim-a-blocked');
     chmodSync(join(leftovers[0]!.directory, 'blocked'), 0o700);
-    await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+    await runGc({ delete: true }, deps);
     expect(listOrphanedAvdDirectories()).toEqual([]);
   },
 );
@@ -296,7 +300,8 @@ test('an unreadable or symlinked orphan prevents stale device records from being
   mkdirSync(outside);
   symlinkSync(outside, join(avdRoot, 'stim-linked.avd'));
   upsertProject(home, { platforms: { android: { avdName: 'stim-linked', owned: true } } });
-  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  const report = await collectGcReport({}, deps);
   expect(report.staleDeviceRecords).toEqual([]);
   expect(report.deviceSweepNotices.join('\n')).toContain('Cannot verify AVD data');
 });
@@ -305,7 +310,8 @@ test('GC reclaims orphan data after pruning its dead workspace reference', async
   const directory = orphan();
   upsertProject(join(home, 'gone'), { platforms: { android: { avdName: 'stim-orphan', owned: true } } });
   const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-  await runGc({ delete: true, unsafeAllowScopedDeviceSweep: true }, deps);
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  await runGc({ delete: true }, deps);
   expect(existsSync(directory)).toBe(false);
   expect(log.mock.calls.flat().join('\n')).not.toContain('Failed to delete');
 });
@@ -324,7 +330,8 @@ test.each(['absolute', 'relative', 'symlink'])(
     }
     writeFileSync(join(avdRoot, 'Personal_Phone.ini'), registration);
     listed.push('Personal_Phone');
-    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+    const report = await collectGcReport({}, deps);
     expect(report.orphanedDevices).toEqual([]);
     expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
     expect(readFileSync(join(directory, 'userdata.img')).length).toBe(8192);
@@ -337,7 +344,8 @@ describe.skipIf(process.getuid?.() === 0)('unverifiable registrations', () => {
     const registration = join(avdRoot, 'Personal_Phone.ini');
     writeFileSync(registration, failure === 'malformed' ? 'avd.ini.encoding=UTF-8\n' : `path=${directory}\n`);
     if (failure === 'unreadable') chmodSync(registration, 0);
-    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+    const report = await collectGcReport({}, deps);
     expect(report.orphanedDevices).toEqual([]);
     expect(report.deviceSweepNotices.join('\n')).toContain('android data sweep skipped');
     expect(teardownOwnedAvd('stim-orphan', { del: true }).status).toBe('failed');
@@ -358,7 +366,8 @@ test.each(['ANDROID_USER_HOME', 'ANDROID_EMULATOR_HOME', 'ANDROID_SDK_HOME'])(
     mkdirSync(root, { recursive: true });
     writeFileSync(join(root, 'Personal_Phone.ini'), `path=${directory}\n`);
     listed.push('Personal_Phone');
-    const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+    vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+    const report = await collectGcReport({}, deps);
     expect(report.orphanedDevices).toEqual([]);
     expect(teardownOwnedAvd('stim-orphan', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
     expect(existsSync(join(directory, 'userdata.img'))).toBe(true);
@@ -377,7 +386,8 @@ test('a relative alias registration in a symlinked root protects its data when t
     `path=${join(home, 'missing.avd')}\npath.rel=avd/stim-retained.avd\n`,
   );
   listed.push('Personal_Phone');
-  const report = await collectGcReport({ unsafeAllowScopedDeviceSweep: true }, deps);
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  const report = await collectGcReport({}, deps);
   expect(report.orphanedDevices).toEqual([]);
   expect(teardownOwnedAvd('stim-retained', { del: true, orphanedDirectory: candidate }).status).toBe('failed');
   expect(existsSync(join(directory, 'userdata.img'))).toBe(true);

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -38,6 +38,7 @@ import gcCommand, {
   selectCaches,
 } from '../commands/gc.ts';
 import { adoptParked, parkSim, readParked } from '../sim-pool.ts';
+import * as gcDevices from '../commands/gc/devices.ts';
 import {
   makeConfig,
   makeIosSim,
@@ -234,7 +235,7 @@ test('parked deletion keeps ownership records when simulator listing was unavail
   };
   parkSim({ platform: 'ios', projectPath: '/tmp/source', record, max: 3 });
   const report = await collectGcReport(
-    { unsafeAllowScopedDeviceSweep: true },
+    {},
     {
       listAllIosSims: () => {
         throw new Error('simctl unavailable');
@@ -367,6 +368,7 @@ test('a simulator in the parked pool is referenced rather than orphaned', () => 
 });
 
 test('gc sizes only listed owned Android AVDs after ownership classification', async () => {
+  vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
   const now = Date.now();
   const project = join(tmpHome, 'stale-project');
   mkdirSync(project, { recursive: true });
@@ -397,7 +399,6 @@ test('gc sizes only listed owned Android AVDs after ownership classification', a
       olderThan: 30,
       now,
       lastTouched: () => now - 90 * DAY_MS,
-      unsafeAllowScopedDeviceSweep: true,
     },
     {
       avdDirectory: (name) => `/avds/${name}.avd`,
@@ -710,7 +711,12 @@ async function cli(args: string[] = []) {
 }
 
 async function sweepingGc(opts = {}) {
-  await runGc({ unsafeAllowScopedDeviceSweep: true, ...opts });
+  const scope = vi.spyOn(gcDevices, 'deviceSweepIsScoped').mockReturnValue(false);
+  try {
+    await runGc(opts);
+  } finally {
+    scope.mockRestore();
+  }
 }
 
 function captureLog(fn: () => unknown) {
@@ -866,6 +872,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const [key, value] of Object.entries(originalAvdRoots)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -2064,11 +2071,19 @@ function installDeviceExecutor({
       }
       return '';
     },
+    runFile(file, args: string[] = []) {
+      const cmd = [file, ...args].join(' ');
+      execCalls.push(cmd);
+      if (cmd.includes('simctl list devices --json')) return iosListJson(devices);
+      if (cmd.startsWith('xcrun simctl delete ')) return '';
+      throw new Error(`unexpected runFile: ${cmd}`);
+    },
     runFileQuiet(file: string, args: string[] = []) {
       execCalls.push([file, ...args].join(' '));
       return '';
     },
-    spawn(cmd) {
+    spawn(cmd, args: readonly string[] = []) {
+      execCalls.push([cmd, ...args].join(' '));
       throw new Error(`unexpected spawn: ${cmd}`);
     },
   });
@@ -2154,7 +2169,7 @@ test('gc with no config names Stim devices it cannot verify, but never touches t
     execCalls,
   });
 
-  const output = await captureLog(() => sweepingGc({ delete: true }));
+  const output = await captureLog(() => runGc({ delete: true }));
 
   expect(output).toMatch(/stim-someones-live-env/);
   expect(output).toMatch(/no Stim config found/i);
@@ -2164,31 +2179,36 @@ test('gc with no config names Stim devices it cannot verify, but never touches t
   expect(execCalls.some((c) => c.startsWith('xcrun simctl delete'))).toBe(false);
 });
 
-test('a config scoped by STIM_HOME never sweeps machine-global devices', async () => {
-  const execCalls: string[] = [];
-  installDeviceExecutor({
-    devices: [
-      { udid: 'UDID-REAL-1', name: 'stim-real-env-1', state: 'Booted' },
-      { udid: 'UDID-REAL-2', name: 'stim-real-env-2' },
-    ],
-    execCalls,
-  });
-  const livePath = join(fakeHome, 'some-project');
-  mkdirSync(livePath, { recursive: true });
-  saveConfig({
-    version: 2,
-    projects: { [livePath]: { metroPort: 8100, platforms: { ios: { deviceUdid: 'UDID-ELSEWHERE', owned: true } } } },
-    repos: {},
-  });
+test.each(['CLI', 'obsolete internal option'])(
+  'a config scoped by STIM_HOME never sweeps machine-global devices through the %s',
+  async (entry) => {
+    const execCalls: string[] = [];
+    installDeviceExecutor({
+      devices: [
+        { udid: 'UDID-REAL-1', name: 'stim-real-env-1', state: 'Booted' },
+        { udid: 'UDID-REAL-2', name: 'stim-real-env-2' },
+      ],
+      execCalls,
+    });
+    const livePath = join(fakeHome, 'some-project');
+    mkdirSync(livePath, { recursive: true });
+    saveConfig({
+      version: 2,
+      projects: { [livePath]: { metroPort: 8100, platforms: { ios: { deviceUdid: 'UDID-ELSEWHERE', owned: true } } } },
+      repos: {},
+    });
 
-  const output = await captureLog(() => cli(['--delete']));
+    const configBefore = currentConfig();
+    const obsoleteOptions = { delete: true, unsafeAllowScopedDeviceSweep: true };
+    const output = await captureLog(() => (entry === 'CLI' ? cli(['--delete']) : runGc(obsoleteOptions)));
 
-  expect(output).not.toMatch(/Orphaned devices/i);
-  expect(output).toMatch(/STIM_HOME/);
-  expect(output).toMatch(/stim-real-env-1/);
-  expect(execCalls.some((c) => c.startsWith('xcrun simctl shutdown'))).toBe(false);
-  expect(execCalls.some((c) => c.startsWith('xcrun simctl delete'))).toBe(false);
-});
+    expect(output).not.toMatch(/Orphaned devices/i);
+    expect(output).toMatch(/STIM_HOME/);
+    expect(output).toMatch(/stim-real-env-1/);
+    expect(execCalls.filter((cmd) => cmd.includes('UDID-REAL-'))).toEqual([]);
+    expect(currentConfig()).toEqual(configBefore);
+  },
+);
 
 test('the STIM_HOME guard does not disable dead-entry pruning', async () => {
   const localDeadPath = join(fakeHome, 'no-longer-here');

--- a/packages/stim-cli/src/commands/gc.ts
+++ b/packages/stim-cli/src/commands/gc.ts
@@ -63,14 +63,12 @@ interface CollectGcReportOptions {
   cache?: string | null;
   now?: number;
   lastTouched?: (path: string) => number;
-  unsafeAllowScopedDeviceSweep?: boolean;
 }
 
 interface RunGcOptions {
   olderThan?: number;
   cache?: string;
   delete?: boolean;
-  unsafeAllowScopedDeviceSweep?: boolean;
 }
 
 interface GcDependencies extends EasGcDependencies, GcDeviceDependencies {
@@ -93,13 +91,7 @@ function projectLastTouched(path: string): number {
 }
 
 export async function collectGcReport(
-  {
-    olderThan = null,
-    cache = null,
-    now = Date.now(),
-    lastTouched = projectLastTouched,
-    unsafeAllowScopedDeviceSweep = false,
-  }: CollectGcReportOptions = {},
+  { olderThan = null, cache = null, now = Date.now(), lastTouched = projectLastTouched }: CollectGcReportOptions = {},
   deps: GcDependencies = {},
 ): Promise<GcReport> {
   const scope = typeof cache === 'string' && cache.trim() ? cache : null;
@@ -181,7 +173,7 @@ export async function collectGcReport(
   const unsweepableReason =
     cfg === null
       ? 'no Stim config found'
-      : deviceSweepIsScoped(unsafeAllowScopedDeviceSweep)
+      : deviceSweepIsScoped()
         ? 'STIM_HOME scopes this config, but simulators and AVDs are machine-global'
         : null;
 
@@ -390,7 +382,6 @@ async function runGcCore(opts: RunGcOptions, deps: GcDependencies): Promise<void
     {
       olderThan,
       cache,
-      unsafeAllowScopedDeviceSweep: opts.unsafeAllowScopedDeviceSweep,
     },
     deps,
   );

--- a/packages/stim-cli/src/commands/gc/devices.ts
+++ b/packages/stim-cli/src/commands/gc/devices.ts
@@ -387,8 +387,8 @@ export function deleteParkedSims(parkedSims: readonly ParkedSimReport[], deps: G
   return failures;
 }
 
-export function deviceSweepIsScoped(unsafeAllowScopedDeviceSweep?: boolean): boolean {
-  return Boolean(process.env.STIM_HOME) && !unsafeAllowScopedDeviceSweep;
+export function deviceSweepIsScoped(): boolean {
+  return Boolean(process.env.STIM_HOME);
 }
 
 export function collectDeviceLeases(now: number): DeviceLeaseGarbage {


### PR DESCRIPTION
## Description

The internal `unsafeAllowScopedDeviceSweep` option let callers disable GC's protection for a scoped `STIM_HOME`, even though the CLI never exposed it. A scoped registry cannot establish which machine-global devices are orphaned.

## Solution

Remove the production override and keep mocked inventory tests' scope decisions in local, restored spies. Existing JavaScript callers passing the obsolete option now retain the guard. Add validation guidance requiring exact fixture cleanup without bypassing scoped GC.

## Test plan

Extend the scoped-GC regression across the CLI and an internal call carrying the obsolete option. With booted and stopped fake shared simulators, both paths report the scope restriction, issue no commands targeting those devices across executor methods, and preserve registry records. The obsolete-option case failed before the fix and passes afterward.

Fixes #738
