### PR TITLE
fix: reconnect Android emulators after serial changes

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
 import { ClaimRefusedError, ClaimUnavailableError, claimRemoveCommand } from '../ownership-claim.ts';
 import { AvdRecoveryError } from '../engine/device.ts';
+import { ensureRemoteBootOwned } from '../engine/device-remote.ts';
 import { once } from 'node:events';
 import { type ChildProcess, spawn } from 'node:child_process';
 import {
@@ -22,7 +23,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Command } from 'commander';
 import { collectorProcessTitle } from '../collector/ownership.ts';
-import { loadConfig, setProjectSetting, upsertProject } from '../config.ts';
+import { loadConfig, setDevice, setProjectSetting, upsertProject } from '../config.ts';
 import { parseNdjsonText } from '../ndjson.ts';
 import { emulatorLogFile, workspaceLogsDir, workspaceStateFile } from '../paths.ts';
 import { writeWorkspaceState } from '../supervisor/run.ts';
@@ -278,6 +279,8 @@ function harness(overrides = {}) {
   const stdout: string[] = [];
   const options = {
     root,
+    ensureRemoteBootOwned: (args: Parameters<typeof ensureRemoteBootOwned>[0]) =>
+      ensureRemoteBootOwned({ ...args, ledgerRoot: join(home, 'machine-eas') }),
     deviceAbi: () => null,
     ensureDevice: async (args: unknown = {}) => {
       calls.ensureDevice.push(args);
@@ -288,6 +291,8 @@ function harness(overrides = {}) {
       calls.booted.push(args);
       return { ok: true, serial: 'emulator-5584' };
     },
+    resolveAvdSerial: () => ({ serial: 'emulator-5584' }),
+    waitForDeviceBoot: never('an unchanged serial readiness wait'),
     resolveMetro: async (port: number, path: string) => {
       calls.metro.push([port, path]);
       return { metro: { pid: 41233, leader: 41233, cwd: root } };
@@ -454,7 +459,21 @@ function harness(overrides = {}) {
     emit: (line: string) => stdout.push(line),
     ...overrides,
   };
-  return { calls, stderr, stdout, run: () => runAndroid(options) };
+  const ensureDevice = options.ensureDevice;
+  return {
+    calls,
+    stderr,
+    stdout,
+    run: () =>
+      runAndroid({
+        ...options,
+        ensureDevice: async (args) => {
+          const device = await ensureDevice(args);
+          if (device.owned) setDevice(root, 'android', device);
+          return device;
+        },
+      }),
+  };
 }
 
 test('an invalid Android pool bound refuses before device creation and emits one JSON error', async () => {
@@ -566,6 +585,7 @@ describe('explicit remote backend behavior', () => {
         };
       },
       ensureMetroReachable: async () => ({ ok: true as const }),
+      resolveAvdSerial: never('local AVD resolution for a remote device'),
       remoteDeviceDeps: () => ({
         ctx: { root, label: 'app', backend, easBin: '/bin/eas', agentDeviceBin: '/bin/agent-device' },
         checkCapacity: () => null,
@@ -1311,6 +1331,87 @@ describe('a cache miss', () => {
     const h = harness({ prebuild: never('prebuild') });
     expect((await h.run()).ok).toBe(true);
   });
+});
+
+describe('owned AVD identity after the build', () => {
+  test('an unchanged serial refuses when the workspace AVD assignment changes during the build', async () => {
+    const replacement = { avdName: 'stim-replacement', consolePort: 5586, owned: true };
+    const h = harness({
+      build: async () => {
+        setDevice(root, 'android', replacement);
+        return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      },
+    });
+    const result = await h.run();
+    expect(result.error?.code).toBe(NO_DEVICE);
+    expect(h.calls.install).toEqual([]);
+    expect(h.calls.launch).toEqual([]);
+    expect(loadConfig()?.projects[root]?.platforms?.android).toEqual(replacement);
+  });
+
+  test('an emulator restart during the build retargets install, launch, collection, and output', async () => {
+    const device = { avdName: 'stim-app-412', consolePort: 5584, owned: true };
+    setDevice(root, 'android', device);
+    let currentSerial = 'emulator-5584';
+    const resolutions: string[] = [];
+    const readySerials: string[] = [];
+    const h = harness({
+      json: true,
+      build: async () => {
+        currentSerial = 'emulator-5586';
+        return { ok: true, apkPath: fakeApk(), durationMs: 161000, lastLines: [] };
+      },
+      resolveAvdSerial: (avdName: string) => {
+        expect(avdName).toBe(device.avdName);
+        resolutions.push(currentSerial);
+        return { serial: currentSerial };
+      },
+      waitForDeviceBoot: async (serial: string) => {
+        readySerials.push(serial);
+        return { ok: true };
+      },
+    });
+    const result = await h.run();
+    expect(result.ok).toBe(true);
+    expect(resolutions).toEqual(['emulator-5586', 'emulator-5586']);
+    expect(readySerials).toEqual(['emulator-5586']);
+    expect(h.calls.install.map((call) => call.serial)).toEqual(['emulator-5586']);
+    expect(h.calls.launch.map((call) => [call.serial, call.metroPort])).toEqual([['emulator-5586', 8082]]);
+    expect(JSON.stringify(h.calls.spawn)).toContain('emulator-5586');
+    expect(JSON.stringify(h.calls.spawn)).not.toContain('emulator-5584');
+    expect(loadConfig()?.projects[root]?.platforms?.android).toEqual({ ...device, consolePort: 5586 });
+    expect(readState().launches.android.deviceId).toBe('emulator-5586');
+    expect(result.facts?.serial).toBe('emulator-5586');
+    expect(h.stdout).toHaveLength(1);
+    expect(JSON.parse(h.stdout[0]!).serial).toBe('emulator-5586');
+  });
+
+  test.each(['missing', 'notRunning', 'notOwned', 'probe-failed', 'not-ready', 'changed-again'] as const)(
+    '%s refuses installation after the build and retains the owned AVD record',
+    async (failure) => {
+      const device = { avdName: 'stim-app-412', consolePort: 5584, owned: true };
+      setDevice(root, 'android', device);
+      let probes = 0;
+      const h = harness({
+        resolveAvdSerial: () => {
+          probes++;
+          if (failure === 'probe-failed') throw new Error('AVD lookup timed out');
+          if (failure === 'missing' || failure === 'notRunning' || failure === 'notOwned') return { [failure]: true };
+          return { serial: failure === 'changed-again' && probes > 1 ? 'emulator-5588' : 'emulator-5586' };
+        },
+        waitForDeviceBoot: async () => ({ ok: failure !== 'not-ready' }),
+      });
+      const result = await h.run();
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe(NO_DEVICE);
+      expect(h.calls.build).toHaveLength(1);
+      expect(h.calls.install).toEqual([]);
+      expect(h.calls.launch).toEqual([]);
+      expect(h.calls.booted).toHaveLength(1);
+      expect(loadConfig()?.projects[root]?.platforms?.android).toEqual(device);
+      expect(result.error?.remedy).toContain('stim android');
+    },
+  );
 });
 
 describe('product flavors (--variant / android.variant)', () => {
@@ -4443,6 +4544,7 @@ describe('--device (a physical Android device)', () => {
       checkCapacity: never('the device-capacity check'),
       ensureDevice: never('the owned-device path'),
       ensureDeviceBooted: never('the emulator boot'),
+      resolveAvdSerial: never('AVD resolution for a physical device'),
       ...overrides,
     });
   }

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { createServer } from 'http';
 import { Command } from 'commander';
 import { setExecutor, resetExecutor } from '../exec.ts';
-import { saveConfig } from '../config.ts';
+import { saveConfig, loadConfig } from '../config.ts';
 import type { AddressInfo } from 'node:net';
 import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
@@ -576,3 +576,59 @@ describe('the device lease section', () => {
     expect(payload.deviceLeases[0]).toMatchObject({ parsed: false, holder: null, mine: false, expired: false });
   });
 });
+
+test.each(['moved', 'absent', 'missing', 'unavailable'] as const)(
+  'status observes owned Android serials without changing state (%s)',
+  async (scenario) => {
+    saveConfig(
+      makeConfig({
+        projects: {
+          '/proj/android': {
+            label: 'android',
+            platforms: { android: { avdName: 'stim-app', consolePort: 5554, owned: true } },
+          },
+        },
+      }),
+    );
+    const before = loadConfig();
+    const commands: string[] = [];
+    setExecutor({
+      run(cmd, options) {
+        commands.push(cmd);
+        if (cmd.includes('simctl list')) return '{"devices":{}}';
+        if (cmd.includes('-list-avds')) {
+          expect(options.timeoutMs).toBeGreaterThan(0);
+          expect(options.timeoutMs).toBeLessThanOrEqual(5000);
+          if (scenario === 'unavailable') throw new Error('emulator listing unavailable');
+          return scenario === 'missing' ? '' : 'stim-app\n';
+        }
+        if (cmd.endsWith(' devices'))
+          return scenario === 'moved'
+            ? 'List of devices attached\nemulator-5556\tdevice\n'
+            : 'List of devices attached\n';
+        return '';
+      },
+      runQuiet(cmd) {
+        commands.push(cmd);
+        return cmd.includes('-s emulator-5556 emu avd name') ? 'stim-app\nOK' : null;
+      },
+      runFileQuiet: () => null,
+      spawn() {
+        throw new Error('status must not spawn a device');
+      },
+    });
+    const payload = await runStatusJson();
+    const state = payload.environments[0];
+    const expected = {
+      moved: { serial: 'emulator-5556', state: 'detected', warning: /emulator-5554 -> emulator-5556.*stim android/ },
+      absent: { serial: null, state: 'not-detected', warning: /not detected by adb/ },
+      missing: { serial: null, state: 'missing', warning: /no longer exists/ },
+      unavailable: { serial: null, state: 'unknown', warning: /could not check.*listing unavailable/ },
+    }[scenario];
+    expect(state.android).toMatchObject({ serial: expected.serial, state: expected.state, owned: true });
+    expect(state.warnings.join(' ')).toMatch(expected.warning);
+    expect(state.live).toBe(scenario === 'moved');
+    expect(loadConfig()).toEqual(before);
+    expect(commands.some((cmd) => /reverse|emu kill|\bboot\b/.test(cmd))).toBe(false);
+  },
+);

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -116,7 +116,9 @@ import {
   listInstalledSystemImages,
   physicalDeviceModel,
   probeEmulatorSerial,
+  resolveOwnedAvdSerial,
   resolvePhysicalDevice,
+  waitForBoot,
 } from '../sim/android.ts';
 import {
   checkDeviceCapacity,
@@ -362,6 +364,8 @@ interface RunAndroidOptions {
   releaseSlot?: typeof releaseBuildSlot;
   ensureDevice?: typeof ensureOwnedDevice;
   ensureDeviceBooted?: typeof ensureBooted;
+  resolveAvdSerial?: typeof resolveOwnedAvdSerial;
+  waitForDeviceBoot?: typeof waitForBoot;
   resolveMetro?: typeof resolveProjectMetro;
   warmMetro?: typeof warmMetro;
   resolveMetroRetrying?: typeof resolveMetroWithRetry;
@@ -442,6 +446,8 @@ function resolveRunAndroidOptions(
     ensureDevice = ensureOwnedDevice,
     listSystemImages = listInstalledSystemImages,
     ensureDeviceBooted = ensureBooted,
+    resolveAvdSerial = resolveOwnedAvdSerial,
+    waitForDeviceBoot = waitForBoot,
     resolveMetro = resolveProjectMetro,
     warmMetro: prewarmMetro = warmMetro,
     resolveMetroRetrying = resolveMetroWithRetry,
@@ -521,6 +527,8 @@ function resolveRunAndroidOptions(
     ensureDevice,
     listSystemImages,
     ensureDeviceBooted,
+    resolveAvdSerial,
+    waitForDeviceBoot,
     resolveMetro,
     prewarmMetro,
     resolveMetroRetrying,
@@ -602,6 +610,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     ensureDevice,
     listSystemImages,
     ensureDeviceBooted,
+    resolveAvdSerial,
+    waitForDeviceBoot,
     resolveMetro,
     prewarmMetro,
     resolveMetroRetrying,
@@ -1680,6 +1690,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         physical,
         remoteDevice,
         bootPromise,
+        resolveAvdSerial,
+        waitForDeviceBoot,
         bootDuration: () => bootDuration,
         apkPath,
         androidPackage,

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -1,4 +1,4 @@
-import { resetAdoptedAvd } from '../../sim/android.ts';
+import { resetAdoptedAvd, type resolveOwnedAvdSerial, type waitForBoot } from '../../sim/android.ts';
 import type { ChildProcess } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { basename } from 'node:path';
@@ -54,7 +54,7 @@ import { remoteAndroidDeps } from '../../engine/device-remote.ts';
 import { type RunLease, DEBUG_VERIFY_STEP_MS, lostLine, lostRefusal } from '../../engine/device-lease-run.ts';
 import { type LoadProjectProviderResult, exitAfterFlush } from '../../engine/remote-cache.ts';
 import { type ReportAndroidResultArgs, finishAndroidUpload, reportAndroidResult, persistLastBuild } from './result.ts';
-import { loadConfig, saveConfig, withConfigLock, upsertProject } from '../../config.ts';
+import { loadConfig, saveConfig, setDevice, withConfigLock, upsertProject } from '../../config.ts';
 import { providerUploadOutcome } from '../../build-cache.ts';
 import { detectAndroidPackage } from '../../project.ts';
 import { launchOutcomeRecord } from '../native-runtime.ts';
@@ -78,7 +78,7 @@ interface VerifyAndroidRunArgs {
   metroPort: number | null;
   isExpo: boolean;
   physical: boolean;
-  newEmulator: boolean;
+  device: OwnedDeviceRecord;
   scheme?: string | null;
   component?: string | null;
   phase: (label: unknown, text: string) => void;
@@ -100,7 +100,7 @@ async function verifyAndroidRun({
   metroPort,
   isExpo,
   physical,
-  newEmulator,
+  device,
   scheme,
   component = null,
   phase,
@@ -153,6 +153,7 @@ async function verifyAndroidRun({
     return { state: LAUNCH_FATAL };
   }
 
+  const newEmulator = Boolean(device.created && device.owned && !remoteDevice);
   const timeoutMs = newEmulator ? 60000 : VERIFY_TIMEOUT_MS;
   if (metroCheck && newEmulator) phase('verify', 'waiting up to 60s for bundle load (new emulator)');
   const verification: VerifyLaunchResultLike = metroCheck
@@ -304,6 +305,8 @@ interface FinishAndroidRunArgs {
   physical: boolean;
   remoteDevice: ReturnType<typeof remoteAndroidDeps> | null;
   bootPromise: Promise<AndroidBootLike>;
+  resolveAvdSerial: typeof resolveOwnedAvdSerial;
+  waitForDeviceBoot: typeof waitForBoot;
   bootDuration: () => string;
   apkPath: string | null;
   androidPackage: string | null;
@@ -345,6 +348,48 @@ interface FinishAndroidRunArgs {
   recordRun: ReportAndroidResultArgs['recordRun'];
 }
 
+async function resolveInstallSerial({
+  root,
+  device,
+  physical,
+  remoteDevice,
+  serial,
+  resolveAvdSerial,
+  waitForDeviceBoot,
+  phase,
+}: Pick<
+  FinishAndroidRunArgs,
+  'root' | 'device' | 'physical' | 'remoteDevice' | 'resolveAvdSerial' | 'waitForDeviceBoot' | 'phase'
+> & { serial: string }): Promise<string> {
+  if (physical || remoteDevice || !device.owned || !device.avdName) return serial;
+  const resolved = resolveAvdSerial(device.avdName, { timeoutMs: 5000 });
+  if (!resolved.serial) throw new Error(`Could not verify a running owned AVD ${device.avdName} before installation.`);
+  if (resolved.serial !== serial) {
+    phase(
+      'device',
+      `${device.avdName} changed serial (${serial} -> ${resolved.serial}); checking readiness before installation`,
+    );
+    const ready = await waitForDeviceBoot(resolved.serial, 60000, { commandTimeoutMs: 5000 });
+    if (!ready.ok)
+      throw new Error(
+        `Emulator ${resolved.serial} never reported boot completion. Diagnostic: ${JSON.stringify(ready.diagnostic)}`,
+      );
+    if (resolveAvdSerial(device.avdName, { timeoutMs: 5000 }).serial !== resolved.serial)
+      throw new Error(
+        `Could not verify AVD ${device.avdName} still runs on ${resolved.serial} after checking readiness.`,
+      );
+    phase('device', `reopen agent-device on ${resolved.serial}`);
+  }
+  const consolePort = Number(resolved.serial.replace(/^emulator-/, ''));
+  withConfigLock(() => {
+    const current = loadConfig()?.projects?.[root]?.platforms?.android;
+    if (!current?.owned || current.avdName !== device.avdName)
+      throw new Error('The owned emulator assignment changed before installation.');
+    if (current.consolePort !== consolePort) setDevice(root, PLATFORM, { ...current, consolePort });
+  });
+  return resolved.serial;
+}
+
 export async function finishAndroidRun({
   lease,
   releaseLease,
@@ -362,6 +407,8 @@ export async function finishAndroidRun({
   physical,
   remoteDevice,
   bootPromise,
+  resolveAvdSerial,
+  waitForDeviceBoot,
   bootDuration,
   apkPath,
   androidPackage: initialPackage,
@@ -426,7 +473,25 @@ export async function finishAndroidRun({
       logPath: diag.logPath ? displayPath(root, diag.logPath) : null,
     });
   }
-  const serial = booted.serial!;
+  let serial: string;
+  try {
+    serial = await resolveInstallSerial({
+      root,
+      device,
+      physical,
+      remoteDevice,
+      serial: booted.serial!,
+      resolveAvdSerial,
+      waitForDeviceBoot,
+      phase,
+    });
+  } catch (error) {
+    return fail(
+      NO_DEVICE,
+      error instanceof Error ? error.message : String(error),
+      'Run `stim status` to inspect the owned AVD, then retry `stim android`; the APK was not installed.',
+    );
+  }
   phase(
     'device',
     physical
@@ -652,7 +717,7 @@ export async function finishAndroidRun({
     metroPort,
     isExpo,
     physical,
-    newEmulator: Boolean(device.created && device.owned && !remoteDevice),
+    device,
     scheme,
     component: launched.component ?? null,
     phase,

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -14,6 +14,7 @@ import { workspaceLogsDir } from '../paths.ts';
 import { readSupervisorState } from './stop.ts';
 import { findProjectRoot, projectShortcut } from '../project.ts';
 import { listAllIosSims } from '../sim/ios.ts';
+import { resolveOwnedAvdSerial } from '../sim/android.ts';
 import type { IosSimRecord } from '../sim/ios.ts';
 import { listWorktrees } from '../worktree.ts';
 import type { WorktreeEntry } from '../worktree.ts';
@@ -31,7 +32,14 @@ import {
   unprovisionedWorktrees,
 } from '../status.ts';
 import { parkedMaxSetting, POOL_SETTING_REMEDY, readParked } from '../sim-pool.ts';
-import type { EnvironmentState, VolumeInfo, SimFacts, MetroFacts, WorktreeFacts } from '../status.ts';
+import type {
+  AndroidRuntimeFacts,
+  EnvironmentState,
+  VolumeInfo,
+  SimFacts,
+  MetroFacts,
+  WorktreeFacts,
+} from '../status.ts';
 
 type SupervisorRecordExt = SupervisorRecord & { mode?: string | null };
 
@@ -83,6 +91,10 @@ export default function statusCommand(program: Command): void {
               metro: metro as unknown as MetroFacts | null,
               worktrees: worktrees as unknown as WorktreeFacts[],
               simsAvailable,
+              androidRuntime:
+                proj.platforms?.android?.owned && proj.platforms.android.avdName
+                  ? readAndroidRuntime(proj.platforms.android.avdName)
+                  : null,
               supervisor,
               logs: logFacts(path),
             },
@@ -172,8 +184,11 @@ export default function statusCommand(program: Command): void {
         }
         if (state.android) {
           const kind = state.android.physical ? chalk.dim('(physical)') : chalk.dim('(emulator)');
+          const observed = state.android.state
+            ? ` ${state.android.state}${state.android.serial ? ` (${state.android.serial})` : ''}`
+            : '';
           console.log(
-            `  android: ${chalk.cyan(state.android.name)} ${kind}${state.android.owned ? chalk.dim(' (owned)') : ''}`,
+            `  android: ${chalk.cyan(state.android.name)} ${kind}${observed}${state.android.owned ? chalk.dim(' (owned)') : ''}`,
           );
         }
         for (const w of state.warnings) console.log(chalk.yellow(`  ! ${w}`));
@@ -223,6 +238,24 @@ export default function statusCommand(program: Command): void {
         );
       }
     });
+}
+
+function readAndroidRuntime(avdName: string): AndroidRuntimeFacts {
+  try {
+    const resolved = resolveOwnedAvdSerial(avdName, { timeoutMs: 5000 });
+    return {
+      serial: resolved.serial ?? null,
+      state: resolved.serial
+        ? 'detected'
+        : resolved.missing
+          ? 'missing'
+          : resolved.notRunning
+            ? 'not-detected'
+            : 'unknown',
+    };
+  } catch (error) {
+    return { serial: null, state: 'unknown', error: String((error as Error)?.message || error).split('\n')[0] };
+  }
 }
 
 export function readVolumes(projectPath: string): VolumeInfo[] {

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -575,6 +575,14 @@ async function ensureOwnedAndroidDevice({
         );
       } else if (resolved.serial) {
         const consolePort = Number(resolved.serial.replace(/^emulator-/, ''));
+        if (record.consolePort && record.consolePort !== consolePort) {
+          out(
+            phaseLine(
+              'device',
+              `${record.avdName} changed serial (emulator-${record.consolePort} -> ${resolved.serial}); reconnecting this run, reopen agent-device on ${resolved.serial}`,
+            ),
+          );
+        }
         const updated = {
           ...record,
           avdName: record.avdName,

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -159,7 +159,9 @@ RULES DURING THE LOOP
 - Use stim status when resuming a workspace or recovering missing device,
   port, server, or build facts. A normal start and platform run already print
   them. Use stim doctor when a build is unexpectedly slow or the environment
-  looks incomplete.
+  looks incomplete. If status reports a changed Android serial, rerun stim
+  android with the same build options to restore forwarding, then reopen your automation
+  session on the reported serial (guide lifecycle).
 
 OWNERSHIP AND DELETION
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -149,6 +149,15 @@ emulators, remote targets, and physical devices keep the 20-second budget.
 Bundle delivery still requires the usual stability or app readiness check;
 an observed fatal error ends verification without waiting for the deadline.
 
+ANDROID EMULATOR RESTARTS
+  \`stim status\` resolves owned AVDs to their currently detected adb serial.
+  Its Android JSON adds serial and state (detected, not-detected, missing,
+  or unknown). Detection confirms device identity, not app health. Status
+  reports a serial change without changing forwarding or restarting anything.
+  Rerun \`stim android\` with the same build options in that workspace to restore Metro
+  forwarding, then reopen agent-device on the serial that run reports.
+  Other workspaces' simulators and automation sessions remain theirs.
+
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB
   gc --delete --cache all empties the shared build caches every project uses

--- a/packages/stim-cli/src/status.ts
+++ b/packages/stim-cli/src/status.ts
@@ -38,13 +38,25 @@ export interface WorktreeFacts {
   [key: string]: unknown;
 }
 
+export interface AndroidRuntimeFacts {
+  serial: string | null;
+  state: 'detected' | 'not-detected' | 'missing' | 'unknown';
+  error?: string;
+}
+
 export interface EnvironmentState {
   path: string;
   live: boolean;
   memoryMb: number;
   warnings: string[];
   ios?: { name: string | null; udid: string; owned: boolean; state: string } | null;
-  android?: { name: string | undefined; owned: boolean; physical: boolean } | null;
+  android?: {
+    name: string | undefined;
+    owned: boolean;
+    physical: boolean;
+    serial?: string | null;
+    state?: AndroidRuntimeFacts['state'];
+  } | null;
   metro?: { port: number; running: boolean; pid: number | null } | null;
   supervisor?: { pid: number | null; mode: string | null; startedAt: string | null; healthy: boolean } | null;
   logs?: { dir: string; errorsSinceMarker: number } | null;
@@ -80,6 +92,7 @@ export function environmentState(
     metro = null,
     worktrees = [],
     simsAvailable = true,
+    androidRuntime = null,
     supervisor = null,
     logs = null,
   }: {
@@ -87,6 +100,7 @@ export function environmentState(
     metro?: MetroFacts | null;
     worktrees?: WorktreeFacts[];
     simsAvailable?: boolean;
+    androidRuntime?: AndroidRuntimeFacts | null;
     supervisor?: SupervisorFacts | null;
     logs?: LogsFacts | null;
   } = {},
@@ -97,11 +111,12 @@ export function environmentState(
 
   const simBooted = Boolean(sim && sim.state === 'Booted');
   const metroRunning = Boolean(metro?.metro);
-  const live = simBooted || metroRunning || Boolean(android?.serial);
+  const androidDetected = androidRuntime ? Boolean(androidRuntime.serial) : Boolean(android?.serial);
+  const live = simBooted || metroRunning || androidDetected;
 
   let memoryMb = 0;
   if (simBooted) memoryMb += IOS_SIM_MB;
-  if (android?.serial) memoryMb += ANDROID_EMULATOR_MB;
+  if (androidDetected) memoryMb += ANDROID_EMULATOR_MB;
   if (metroRunning) memoryMb += METRO_MB;
 
   const warnings: string[] = [];
@@ -109,6 +124,20 @@ export function environmentState(
   if (ios && !sim && simsAvailable) warnings.push(`recorded sim ${ios.deviceUdid} no longer exists`);
   if (simBooted && project.metroPort && !metroRunning) {
     warnings.push('simulator is booted with no Metro serving it');
+  }
+  if (androidRuntime && android?.avdName) {
+    const recordedSerial = android.consolePort ? `emulator-${android.consolePort}` : android.serial;
+    if (androidRuntime.serial && recordedSerial && androidRuntime.serial !== recordedSerial) {
+      warnings.push(
+        `owned AVD ${android.avdName} changed serial (${recordedSerial} -> ${androidRuntime.serial}); rerun your \`stim android\` command in this workspace to restore Metro forwarding, then reopen agent-device on ${androidRuntime.serial}`,
+      );
+    }
+    if (androidRuntime.state === 'missing') warnings.push(`recorded AVD ${android.avdName} no longer exists`);
+    if (androidRuntime.state === 'not-detected')
+      warnings.push(
+        `owned AVD ${android.avdName} is not detected by adb; rerun your \`stim android\` command in this workspace to reconnect`,
+      );
+    if (androidRuntime.error) warnings.push(`could not check owned AVD ${android.avdName}: ${androidRuntime.error}`);
   }
   if (supervisor && supervisor.alive === false) {
     warnings.push(`stale supervisor record for ${project.__path}`);
@@ -132,6 +161,7 @@ export function environmentState(
           name: android.avdName ?? android.serial,
           owned: Boolean(android.owned),
           physical: Boolean(android.serial && !android.avdName),
+          ...(androidRuntime ? { serial: androidRuntime.serial, state: androidRuntime.state } : {}),
         }
       : null,
     metro: project.metroPort


### PR DESCRIPTION
## Description

An Android emulator can restart on another serial while Stim builds the app. Installation then uses the serial captured before the build. Status also reports recorded ownership without checking the current AVD serial, making the broken connection difficult to diagnose.

Fixes #750.

## Solution

Resolve the owned AVD again before installation. A changed serial must finish booting and still identify the same AVD; the workspace must still own that assignment. Refuse when identity or readiness cannot be confirmed. Persist the new console port and use the verified serial for the rest of the run.

Status reports the detected serial and warns about changes without changing state. Recovery guidance tells users to rerun their Android command with the same build options and reopen automation on the reported serial.

## Test plan

- Command regressions cover a serial change during the build, unchanged serials, missing or unready devices, changed-again identity, and reassigned ownership. Physical and remote paths do not run local AVD probes.
- Status regressions cover changed, absent, missing, and unreadable devices while asserting the registry remains unchanged.
- Real API 36 QA emulator restarted from emulator-5554 to emulator-5556. Status reported the change without writing the registry. The candidate Android run updated the assignment, restored forwarding (verified with adb reverse --list), and launched successfully; UI and error logs were checked. The exact QA device and worktree were removed afterward.
