### PR TITLE
fix: fence release-note output for the website

### DIFF
--- a/docs/releases/1.1.0.md
+++ b/docs/releases/1.1.0.md
@@ -68,15 +68,19 @@ The evidence that bears directly on the lock migration is `single-flight`, on bo
 
 iOS, through xcodebuild:
 
-    wt3: cacheHit="local" waitedForBuild={"pid":37959,"ms":67452} durationMs=85630
-    wt4: cacheHit=false   waitedForBuild=null                    durationMs=85659
-    both racers computed the same key: b75c50589e37f1b49ff92feca64e128fc05852b2-debug-sim
+```text
+wt3: cacheHit="local" waitedForBuild={"pid":37959,"ms":67452} durationMs=85630
+wt4: cacheHit=false   waitedForBuild=null                    durationMs=85659
+both racers computed the same key: b75c50589e37f1b49ff92feca64e128fc05852b2-debug-sim
+```
 
 Android, through Gradle:
 
-    wt3: cacheHit="local" waitedForBuild={"pid":67582,"ms":23053} durationMs=67306
-    wt4: cacheHit=false   waitedForBuild=null                    durationMs=63857
-    build  waited 23.1s for .../e2e-cache-4's build -> installed from cache
+```text
+wt3: cacheHit="local" waitedForBuild={"pid":67582,"ms":23053} durationMs=67306
+wt4: cacheHit=false   waitedForBuild=null                    durationMs=63857
+build  waited 23.1s for .../e2e-cache-4's build -> installed from cache
+```
 
 One workspace compiled and the other waited on the claim and installed what it stored, on each platform. The surrounding checks cover the rest of what the migration touches: `gradle-cache` proves `--build-cache` reached the real argv with 651 new entries and 89 `FROM-CACHE` tasks in the second worktree; `xcode-cas` proves all five compilation-cache settings reached the real argv with 69% of the cold compile's CAS files reused by a never-compiled workspace; `pods-reuse` proves a carried, matching `Pods` skips `pod install` outright rather than merely running it quickly; and `zero-config` proves the source checkout was porcelain-clean afterwards with all four worktrees removed without `--force`.
 


### PR DESCRIPTION
## Description

The website build fails on JSON braces in two indented output examples from the 1.1.0 release notes. MDX treats that indentation as prose.

## Solution

Use fenced text blocks in the source release notes so the generated changelog treats both examples as literal output.

## Test plan

- Reproduced the MDX/acorn failure with `pnpm --filter website run build`; the same build now passes, along with website typecheck.
- Verified that both original three-line examples are preserved exactly in the generated HTML code blocks.

Fixes #742
