### PR TITLE
fix: guide orphaned AVD cleanup and reuse running emulators

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5,6 +5,7 @@ import { resetExecutor, setExecutor } from '../exec.ts';
 import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
 import { ClaimRefusedError, ClaimUnavailableError, claimRemoveCommand } from '../ownership-claim.ts';
+import { AvdRecoveryError } from '../engine/device.ts';
 import { once } from 'node:events';
 import { type ChildProcess, spawn } from 'node:child_process';
 import {
@@ -1694,6 +1695,45 @@ describe('the other refusals', () => {
     expect(result.error.message).toMatch(/ENOSPC/);
     expect(result.error.remedy).toMatch(/~\/.android\/avd/);
     expect(result.error.remedy).not.toMatch(/JAVA_HOME|ANDROID_HOME|sdkmanager/);
+  });
+
+  test('an unregistered AVD collision reports GC recovery even when an earlier boot left a fatal log', async () => {
+    writeEmulatorLog([DISK_FATAL]);
+    const h = harness({
+      ensureDevice: async () => {
+        throw new AvdRecoveryError(
+          'AVD stim-app already exists on disk but is not listed by the emulator.',
+          'Run `npx stim gc` to inspect orphaned owned AVDs, then `npx stim gc --delete` to reclaim those safe to delete.',
+        );
+      },
+      build: never('the build'),
+    });
+    const result = await h.run();
+    assert(result.error);
+    expect(result.error.code).toBe(NO_DEVICE);
+    expect(result.error.message).toMatch(/AVD stim-app.*not listed/);
+    expect(result.error.message).not.toContain(DISK_FATAL);
+    expect(result.error.remedy).toContain('npx stim gc');
+    expect(result.error.remedy).toContain('npx stim gc --delete');
+    expect(result.error.remedy).not.toMatch(/JAVA_HOME|ANDROID_HOME|sdkmanager|rm -rf/);
+  });
+
+  test('a pre-boot recovery refusal keeps its current diagnostic over an earlier fatal boot log', async () => {
+    writeEmulatorLog([DISK_FATAL]);
+    const message = 'Could not recover owned AVD stim-app: still has a live emulator process (1234).';
+    const remedy = 'Inspect `npx stim status` and `adb devices`, then retry when the other run finishes.';
+    const h = harness({
+      ensureDevice: async () => {
+        throw new AvdRecoveryError(message, remedy);
+      },
+      build: never('the build'),
+    });
+    const result = await h.run();
+    assert(result.error);
+    expect(result.error.code).toBe(NO_DEVICE);
+    expect(result.error.message).toContain(message);
+    expect(result.error.message).not.toContain(DISK_FATAL);
+    expect(result.error.remedy).toBe(remedy);
   });
 
   test('the generic remedy stands when emulator.log has no severity markers', async () => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -9,6 +9,7 @@ import {
   deviceTypeMismatch,
   ensureBooted,
   ensureOwnedDevice,
+  AvdRecoveryError,
   unknownAndroidSystemImageRefusal,
   unknownIosDeviceTypeRefusal,
   unknownIosRuntimeRefusal,
@@ -1238,6 +1239,7 @@ describe('ensureOwnedDevice: android', () => {
     beforeCreateAvdError = () => {},
     bootCompletes = true,
     runningAvdName = '',
+    adbDevices = 'List of devices attached\n',
     onSpawn = () => {},
   }: {
     avds?: string[];
@@ -1246,6 +1248,7 @@ describe('ensureOwnedDevice: android', () => {
     beforeCreateAvdError?: () => void;
     bootCompletes?: boolean;
     runningAvdName?: string;
+    adbDevices?: string | Error;
     onSpawn?: () => void;
   } = {}) {
     const run: string[] = [];
@@ -1282,7 +1285,10 @@ describe('ensureOwnedDevice: android', () => {
             rmSync(join(process.env.ANDROID_AVD_HOME!, `${name}.avd`), { recursive: true, force: true });
             return '';
           }
-          if (cmd === 'adb devices') return 'List of devices attached\n';
+          if (cmd === 'adb devices') {
+            if (adbDevices instanceof Error) throw adbDevices;
+            return adbDevices;
+          }
           if (/emu avd name/.test(cmd)) return runningAvdName;
           if (/getprop sys\.boot_completed/.test(cmd)) return bootCompletes ? '1' : '';
           if (/getprop /.test(cmd)) return '';
@@ -1478,7 +1484,7 @@ describe('ensureOwnedDevice: android', () => {
     writeFileSync(join(avdRoot, 'stim-app.ini'), `path=${content}\n`);
     writeFileSync(join(content, 'config.ini'), 'disk.dataPartition.size=10G\n');
     try {
-      const { exec } = androidExecutor({
+      const { exec, spawn } = androidExecutor({
         avds: ['stim-app'],
         createAvdError: 'Error: AVD stim-app already exists.',
       });
@@ -1493,6 +1499,99 @@ describe('ensureOwnedDevice: android', () => {
           throw new Error('must not configure a recovered AVD');
         },
       });
+      expect(readFileSync(join(content, 'config.ini'), 'utf8')).toBe('disk.dataPartition.size=10G\n');
+      expect(spawn).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each(['device', 'offline'])('recovery reuses a %s emulator whose AVD identity is verified', async (state) => {
+    const root = projectDir();
+    try {
+      const { exec, spawn } = androidExecutor({
+        avds: ['stim-app'],
+        createAvdError: 'Error: AVD stim-app already exists.',
+        adbDevices: `List of devices attached\nemulator-5584\t${state}\n`,
+        runningAvdName: 'stim-app',
+      });
+      setExecutor(exec);
+      const result = await ensureOwnedDevice({
+        platform: 'android',
+        project: getProject(root),
+        projectPath: root,
+        label: 'app',
+        settings: {},
+      });
+      expect(result).toMatchObject({ avdName: 'stim-app', serial: 'emulator-5584', consolePort: 5584, owned: true });
+      expect(getProject(root)?.platforms?.android).toMatchObject({ avdName: 'stim-app', consolePort: 5584 });
+      expect(spawn).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ['unresolved offline identity', 'List of devices attached\nemulator-5584\toffline\n', /live emulator process/],
+    ['failed ADB query', new Error('cannot connect to daemon'), /cannot connect to daemon/],
+  ])('recovery refuses a live AVD after %s', async (_label, adbDevices, failure) => {
+    const root = projectDir();
+    const content = join(process.env.ANDROID_AVD_HOME!, 'stim-app.avd');
+    mkdirSync(content, { recursive: true });
+    writeFileSync(join(process.env.ANDROID_AVD_HOME!, 'stim-app.ini'), `path=${content}\n`);
+    writeFileSync(join(content, 'hardware-qemu.ini.lock'), String(process.pid));
+    try {
+      const { exec, spawn } = androidExecutor({
+        avds: ['stim-app'],
+        createAvdError: 'Error: AVD stim-app already exists.',
+        adbDevices,
+      });
+      setExecutor(exec);
+      await expect(
+        ensureOwnedDevice({
+          platform: 'android',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+        }),
+      ).rejects.toMatchObject({
+        constructor: AvdRecoveryError,
+        message: expect.stringMatching(failure),
+        remedy: expect.stringContaining('npx stim status'),
+      });
+      expect(getProject(root)?.platforms?.android).toBeUndefined();
+      expect(spawn).toEqual([]);
+      expect(existsSync(content)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('an unregistered AVD directory refuses creation with a GC remedy and keeps its data', async () => {
+    const root = projectDir();
+    const content = join(process.env.ANDROID_AVD_HOME!, 'stim-app.avd');
+    mkdirSync(content, { recursive: true });
+    writeFileSync(join(content, 'config.ini'), 'disk.dataPartition.size=10G\n');
+    try {
+      const { exec, spawn, run } = androidExecutor({ createAvdError: `Error: ${content} already exists!` });
+      setExecutor(exec);
+      await expect(
+        ensureOwnedDevice({
+          platform: 'android',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+        }),
+      ).rejects.toMatchObject({
+        constructor: AvdRecoveryError,
+        message: expect.stringContaining(`AVD stim-app already exists on disk but is not listed`),
+        remedy: expect.stringContaining('npx stim gc --delete'),
+      });
+      expect(getProject(root)?.platforms?.android).toBeUndefined();
+      expect(spawn).toEqual([]);
+      expect(run.some((cmd) => cmd.includes('delete avd'))).toBe(false);
       expect(readFileSync(join(content, 'config.ini'), 'utf8')).toBe('disk.dataPartition.size=10G\n');
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -118,7 +118,13 @@ import {
   probeEmulatorSerial,
   resolvePhysicalDevice,
 } from '../sim/android.ts';
-import { checkDeviceCapacity, ensureBooted, ensureOwnedDevice, type OwnedDeviceRecord } from '../engine/device.ts';
+import {
+  checkDeviceCapacity,
+  ensureBooted,
+  ensureOwnedDevice,
+  AvdRecoveryError,
+  type OwnedDeviceRecord,
+} from '../engine/device.ts';
 import {
   ensureRemoteBootOwned,
   ensureMetroReachable as ensureRemoteMetroReachable,
@@ -1024,8 +1030,11 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       const diag = noDeviceDiagnostic({
         reason: `Could not ensure an owned Android emulator: ${(err as Error)?.message || err}`,
         logFile: emuLog,
+        localEmulator: !(err instanceof AvdRecoveryError),
         remedy:
-          'Check that JAVA_HOME and ANDROID_HOME are set correctly, and that an arm64 system image is installed (`sdkmanager "system-images;android-36;google_apis;arm64-v8a"`).',
+          err instanceof AvdRecoveryError
+            ? err.remedy
+            : 'Check that JAVA_HOME and ANDROID_HOME are set correctly, and that an arm64 system image is installed (`sdkmanager "system-images;android-36;google_apis;arm64-v8a"`).',
       });
       return fail(NO_DEVICE, diag.message, diag.remedy, {
         lines: diag.lines,

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -513,6 +513,15 @@ function findOtherProjectOwningAvd(avdName: string, projectPath: string): string
   return null;
 }
 
+export class AvdRecoveryError extends Error {
+  readonly remedy: string;
+
+  constructor(message: string, remedy: string, cause?: unknown) {
+    super(message, { cause });
+    this.remedy = remedy;
+  }
+}
+
 async function ensureOwnedAndroidDevice({
   record,
   projectPath,
@@ -670,7 +679,7 @@ async function ensureOwnedAndroidDevice({
       };
     }
   }
-  let created: { avdName: string; systemImage: string | null };
+  let created: { avdName: string; systemImage: string | null; consolePort?: number; serial?: string };
   let fresh = false;
   try {
     created = withConfigLock(() => {
@@ -697,31 +706,63 @@ async function ensureOwnedAndroidDevice({
   } catch (e) {
     const message = String((e as Error)?.message || e);
     const avdName = ownedAvdName(label);
-    if (message.includes('already exists') && listAvds().includes(avdName)) {
-      created = withConfigLock(() => {
-        if (readParked('android').some((entry) => entry.name === avdName)) {
-          throw new Error(`AVD ${avdName} was parked by another Stim run. Retry to adopt it safely.`, { cause: e });
-        }
-        const owner = findOtherProjectOwningAvd(avdName, projectPath);
-        if (owner) {
-          throw new Error(
-            `AVD ${avdName} already exists and is owned by another project (${owner}). Retry to allocate a distinct owned emulator.`,
-            { cause: e },
+    if (message.includes('already exists')) {
+      try {
+        if (!listAvds().includes(avdName)) {
+          throw new AvdRecoveryError(
+            `AVD ${avdName} already exists on disk but is not listed by the emulator. ${message}`,
+            'Run `npx stim gc` to inspect orphaned owned AVDs, then `npx stim gc --delete` to reclaim those safe to delete. Retry `stim android` after cleanup; keep any AVD that GC cannot verify.',
+            e,
           );
         }
-        const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
-        if (current?.avdName) {
-          const state = current.setupIncomplete ? 'has incomplete setup' : 'was registered';
-          throw new Error(
-            `AVD ${current.avdName} ${state} by another concurrent Stim run. Retry after that run finishes so the recorded device is resolved safely.`,
-            { cause: e },
-          );
-        }
-        const result = { avdName, systemImage: ownedAvdSystemImage(avdName) };
-        setDevice(projectPath, 'android', { avdName, owned: true, deviceName: avdName });
-        return result;
-      });
+        created = withConfigLock(() => {
+          if (readParked('android').some((entry) => entry.name === avdName)) {
+            throw new Error(`AVD ${avdName} was parked by another Stim run. Retry to adopt it safely.`, { cause: e });
+          }
+          const owner = findOtherProjectOwningAvd(avdName, projectPath);
+          if (owner) {
+            throw new Error(
+              `AVD ${avdName} already exists and is owned by another project (${owner}). Retry to allocate a distinct owned emulator.`,
+              { cause: e },
+            );
+          }
+          const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
+          if (current?.avdName) {
+            const state = current.setupIncomplete ? 'has incomplete setup' : 'was registered';
+            throw new Error(
+              `AVD ${current.avdName} ${state} by another concurrent Stim run. Retry after that run finishes so the recorded device is resolved safely.`,
+              { cause: e },
+            );
+          }
+          const resolved = resolveOwnedAvdSerial(avdName);
+          if (resolved.missing || resolved.notOwned) {
+            throw new Error(
+              `AVD ${avdName} could not be verified for recovery. Retry after checking its registration.`,
+              {
+                cause: e,
+              },
+            );
+          }
+          if (!resolved.serial) assertOwnedAvdStopped(avdName);
+          const recovered = {
+            avdName,
+            owned: true,
+            deviceName: avdName,
+            ...(resolved.serial ? { consolePort: Number(resolved.serial.replace(/^emulator-/, '')) } : {}),
+          };
+          setDevice(projectPath, 'android', recovered);
+          return { ...recovered, systemImage: ownedAvdSystemImage(avdName), serial: resolved.serial };
+        });
+      } catch (error) {
+        if (error instanceof AvdRecoveryError) throw error;
+        throw new AvdRecoveryError(
+          `Could not recover owned AVD ${avdName}: ${String((error as Error)?.message || error)}`,
+          'Inspect `npx stim status` and `adb devices`. Wait for any other Stim run using this AVD to finish, then retry `stim android`. Keep the AVD and its process locks while its state is unverified.',
+          error,
+        );
+      }
       out(chalk.dim(phaseLine('device', `recovered ${avdName} (unrecorded from a prior run)`)));
+      if (created.serial) return { ...created, owned: true, deviceName: avdName, created: true };
     } else {
       throw e;
     }

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -498,6 +498,14 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   reach a booted state. \`stim doctor\` checks the toolchain; \`stim status\` says what
   Stim thinks it owns. Re-running the command creates a fresh owned device
   when the recorded one is gone.
+  If Android creation says an AVD already exists on disk but is not listed,
+  run \`npx stim gc\` to inspect orphaned owned AVDs, then \`npx stim gc --delete\`
+  to reclaim those safe to delete before retrying. Keep anything GC cannot
+  verify; do not delete AVD directories by hand. A registered unrecorded owned
+  AVD is recovered, reusing its existing emulator when its identity is verified.
+  If recovery cannot verify registration or process state, inspect \`npx stim status\`
+  and \`adb devices\`, then retry after any other run finishes. Keep the AVD and
+  its process locks while its state is unverified.
   On iOS a slow first boot is waited out for up to ten minutes while the
   simulator still reports Booting -- a long silent wait on a loaded machine
   is patience, not a hang. The failure names the udid and the wait.


### PR DESCRIPTION
## Description

An AVD directory without its registration blocks creation, but Stim reports a Java/SDK setup remedy. Recovering a registered, unrecorded AVD also launches a second emulator even when the first is already running.

## Solution

Point unregistered AVD collisions at the existing GC inspection and cleanup commands. Pre-boot recovery refusals keep their current diagnostic and remedy even when an earlier boot left a fatal emulator log.

Resolve a recovered AVD's identity and reuse its existing serial. Check its process lock before booting when no serial can be verified, while preserving workspace and pool ownership checks.

## Test plan

- Focused regressions cover stopped recovery, verified running/offline reuse without spawning, failed ADB and unresolved live-process refusal, retained orphan data, concurrent ownership, and stale boot-log suppression.
- Using Android command-line tools 19.0 and emulator 35.6.11 in private roots, exercised the real orphan-creation error and GC remedy, exact orphan teardown, creation retry, and recovery of the same running serial with one emulator spawn. Centralized teardown then shut down and deleted the private AVD.

Fixes #710
