### PR TITLE
fix: skip ignored .idea directories when warming worktrees

### DIFF
--- a/packages/stim-cli/src/__tests__/worktree-warm.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-warm.test.ts
@@ -337,30 +337,53 @@ test('warm reports carried dependency and Pods lockfile mismatches against the l
   expect(readFileSync(join(target, 'ios/Podfile.lock'), 'utf-8')).toBe('branch pods\n');
 });
 
-test('warm copies literal ignored filenames and skips Finder and derived data', () => {
-  write(root, '.gitignore', readFileSync(join(root, '.gitignore'), 'utf-8') + '.DS_Store\n');
+test('warm copies literal ignored filenames and skips Finder, IDE, and derived data', () => {
+  write(root, '.gitignore', readFileSync(join(root, '.gitignore'), 'utf-8') + '.DS_Store\n.idea/\n');
+  write(root, 'tracked-app/.idea/codeStyles.xml', 'shared IDE settings');
+  git(root, 'add', '-f', 'tracked-app/.idea/codeStyles.xml');
+  git(root, 'commit', '-qm', 'tracked IDE settings');
+  git(target, 'merge', '--ff-only', 'main');
+  expect(readFileSync(join(target, 'tracked-app/.idea/codeStyles.xml'), 'utf-8')).toBe('shared IDE settings');
+  write(root, 'tracked-app/.idea/codeStyles.xml', 'local source changes');
+  write(root, '.idea/workspace.xml', 'source IDE state');
   write(root, '.DS_Store', 'source Finder metadata');
   write(root, '.env with "quotes"', 'literal env');
   write(root, 'node_modules/pkg/.DS_Store', 'nested Finder metadata');
   write(root, 'node_modules/pkg/.DS_Store.keep', 'package data');
+  write(root, 'node_modules/pkg/.idea/workspace.xml', 'nested IDE state');
+  write(root, 'node_modules/pkg/.idea-extra/keep', 'package IDE data');
   write(root, 'node_modules/pkg/.DerivedData/large', 'skip');
   write(root, 'node_modules/pkg/index.js', 'package');
   const result = warm();
   expect(result.failed).toEqual([]);
   expect(result.copied).not.toContain('.DS_Store');
+  expect(result.copied).not.toContain('.idea');
   expect(readFileSync(join(target, '.env with "quotes"'), 'utf-8')).toBe('literal env');
   expect(existsSync(join(target, '.DS_Store'))).toBe(false);
   expect(existsSync(join(target, 'node_modules/pkg/.DS_Store'))).toBe(false);
   expect(readFileSync(join(target, 'node_modules/pkg/.DS_Store.keep'), 'utf-8')).toBe('package data');
+  expect(existsSync(join(target, '.idea'))).toBe(false);
+  expect(existsSync(join(target, 'node_modules/pkg/.idea'))).toBe(false);
+  expect(readFileSync(join(target, 'node_modules/pkg/.idea-extra/keep'), 'utf-8')).toBe('package IDE data');
+  expect(readFileSync(join(target, 'tracked-app/.idea/codeStyles.xml'), 'utf-8')).toBe('shared IDE settings');
   expect(existsSync(join(target, 'node_modules/pkg/.DerivedData'))).toBe(false);
   expect(readFileSync(join(root, '.DS_Store'), 'utf-8')).toBe('source Finder metadata');
   expect(readFileSync(join(root, 'node_modules/pkg/.DS_Store'), 'utf-8')).toBe('nested Finder metadata');
+  expect(readFileSync(join(root, '.idea/workspace.xml'), 'utf-8')).toBe('source IDE state');
+  expect(readFileSync(join(root, 'node_modules/pkg/.idea/workspace.xml'), 'utf-8')).toBe('nested IDE state');
+  expect(readFileSync(join(root, 'tracked-app/.idea/codeStyles.xml'), 'utf-8')).toBe('local source changes');
 
   write(target, '.DS_Store', 'destination Finder metadata');
   write(target, 'node_modules/pkg/.DS_Store', 'destination nested metadata');
+  write(target, '.idea/workspace.xml', 'destination IDE state');
+  write(target, 'node_modules/pkg/.idea/workspace.xml', 'destination nested IDE state');
   expect(warm().failed).toEqual([]);
   expect(readFileSync(join(target, '.DS_Store'), 'utf-8')).toBe('destination Finder metadata');
   expect(readFileSync(join(target, 'node_modules/pkg/.DS_Store'), 'utf-8')).toBe('destination nested metadata');
+  expect(readFileSync(join(target, '.idea/workspace.xml'), 'utf-8')).toBe('destination IDE state');
+  expect(readFileSync(join(target, 'node_modules/pkg/.idea/workspace.xml'), 'utf-8')).toBe(
+    'destination nested IDE state',
+  );
 });
 
 test.each(['android/build/', 'apps/mobile/'])('warm excludes generated autolinking from ignored %s', (ignored) => {

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -948,17 +948,18 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   paths eligible under the source checkout's Git ignore rules, including .env
   and local configuration. The source's nonempty
   .worktreeexclude replaces its resolved worktree.exclude setting. Nested
-  registered worktrees, .DS_Store, .DerivedData, and
+  registered worktrees, .DS_Store, .DerivedData, .idea, and
   android/build/generated/autolinking caches are excluded, including inside
   newly copied directories. Gradle regenerates autolinking
   for the destination checkout on its next build. Warm also skips paths
   overlapping a nested destination worktree or below a symlink ancestor.
+  Tracked .idea settings come from Git and stay untouched by warm.
 
   Other generated state stays eligible: .gradle, .cxx, *.tsbuildinfo, build
   directories, and embedded JavaScript need project-specific decisions about
   regeneration. Native intermediates can record the source checkout's paths;
-  warm does not relocate them. Whole .idea or .expo exclusions can also drop
-  useful project settings or generated TypeScript inputs.
+  warm does not relocate them. Excluding the whole .expo directory can drop
+  generated TypeScript inputs.
 
   To choose exclusions, run this in the source checkout's repository root:
 

--- a/packages/stim-cli/src/worktree.ts
+++ b/packages/stim-cli/src/worktree.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { getExecutor } from './exec.ts';
 import { removeTemporaryEntry } from './temporary.ts';
 
-const CARRY_SKIP_BASENAMES = new Set(['.DerivedData', '.DS_Store']);
+const CARRY_SKIP_BASENAMES = new Set(['.DerivedData', '.DS_Store', '.idea']);
 
 export function isCarrySkipped(rel: string): boolean {
   return (

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -48,7 +48,7 @@ copying, not during it. Concurrent files can be overwritten or removed.
 Stim excludes:
 
 - Nested registered Git worktrees, including ignored parents containing them.
-- `.DS_Store` files and any `.DerivedData` directory, including inside newly copied directories.
+- `.DS_Store` files and any `.DerivedData` or `.idea` directory, including inside newly copied directories.
 - `android/build/generated/autolinking`, including in nested apps, so Gradle
   regenerates paths for the new checkout.
 - Paths matched by the source checkout's nonempty `.worktreeexclude`, or its
@@ -56,11 +56,13 @@ Stim excludes:
 - Destination paths that overlap a registered nested worktree or have symlink
   ancestors.
 
+Tracked `.idea` settings come from Git and stay untouched by warm.
+
 Other generated state stays eligible: `.gradle`, `.cxx`, `*.tsbuildinfo`,
 `build` directories, and embedded JavaScript need project-specific decisions
 about regeneration. Native intermediates can record the source checkout's
-paths; warm does not relocate them. Whole `.idea` or `.expo` exclusions can
-also drop useful project settings or generated TypeScript inputs.
+paths; warm does not relocate them. Excluding the whole `.expo` directory can
+drop generated TypeScript inputs.
 
 Choose exclusions against the entries Git lists from the source checkout's
 repository root:


### PR DESCRIPTION
## Description

Ignored IDE workspace state should remain local to its checkout. The carry policy [keeps `.idea` eligible](https://github.com/appandflow/stim/commit/25889af6e7f5d3c58e6cfa0019366898873f81bd) for IDE convenience. #743 changes that default so `worktree warm` leaves ignored IDE state behind while tracked settings continue to come from Git.

## Solution

Apply the existing basename exclusion to `.idea` at every depth, including inside newly copied ignored directories. Sources and existing destination entries remain untouched. The guide and website describe this default while retaining the caution about excluding `.expo` generated types.

## Test plan

- The extended real-Git regression fails before the fix and passes after it. It verifies root/nested exclusion, similarly named files, tracked settings obtained through Git, and preservation of source files and existing destination state.
- `pnpm test`: 4,199 passed, one skipped. `pnpm run test:e2e`: 84 passed. All required static checks passed.
- The known website build failure is tracked in #742; its changelog generator and release notes are unchanged.

Fixes #743
