### PR TITLE
fix: detect stalled iOS simulators and report memory pressure

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -58,6 +58,13 @@ one native platform is in scope; shared project checks still run. Doctor also
 prints the running CLI version and the `stim` installation resolved from PATH,
 and flags a resolved installation that is older than another available one.
 
+For parallel iOS work, SimSlim is recommended as an optional way to reduce
+simulator background services and memory use. Run `stim guide lifecycle simslim`
+to review the service tradeoffs and configure a profile. Doctor recommends the
+setup without installing or enabling it. When a simulator cannot start
+processes, Stim bounds the wait and reports observed host memory pressure when
+available; free memory before retrying. A timeout alone does not prove OOM.
+
 For stale Android CMake launcher findings, stop native builds and run
 `stim doctor --fix --platform android` in the affected checkout. It clears
 affected ignored, untracked generated `.cxx` configurations in the app and

--- a/packages/stim-cli/src/__tests__/doctor.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor.test.ts
@@ -1212,8 +1212,8 @@ test('runDoctor emits one concurrency note when a limit is set', () => {
   rmSync(project, { recursive: true, force: true });
 });
 
-test('checkSimSlim reports only configured profiles that cannot run', () => {
-  expect(checkSimSlim()).toBeNull();
+test('checkSimSlim recommends optional profiles and reports configured profiles that cannot run', () => {
+  expect(checkSimSlim()).toMatchObject({ level: 'note', fix: expect.stringContaining('stim guide lifecycle simslim') });
   expect(checkSimSlim({ configured: true, onPath: true })).toBeNull();
   const missing = checkSimSlim({ configured: true, onPath: false });
   assert(missing);
@@ -1224,6 +1224,34 @@ test('checkSimSlim reports only configured profiles that cannot run', () => {
   assert(invalid);
   expect(invalid.title).toMatch(/invalid/i);
   expect(invalid.detail).toMatch(/missing profile/);
+});
+
+test('runDoctor reports observed local iOS memory pressure without applying SimSlim', () => {
+  const project = mkdtempSync(join(tmpdir(), 'stim-doctor-memory-'));
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'x' }));
+    const memoryPressure = vi.fn<() => 'critical'>(() => 'critical');
+    const options = { concurrency: { maxBuilds: 0, maxDevices: 0 }, memoryPressure };
+    const ios = runDoctor(project, { ...options, platform: 'ios' });
+    expect(ios).toContainEqual(
+      expect.objectContaining({
+        level: 'cost',
+        detail: expect.stringContaining('critical host memory pressure'),
+      }),
+    );
+    expect(ios).toContainEqual(expect.objectContaining({ level: 'note', title: expect.stringContaining('SimSlim') }));
+    expect(existsSync(join(project, '.stim.json'))).toBe(false);
+    memoryPressure.mockClear();
+    const android = runDoctor(project, { ...options, platform: 'android' });
+    expect(memoryPressure).not.toHaveBeenCalled();
+    expect(android.some((f) => /memory pressure|SimSlim/.test(f.title))).toBe(false);
+    writeFileSync(join(project, '.stim.json'), JSON.stringify({ ios: { remote: 'eas' } }));
+    const remote = runDoctor(project, { ...options, platform: 'ios' });
+    expect(memoryPressure).not.toHaveBeenCalled();
+    expect(remote.some((f) => /memory pressure|SimSlim/.test(f.title))).toBe(false);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
 });
 
 test('runDoctor reports a configured SimSlim profile when the binary is missing', () => {

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -63,20 +63,26 @@ type LaunchResult = {
 
 interface RecordingExec extends Executor {
   calls: string[][];
+  options: Parameters<Executor['runFile']>[2][];
 }
 function recordingExec({
   fail = null,
+  failCode,
   outputs = {},
-}: { fail?: string | null; outputs?: Record<string, string> } = {}): RecordingExec {
+}: { fail?: string | null; failCode?: string; outputs?: Record<string, string> } = {}): RecordingExec {
   const calls: string[][] = [];
+  const options: Parameters<Executor['runFile']>[2][] = [];
   return {
     calls,
-    runFile(file: string, args: string[] = []) {
+    options,
+    runFile(file: string, args: string[] = [], opts) {
       calls.push([file, ...args]);
+      options.push(opts);
       const key = [file, ...args].join(' ');
       if (fail && key.includes(fail)) {
         const err = new Error(`Command failed: ${key}`);
         (err as Error & { stderr?: string }).stderr = 'device not booted';
+        if (failCode) (err as NodeJS.ErrnoException).code = failCode;
         throw err;
       }
       for (const [match, value] of Object.entries(outputs)) {
@@ -275,6 +281,7 @@ describe('ios', () => {
         'com.example.app',
       ],
     ]);
+    expect(exec.options.slice(2)).toEqual(Array.from({ length: 4 }, () => ({ timeoutMs: 60000 })));
   });
 
   test('installIosApp times the artifact step separately from dev-client preparation', () => {
@@ -305,20 +312,24 @@ describe('ios', () => {
     });
   });
 
-  test('a failed dev-client preference write reports a failed install result', () => {
-    const exec = recordingExec({ fail: 'EXDevMenuShowsAtLaunch' });
-    const result = installIosApp(
-      {
-        udid: 'U1',
-        appPath: '/tmp/My App.app',
-        bundleId: 'com.example.app',
-        devClientScheme: 'myapp',
-      },
-      { exec },
-    );
-    expect(result.code).toBe(INSTALL_ERROR);
-    expect(result.reason).toMatch(/prepare the dev client/);
-  });
+  test.each([undefined, 'ETIMEDOUT'])(
+    'a failed dev-client preference write reports a failed install result (%s)',
+    (failCode) => {
+      const exec = recordingExec({ fail: 'EXDevMenuShowsAtLaunch', failCode });
+      const result = installIosApp(
+        {
+          udid: 'U1',
+          appPath: '/tmp/My App.app',
+          bundleId: 'com.example.app',
+          devClientScheme: 'myapp',
+        },
+        { exec },
+      );
+      expect(result.code).toBe(INSTALL_ERROR);
+      expect(result.reason).toMatch(/prepare the dev client/);
+      expect(result.reason?.includes('Activity Monitor')).toBe(failCode === 'ETIMEDOUT');
+    },
+  );
 
   test('a failed scheme approval reports a failed install result', () => {
     const exec = recordingExec({ fail: 'schemeapproval' });
@@ -344,6 +355,7 @@ describe('ios', () => {
       ['xcrun', 'simctl', 'spawn', 'U1', 'defaults', 'write', 'com.example.app', 'RCT_jsLocation', 'localhost:8082'],
       ['xcrun', 'simctl', 'launch', 'U1', 'com.example.app'],
     ]);
+    expect(exec.options).toEqual([{ timeoutMs: 60000 }, { timeoutMs: 60000 }]);
   });
 
   test('launchIosApp opens the preapproved dev-client URL after the RCT defaults write', () => {
@@ -363,6 +375,7 @@ describe('ios', () => {
         'myapp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082%2F%3FdisableOnboarding%3D1&disableFab=1',
       ],
     ]);
+    expect(exec.options).toEqual([{ timeoutMs: 60000 }, { timeoutMs: 60000 }]);
   });
 
   test('a failed defaults write stops the launch rather than launching unwired', () => {
@@ -371,7 +384,28 @@ describe('ios', () => {
     expect(result.code).toBe(LAUNCH_ERROR);
     expect(result.reason).toMatch(/RCT_jsLocation/);
     expect(exec.calls.length).toBe(1);
+    expect(result.reason).not.toContain('Activity Monitor');
   });
+
+  test.each(['defaults write', 'simctl openurl', 'simctl launch'])(
+    'a timed-out %s keeps the launch refusal and adds simulator recovery advice',
+    (fail) => {
+      const exec = recordingExec({ fail, failCode: 'ETIMEDOUT' });
+      const result = launchIosApp(
+        {
+          udid: 'U1',
+          bundleId: 'com.example.app',
+          metroPort: 8082,
+          ...(fail === 'simctl openurl' ? { devClientScheme: 'myapp' } : {}),
+        },
+        { exec },
+      );
+      expect(result.failed).toBe(true);
+      expect(result.code).toBe(LAUNCH_ERROR);
+      expect(result.reason).toContain('Activity Monitor');
+      expect(result.reason).not.toMatch(/out of memory|OOM/i);
+    },
+  );
 
   test('a cold Expo launch attaches console capture and passes its project URL without launching two React hosts', () => {
     const exec = recordingExec({ outputs: { 'simctl launch': 'com.example.app: 4242' } });

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -72,6 +72,7 @@ function simList(devices: SimEntry[]) {
 describe('ensureBooted: ios', () => {
   test('returns the udid without touching simctl boot when the sim is already Booted', async () => {
     const commands: string[] = [];
+    const probes: unknown[] = [];
     setExecutor({
       run: (cmd) => {
         commands.push(cmd);
@@ -81,7 +82,10 @@ describe('ensureBooted: ios', () => {
         commands.push(cmd);
         return '';
       },
-      runFile: () => '',
+      runFile: (file, args = [], options) => {
+        probes.push([file, ...args, options]);
+        return '';
+      },
       spawn: (cmd: string, args: readonly string[] = []) => {
         commands.push([cmd, ...args].join(' '));
         return makeExitingChild();
@@ -93,6 +97,30 @@ describe('ensureBooted: ios', () => {
     });
     expect(commands.filter((c) => c.includes('simctl boot')).length).toBe(0);
     expect(commands.some((c) => c.includes('simctl bootstatus'))).toBe(false);
+    expect(probes).toEqual([['xcrun', 'simctl', 'spawn', 'U1', '/usr/bin/true', { timeoutMs: 30000 }]]);
+  });
+
+  test.each([false, true])('refuses a simulator that cannot spawn a process after boot (joined=%s)', async (joined) => {
+    setExecutor({
+      run: () => simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]),
+      runFile: () => {
+        throw Object.assign(new Error('simctl spawn timed out'), { code: 'ETIMEDOUT' });
+      },
+      runFileQuiet: () => null,
+    });
+    const result = await ensureBooted({
+      platform: 'ios',
+      device: {
+        deviceUdid: 'U1',
+        owned: true,
+        ...(joined ? { booting: { udid: 'U1', done: Promise.resolve() } } : {}),
+      },
+    });
+    expect(result.ok).toBeUndefined();
+    expect(result.failed).toBe(true);
+    expect(result.reason).toMatch(/U1.*process-spawn readiness.*simctl spawn timed out/);
+    expect(result.reason).toContain('Activity Monitor');
+    expect(result.reason).not.toMatch(/out of memory|OOM/i);
   });
 
   test('boots a shut-down owned sim and waits for the Booted state', async () => {
@@ -212,6 +240,7 @@ describe('ensureBooted: ios', () => {
 
   test('joins the boot this run started instead of listing simulators again', async () => {
     const commands: string[] = [];
+    let finished = false;
     setExecutor({
       run: (cmd: string) => {
         commands.push(cmd);
@@ -221,10 +250,13 @@ describe('ensureBooted: ios', () => {
         commands.push(cmd);
         return '';
       },
-      runFile: () => '',
+      runFile: (file, args = []) => {
+        expect(finished).toBe(true);
+        commands.push([file, ...args].join(' '));
+        return '';
+      },
       spawn: () => null,
     });
-    let finished = false;
     const done = new Promise<void>((resolve) =>
       setTimeout(() => {
         finished = true;
@@ -237,7 +269,7 @@ describe('ensureBooted: ios', () => {
     });
     expect(result).toEqual({ ok: true, udid: 'U1' });
     expect(finished).toBe(true);
-    expect(commands).toEqual([]);
+    expect(commands).toEqual(['xcrun simctl spawn U1 /usr/bin/true']);
   });
 
   test('reports the failure of the boot this run started, before anything is installed', async () => {
@@ -622,6 +654,51 @@ function iosExecutor(devices: SimEntry[]) {
 }
 
 describe('ensureOwnedDevice: ios', () => {
+  test.each(['2', '1', 'unknown'])('reports only observed memory pressure before boot (%s)', async (pressure) => {
+    const root = projectDir();
+    const { exec } = iosExecutor([]);
+    const events: string[] = [];
+    setExecutor({
+      ...exec,
+      run(cmd: string) {
+        if (cmd.startsWith('xcrun simctl boot ')) events.push('boot');
+        return exec.run(cmd);
+      },
+      runFile(file, args = [], options) {
+        if (file === '/usr/sbin/sysctl') {
+          events.push('pressure');
+          expect(args).toEqual(['-n', 'kern.memorystatus_vm_pressure_level']);
+          expect(options).toEqual({ timeoutMs: 2000 });
+          return pressure;
+        }
+        return exec.runFile(file, args);
+      },
+    });
+    try {
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        projectPath: root,
+        label: 'memory-fixture',
+        settings: {},
+        out: (line) => {
+          if (line.includes('host memory pressure')) events.push('warning');
+        },
+      });
+      await device.booting?.done;
+      expect(events.filter((event) => event === 'pressure')).toHaveLength(process.platform === 'darwin' ? 1 : 0);
+      expect(events).toContain('boot');
+      const expectedEvents =
+        process.platform === 'darwin'
+          ? pressure === '2'
+            ? ['pressure', 'warning', 'boot']
+            : ['pressure', 'boot']
+          : ['boot'];
+      expect(events).toEqual(expectedEvents);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('concurrent allocations disambiguate names after truncation and preserve the suffix on reuse', async () => {
     const roots = [projectDir(), projectDir()];
     const label = 'same-worktree-name-'.repeat(5);

--- a/packages/stim-cli/src/__tests__/host-memory.test.ts
+++ b/packages/stim-cli/src/__tests__/host-memory.test.ts
@@ -1,0 +1,43 @@
+import { readHostMemoryPressure, hostMemoryPressureAdvice } from '../host-memory.ts';
+import { getExecutor, resetExecutor, setExecutor } from '../exec.ts';
+
+afterEach(resetExecutor);
+
+test.each([
+  ['1\n', 'normal'],
+  ['2', 'warning'],
+  ['4', 'critical'],
+  ['0', null],
+  ['3', null],
+  ['8', null],
+  ['', null],
+  ['permission denied', null],
+])('reads macOS dispatch pressure value %j without guessing unknown states', (output, expected) => {
+  const runFile = vi.fn<() => string>(() => output);
+  setExecutor({ runFile });
+  expect(readHostMemoryPressure(getExecutor(), 'darwin')).toBe(expected);
+  expect(runFile).toHaveBeenCalledWith('/usr/sbin/sysctl', ['-n', 'kern.memorystatus_vm_pressure_level'], {
+    timeoutMs: 2000,
+  });
+});
+
+test('unavailable pressure stays unknown and unsupported platforms do not run sysctl', () => {
+  const runFile = vi.fn<() => string>(() => {
+    throw Object.assign(new Error('denied'), { code: 'EPERM' });
+  });
+  setExecutor({ runFile });
+  expect(readHostMemoryPressure(getExecutor(), 'darwin')).toBeNull();
+  runFile.mockClear();
+  expect(readHostMemoryPressure(getExecutor(), 'linux')).toBeNull();
+  expect(runFile).not.toHaveBeenCalled();
+});
+
+test('only observed pressure recommends memory recovery and an optional SimSlim profile', () => {
+  expect(hostMemoryPressureAdvice(null)).toBeNull();
+  expect(hostMemoryPressureAdvice('normal')).toBeNull();
+  for (const pressure of ['warning', 'critical'] as const) {
+    expect(hostMemoryPressureAdvice(pressure)).toContain(`${pressure} host memory pressure`);
+    expect(hostMemoryPressureAdvice(pressure)).toContain('stim guide lifecycle simslim');
+    expect(hostMemoryPressureAdvice(pressure)).toContain('does not establish an OOM crash');
+  }
+});

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -3016,6 +3016,21 @@ describe('--remote', () => {
     expect(calls.order.includes('installIosApp')).toBeFalsy();
   });
 
+  test.each([false, true])('host-memory recovery is limited to local launch failures (remote=%s)', async (isRemote) => {
+    reserve();
+    const remote = remoteStub();
+    const launchIosApp = () => ({ failed: true, code: 'STIM_LAUNCH_FAILED', reason: 'launch timed out' });
+    const deps = isRemote
+      ? { ...remote.deps, remoteIosDeps: () => ({ ...remote.deps.remoteIosDeps(), launchIosApp }) }
+      : { launchIosApp };
+    const { logs, exitCode } = await run({ json: true, ...(isRemote ? { remote: 'eas' } : {}) }, deps);
+    expect(exitCode).toBe(1);
+    const failure = parseFirst(logs);
+    expect(failure.code).toBe('STIM_LAUNCH_FAILED');
+    expect(failure.remedy.includes('host memory pressure')).toBe(!isRemote);
+    expect(failure.remedy.includes('stim doctor --platform ios')).toBe(!isRemote);
+  });
+
   test('the build still happens locally -- only the device moved', async () => {
     const remote = remoteStub();
     reserve();

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -467,6 +467,13 @@ function recordIosReloadTarget({
   }
 }
 
+function simulatorLaunchFailureRemedy(remote: boolean, udid: string, bundleId: string, logFile: string): string {
+  const prefix = remote
+    ? 'Run'
+    : 'If the simulator timed out, run `stim doctor --platform ios` and resolve any reported host memory pressure before retrying. Otherwise run';
+  return `${prefix} \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`;
+}
+
 export async function finishIosRun({
   d,
   root,
@@ -727,7 +734,7 @@ export async function finishIosRun({
       return fail({
         code: launched.code || 'STIM_LAUNCH_FAILED',
         message: launched.reason,
-        remedy: `If the simulator timed out, run \`stim doctor --platform ios\` and resolve any reported host memory pressure before retrying. Otherwise run \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`,
+        remedy: simulatorLaunchFailureRemedy(Boolean(remoteDevice), udid, bundleId!, logFile),
         build: { ...buildFailure, appPath, bundleId },
       });
     }

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -727,7 +727,7 @@ export async function finishIosRun({
       return fail({
         code: launched.code || 'STIM_LAUNCH_FAILED',
         message: launched.reason,
-        remedy: `Run \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`,
+        remedy: `If the simulator timed out, run \`stim doctor --platform ios\` and resolve any reported host memory pressure before retrying. Otherwise run \`xcrun simctl launch --console ${udid} ${bundleId}\` to see what the app reports, and check ${logFile}.`,
         build: { ...buildFailure, appPath, bundleId },
       });
     }

--- a/packages/stim-cli/src/doctor.ts
+++ b/packages/stim-cli/src/doctor.ts
@@ -16,6 +16,7 @@ import { type Config, type ConcurrencyLimits, getConcurrencyLimits, loadConfig }
 import { podInstallCommand } from './engine/bundler.ts';
 import { liveOwnedDeviceCount } from './engine/device.ts';
 import { simslimIsOnPath } from './engine/simslim.ts';
+import { readHostMemoryPressure, hostMemoryPressureAdvice, type HostMemoryPressure } from './host-memory.ts';
 import { listBuildSlots } from './engine/build-slots.ts';
 import { type IosSimRecord, listAllIosSims } from './sim/ios.ts';
 import { parkedMaxSetting, POOL_SETTING_REMEDY } from './sim-pool.ts';
@@ -731,7 +732,15 @@ export function checkSimSlim({
       'Set ios.simslimProfile to a readable JSON profile inside the repository.',
     );
   }
-  if (!configured || onPath) return null;
+  if (!configured) {
+    return finding(
+      'note',
+      'SimSlim is recommended for parallel iOS simulator work',
+      'A reviewed profile can reduce background simulator services and memory use. It is optional: disabling services can affect tests that depend on them, and installing the binary alone does not apply a profile.',
+      'Run `stim guide lifecycle simslim` to install SimSlim and configure ios.simslimProfile. Stim does not enable a profile through doctor --fix.',
+    );
+  }
+  if (onPath) return null;
   return finding(
     'cost',
     'A SimSlim profile is configured, but SimSlim is not installed',
@@ -753,6 +762,7 @@ export function runDoctor(
     lookupAgentDevice = null,
     lookupEasCli = null,
     lookupSimSlim = null,
+    memoryPressure = readHostMemoryPressure,
     lookupCcache = null,
     platform,
   }: {
@@ -766,6 +776,7 @@ export function runDoctor(
     lookupAgentDevice?: (() => boolean) | null;
     lookupEasCli?: (() => boolean) | null;
     lookupSimSlim?: (() => boolean) | null;
+    memoryPressure?: () => HostMemoryPressure | null;
     lookupCcache?: (() => boolean) | null;
     platform?: DoctorPlatform;
   } = {},
@@ -865,7 +876,7 @@ export function runDoctor(
     }
   }
   const simslimFinding =
-    platform === 'android'
+    platform === 'android' || (!simslimProfile && !simslimProfileError && remoteIosSetting(projectSettings))
       ? null
       : checkSimSlim({
           configured: Boolean(simslimProfile),
@@ -902,6 +913,9 @@ export function runDoctor(
     )
     .filter((remoteFinding): remoteFinding is Finding => remoteFinding !== null);
 
+  const memoryAdvice =
+    platform !== 'android' && !remoteIosSetting(projectSettings) ? hostMemoryPressureAdvice(memoryPressure()) : null;
+
   return [
     checkAppProject(projectRoot),
     ...checkMainCheckout(projectRoot, { platform }),
@@ -918,6 +932,14 @@ export function runDoctor(
     remoteBuildCache ? checkBuildCacheProvider(appConfig, sdkMajor, isExpo, dynamicConfig) : null,
     easFinding,
     concurrencyFinding,
+    memoryAdvice
+      ? finding(
+          'cost',
+          'Host memory pressure can stall the iOS simulator',
+          memoryAdvice,
+          'Free host memory, then retry. Run `stim guide lifecycle simslim` for the optional memory reduction setup.',
+        )
+      : null,
     simslimFinding,
     ...remoteFindings,
     ...settingShapeFindings,

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -5,7 +5,7 @@ import { getExecutor, type Executor } from '../exec.ts';
 import { parseNdjsonText, type NdjsonRecord } from '../ndjson.ts';
 import { deviceHoldsApk, deviceHoldsBundle } from './installed-artifact.ts';
 import { DEV_MENU_LAUNCH_ARGS } from '../collector/ios-device.ts';
-import { listUserApps, uninstallIosApp } from '../sim/ios.ts';
+import { iosSimulatorFailureAdvice, listUserApps, uninstallIosApp } from '../sim/ios.ts';
 import { APP_READINESS_TIMEOUT_MS, appReadinessSignal, type AppReadiness } from './app-readiness.ts';
 
 export const INSTALL_ERROR = 'STIM_INSTALL_FAILED';
@@ -19,6 +19,13 @@ const IOS_DEV_MENU_OFF_KEYS = ['EXDevMenuShowsAtLaunch', 'EXDevMenuShowFloatingA
 const DEV_CLIENT_ONBOARDING_QUERY = 'disableOnboarding=1';
 const DEV_CLIENT_DISABLE_FAB_QUERY = 'disableFab=1';
 const ANDROID_DISABLE_AUTO_LAUNCH_EXTRA = 'EXDevMenuDisableAutoLaunch';
+
+function describeIosSimulatorFailure(error: unknown, exec: Executor): string {
+  const detail = describe(error);
+  return (error as NodeJS.ErrnoException)?.code === 'ETIMEDOUT'
+    ? `${detail}. ${iosSimulatorFailureAdvice(exec)}`
+    : detail;
+}
 
 interface ExecOpt {
   exec?: Executor | null;
@@ -107,26 +114,22 @@ export function installIosApp(
   if (bundleId && devClientScheme) {
     try {
       for (const key of IOS_DEV_MENU_OFF_KEYS) {
-        e.runFile('xcrun', ['simctl', 'spawn', udid, 'defaults', 'write', bundleId, key, '-bool', 'false']);
+        e.runFile('xcrun', ['simctl', 'spawn', udid, 'defaults', 'write', bundleId, key, '-bool', 'false'], {
+          timeoutMs: 60000,
+        });
       }
       for (const key of iosSchemeApprovalKeys(bundleId, devClientScheme)) {
-        e.runFile('xcrun', [
-          'simctl',
-          'spawn',
-          udid,
-          'defaults',
-          'write',
-          IOS_SCHEME_APPROVAL_DOMAIN,
-          key,
-          '-string',
-          bundleId,
-        ]);
+        e.runFile(
+          'xcrun',
+          ['simctl', 'spawn', udid, 'defaults', 'write', IOS_SCHEME_APPROVAL_DOMAIN, key, '-string', bundleId],
+          { timeoutMs: 60000 },
+        );
       }
     } catch (err) {
       return {
         failed: true,
         code: INSTALL_ERROR,
-        reason: `Installed ${bundleId}, but could not prepare the dev client: ${describe(err)}`,
+        reason: `Installed ${bundleId}, but could not prepare the dev client: ${describeIosSimulatorFailure(err, e)}`,
       };
     }
   }
@@ -245,21 +248,16 @@ export function launchIosApp(
   ];
   if (metroPort !== null) {
     try {
-      e.runFile('xcrun', [
-        'simctl',
-        'spawn',
-        udid,
-        'defaults',
-        'write',
-        bundleId,
-        'RCT_jsLocation',
-        jsLocationValue(metroPort),
-      ]);
+      e.runFile(
+        'xcrun',
+        ['simctl', 'spawn', udid, 'defaults', 'write', bundleId, 'RCT_jsLocation', jsLocationValue(metroPort)],
+        { timeoutMs: 60000 },
+      );
     } catch (err) {
       return {
         failed: true,
         code: LAUNCH_ERROR,
-        reason: `Could not point ${bundleId} at Metro port ${metroPort} (defaults write RCT_jsLocation): ${describe(err)}`,
+        reason: `Could not point ${bundleId} at Metro port ${metroPort} (defaults write RCT_jsLocation): ${describeIosSimulatorFailure(err, e)}`,
       };
     }
 
@@ -275,10 +273,14 @@ export function launchIosApp(
           );
           return { ok: true, mode: 'launch', url, jsLocation: jsLocationValue(metroPort), pid };
         }
-        e.runFile('xcrun', ['simctl', 'openurl', udid, url]);
+        e.runFile('xcrun', ['simctl', 'openurl', udid, url], { timeoutMs: 60000 });
         return { ok: true, mode: 'openurl', url, jsLocation: jsLocationValue(metroPort) };
       } catch (err) {
-        return { failed: true, code: LAUNCH_ERROR, reason: `simctl openurl ${url} failed: ${describe(err)}` };
+        return {
+          failed: true,
+          code: LAUNCH_ERROR,
+          reason: `simctl openurl ${url} failed: ${describeIosSimulatorFailure(err, e)}`,
+        };
       }
     }
   }
@@ -289,7 +291,11 @@ export function launchIosApp(
     if (metroPort !== null) result.jsLocation = jsLocationValue(metroPort);
     return result;
   } catch (err) {
-    return { failed: true, code: LAUNCH_ERROR, reason: `simctl launch ${bundleId} failed: ${describe(err)}` };
+    return {
+      failed: true,
+      code: LAUNCH_ERROR,
+      reason: `simctl launch ${bundleId} failed: ${describeIosSimulatorFailure(err, e)}`,
+    };
   }
 }
 

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -16,10 +16,13 @@ import {
   type ProjectRecord,
 } from '../config.ts';
 import { pidExists } from '../metro.ts';
+import { getExecutor } from '../exec.ts';
+import { hostMemoryPressureAdvice, readHostMemoryPressure } from '../host-memory.ts';
 import {
   bootIosSim,
   createOwnedIosSim,
   IOS_BOOT_TIMEOUT_MS,
+  iosSimulatorFailureAdvice,
   listAllIosSims,
   iosRuntimeMatches,
   listIosDeviceTypes,
@@ -217,6 +220,8 @@ async function ensureOwnedIosDevice({
   out: Notify;
   reconcileIosSimulator: typeof reconcileSimSlim;
 }): Promise<OwnedDeviceRecord> {
+  const memoryAdvice = hostMemoryPressureAdvice(readHostMemoryPressure());
+  if (memoryAdvice) out(chalk.yellow(phaseLine('memory', memoryAdvice)));
   const simslimProfile = iosSimSlimProfileSetting(settings, settingsRoot);
   if (record?.deviceUdid) {
     if (record.owned) {
@@ -1125,6 +1130,17 @@ async function ensureIosBooted({
 }): Promise<BootResult> {
   const udid = device?.deviceUdid;
   if (!udid) return { failed: true, reason: 'No iOS simulator is recorded for this project.' };
+  const ready = (): BootResult => {
+    try {
+      getExecutor().runFile('xcrun', ['simctl', 'spawn', udid, '/usr/bin/true'], { timeoutMs: 30000 });
+      return { ok: true, udid };
+    } catch (error) {
+      return {
+        failed: true,
+        reason: `Simulator ${udid} failed its process-spawn readiness check: ${(error as Error)?.message || error}. ${iosSimulatorFailureAdvice()}`,
+      };
+    }
+  };
   const booting = device?.booting;
   if (booting?.udid === udid) {
     try {
@@ -1132,7 +1148,7 @@ async function ensureIosBooted({
     } catch (e) {
       return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
     }
-    return { ok: true, udid };
+    return ready();
   }
 
   let resolved;
@@ -1154,7 +1170,7 @@ async function ensureIosBooted({
     };
   }
   const sim = resolved.sim as SimRecord;
-  if (sim.state === 'Booted') return { ok: true, udid };
+  if (sim.state === 'Booted') return ready();
 
   out(chalk.dim(phaseLine('device', `booting ${sim.name} (${udid})`)));
   const bootDeadline = Date.now() + timeoutMs;
@@ -1171,7 +1187,7 @@ async function ensureIosBooted({
     try {
       state = listAllIosSims({ timeoutMs: 30000 }).find((s) => s.udid === udid)?.state ?? null;
     } catch {}
-    if (state === 'Booted') return { ok: true, udid };
+    if (state === 'Booted') return ready();
   }
   return {
     failed: true,

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -59,6 +59,11 @@ Doctor reports cross-volume staging and build-cache copies; read guide settings
 for placement overrides and guide lifecycle options for warm behavior.
 For iOS Debug architecture findings, review the project's overrides and imported
 Podfile helpers using guide lifecycle options. Doctor --fix does not change them.
+For parallel iOS work, review the recommended optional SimSlim setup in
+stim guide lifecycle simslim. If simulator process startup times out, check
+host memory pressure and free memory before retrying; do not restart other
+workspaces' devices or close their apps without asking. That guide covers
+the recovery steps and profile tradeoffs.
 For a linked native library carrying Git metadata, add the printed .git entries to
 .fingerprintignore only when the native build does not read Git state.
 

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -275,6 +275,11 @@ code, never on the message.`,
       body: () => `STIM_LAUNCH_FAILED
   Installed, but the app would not start. On Android this usually means no
   launchable activity resolved.
+  On a local iOS simulator, a timed-out launch can mean the simulator cannot
+  spawn processes, even while it reports Booted. Check the reported memory
+  pressure and free host memory before retrying; a timeout alone is not an OOM
+  diagnosis. See \`stim guide lifecycle simslim\` for recovery and the optional
+  SimSlim recommendation.
   On a PHONE it means the app never appeared in the device's own process list
   after \`devicectl device process launch\`, and the devicectl lines that
   explain it are quoted under the message. The refusal a first launch usually
@@ -509,6 +514,10 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   On iOS a slow first boot is waited out for up to ten minutes while the
   simulator still reports Booting -- a long silent wait on a loaded machine
   is patience, not a hang. The failure names the udid and the wait.
+  After boot, a process-spawn probe must finish within 30 seconds before
+  installation. If it fails, the refusal includes observed host memory pressure
+  when available. Free memory before retrying under pressure; see
+  \`stim guide lifecycle simslim\`. Booted alone does not prove readiness.
   On Android the emulator's own stdio is captured to
   the global workspace logs/emulator.log (truncated per boot), and when it printed a
   \`FATAL |\` / \`ERROR |\` / \`PANIC:\` line THAT is the message and the remedy

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1321,22 +1321,50 @@ THE POOL: WHICH DEVICE AN ID-LESS \`--device\` PICKS
   \`.ipa\` export, store signing and distribution stay out of scope.`,
     },
     simslim: {
-      summary: 'installing SimSlim and what ios.simslimProfile does to an owned simulator',
-      body: () => `OPTIONAL SIMSLIM PROFILE
+      summary: 'recommended SimSlim profiles and recovery from host memory pressure',
+      body: () => `SIMSLIM FOR PARALLEL IOS WORK
+  SimSlim is recommended as an optional way to reduce simulator background
+  services and memory use, especially with several workspaces. Review which
+  services your app and tests need; a slim profile can disable those features.
+  It does not guarantee that a memory stall or crash will be fixed.
+
   Install SimSlim once on each Mac:
 
     brew install mobai-app/tap/simslim
 
-  Then commit a profile and select it in .stim.json:
+  Review the categories and create a profile in an interactive terminal:
+
+    simslim profiles
+    mkdir -p .simslim
+    simslim profile .simslim/dev.json
+
+  Selected categories in the wizard stay enabled. The wizard writes the
+  profile without applying it. Review and commit it, then select it in .stim.json:
 
     { "ios": { "simslimProfile": ".simslim/dev.json" } }
 
-  SimSlim requires an iOS 18 or newer simulator. On each local \`stim ios\`,
+  SimSlim 0.8 requires iOS 18.5 or newer. On each local \`stim ios\`,
   Stim reconciles that profile on the owned simulator before the app build.
   The first change can update services and reboot the simulator. A matching
   profile is a fast no-op on later launches. The settings persist across normal
   shutdowns and reboots. Removing the setting restores stock services when
-  Stim applied the profile. Stim never changes an unowned or remote simulator.`,
+  Stim applied the profile. Stim never changes an unowned or remote simulator.
+  Doctor recommends this setup but never installs SimSlim or applies a profile.
+  Profile schema and service tradeoffs: https://github.com/MobAI-App/simslim
+
+HOST MEMORY PRESSURE AND STALLED SIMULATORS
+  Booted and a working screenshot do not prove that simulator processes can
+  start. Stim checks a bounded process spawn before install and bounds local
+  simulator launch operations. A timeout is not proof of an app crash or OOM.
+  Doctor and failure diagnostics report macOS memory pressure when available;
+  a failed query remains unknown. Existing swap or low free RAM alone is not
+  enough to diagnose pressure.
+
+  If pressure is elevated, free host memory before retrying. Use \`stim stop\`
+  only in workspaces you own and have finished using; ask before closing other
+  agents' simulators or heavy apps. Rebooting a simulator under the same pressure
+  can repeat the stall. Consider fewer concurrent builds/devices (guide lifecycle
+  concurrency) and a reviewed SimSlim profile for future runs.`,
     },
   },
 };

--- a/packages/stim-cli/src/guide/settings.ts
+++ b/packages/stim-cli/src/guide/settings.ts
@@ -64,7 +64,9 @@ KEYS STIM READS
                         at most 64 KiB. Install the
                         external tool once with
                         \`brew install mobai-app/tap/simslim\`. SimSlim requires
-                        an iOS 18 or newer simulator. Each local \`stim ios\`
+                        iOS 18.5 or newer in SimSlim 0.8. Recommended for parallel
+                        iOS work after reviewing service tradeoffs; see
+                        \`stim guide lifecycle simslim\`. Each local \`stim ios\`
                         reconciles the profile on its Stim-owned simulator.
                         The first change can reboot it; a matching profile is a
                         fast no-op. Removing the setting restores stock services

--- a/packages/stim-cli/src/host-memory.ts
+++ b/packages/stim-cli/src/host-memory.ts
@@ -1,0 +1,32 @@
+import { getExecutor, type Executor } from './exec.ts';
+
+export type HostMemoryPressure = 'normal' | 'warning' | 'critical';
+
+export function readHostMemoryPressure(
+  exec: Executor = getExecutor(),
+  platform: NodeJS.Platform = process.platform,
+): HostMemoryPressure | null {
+  if (platform !== 'darwin') return null;
+  try {
+    const value = exec.runFile('/usr/sbin/sysctl', ['-n', 'kern.memorystatus_vm_pressure_level'], { timeoutMs: 2000 });
+    // XNU exposes dispatch flags here, not its internal pressure enum:
+    // https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_memorystatus_notify.c
+    switch (value.trim()) {
+      case '1':
+        return 'normal';
+      case '2':
+        return 'warning';
+      case '4':
+        return 'critical';
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+export function hostMemoryPressureAdvice(pressure: HostMemoryPressure | null): string | null {
+  if (pressure === null || pressure === 'normal') return null;
+  return `macOS reports ${pressure} host memory pressure. Simulator processes can stall even when the device is Booted. Free memory before retrying: use \`stim stop\` only in workspaces you own, and ask before closing other apps or devices. For parallel iOS work, consider a reviewed SimSlim profile (\`stim guide lifecycle simslim\`). This observation does not establish an OOM crash.`;
+}

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getExecutor } from '../exec.ts';
+import { getExecutor, type Executor } from '../exec.ts';
+import { hostMemoryPressureAdvice, readHostMemoryPressure } from '../host-memory.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
 
 export interface IosSimRecord {
@@ -155,6 +156,13 @@ export const IOS_BOOT_TIMEOUT_MS: number = 600000;
 const BOOTSTATUS_ATTEMPT_MS = 240000;
 const BOOTSTATUS_ATTEMPT_FLOOR_MS = 1000;
 const BOOT_STATE_LIST_TIMEOUT_MS = 30000;
+
+export function iosSimulatorFailureAdvice(exec: Executor = getExecutor()): string {
+  return (
+    hostMemoryPressureAdvice(readHostMemoryPressure(exec)) ??
+    'The simulator may be unresponsive. Check Activity Monitor for memory pressure and free host memory before retrying.'
+  );
+}
 
 function bootstatusTimeout(udid: string): NodeJS.ErrnoException {
   const e = new Error(`xcrun simctl bootstatus ${udid} -b timed out`) as NodeJS.ErrnoException;

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -31,6 +31,22 @@ defaults or use `ios --device-type`, `ios --runtime`, and
 assumes that the caller finished all device automation for that Stim session.
 It does not block on other processes attached to the owned device.
 
+## Memory pressure and SimSlim
+
+SimSlim is recommended as an optional way to reduce background services and
+memory use when running several iOS workspaces. Review the profile against
+your app's needs: disabled services can affect tests. Current SimSlim 0.8
+requires iOS 18.5 or newer. Run `stim guide lifecycle simslim` for installation
+and profile setup; `doctor` recommends it without applying it automatically.
+
+A simulator can report Booted and show SpringBoard while process startup is
+stalled. Stim checks a bounded process spawn before installation and bounds
+local launch calls. When macOS reports elevated memory pressure, diagnostics
+recommend freeing memory before retrying. A timeout or existing swap usage
+alone does not establish OOM. Stop only workspaces you own and have finished
+using; ask before closing other agents' simulators or heavy apps. SimSlim can
+reduce future resource use but is not a guaranteed fix for a stalled host.
+
 ## Remote devices
 
 Stim supports two optional remote backends:


### PR DESCRIPTION
## Description

A simulator can report Booted while processes inside it cannot start. Stim accepted that state and could wait indefinitely in dev-client preparation or `openurl`. The reported incident coincided with severe host memory use; its underlying cause was not confirmed.

Fixes #752.

## Solution

Require a process-spawn probe to complete within 30 seconds before installation, and bound the missing simulator preparation and launch calls to 60 seconds. Report macOS memory pressure before boot and on startup failures when available; unknown readings remain unknown, and timeouts are not labeled OOM crashes. Recovery guidance puts freeing memory ahead of another launch attempt.

Doctor recommends optional SimSlim profiles for parallel iOS work without installing or enabling them; review disabled services for effects on app behavior and tests.

## Test plan

- Regression cases cover unresponsive simulators, bounded calls, memory-pressure interpretation, and platform isolation.
- On macOS with iPhone 17 / iOS 26.5, the candidate installed and launched an Expo dev client on a fresh Stim-owned simulator (`launched: true`). Real `simctl spawn /usr/bin/true`, `defaults write`, and `openurl` calls succeeded; cleanup removed the exact owned simulator and worktree.
- Read-only macOS pressure query returned normal. Deliberate host memory exhaustion was not tested.

