### PR TITLE
fix: stop requiring expo-dev-client in doctor

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -21,7 +21,6 @@ import {
   checkCcacheInstalled,
   checkCxxCompilerLauncher,
   parseCmakeCacheLauncher,
-  checkDevClient,
   checkEasAuth,
   checkFingerprintParity,
   checkMetroCache,
@@ -847,15 +846,29 @@ test('an iOS-only checkout is not told about the Android C++ cache', () => {
   }
 });
 
-test('a bare React Native project is not told to install expo-dev-client', () => {
-  expect(checkDevClient({ dependencies: { 'react-native': '0.86.2' } })).toBe(null);
-});
-
-test('an Expo project without the dev client is flagged, because a reserved port cannot reach it', () => {
-  const f = checkDevClient({ dependencies: { expo: '~57.0.0' } });
-  assert(f);
-  expect(f.level).toBe('cost');
-  expect(f.detail).toMatch(/8081/);
+test.each(['ios', 'android'] as const)('doctor does not require an Expo dev client for %s', (platform) => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doc-expo-native-'));
+  try {
+    writeFileSync(
+      join(project, 'package.json'),
+      JSON.stringify({ dependencies: { expo: '~57.0.0', 'react-native': '0.86.3' } }),
+    );
+    writeFileSync(join(project, 'package-lock.json'), '{}');
+    writeFileSync(join(project, 'app.json'), JSON.stringify({ expo: { name: 'fixture' } }));
+    mkdirSync(join(project, 'ios'));
+    writeFileSync(join(project, 'ios', 'Podfile.lock'), 'pods\n');
+    mkdirSync(join(project, 'android'));
+    const findings = runDoctor(project, {
+      platform,
+      concurrency: { maxBuilds: 0, maxDevices: 0 },
+      lookupCcache: () => false,
+    });
+    expect(JSON.stringify(findings)).not.toContain('expo-dev-client');
+    expect(findings.some((finding) => finding.title.includes('no installed dependencies'))).toBe(true);
+    expect(findings.some((finding) => finding.title.includes('CocoaPods state is missing'))).toBe(platform === 'ios');
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
 });
 
 test('a project that configures no cacheStores is reported as nothing at all', () => {
@@ -914,27 +927,6 @@ test('detectXcodeMajor reports unknown rather than throwing when xcodebuild is m
   } finally {
     resetExecutor();
   }
-});
-
-test('an expo-dependency project that builds with react-native run-ios is not flagged', () => {
-  const pkg = { dependencies: { expo: '53.0.23', 'react-native': '0.79.6' } };
-  expect(checkDevClient(pkg, false)).toBe(null);
-});
-
-test('the dev client finding still fires for a project that builds with expo run:ios', () => {
-  const pkg = { dependencies: { expo: '~57.0.0' } };
-  const f = checkDevClient(pkg, true);
-  assert(f);
-  expect(f.level).toBe('cost');
-});
-
-test('the dev client fix names the install, the rebuild, and why not to bake the port in', () => {
-  const f = checkDevClient({ dependencies: { expo: '~57.0.0' } });
-  assert(f);
-  expect(f.fix).toMatch(/npx expo install expo-dev-client/);
-  expect(f.fix).toMatch(/rebuild/i);
-  expect(f.fix).toMatch(/NATIVE dependency/);
-  expect(f.fix).toMatch(/RCT_METRO_PORT/);
 });
 
 test('a cacheStores behind an env-var conditional is downgraded to a note, not a pass', () => {
@@ -1721,7 +1713,7 @@ test('doctor success output groups iOS checks and optional capabilities', () => 
   expect(output).toContain('resolved    not found on PATH');
   expect(output).toContain('Project');
   expect(output).toContain('iOS');
-  expect(output).toContain('setup       CocoaPods, warm state, dev client');
+  expect(output).toContain('setup       CocoaPods, warm state, effective Debug simulator architectures');
   expect(output).toContain('caches      Metro, Xcode compilation, ccache, build provider');
   expect(output).toContain('Handled automatically');
   expect(output).toContain('missing project cache settings are healthy');
@@ -1734,7 +1726,7 @@ test('doctor success output scopes native checks to Android', () => {
 
   expect(output).toContain('Doctor (Android)');
   expect(output).toContain('Android');
-  expect(output).toContain('setup       warm state, dev client');
+  expect(output).toContain('setup       warm state');
   expect(output).toContain('caches      Metro, Gradle, ccache, build provider');
   expect(output).not.toContain('Xcode compilation');
   expect(output).not.toContain('SimSlim');

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -62,13 +62,13 @@ export function doctorSuccessLines(platform: DoctorPlatform | undefined, stim: S
 
   if (platform !== 'android') {
     lines.push('', 'iOS');
-    lines.push(phaseLine('setup', 'CocoaPods, warm state, dev client, effective Debug simulator architectures'));
+    lines.push(phaseLine('setup', 'CocoaPods, warm state, effective Debug simulator architectures'));
     lines.push(phaseLine('caches', 'Metro, Xcode compilation, ccache, build provider'));
     lines.push(phaseLine('devices', 'remote device, SimSlim profile'));
   }
   if (platform !== 'ios') {
     lines.push('', 'Android');
-    lines.push(phaseLine('setup', 'warm state, dev client'));
+    lines.push(phaseLine('setup', 'warm state'));
     lines.push(phaseLine('caches', 'Metro, Gradle, ccache, build provider'));
     lines.push(phaseLine('devices', 'remote device'));
   }

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -422,21 +422,6 @@ export function checkMainCheckout(
   return findings;
 }
 
-export function checkDevClient(pkg: AnyJson | null, isExpo: boolean = true): Finding | null {
-  const deps = {
-    ...(pkg?.dependencies as AnyJson | undefined),
-    ...(pkg?.devDependencies as AnyJson | undefined),
-  };
-  if (deps['expo-dev-client']) return null;
-  if (!isExpo || !deps.expo) return null;
-  return finding(
-    'cost',
-    'expo-dev-client is not installed',
-    'A Metro port reserved by Stim cannot reach the app without it: the port travels in the dev-client deep link `stim ios` opens, and without the dev client nothing handles that URL. The app falls back to port 8081 and shows "No script URL provided".',
-    'npx expo install expo-dev-client, then rebuild with `stim ios` / `stim android`. It is a NATIVE dependency: an app already on the device will not pick it up, and the first build after installing it is a cache miss by design because the native fingerprint moved. Do not solve this by compiling the port in (RCT_METRO_PORT, or the dev client defaultLaunchURL) -- the build cache does not key on the port, so a binary built for one workspace would silently talk to another workspace bundler.',
-  );
-}
-
 export function checkMetroCache(metroConfigSource: string | null): Finding | null {
   if (metroConfigSource == null) return null;
   const lines = String(metroConfigSource).split('\n');
@@ -922,7 +907,6 @@ export function runDoctor(
     ...checkMainCheckout(projectRoot, { platform }),
     ...(platform === 'android' ? [] : inspectIosDebugArchitectures(mainCheckoutProjectRoot(projectRoot))),
     ...checkStorageLayout(projectRoot, { platform }),
-    checkDevClient(pkg, isExpo),
     optimizations?.metroSharedCache ? checkMetroCache(metroConfig) : null,
     platform === 'android' || !optimizations?.ios.compilationCache ? null : checkCompilationCache(podfile, xcodeMajor),
     platform === 'android' || !optimizations?.ios.compilationCache

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -595,7 +595,7 @@ changing modes selects another profile. See \`guide settings\` for cleanup.
 
 Each reports its cache setup. \`stim doctor\` checks missing or stale setup
 when a build is blocked or slow. It reports what Stim cannot handle itself
-(a missing dev client, ccache absent from PATH or a .cxx that predates the
+(ccache absent from PATH or a .cxx that predates the
 launcher, a fingerprint no fresh worktree reproduces, a provider on a key this
 SDK ignores) and settings for builds outside Stim.
 

--- a/website/docs/requirements.md
+++ b/website/docs/requirements.md
@@ -19,7 +19,6 @@ Commands use `stim`. If it is not installed globally, replace `stim` with
   runtime.
 - A compatible Ruby and CocoaPods setup when the project uses pods. Install
   Bundler when the project pins CocoaPods in `Gemfile.lock`.
-- `expo-dev-client` for an Expo Debug build on a reserved Metro port.
 
 ## Android
 


### PR DESCRIPTION
## Description

Doctor tells Expo native projects to install `expo-dev-client` to reach a reserved Metro port. The [existing check](https://github.com/appandflow/stim/commit/cc9276bfc338debe6aae9042b44a0bf0d34f989d) assumes the port requires a dev-client deep link, but the iOS simulator launch path already sets `RCT_jsLocation` without one. Release QA in #747 confirmed an Expo 57 iOS app launched on its reserved port without the dependency.

## Solution

Remove the blanket dependency finding and the corresponding prerequisite claims in doctor's success summary, guide, and website. Keep actual dependency and native-state checks; launch behavior is unchanged.

## Test plan

- The `runDoctor` regression fails before the fix and passes after it for both platform filters. It verifies there is no dev-client requirement while missing installed dependencies and platform-appropriate CocoaPods findings remain.
- All required static checks and the website production build passed. `pnpm test`: 4,197 passed, one skipped. `pnpm run test:e2e`: 84 passed.

Fixes #747
