### PR TITLE
fix: skip Finder metadata when warming worktrees

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -337,14 +337,30 @@ test('warm reports carried dependency and Pods lockfile mismatches against the l
   expect(readFileSync(join(target, 'ios/Podfile.lock'), 'utf-8')).toBe('branch pods\n');
 });
 
-test('warm copies literal ignored filenames and skips excluded derived data', () => {
+test('warm copies literal ignored filenames and skips Finder and derived data', () => {
+  write(root, '.gitignore', readFileSync(join(root, '.gitignore'), 'utf-8') + '.DS_Store\n');
+  write(root, '.DS_Store', 'source Finder metadata');
   write(root, '.env with "quotes"', 'literal env');
+  write(root, 'node_modules/pkg/.DS_Store', 'nested Finder metadata');
+  write(root, 'node_modules/pkg/.DS_Store.keep', 'package data');
   write(root, 'node_modules/pkg/.DerivedData/large', 'skip');
   write(root, 'node_modules/pkg/index.js', 'package');
   const result = warm();
   expect(result.failed).toEqual([]);
+  expect(result.copied).not.toContain('.DS_Store');
   expect(readFileSync(join(target, '.env with "quotes"'), 'utf-8')).toBe('literal env');
+  expect(existsSync(join(target, '.DS_Store'))).toBe(false);
+  expect(existsSync(join(target, 'node_modules/pkg/.DS_Store'))).toBe(false);
+  expect(readFileSync(join(target, 'node_modules/pkg/.DS_Store.keep'), 'utf-8')).toBe('package data');
   expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
+  expect(readFileSync(join(root, '.DS_Store'), 'utf-8')).toBe('source Finder metadata');
+  expect(readFileSync(join(root, 'node_modules/pkg/.DS_Store'), 'utf-8')).toBe('nested Finder metadata');
+
+  write(target, '.DS_Store', 'destination Finder metadata');
+  write(target, 'node_modules/pkg/.DS_Store', 'destination nested metadata');
+  expect(warm().failed).toEqual([]);
+  expect(readFileSync(join(target, '.DS_Store'), 'utf-8')).toBe('destination Finder metadata');
+  expect(readFileSync(join(target, 'node_modules/pkg/.DS_Store'), 'utf-8')).toBe('destination nested metadata');
 });
 
 test.each(['android/build/', 'apps/mobile/'])('warm excludes generated autolinking from ignored %s', (ignored) => {

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -948,10 +948,26 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   paths eligible under the source checkout's Git ignore rules, including .env
   and local configuration. The source's nonempty
   .worktreeexclude replaces its resolved worktree.exclude setting. Nested
-  registered worktrees, .DerivedData, and android/build/generated/autolinking
-  caches are excluded, including in nested apps. Gradle regenerates autolinking
+  registered worktrees, .DS_Store, .DerivedData, and
+  android/build/generated/autolinking caches are excluded, including inside
+  newly copied directories. Gradle regenerates autolinking
   for the destination checkout on its next build. Warm also skips paths
   overlapping a nested destination worktree or below a symlink ancestor.
+
+  Other generated state stays eligible: .gradle, .cxx, *.tsbuildinfo, build
+  directories, and embedded JavaScript need project-specific decisions about
+  regeneration. Native intermediates can record the source checkout's paths;
+  warm does not relocate them. Whole .idea or .expo exclusions can also drop
+  useful project settings or generated TypeScript inputs.
+
+  To choose exclusions, run this in the source checkout's repository root:
+
+    git ls-files --others --ignored --exclude-standard --directory --no-empty-directory
+
+  Patterns match those entries with the trailing / removed. They do not prune
+  children of a whole ignored directory: if Git lists android/app/src/main/assets/,
+  excluding its bundle.jsbundle child has no effect. Exclude the assets entry
+  only when the project regenerates everything inside it.
 
   Warm copies directly into the destination, without intermediate staging.
   Keep the source checkout and the linked worktree on the same volume to

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
 import { removeTemporaryEntry } from './temporary.ts';
 
-const CARRY_SKIP_BASENAMES = new Set(['.DerivedData']);
+const CARRY_SKIP_BASENAMES = new Set(['.DerivedData', '.DS_Store']);
 
 export function isCarrySkipped(rel: string): boolean {
   return (

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -48,13 +48,32 @@ copying, not during it. Concurrent files can be overwritten or removed.
 Stim excludes:
 
 - Nested registered Git worktrees, including ignored parents containing them.
-- Any `.DerivedData` directory.
+- `.DS_Store` files and any `.DerivedData` directory, including inside newly copied directories.
 - `android/build/generated/autolinking`, including in nested apps, so Gradle
   regenerates paths for the new checkout.
 - Paths matched by the source checkout's nonempty `.worktreeexclude`, or its
   resolved `worktree.exclude` setting when that file is absent or empty.
 - Destination paths that overlap a registered nested worktree or have symlink
   ancestors.
+
+Other generated state stays eligible: `.gradle`, `.cxx`, `*.tsbuildinfo`,
+`build` directories, and embedded JavaScript need project-specific decisions
+about regeneration. Native intermediates can record the source checkout's
+paths; warm does not relocate them. Whole `.idea` or `.expo` exclusions can
+also drop useful project settings or generated TypeScript inputs.
+
+Choose exclusions against the entries Git lists from the source checkout's
+repository root:
+
+```sh
+git ls-files --others --ignored --exclude-standard --directory --no-empty-directory
+```
+
+Patterns match these entries with the trailing `/` removed; they do not prune
+children of a whole ignored directory. If Git lists
+`android/app/src/main/assets/`, excluding its `bundle.jsbundle` child has no
+effect. Exclude `android/app/src/main/assets` only when the project regenerates
+everything inside it. Existing destination entries are always preserved.
 
 Warm writes only to stderr: copied, kept, and failed entry counts, plus any
 lockfile remedies. A failure exits 1; files already copied remain. Inspect


### PR DESCRIPTION
## Description

`worktree warm` carries ignored Finder metadata from the source checkout, including `.DS_Store` files inside dependency directories. Other generated directories can contain useful state, so their exclusion remains project-specific.

## Solution

Add `.DS_Store` to the existing exclusions applied to ignored entries and newly copied directories. Keep existing destination files and source files untouched. Document how to choose other exclusions from Git's actual ignored inventory: a child pattern cannot prune a directory that Git lists as one ignored entry.

## Test plan

- The extended real-Git warm regression fails before the fix and passes after it. It and a built-CLI worktree proof verify root/nested metadata omission, useful state and source/destination preservation, empty stdout, repeat warming, and child-versus-directory exclusion patterns. All 99 focused worktree and guide tests passed.
- Website typecheck passed. Website build remains blocked by existing MDX parsing of an indented JSON sample in generated `changelog.md`; its release-note source and generator match `origin/main`.
- `pnpm test`: 4,191 passed, one skipped. `pnpm run test:e2e`: 84 passed.

Fixes #709
