### PR TITLE
fix: allow cold Android emulators more time to load

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -63,6 +63,7 @@ import {
   installAndroidApp,
   deviceShellArg,
   androidDevClientUrl,
+  verifyLaunch,
 } from '../engine/app-install.ts';
 import type { AssetManifest } from '../engine/asset-manifest.ts';
 import { PREBUILD_ERROR } from '../engine/prebuild.ts';
@@ -204,6 +205,7 @@ interface VerifyArgs {
   since?: string | number;
   metroPort?: string | number | null;
   platform?: string | null;
+  timeoutMs?: number;
 }
 
 interface Calls {
@@ -602,6 +604,7 @@ describe('explicit remote backend behavior', () => {
       expect(remoteCalls).toEqual(['ensureDevice', 'ensureDeviceBooted', 'install', 'launch']);
       expect(h.calls.ensureDevice).toEqual([]);
       expect(h.calls.fingerprint.length).toBe(2);
+      expect(h.calls.verify[0]?.timeoutMs).toBe(20000);
     },
   );
 
@@ -1555,12 +1558,18 @@ describe('metro is verified before any build work', () => {
     expect(result.error.message).toMatch(/No Metro port is reserved/);
   });
 
-  test('--no-metro-check proceeds without probing anything', async () => {
-    const h = harness({ metroCheck: false, resolveMetro: never('the metro probe') });
+  test('--no-metro-check proceeds without probing anything on a new emulator', async () => {
+    const h = harness({
+      metroCheck: false,
+      resolveMetro: never('the metro probe'),
+      ensureDevice: async () => ({ avdName: 'stim-app-412', consolePort: 5584, owned: true, created: true }),
+    });
     const result = await h.run();
     expect(result.ok).toBe(true);
     expect(labelled(h.stderr, 'metro')[0]).toMatch(/not checked/);
     expect(h.calls.launch[0]?.metroPort).toBe(8082);
+    expect(h.calls.verify).toEqual([]);
+    expect(h.stderr.join('\n')).not.toContain('60s for bundle load');
     expect(h.stdout[0]).toContain(phaseLine('metro', 'check skipped on port 8082'));
   });
 
@@ -2846,6 +2855,69 @@ describe('the device preparation step', () => {
 });
 
 describe('launch verification', () => {
+  test.each([
+    { created: true, event: 'bundle_response_finished', state: true, waitedMs: 26000 },
+    { created: false, event: 'bundle_response_finished', state: 'unverified', waitedMs: 20000 },
+    { created: true, event: null, state: 'unverified', waitedMs: 60000 },
+    { created: true, event: 'bundle_response_started', state: 'bundling', waitedMs: 60000 },
+    { created: true, event: 'bundle_response_failed', state: 'fatal', waitedMs: 23000 },
+  ])(
+    'created=$created, bundle=$event verifies as $state after $waitedMs ms',
+    async ({ created, event, state, waitedMs }) => {
+      const crashes = vi.spyOn(crashDiagnostics, 'captureNativeCrashes').mockReturnValue([]);
+      let elapsed = 0;
+      try {
+        const h = harness({
+          ensureDevice: async () => ({ avdName: 'stim-app-412', consolePort: 5584, owned: true, created }),
+          verifyLaunched: async (args: Parameters<typeof verifyLaunch>[0]) => {
+            const started = Number(args?.since);
+            return verifyLaunch({
+              ...args,
+              now: () => started + elapsed,
+              sleep: async (ms) => {
+                elapsed += ms;
+              },
+              readRecords: () =>
+                elapsed >= 23000 && event
+                  ? [
+                      {
+                        ts: started + 23000,
+                        platform: 'android',
+                        event: 'bundle_response_started',
+                        requestId: 'cold-launch',
+                      },
+                      ...(event === 'bundle_response_started'
+                        ? []
+                        : [
+                            {
+                              ts: started + 23000,
+                              platform: 'android',
+                              event,
+                              requestId: 'cold-launch',
+                              msg: event === 'bundle_response_failed' ? 'Bundle delivery failed' : 'Bundle response',
+                            },
+                          ]),
+                    ]
+                  : [],
+              readDeviceRecords: () => [],
+              readClientRecords: () => [],
+              processAlive: () => true,
+            });
+          },
+        });
+        const result = await h.run();
+        expect(elapsed).toBe(waitedMs);
+        expect(result.ok).toBe(state !== 'fatal');
+        expect(result.error?.code).toBe(state === 'fatal' ? 'STIM_LAUNCH_FAILED' : undefined);
+        expect(result.facts?.launched).toBe(state === 'fatal' ? undefined : state);
+        expect(h.stderr.join('\n').includes('60s for bundle load (new emulator)')).toBe(created);
+        expect(h.stderr.join('\n').includes(`within ${waitedMs / 1000}s`)).toBe(state === 'unverified');
+      } finally {
+        crashes.mockRestore();
+      }
+    },
+  );
+
   test("a verified launch reports launched: true and polls this workspace's timeline", async () => {
     const h = harness();
     const result = await h.run();
@@ -2854,6 +2926,7 @@ describe('launch verification', () => {
     expect(h.calls.verify[0]?.logsDir).toBe(workspaceLogsDir(root));
     expect(Number.isFinite(h.calls.verify[0]?.since)).toBeTruthy();
     expect(h.calls.verify[0]?.platform).toBe('android');
+    expect(h.calls.verify[0]?.timeoutMs).toBe(20000);
     expect(
       h.stderr.some((l) => /verify.*bundle loaded, stable for 3s -- the first screen may still be rendering/.test(l)),
     ).toBeTruthy();
@@ -3404,7 +3477,11 @@ describe('variant resolution', () => {
 
 describe('release skips Metro entirely', () => {
   test('no gate, no reservation needed, no port wiring, plain am start', async () => {
-    const h = harness({ variant: 'productionRelease', resolveMetro: never('the metro probe') });
+    const h = harness({
+      variant: 'productionRelease',
+      resolveMetro: never('the metro probe'),
+      ensureDevice: async () => ({ avdName: 'stim-app-412', consolePort: 5584, owned: true, created: true }),
+    });
     const result = await h.run();
     expect(result.ok).toBe(true);
     expect(h.calls.metro.length).toBe(0);
@@ -4382,6 +4459,7 @@ describe('--device (a physical Android device)', () => {
     expect(result.ok).toBe(true);
     expect(h.calls.install[0]?.serial).toBe('RFCR7081Q9L');
     expect(h.calls.launch[0]?.serial).toBe('RFCR7081Q9L');
+    expect(h.calls.verify[0]?.timeoutMs).toBe(20000);
   });
 
   test('a physical Debug run builds for the device primary ABI', async () => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1566,7 +1566,7 @@ describe('ensureOwnedDevice: android', () => {
         createAvdError: 'Error: AVD stim-app already exists.',
       });
       setExecutor(exec);
-      await ensureOwnedDevice({
+      const recovered = await ensureOwnedDevice({
         platform: 'android',
         project: getProject(root),
         projectPath: root,
@@ -1578,6 +1578,7 @@ describe('ensureOwnedDevice: android', () => {
       });
       expect(readFileSync(join(content, 'config.ini'), 'utf8')).toBe('disk.dataPartition.size=10G\n');
       expect(spawn).toHaveLength(1);
+      expect(recovered.created).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1600,7 +1601,13 @@ describe('ensureOwnedDevice: android', () => {
         label: 'app',
         settings: {},
       });
-      expect(result).toMatchObject({ avdName: 'stim-app', serial: 'emulator-5584', consolePort: 5584, owned: true });
+      expect(result).toMatchObject({
+        avdName: 'stim-app',
+        serial: 'emulator-5584',
+        consolePort: 5584,
+        owned: true,
+        created: false,
+      });
       expect(getProject(root)?.platforms?.android).toMatchObject({ avdName: 'stim-app', consolePort: 5584 });
       expect(spawn).toEqual([]);
     } finally {

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -19,6 +19,7 @@ import {
   launchAndroidReleaseApp,
   ADB_INSTALL_TIMEOUT_MS,
   RELEASE_VERIFY_WAIT_MS,
+  VERIFY_TIMEOUT_MS,
   installConflictKind,
   deviceShellArg,
 } from '../../engine/app-install.ts';
@@ -77,6 +78,7 @@ interface VerifyAndroidRunArgs {
   metroPort: number | null;
   isExpo: boolean;
   physical: boolean;
+  newEmulator: boolean;
   scheme?: string | null;
   component?: string | null;
   phase: (label: unknown, text: string) => void;
@@ -98,6 +100,7 @@ async function verifyAndroidRun({
   metroPort,
   isExpo,
   physical,
+  newEmulator,
   scheme,
   component = null,
   phase,
@@ -150,8 +153,11 @@ async function verifyAndroidRun({
     return { state: LAUNCH_FATAL };
   }
 
+  const timeoutMs = newEmulator ? 60000 : VERIFY_TIMEOUT_MS;
+  if (metroCheck && newEmulator) phase('verify', 'waiting up to 60s for bundle load (new emulator)');
   const verification: VerifyLaunchResultLike = metroCheck
     ? await verifyLaunched({
+        timeoutMs,
         requireBundleResponse: true,
         onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
@@ -646,6 +652,7 @@ export async function finishAndroidRun({
     metroPort,
     isExpo,
     physical,
+    newEmulator: Boolean(device.created && device.owned && !remoteDevice),
     scheme,
     component: launched.component ?? null,
     phase,

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -767,7 +767,7 @@ async function ensureOwnedAndroidDevice({
         );
       }
       out(chalk.dim(phaseLine('device', `recovered ${avdName} (unrecorded from a prior run)`)));
-      if (created.serial) return { ...created, owned: true, deviceName: avdName, created: true };
+      if (created.serial) return { ...created, owned: true, deviceName: avdName, created: false };
     } else {
       throw e;
     }
@@ -801,7 +801,7 @@ async function ensureOwnedAndroidDevice({
       logFile,
       alive,
     })),
-    created: true,
+    created: fresh,
     systemImage: created.systemImage,
   };
 }

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -143,6 +143,12 @@ If the app is stuck before loading its first bundle, restart its process with
 the printed force-stop and launcher commands. Foregrounding the same process
 does not restart initialization. Confirm the bundle request and expected UI.
 
+Debug Android launches on an owned emulator created in the same run get up to
+60 seconds for bundle loading; the verify phase names that budget. Existing
+emulators, remote targets, and physical devices keep the 20-second budget.
+Bundle delivery still requires the usual stability or app readiness check;
+an observed fatal error ends verification without waiting for the deadline.
+
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
   gc --delete --cache all empties the shared build caches every project uses

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -147,6 +147,10 @@ bundle response finishes; build-complete output alone does not close an observed
 request. Without response capture, Stim falls back to the build-complete marker.
 When Android reports queued JavaScript loading, Stim waits for device JavaScript
 activity before starting stability, bounded by the bundle timeout.
+Debug Android launches on an owned emulator created in the same run get a
+60-second bundle timeout, reported in the verify phase. Existing emulators,
+remote targets, and physical devices keep the 20-second budget. Fatal errors
+still end verification immediately.
 A `pending` observed before that window closes opts into waiting for `ready`, up
 to 30 seconds after the same completion signal.
 Repeated `pending` logs do not extend the deadline. A matching `ready` can end


### PR DESCRIPTION
## Description

A healthy app on a newly created Android emulator can request its first bundle just after Stim's 20-second verification window, leaving an unverified result even though the app loads normally.

Fixes #749.

## Solution

Allow up to 60 seconds for the first bundle on a new owned Android emulator and print the selected budget. Existing emulators retain the 20-second window. Fatal errors still end verification immediately, and remote, physical-device, and release behavior is unchanged.

## Test plan

- Command regression uses the actual verifier with a bundle arriving at 23 seconds: the new-emulator run verifies, while the existing-emulator run remains unverified at 20 seconds.
- Missing or unfinished cold bundles stop at 60 seconds; a fatal error at 23 seconds stops immediately.
- Real Expo 57 / Android API 36 run printed the 60-second budget and returned unverified at that deadline while showing the dev-client picker. Resending the printed deep link loaded the expected screen with no captured errors. The late-bundle success case is covered by the controlled regression.
