### PR TITLE
fix: gate the doctor --fix sandbox write on the reported finding

### DIFF
--- a/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
+++ b/packages/stim-cli/src/__tests__/doctor-cxx.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, expect, test } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { getExecutor } from '../exec.ts';
 import { acquireBuildLock, releaseBuildLock } from '../engine/build-lock.ts';
 import { readCxxLauncherStates, repairCxxLauncherState } from '../doctor-cxx.ts';
-import { checkCxxCompilerLauncher } from '../doctor.ts';
+import { checkCxxCompilerLauncher, type Finding } from '../doctor.ts';
 import { claudeLocalSettingsPath, missingAllowance } from '../sandbox.ts';
 import { writeCasToolchain } from './_factories.ts';
 
@@ -121,31 +121,59 @@ test('repair follows pnpm package links within the checkout for Git safety check
   expect(existsSync(stale)).toBe(false);
 });
 
+const cli = join(import.meta.dirname, '../../dist/cli.mjs');
+
+function doctorJson(args: string[], env: Record<string, string>, omitEnv: string[] = []): { findings: Finding[] } {
+  return JSON.parse(
+    getExecutor().runFile(process.execPath, [cli, 'doctor', '--json', ...args], { cwd: root, env, omitEnv }),
+  );
+}
+
 test.each(['claude', 'codex'])(
-  'Android doctor --json --fix repairs CMake under %s without a false sandbox failure',
+  'Android doctor --json --fix repairs CMake under unsandboxed %s and leaves the sandbox allowance alone',
   (harness) => {
     writeFileSync(
       join(root, 'package.json'),
       JSON.stringify({ name: 'fixture', dependencies: { 'react-native': '0.81.0' } }),
     );
     const stale = cache('android/app', null);
-    const cli = join(import.meta.dirname, '../../dist/cli.mjs');
-    const plain = JSON.parse(
-      getExecutor().runFile(process.execPath, [cli, 'doctor', '--json', '--platform', 'android'], { cwd: root }),
-    );
-    expect(plain.findings.some((finding: { code?: string }) => finding.code === 'android-cmake-launcher')).toBe(true);
+    const env: Record<string, string> = harness === 'claude' ? { CLAUDECODE: '1' } : { CODEX_SANDBOX: 'seatbelt' };
+    const omitEnv = harness === 'codex' ? ['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT'] : [];
+    const plain = doctorJson(['--platform', 'android'], env, omitEnv);
+    expect(plain.findings.some((finding) => finding.code === 'android-cmake-launcher')).toBe(true);
+    expect(plain.findings.some((finding) => finding.title.includes('sandbox'))).toBe(false);
     expect(existsSync(stale)).toBe(true);
-    const fixed = JSON.parse(
-      getExecutor().runFile(process.execPath, [cli, 'doctor', '--json', '--fix', '--platform', 'android'], {
-        cwd: root,
-        env: harness === 'claude' ? { CLAUDECODE: '1' } : { CODEX_SANDBOX: 'seatbelt' },
-        omitEnv: harness === 'codex' ? ['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT'] : [],
-      }),
-    );
-    expect(fixed.findings.some((finding: { code?: string }) => finding.code === 'android-cmake-launcher')).toBe(false);
-    expect(missingAllowance([claudeLocalSettingsPath(root)], home)).toHaveLength(harness === 'claude' ? 0 : 3);
-    expect(existsSync(claudeLocalSettingsPath(root))).toBe(harness === 'claude');
+    const fixed = doctorJson(['--fix', '--platform', 'android'], env, omitEnv);
+    expect(fixed.findings.some((finding) => finding.code === 'android-cmake-launcher')).toBe(false);
+    expect(existsSync(claudeLocalSettingsPath(root))).toBe(false);
     expect(existsSync(stale)).toBe(false);
+  },
+);
+
+test.skipIf(process.getuid?.() === 0)(
+  'doctor --fix --platform android writes the allowance the report names when the sandbox blocks STIM_HOME',
+  () => {
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'fixture', dependencies: { 'react-native': '0.81.0' } }),
+    );
+    const locked = join(home, 'locked');
+    mkdirSync(locked);
+    chmodSync(locked, 0o500);
+    const blockedHome = join(locked, 'stim-home');
+    try {
+      const env = { CLAUDECODE: '1', STIM_HOME: blockedHome };
+      const plain = doctorJson(['--platform', 'android'], env);
+      const reported = plain.findings.find((finding) => finding.title.includes('sandbox'));
+      expect(reported?.fix).toContain(claudeLocalSettingsPath(root));
+      expect(existsSync(claudeLocalSettingsPath(root))).toBe(false);
+
+      const fixed = doctorJson(['--fix', '--platform', 'android'], env);
+      expect(missingAllowance([claudeLocalSettingsPath(root)], blockedHome)).toEqual([]);
+      expect(fixed.findings.some((finding) => finding.title.includes('has not picked it up'))).toBe(true);
+    } finally {
+      chmodSync(locked, 0o700);
+    }
   },
 );
 

--- a/packages/stim-cli/src/__tests__/sandbox.test.ts
+++ b/packages/stim-cli/src/__tests__/sandbox.test.ts
@@ -263,14 +263,31 @@ test('sandboxFinding says nothing when the harness is present but writes go thro
   }
 });
 
-test('sandboxFinding points Claude Code at the one command that fixes it', () => {
+test('sandboxFinding names the file and the three keys doctor --fix writes, whichever are missing', () => {
   const dir = scratch();
   try {
+    const keys = [
+      'sandbox.filesystem.allowWrite',
+      'sandbox.network.allowMachLookup',
+      'sandbox.network.allowLocalBinding',
+    ];
     const f = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir, blocked: true });
     expect(f?.level).toBe('cost');
-    expect(f?.detail).toContain('sandbox.filesystem.allowWrite');
+    expect(f?.detail).toContain(`Missing: ${keys.join(', ')}.`);
     expect(f?.fix).toContain('stim doctor --fix');
-    expect(f?.fix).toContain(join('.claude', 'settings.local.json'));
+    expect(f?.fix).toContain(claudeLocalSettingsPath(dir));
+    for (const key of keys) expect(f?.fix).toContain(key);
+
+    mkdirSync(join(dir, '.claude'));
+    writeFileSync(
+      join(dir, '.claude', 'settings.json'),
+      JSON.stringify({
+        sandbox: { network: { allowMachLookup: ['com.apple.coresimulator.*'], allowLocalBinding: true } },
+      }),
+    );
+    const partial = sandboxFinding(dir, { env: { CLAUDECODE: '1' }, home: dir, blocked: true });
+    expect(partial?.detail).toContain('Missing: sandbox.filesystem.allowWrite.');
+    for (const key of keys) expect(partial?.fix).toContain(key);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/stim-cli/src/commands/doctor.ts
+++ b/packages/stim-cli/src/commands/doctor.ts
@@ -171,7 +171,7 @@ export default function doctorCommand(
     )
     .option(
       '--fix',
-      'repair the sandbox allowance and stale Android .cxx configurations in this checkout. Stop native builds first. Generated CMake output must be ignored and untracked; custom launcher settings and source files are preserved.',
+      'repair the sandbox allowance when the report names it, and stale Android .cxx configurations in this checkout. Stop native builds first. Generated CMake output must be ignored and untracked; custom launcher settings and source files are preserved.',
     )
     .action(async (opts: DoctorOptions) => {
       const root = findProjectRoot(process.cwd());
@@ -182,7 +182,7 @@ export default function doctorCommand(
       }
 
       if (opts.fix) {
-        if (detectHarness() !== 'codex' || sandboxFinding(repoRoot(root) ?? root)) applySandboxFix(root);
+        if (sandboxFinding(repoRoot(root) ?? root)) applySandboxFix(root);
         if (opts.platform !== 'ios') {
           try {
             const repair = repairCxxLauncherState(root);

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -1053,9 +1053,11 @@ changes nothing  (worktree warm --refresh)
   blocks network egress by default, which breaks a cache lookup and a fetch.
 
   \`stim doctor\` names this when a write to STIM_HOME actually fails, not
-  merely when a harness that can sandbox is present, and
-  \`stim doctor --fix\` writes the three keys into .claude/settings.local.json,
-  the per-user file, merging with what is there. It refuses under Codex, which
+  merely when a harness that can sandbox is present. \`stim doctor --fix\`
+  writes only when the report shows that finding, and only what the finding
+  names: the three keys, into .claude/settings.local.json, the per-user file,
+  merging with what is there. A report without the finding, with or without
+  --platform, leaves that file alone. It refuses under Codex, which
   has no per-path allowance to add, and refuses any settings file it cannot
   parse rather than replace it: comments make one unparseable here even though
   Claude Code accepts them. Claude Code reads project settings from the

--- a/packages/stim-cli/src/sandbox.ts
+++ b/packages/stim-cli/src/sandbox.ts
@@ -257,6 +257,6 @@ export function sandboxFinding(
     level: 'cost',
     title,
     detail: `${symptoms} Missing: ${missing.join(', ')}.`,
-    fix: `Run \`stim doctor --fix\` to add them to ${paths[0]}, or add them by hand. See \`stim guide errors sandbox\`.`,
+    fix: `Run \`stim doctor --fix\` to write sandbox.filesystem.allowWrite, sandbox.network.allowMachLookup, and sandbox.network.allowLocalBinding into ${paths[0]}, merged with what is there, or add the missing keys by hand. See \`stim guide errors sandbox\`.`,
   };
 }

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -53,9 +53,10 @@ the simulator service, the adb server, and Stim's own state directory.
 For that finding, `--fix` writes the missing allowance into `.claude/settings.local.json` at the
 repository root, the per-user file, merging it with whatever is already there
 and preserving other settings. It cannot add a Codex allowance because that
-sandbox has no per-path allowance to add. This repair does nothing when no
-sandboxing harness is present. See `stim guide errors sandbox` for the
-failure signatures and the manual settings.
+sandbox has no per-path allowance to add. This repair runs only when the
+report shows that finding, so an unsandboxed session leaves the file alone.
+See `stim guide errors sandbox` for the failure signatures and the manual
+settings.
 
 Unless `--platform ios` is selected, `--fix` also removes stale ignored,
 untracked Android `.cxx` configurations with obsolete compiler launchers,


### PR DESCRIPTION
## Description

**`stim doctor --fix` wrote `<repo>/.claude/settings.local.json` under Claude Code even when the report showed no sandbox finding.** The report is gated on a harness being present and a probe write to `STIM_HOME` failing; the write was gated on `detectHarness() !== 'codex' || sandboxFinding(...)`, which is always true under Claude Code. So an unsandboxed `stim doctor --fix --platform android` touched a file the report never mentioned. The gate came from #442 (008d05794), which excluded unrestricted Codex from a false "Nothing to apply" failure instead of gating on the finding.

## Solution

`--fix` applies the sandbox allowance only when `sandboxFinding(...)` is non-null, the same condition that puts the finding in the report.

The finding's remedy now names the file and all three keys `--fix` writes (`sandbox.filesystem.allowWrite`, `sandbox.network.allowMachLookup`, `sandbox.network.allowLocalBinding`), even when only some are missing, because `applyClaudeAllowance` merges all three into the local file. The report is the consent for the write.

`--platform` needs no extra scoping: the sandbox finding is shared, shown for every platform, so `--fix --platform android` applies it exactly when it is reported. Sandboxed Codex is unchanged (finding reported, `--fix` refuses with exit 1); unsandboxed Codex no longer reaches that message, which is what #442 wanted.

`stim guide errors sandbox` and `website/docs/commands.md` now say the write happens only when the report shows the finding.

## Test plan

- `doctor-cxx.test.ts`: the `--json --fix --platform android` CLI case asserts, for unsandboxed Claude Code and Codex, that `.cxx` state is repaired and `.claude/settings.local.json` does not exist afterward. Fails on `main` for Claude Code.
- `doctor-cxx.test.ts`: new case with `STIM_HOME` under a `0o500` directory and `CLAUDECODE=1`. Plain `doctor --platform android` reports the finding naming the settings path without writing; `--fix --platform android` writes all three keys and the follow-up report says the session has not picked them up. Skipped as root.
- `sandbox.test.ts`: the finding's `fix` text names `.claude/settings.local.json` and all three keys, both when all are missing and when two are already held in `.claude/settings.json`. Fails on `main`.
- Manual, built CLI in a scratch RN fixture: `CLAUDECODE=1 STIM_HOME=<writable> stim doctor --fix --platform android` prints PASS and leaves no `.claude/` directory. With `STIM_HOME` under a `chmod 500` parent, plain `doctor` shows the finding, `--fix` prints `Wrote .../.claude/settings.local.json` with the three keys, and the report then shows "has not picked it up".

Fixes #751
