### PR TITLE
fix: bound local iOS discovery and device operations

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -2611,3 +2611,21 @@ describe('launch verification after Metro prefetch', () => {
     expect(Boolean(result.fatal)).toBe(event === 'bundle_response_failed');
   });
 });
+
+test('a simulator install timeout fails before dev-client preparation and gives host recovery guidance', () => {
+  const exec = recordingExec({ fail: 'simctl install', failCode: 'ETIMEDOUT' });
+  const result = installIosApp(
+    {
+      udid: 'U1',
+      appPath: '/private/app with spaces.app',
+      bundleId: 'com.example.app',
+      devClientScheme: 'example',
+      proveInstalled: false,
+    },
+    { exec },
+  );
+  expect(result).toMatchObject({ failed: true, code: INSTALL_ERROR });
+  expect(result.reason).toMatch(/simctl install failed.*Activity Monitor/);
+  expect(exec.options[0]).toEqual({ timeoutMs: 300000, killSignal: 'SIGKILL' });
+  expect(exec.calls.some((args) => args.includes('defaults'))).toBe(false);
+});

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -82,7 +82,8 @@ describe('ensureBooted: ios', () => {
         commands.push(cmd);
         return '';
       },
-      runFile: (file, args = [], options) => {
+      runFile(file, args = [], options) {
+        if (file === 'xcrun' && args[1] === 'list') return this.run!([file, ...args].join(' '));
         probes.push([file, ...args, options]);
         return '';
       },
@@ -103,7 +104,8 @@ describe('ensureBooted: ios', () => {
   test.each([false, true])('refuses a simulator that cannot spawn a process after boot (joined=%s)', async (joined) => {
     setExecutor({
       run: () => simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]),
-      runFile: () => {
+      runFile(file, args = []) {
+        if (file === 'xcrun' && args[1] === 'list') return this.run!([file, ...args].join(' '));
         throw Object.assign(new Error('simctl spawn timed out'), { code: 'ETIMEDOUT' });
       },
       runFileQuiet: () => null,
@@ -137,7 +139,12 @@ describe('ensureBooted: ios', () => {
         return '';
       },
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: (cmd: string, args: readonly string[] = []) => {
         commands.push([cmd, ...args].join(' '));
         return makeExitingChild();
@@ -163,8 +170,20 @@ describe('ensureBooted: ios', () => {
         return '';
       },
       runQuiet: () => '',
-      runFile: () => '',
-      spawn: () => makeChildProcess(),
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
+      spawn: () => {
+        const child = makeChildProcess();
+        child.kill = () => {
+          queueMicrotask(() => child.emit('exit', null, 'SIGKILL'));
+          return true;
+        };
+        return child;
+      },
     });
 
     const result = await ensureBooted({
@@ -187,7 +206,12 @@ describe('ensureBooted: ios', () => {
         return '';
       },
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => makeExitingChild(1, 'CoreLocationMigrator failed'),
     });
 
@@ -202,7 +226,12 @@ describe('ensureBooted: ios', () => {
     setExecutor({
       run: () => simList([{ udid: 'U1', name: 'My iPhone', state: 'Shutdown', isAvailable: true }]),
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => {
         throw new Error('must not boot a foreign sim');
       },
@@ -213,7 +242,17 @@ describe('ensureBooted: ios', () => {
   });
 
   test('reports a sim that no longer exists rather than booting a stale udid', async () => {
-    setExecutor({ run: () => simList([]), runQuiet: () => '', runFile: () => '', spawn: () => null });
+    setExecutor({
+      run: () => simList([]),
+      runQuiet: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
+      spawn: () => null,
+    });
     const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'GONE' } });
     expect(result.reason).toMatch(/no longer exists/);
     expect(result.reason).toMatch(/stim ios/);
@@ -226,7 +265,12 @@ describe('ensureBooted: ios', () => {
           ? simList([{ udid: 'U1', name: 'stim-app', state: 'Booting', isAvailable: true }])
           : '',
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => makeExitingChild(),
     });
     const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1' }, timeoutMs: 60, pollMs: 5 });
@@ -234,7 +278,17 @@ describe('ensureBooted: ios', () => {
   });
 
   test('reports a missing record rather than throwing', async () => {
-    setExecutor({ run: () => '', runQuiet: () => '', runFile: () => '', spawn: () => null });
+    setExecutor({
+      run: () => '',
+      runQuiet: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
+      spawn: () => null,
+    });
     expect((await ensureBooted({ platform: 'ios', device: {} })).reason).toMatch(/No iOS simulator is recorded/);
   });
 
@@ -276,7 +330,12 @@ describe('ensureBooted: ios', () => {
     setExecutor({
       run: () => simList([{ udid: 'U1', name: 'stim-app', state: 'Shutdown', isAvailable: true }]),
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => null,
     });
     const done = Promise.reject(new Error('CoreLocationMigrator failed'));
@@ -297,7 +356,12 @@ describe('ensureBooted: ios', () => {
         return simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]);
       },
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => null,
     });
     const result = await ensureBooted({ platform: 'ios', device: { deviceUdid: 'U1', owned: true } });
@@ -313,7 +377,12 @@ describe('ensureBooted: ios', () => {
         return simList([{ udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true }]);
       },
       runQuiet: () => '',
-      runFile: () => '',
+      runFileQuiet: () => '',
+      runFile(file, args = []) {
+        return file === 'xcrun' && (args[1] === 'list' || args[1] === 'boot')
+          ? this.run!([file, ...args].join(' '))
+          : '';
+      },
       spawn: () => null,
     });
     const result = await ensureBooted({
@@ -625,6 +694,7 @@ function iosExecutor(devices: SimEntry[]) {
     files,
     spawned,
     exec: {
+      runFileQuiet: () => '',
       run(cmd: string) {
         run.push(cmd);
         if (/simctl list devicetypes --json/.test(cmd)) return DEVICE_TYPES_JSON;
@@ -643,6 +713,8 @@ function iosExecutor(devices: SimEntry[]) {
       },
       runFile(file: string, args: string[] = []) {
         files.push([file, ...args]);
+        if (file === 'xcrun' && args[0] === 'simctl' && (args[1] === 'list' || args[1] === 'boot'))
+          return this.run!([file, ...args].join(' '));
         return '';
       },
       spawn(cmd: string, args: readonly string[] = []) {
@@ -660,11 +732,9 @@ describe('ensureOwnedDevice: ios', () => {
     const events: string[] = [];
     setExecutor({
       ...exec,
-      run(cmd: string) {
-        if (cmd.startsWith('xcrun simctl boot ')) events.push('boot');
-        return exec.run(cmd);
-      },
+
       runFile(file, args = [], options) {
+        if (file === 'xcrun' && args[1] === 'boot') events.push('boot');
         if (file === '/usr/sbin/sysctl') {
           events.push('pressure');
           expect(args).toEqual(['-n', 'kern.memorystatus_vm_pressure_level']);

--- a/packages/stim-cli/src/__tests__/engine-simslim.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-simslim.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeChildProcess, makeError } from './_factories.ts';
@@ -11,6 +11,7 @@ import {
   type ProcessRecord,
 } from '../process-identity.ts';
 import { reconcileSimSlim } from '../engine/simslim.ts';
+import { waitForChild } from '../process-output.ts';
 
 let root: string;
 beforeEach(() => {
@@ -51,6 +52,8 @@ test('applies a profile with the exact UDID and streams progress', async () => {
   const calls: Array<{ command: string; args: readonly string[] }> = [];
   const lines: string[] = [];
   const profile = '/repo/.simslim/dev.json';
+  const signals = ['SIGINT', 'SIGTERM', 'exit'] as const;
+  const listeners = signals.map((signal) => process.listeners(signal));
   const result = await reconcileSimSlim({
     udid: 'U1',
     profile,
@@ -74,6 +77,7 @@ test('applies a profile with the exact UDID and streams progress', async () => {
     ]),
   );
   expect(result).toEqual({ managed: true, profile });
+  expect(signals.map((signal) => process.listeners(signal))).toEqual(listeners);
 });
 
 test('restores stock services after the configured profile is removed', async () => {
@@ -209,3 +213,94 @@ test('a surviving descendant retains the claim and refuses another reconciliatio
     expect(exited).toBe(true);
   }
 });
+
+test.each(['SIGINT', 'SIGTERM', 'exit'] as const)(
+  '%s stops the caller-owned SimSlim group without abandoning descendants',
+  async (interruption) => {
+    const marker = join(root, 'ready.json');
+    const leaderRecord = join(root, 'leader.json');
+    const driver = join(root, 'caller.mjs');
+    const script = `
+    import { writeFileSync } from 'node:fs';
+    import { reconcileSimSlim } from ${JSON.stringify(new URL('../engine/simslim.ts', import.meta.url).href)};
+    import { getExecutor } from ${JSON.stringify(new URL('../exec.ts', import.meta.url).href)};
+    import { captureProcessIdentity } from ${JSON.stringify(new URL('../process-identity.ts', import.meta.url).href)};
+    let leader;
+    process.stdin.on('data', () => process.exit(23));
+    await reconcileSimSlim({
+      udid: 'U1', profile: '/private/profile.json', timeoutMs: 60000, cleanupMs: 1000,
+      out(line) {
+        const match = /descendant:([0-9]+)/.exec(line);
+        if (match) writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ leader, descendant: Number(match[1]) }));
+        console.error(line);
+      },
+      spawn(_command, _args, options) {
+        const child = getExecutor().spawn(process.execPath, ['-e', ${JSON.stringify(`
+          const { spawn } = require('node:child_process');
+          process.on('SIGINT', () => {});
+          process.on('SIGTERM', () => {});
+          const child = spawn(process.execPath, ['-e', 'process.on("SIGINT", () => {}); process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'], { stdio: 'inherit' });
+          console.log('descendant:' + child.pid);
+          setInterval(() => {}, 1000);
+        `)}], options);
+        leader = child.pid;
+        const captured = captureProcessIdentity(leader);
+        if (!captured.ok) {
+          child.kill('SIGKILL');
+          throw new Error('Fixture leader identity unavailable');
+        }
+        writeFileSync(${JSON.stringify(leaderRecord)}, JSON.stringify({ pid: leader, processToken: captured.token }));
+        return child;
+      },
+    });
+  `;
+    writeFileSync(driver, script);
+    const caller = getExecutor().spawn(process.execPath, ['--experimental-strip-types', driver], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const exited = waitForChild(caller);
+    const output: string[] = [];
+    caller.stderr?.on('data', (chunk) => output.push(String(chunk)));
+    caller.on('exit', (code, signal) => output.push(`Caller exited: ${code ?? signal}`));
+    let fixture: { leader: number; descendant: number } | undefined;
+    const identities: ProcessRecord[] = [];
+    try {
+      await vi.waitFor(
+        () => {
+          if (!existsSync(marker)) throw new Error(`Fixture has not started: ${output.join('')}`);
+        },
+        { timeout: 3000 },
+      );
+      fixture = JSON.parse(readFileSync(marker, 'utf8'));
+      for (const pid of [fixture!.leader, fixture!.descendant]) {
+        const captured = captureProcessIdentity(pid);
+        expect(captured.ok).toBe(true);
+        if (captured.ok) identities.push({ pid, processToken: captured.token });
+      }
+      if (interruption === 'exit') caller.stdin?.end('exit');
+      else caller.kill(interruption);
+      await vi.waitFor(() => expect(caller.exitCode).not.toBe(null), { timeout: 3000 });
+      expect((await exited).code).toBe(interruption === 'exit' ? 23 : interruption === 'SIGINT' ? 130 : 143);
+      await vi.waitFor(() => expect(processGroupAlive(fixture!.leader)).toBe(false), { timeout: 2000 });
+      for (const identity of identities) expect(inspectProcessIdentity(identity)).toBe('gone');
+      const survey = readClaimSet(join(root, 'simslim-locks', 'u1.lock'));
+      expect(survey.live).toEqual([]);
+      expect(survey.unresolved).toEqual([]);
+      expect(survey.dead).toHaveLength(interruption === 'exit' ? 1 : 0);
+      expect(output.join('')).toMatch(
+        interruption === 'exit' ? /Caller exited: 23/ : /interrupted by SIG(INT|TERM).*process group has stopped/,
+      );
+    } finally {
+      if (existsSync(leaderRecord)) {
+        const identity: ProcessRecord = JSON.parse(readFileSync(leaderRecord, 'utf8'));
+        if (inspectProcessIdentity(identity) === 'same') process.kill(-(identity.pid as number), 'SIGKILL');
+      }
+      caller.kill('SIGKILL');
+      for (const identity of identities) {
+        if (inspectProcessIdentity(identity) === 'same') process.kill(identity.pid as number, 'SIGKILL');
+      }
+      await exited;
+    }
+  },
+  10000,
+);

--- a/packages/stim-cli/src/__tests__/engine-simslim.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-simslim.test.ts
@@ -1,5 +1,27 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { makeChildProcess, makeError } from './_factories.ts';
+import { getExecutor, resetExecutor } from '../exec.ts';
+import { processGroupAlive, readClaimSet } from '../ownership-claim.ts';
+import {
+  captureProcessIdentity,
+  inspectProcessIdentity,
+  waitForProcessExit,
+  type ProcessRecord,
+} from '../process-identity.ts';
 import { reconcileSimSlim } from '../engine/simslim.ts';
+
+let root: string;
+beforeEach(() => {
+  resetExecutor();
+  root = mkdtempSync(join(tmpdir(), 'stim-simslim-test-'));
+  process.env.STIM_HOME = root;
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
 
 function exitingChild({ stdout = [], stderr = [], code = 0 }: { stdout?: string[]; stderr?: string[]; code?: number }) {
   const child = makeChildProcess();
@@ -85,4 +107,105 @@ test('includes recent SimSlim output when the command fails', async () => {
       spawn: () => exitingChild({ stderr: ['iOS 17 does not persist launchd overrides'], code: 1 }),
     }),
   ).rejects.toThrow(/exit code 1.*iOS 17/);
+});
+
+test('a deadline kills the owned process group and releases its claim only after descendants exit', async () => {
+  const exec = getExecutor();
+  let pid: number | undefined;
+  let descendant: number | undefined;
+  const claimRoot = join(root, 'simslim-locks', 'u1.lock');
+  try {
+    await expect(
+      reconcileSimSlim({
+        udid: 'U1',
+        profile: '/private/profile.json',
+        timeoutMs: 700,
+        cleanupMs: 2000,
+        out: (line) => {
+          const match = /descendant:(\d+)/.exec(line);
+          if (match) descendant = Number(match[1]);
+        },
+        spawn: (_command, _args, options) => {
+          const child = exec.spawn(
+            process.execPath,
+            [
+              '-e',
+              `
+          const { spawn } = require('node:child_process');
+          process.on('SIGTERM', () => {});
+          const child = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'], { stdio: 'inherit' });
+          console.log('descendant:' + child.pid);
+          setInterval(() => {}, 1000);
+        `,
+            ],
+            options,
+          );
+          pid = child.pid;
+          return child;
+        },
+      }),
+    ).rejects.toThrow(/process group has stopped/);
+    expect(descendant).toBeGreaterThan(1);
+    expect(pid && processGroupAlive(pid)).toBe(false);
+    expect(readClaimSet(claimRoot).live).toEqual([]);
+    expect(readClaimSet(claimRoot).unresolved).toEqual([]);
+  } finally {
+    if (pid && processGroupAlive(pid)) process.kill(-pid, 'SIGKILL');
+  }
+});
+
+test('a surviving descendant retains the claim and refuses another reconciliation after its leader exits', async () => {
+  const exec = getExecutor();
+  let descendant: number | undefined;
+  let identity: ProcessRecord | undefined;
+  const claimRoot = join(root, 'simslim-locks', 'u1.lock');
+  try {
+    await expect(
+      reconcileSimSlim({
+        udid: 'U1',
+        profile: '/private/profile.json',
+        timeoutMs: 500,
+        cleanupMs: 100,
+        out: (line) => {
+          const match = /descendant:(\d+)/.exec(line);
+          if (match) {
+            descendant = Number(match[1]);
+            const captured = captureProcessIdentity(descendant);
+            if (captured.ok) identity = { pid: descendant, processToken: captured.token };
+          }
+        },
+        spawn: (_command, _args, options) =>
+          exec.spawn(
+            process.execPath,
+            [
+              '-e',
+              `
+        const { spawn } = require('node:child_process');
+        const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'inherit' });
+        console.log('descendant:' + child.pid);
+        setTimeout(() => process.exit(0), 100);
+      `,
+            ],
+            options,
+          ),
+      }),
+    ).rejects.toThrow(/could not be confirmed stopped.*claim remains/);
+    expect(inspectProcessIdentity(identity)).toBe('same');
+    const survey = readClaimSet(claimRoot);
+    expect(survey.live).toHaveLength(1);
+    expect(survey.live[0]?.childDeclared).toBe(true);
+    await expect(
+      reconcileSimSlim({
+        udid: 'U1',
+        profile: '/private/profile.json',
+        spawn: () => {
+          throw new Error('must refuse before spawning');
+        },
+      }),
+    ).rejects.toThrow(/another SimSlim operation/);
+  } finally {
+    if (descendant && inspectProcessIdentity(identity) === 'same') process.kill(descendant, 'SIGKILL');
+    const exited = identity ? await waitForProcessExit(identity, 2000) : false;
+    expect(exited).toBe(true);
+  }
 });

--- a/packages/stim-cli/src/__tests__/exec.test.ts
+++ b/packages/stim-cli/src/__tests__/exec.test.ts
@@ -33,3 +33,22 @@ test('runFileQuiet passes arguments without a shell, so metacharacters stay lite
   resetExecutor();
   expect(getExecutor().runFileQuiet('echo', ['$HOME `id` "x"'])).toBe('$HOME `id` "x"');
 });
+
+test('an opt-in hard deadline terminates a child that ignores SIGTERM before returning', () => {
+  resetExecutor();
+  const started = Date.now();
+  let failure: NodeJS.ErrnoException & { pid?: number; signal?: string } = new Error('did not fail');
+  try {
+    getExecutor().runFile(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'], {
+      timeoutMs: 200,
+      killSignal: 'SIGKILL',
+    });
+  } catch (error) {
+    failure = error as typeof failure;
+  }
+  expect(failure.code).toBe('ETIMEDOUT');
+  expect(failure.signal).toBe('SIGKILL');
+  expect(Date.now() - started).toBeLessThan(3000);
+  expect(failure.pid).toBeGreaterThan(1);
+  expect(() => process.kill(failure.pid!, 0)).toThrow(/ESRCH/);
+});

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -268,7 +268,8 @@ test('parked deletion keeps ownership records after malformed simctl list output
   };
   parkSim({ platform: 'ios', projectPath: '/tmp/source', record, max: 3 });
   setExecutor({
-    run(cmd) {
+    runFile(_file, args = []) {
+      const cmd = args.join(' ');
       if (cmd.includes('simctl list devices')) return '[]';
       throw new Error(`unexpected run: ${cmd}`);
     },
@@ -389,6 +390,7 @@ test('gc sizes only listed owned Android AVDs after ownership classification', a
       }
       throw new Error(`unexpected run: ${cmd}`);
     },
+    runFile: () => JSON.stringify({ devices: {} }),
     runQuiet: () => null,
     runFileQuiet: () => null,
     spawn: () => null,

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -668,7 +668,8 @@ function simctlClock(step: number) {
   const state = { now: 1_000_000 };
   setExecutor(
     makeExecutor({
-      run: (cmd: string) => {
+      runFile: (file, args = []) => {
+        const cmd = [file, ...args].join(' ');
         if (!cmd.includes('simctl list devices')) return '';
         state.now += step;
         return JSON.stringify({

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -97,6 +97,7 @@ test('reclaimProject keeps the config entry when an owned device delete fails', 
       if (cmd.includes('simctl delete')) throw new Error('Unable to delete device');
       return '';
     },
+    runFile: () => listJson,
     runQuiet: (cmd) => (cmd.includes('simctl list devices --json') ? listJson : null),
     spawn: () => {},
   });
@@ -126,6 +127,7 @@ test('reclaimProject removes the entry when the owned device really is deleted',
   });
   setExecutor({
     run: (cmd) => (cmd.includes('simctl list devices --json') ? listJson : ''),
+    runFile: () => listJson,
     runQuiet: (cmd) => (cmd.includes('simctl list devices --json') ? listJson : null),
     spawn: () => {},
   });

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -152,8 +152,9 @@ test('parseSimctlList can retain unavailable devices and their data sizes', () =
 
 test('listAllIosSims uses simctl via executor', () => {
   setExecutor({
-    run: (cmd) => {
-      expect(cmd).toMatch(/xcrun simctl list devices --json/);
+    runFile: (file, args, options) => {
+      expect([file, ...args]).toEqual(['xcrun', 'simctl', 'list', 'devices', '--json']);
+      expect(options).toEqual({ timeoutMs: 30000, killSignal: 'SIGKILL' });
       return SIMCTL_OUTPUT;
     },
     runQuiet: () => null,
@@ -165,7 +166,7 @@ test('listAllIosSims uses simctl via executor', () => {
 
 test('listBootedIosSims filters by state', () => {
   setExecutor({
-    run: () => SIMCTL_OUTPUT,
+    runFile: () => SIMCTL_OUTPUT,
     runQuiet: () => null,
     spawn: () => null,
   });
@@ -321,7 +322,7 @@ test('sanitizeDeviceLabel strips characters simctl names should not carry', () =
 
 test('deleteIosSim refuses to delete a sim not owned by Stim', () => {
   setExecutor({
-    run: () =>
+    runFile: () =>
       JSON.stringify({
         devices: {
           'com.apple.CoreSimulator.SimRuntime.iOS-17-2': [
@@ -362,8 +363,9 @@ test('deleteIosSim deletes a Stim-owned sim', () => {
   setExecutor({
     run: (cmd) => {
       ran.push(cmd);
-      return cmd.includes('list devices') ? OWNED_SIM_LIST : null;
+      return null;
     },
+    runFile: () => OWNED_SIM_LIST,
     runQuiet: () => null,
     spawn: () => null,
   });
@@ -373,8 +375,8 @@ test('deleteIosSim deletes a Stim-owned sim', () => {
 
 test('deleteIosSim propagates a simctl failure instead of swallowing it', () => {
   setExecutor({
-    run: (cmd) => {
-      if (cmd.includes('list devices')) return OWNED_SIM_LIST;
+    runFile: () => OWNED_SIM_LIST,
+    run: () => {
       throw new Error('simctl: Unable to delete device');
     },
     runQuiet: () => null,
@@ -386,7 +388,7 @@ test('deleteIosSim propagates a simctl failure instead of swallowing it', () => 
 test('deleteIosSim no-ops quietly when the udid is already gone', () => {
   let ranQuiet = false;
   setExecutor({
-    run: () => JSON.stringify({ devices: {} }),
+    runFile: () => JSON.stringify({ devices: {} }),
     runQuiet: () => {
       ranQuiet = true;
       return null;
@@ -431,7 +433,7 @@ test('occupyingApps reports a shut-down device free without probing', async () =
   });
   let probed = false;
   setExecutor({
-    run: () => devices,
+    runFile: () => devices,
     runQuiet: () => {
       probed = true;
       return null;
@@ -574,8 +576,9 @@ test('parked app data cleanup fails closed on unreadable metadata and invalid co
 test('deleteParkedIosSim bounds ownership revalidation and deletion', () => {
   const calls: Array<{ kind: 'run' | 'runFile'; timeoutMs?: number }> = [];
   setExecutor({
-    run(_cmd, options) {
-      calls.push({ kind: 'run', timeoutMs: options?.timeoutMs });
+    runFile(_file, args, options) {
+      calls.push({ kind: 'runFile', timeoutMs: options?.timeoutMs });
+      if (args?.includes('delete')) return '';
       return JSON.stringify({
         devices: {
           'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
@@ -590,10 +593,6 @@ test('deleteParkedIosSim bounds ownership revalidation and deletion', () => {
         },
       });
     },
-    runFile(_file, _args, options) {
-      calls.push({ kind: 'runFile', timeoutMs: options?.timeoutMs });
-      return '';
-    },
     runQuiet: () => null,
     spawn: () => null,
   });
@@ -601,7 +600,7 @@ test('deleteParkedIosSim bounds ownership revalidation and deletion', () => {
   deleteParkedIosSim('U1');
 
   expect(calls).toEqual([
-    { kind: 'run', timeoutMs: 30000 },
+    { kind: 'runFile', timeoutMs: 30000 },
     { kind: 'runFile', timeoutMs: 30000 },
   ]);
 });
@@ -609,8 +608,9 @@ test('deleteParkedIosSim bounds ownership revalidation and deletion', () => {
 test('deleteParkedIosSim re-resolves the name before deletion', () => {
   const calls: string[][] = [];
   setExecutor({
-    run: () =>
-      JSON.stringify({
+    runFile(file, args = []) {
+      calls.push([file, ...args]);
+      return JSON.stringify({
         devices: {
           'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
             {
@@ -622,16 +622,13 @@ test('deleteParkedIosSim re-resolves the name before deletion', () => {
             },
           ],
         },
-      }),
-    runFile(file, args = []) {
-      calls.push([file, ...args]);
-      return '';
+      });
     },
     runQuiet: () => null,
     spawn: () => null,
   });
   expect(() => deleteParkedIosSim('U1')).toThrow(/not Stim-owned/);
-  expect(calls).toEqual([]);
+  expect(calls).toEqual([['xcrun', 'simctl', 'list', 'devices', '--json']]);
 });
 
 function bootSimList(state: string) {
@@ -650,19 +647,25 @@ function bootstatusExecutor(outcomes: BootstatusOutcome[], list: () => string) {
   const spawned: string[] = [];
   const quiet: string[] = [];
   setExecutor({
-    run: (cmd: string) => {
-      if (cmd.includes('list devices')) return list();
+    runFile: (_file, args = []) => {
+      if (args.includes('devices')) return list();
       return '';
     },
-    runQuiet: (cmd: string) => {
-      quiet.push(cmd);
+    runFileQuiet: (file, args = []) => {
+      quiet.push([file, ...args].join(' '));
       return '';
     },
-    runFile: () => '',
     spawn: (cmd: string, args: readonly string[] = []) => {
       spawned.push([cmd, ...args].join(' '));
       const outcome = outcomes[spawned.length - 1] ?? outcomes[outcomes.length - 1] ?? 'hang';
-      if (outcome === 'hang') return makeChildProcess();
+      if (outcome === 'hang') {
+        const child = makeChildProcess();
+        child.kill = () => {
+          queueMicrotask(() => child.emit('exit', null, 'SIGKILL'));
+          return true;
+        };
+        return child;
+      }
       return makeExitingChild(outcome.exitCode, outcome.stderr);
     },
   });
@@ -721,4 +724,94 @@ test('bootIosSim rethrows a bootstatus failure that is not a timeout', async () 
   );
   await expect(bootIosSim('UDID-A')).rejects.toThrow(/CoreLocationMigrator failed/);
   expect(spawned.length).toBe(1);
+});
+
+test('the initial boot request consumes the same deadline as bootstatus', async () => {
+  let now = 1000;
+  const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+  let spawned = false;
+  setExecutor({
+    runFile(_file, args = [], options) {
+      if (args[1] === 'boot') {
+        expect(options).toEqual({ timeoutMs: 200, killSignal: 'SIGKILL' });
+        now += 250;
+        return '';
+      }
+      return bootSimList('Booting');
+    },
+    spawn() {
+      spawned = true;
+      return makeExitingChild();
+    },
+  });
+  try {
+    await expect(bootIosSim('UDID-A', { timeoutMs: 200 })).rejects.toThrow(/did not finish booting/);
+    expect(spawned).toBe(false);
+  } finally {
+    clock.mockRestore();
+  }
+});
+
+test('bootstatus does not survey or retry until its timed-out child has actually exited', async () => {
+  const events: string[] = [];
+  setExecutor({
+    runFile(_file, args = []) {
+      if (args[1] === 'list') {
+        events.push('survey');
+        return bootSimList('Booted');
+      }
+      return '';
+    },
+    runFileQuiet: () => '',
+    spawn() {
+      const child = makeChildProcess();
+      child.kill = () => {
+        events.push('signal');
+        setTimeout(() => {
+          events.push('exit');
+          child.emit('exit', null, 'SIGKILL');
+        }, 20);
+        return true;
+      };
+      return child;
+    },
+  });
+  await bootIosSim('UDID-A', { attemptMs: 10 });
+  expect(events).toEqual(['signal', 'exit', 'survey']);
+});
+
+test('bootstatus refuses a retry when termination cannot be confirmed within the cleanup bound', async () => {
+  vi.useFakeTimers();
+  let surveys = 0;
+  setExecutor({
+    runFile(_file, args = []) {
+      if (args[1] === 'list') surveys++;
+      return '';
+    },
+    spawn: () => makeChildProcess(),
+  });
+  try {
+    const outcome = bootIosSim('UDID-A', { attemptMs: 100 }).then(
+      () => null,
+      (error) => error,
+    );
+    await vi.advanceTimersByTimeAsync(10100);
+    expect(await outcome).toMatchObject({ message: expect.stringMatching(/could not be confirmed stopped/) });
+    expect(surveys).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('opening the Simulator app is bounded and best-effort after successful boot', async () => {
+  setExecutor({
+    runFile: () => '',
+    spawn: () => makeExitingChild(),
+    runFileQuiet(file, args, options) {
+      expect([file, ...args]).toEqual(['open', '-a', 'Simulator']);
+      expect(options).toEqual({ timeoutMs: 5000, killSignal: 'SIGKILL' });
+      return null;
+    },
+  });
+  await expect(bootIosSim('UDID-A')).resolves.toBeUndefined();
 });

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -35,7 +35,8 @@ beforeEach(() => {
     },
   });
   setExecutor({
-    run(cmd) {
+    runFile(_file, args = []) {
+      const cmd = args.join(' ');
       if (cmd.includes('simctl list devices --json')) return listJson;
       return '';
     },
@@ -121,7 +122,8 @@ test('status says nothing extra for a project that has only a Metro port', async
 
 test('status reports simctl as unreadable instead of warning that every sim is gone', async () => {
   setExecutor({
-    run(cmd) {
+    runFile(_file, args = []) {
+      const cmd = args.join(' ');
       if (cmd.includes('simctl list devices --json')) throw new Error('xcrun: simctl not found');
       return '';
     },

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -69,7 +69,13 @@ function iosExecutor({ sims = [], occupied = '', throwOn = null }: IosExecutorOp
     if (/simctl spawn .* launchctl list/.test(cmd)) return occupied;
     return '';
   };
-  return { calls, run: answer, runQuiet: answer, spawn: () => {} };
+  return {
+    calls,
+    run: answer,
+    runFile: (file: string, args: string[] = []) => answer([file, ...args].join(' ')),
+    runQuiet: answer,
+    spawn: () => {},
+  };
 }
 
 const OWNED = { udid: 'U1', name: 'stim-app', state: 'Booted', isAvailable: true };
@@ -201,6 +207,7 @@ test('teardownOwnedIosSim parks an owned simulator and clears its project claim'
         return '';
       },
       runFile(file, args = []) {
+        if (file === 'xcrun' && args[1] === 'list') return this.run!([file, ...args].join(' '));
         calls.push([file, ...args]);
         return '';
       },
@@ -277,6 +284,7 @@ test('a failed overflow eviction retains its parked ownership record', () => {
         return '';
       },
       runFile(_file, args = []) {
+        if (_file === 'xcrun' && args[1] === 'list') return this.run!([_file, ...args].join(' '));
         if (args[1] === 'delete' && args[2] === 'U0') throw new Error('simctl busy');
         return '';
       },
@@ -332,7 +340,9 @@ test('teardownOwnedIosSim falls back to deletion when parking fails', () => {
         }
         return '';
       },
-      runFile: () => '',
+      runFile(file, args = []) {
+        return this.run!([file, ...args].join(' '));
+      },
       runQuiet: () => '',
       spawn: () => null,
     });
@@ -383,7 +393,8 @@ test('teardownOwnedIosSim deletes instead of parking when app data cannot be pro
         }
         return '';
       },
-      runFile(file) {
+      runFile(file, args = []) {
+        if (file === 'xcrun' && args[1] === 'list') return this.run!([file, ...args].join(' '));
         if (file === 'plutil') throw new Error('container metadata unreadable');
         return '';
       },
@@ -465,7 +476,9 @@ test('parking fallback re-resolves ownership immediately before deletion', () =>
         if (cmd.includes('list devicetypes')) throw new Error('device types unavailable');
         return '';
       },
-      runFile: () => '',
+      runFile(file, args = []) {
+        return this.run!([file, ...args].join(' '));
+      },
       runQuiet: () => '',
       spawn: () => null,
     });
@@ -512,6 +525,7 @@ test('teardownOwnedIosSim does not park a simulator that remains booted', () => 
         return '';
       },
       runFile(file, args = []) {
+        if (file === 'xcrun' && args[1] === 'list') return this.run!([file, ...args].join(' '));
         calls.push([file, ...args].join(' '));
         return '';
       },
@@ -549,7 +563,13 @@ function androidExecutor({ avds = [], adb = '', avdName = null, throwOn = null }
     if (/emu avd name/.test(cmd)) return avdName ? `${avdName}\nOK` : '';
     return '';
   };
-  return { calls, run: answer, runQuiet: answer, spawn: () => {} };
+  return {
+    calls,
+    run: answer,
+    runFile: (file: string, args: string[] = []) => answer([file, ...args].join(' ')),
+    runQuiet: answer,
+    spawn: () => {},
+  };
 }
 
 test('teardownOwnedAvd shuts down the running emulator and deletes the AVD', () => {

--- a/packages/stim-cli/src/__tests__/worktree-remove.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-remove.test.ts
@@ -233,6 +233,7 @@ function makeExecutor({
     runFile(file: string, args: string[] = []) {
       const cmd = [file, ...args].join(' ');
       runCalls.push(cmd);
+      if (/simctl list devices --json/.test(cmd)) return simctlList;
       if (/worktree remove/.test(cmd)) {
         if (worktreeRemoveError) throw new Error(worktreeRemoveError);
         return '';

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -100,9 +100,13 @@ export function installIosApp(
   const skipped = bundleId && proveInstalled ? deviceHoldsBundle({ udid, bundleId, appPath }, { exec: e }) : false;
   if (!skipped) {
     try {
-      e.runFile('xcrun', ['simctl', 'install', udid, appPath]);
+      e.runFile('xcrun', ['simctl', 'install', udid, appPath], { timeoutMs: 300000, killSignal: 'SIGKILL' });
     } catch (err) {
-      return { failed: true, code: INSTALL_ERROR, reason: `simctl install failed for ${appPath}: ${describe(err)}` };
+      return {
+        failed: true,
+        code: INSTALL_ERROR,
+        reason: `simctl install failed for ${appPath}: ${describeIosSimulatorFailure(err, e)}`,
+      };
     }
   }
   const artifactFinishedAt = now?.();

--- a/packages/stim-cli/src/engine/simslim.ts
+++ b/packages/stim-cli/src/engine/simslim.ts
@@ -1,6 +1,18 @@
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { join } from 'node:path';
+import { getConfigDir } from '../config.ts';
+import { captureProcessIdentity, inspectProcessIdentity, type ProcessRecord } from '../process-identity.ts';
+import {
+  ClaimRefusedError,
+  claimRemoveCommand,
+  markClaimChildPending,
+  processGroupAlive,
+  releaseClaim,
+  setClaimChild,
+  tryAcquireClaim,
+} from '../ownership-claim.ts';
 import { getExecutor } from '../exec.ts';
-import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
+import { createLineReader, stripAnsi, waitForChild, type ChildResult } from '../process-output.ts';
 
 type SpawnFn = (cmd: string, args: readonly string[], opts: SpawnOptions) => ChildProcess;
 
@@ -15,12 +27,16 @@ export async function reconcileSimSlim({
   previouslyManaged = false,
   out = () => {},
   spawn,
+  timeoutMs = 12 * 60 * 1000,
+  cleanupMs = 10000,
 }: {
   udid: string;
   profile?: string | null;
   previouslyManaged?: boolean;
   out?: (line: string) => void;
   spawn?: SpawnFn;
+  timeoutMs?: number;
+  cleanupMs?: number;
 }): Promise<SimSlimResult> {
   if (!profile && !previouslyManaged) return { managed: false, profile: null };
 
@@ -37,24 +53,92 @@ export async function reconcileSimSlim({
   const stdout = createLineReader(onLine);
   const stderr = createLineReader(onLine);
 
-  let child: ChildProcess;
-  try {
-    child = (spawn ?? ((cmd, childArgs, opts) => getExecutor().spawn(cmd, childArgs, opts)))('simslim', args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
+  const root = join(getConfigDir(), 'simslim-locks', `${encodeURIComponent(udid.toLowerCase())}.lock`);
+  const label = `SimSlim for ${udid}`;
+  const attempt = tryAcquireClaim({ root, mode: 'exclusive', label });
+  if (attempt.pending) releaseClaim(attempt.pending);
+  const claim = attempt.acquired;
+  if (!claim) {
+    throw new ClaimRefusedError({
+      root,
+      claimPath: attempt.held?.path ?? root,
+      label,
+      reason: 'another SimSlim operation is still using this simulator',
     });
-  } catch (error) {
-    throw simslimLaunchError(error);
   }
-  child.stdout?.on('data', (chunk) => stdout.push(chunk));
-  child.stderr?.on('data', (chunk) => stderr.push(chunk));
-  const result = await waitForChild(child);
+
+  let child: ChildProcess | undefined;
+  let result: ChildResult | undefined;
+  let identity: ProcessRecord | undefined;
+  const groupAlive = () => child?.pid !== undefined && processGroupAlive(child.pid);
+  const settled = () => result !== undefined && !groupAlive();
+  const waitUntil = async (deadline: number) => {
+    while (!settled() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, Math.min(50, deadline - Date.now())));
+    }
+    return settled();
+  };
+  try {
+    markClaimChildPending(claim);
+    try {
+      child = (spawn ?? ((cmd, childArgs, opts) => getExecutor().spawn(cmd, childArgs, opts)))('simslim', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
+      });
+    } catch (error) {
+      throw simslimLaunchError(error);
+    }
+    child.stdout?.on('data', (chunk) => stdout.push(chunk));
+    child.stderr?.on('data', (chunk) => stderr.push(chunk));
+    void waitForChild(child).then((value) => {
+      result = value;
+      return undefined;
+    });
+    if (child.pid !== undefined) {
+      const captured = captureProcessIdentity(child.pid);
+      if (captured.ok) {
+        identity = { pid: child.pid, processToken: captured.token };
+        try {
+          setClaimChild(claim, identity);
+        } catch {}
+      }
+    }
+    if (!(await waitUntil(Date.now() + timeoutMs))) {
+      if (child.pid !== undefined && identity && inspectProcessIdentity(identity) === 'same') {
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+        } catch {}
+      }
+      const stopped = await waitUntil(Date.now() + cleanupMs);
+      const detail = lines.length ? ` ${lines.join(' | ')}` : '';
+      const recovery = stopped
+        ? 'Its process group has stopped. Retry stim ios to reconcile the retained simulator settings.'
+        : `Its process group could not be confirmed stopped. The claim remains at ${claim.path}. ` +
+          `Inspect the SimSlim process group ${child.pid ?? 'unknown'} before retrying. ` +
+          `Only when nothing is using it, remove the claim: ${claimRemoveCommand(claim.path)}`;
+      throw Object.assign(
+        new Error(`SimSlim ${action} exceeded ${Math.round(timeoutMs / 1000)}s. ${recovery}${detail}`),
+        {
+          code: 'ETIMEDOUT',
+        },
+      );
+    }
+  } finally {
+    if (!child || settled()) releaseClaim(claim);
+    else {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+      child.unref();
+    }
+  }
+
   stdout.flush();
   stderr.flush();
 
-  if (result.error) throw simslimLaunchError(result.error);
-  if (result.code !== 0) {
+  if (result?.error) throw simslimLaunchError(result.error);
+  if (result?.code !== 0) {
     const detail = lines.length ? ` ${lines.join(' | ')}` : '';
-    throw new Error(`SimSlim ${action} failed with exit code ${result.code ?? 'unknown'}.${detail}`);
+    throw new Error(`SimSlim ${action} failed with exit code ${result?.code ?? 'unknown'}.${detail}`);
   }
   return { managed: Boolean(profile), profile: profile ?? null };
 }

--- a/packages/stim-cli/src/engine/simslim.ts
+++ b/packages/stim-cli/src/engine/simslim.ts
@@ -70,14 +70,32 @@ export async function reconcileSimSlim({
   let child: ChildProcess | undefined;
   let result: ChildResult | undefined;
   let identity: ProcessRecord | undefined;
+  let cancellation: 'SIGINT' | 'SIGTERM' | undefined;
+  const stopGroup = () => {
+    if (child?.pid !== undefined && identity && inspectProcessIdentity(identity) === 'same') {
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {}
+    }
+  };
+  const cancel = (signal: 'SIGINT' | 'SIGTERM') => {
+    cancellation ??= signal;
+    stopGroup();
+  };
+  const onInterrupt = () => cancel('SIGINT');
+  const onTerminate = () => cancel('SIGTERM');
   const groupAlive = () => child?.pid !== undefined && processGroupAlive(child.pid);
   const settled = () => result !== undefined && !groupAlive();
-  const waitUntil = async (deadline: number) => {
+  const waitUntil = async (deadline: number, cancellable = false) => {
     while (!settled() && Date.now() < deadline) {
+      if (cancellable && cancellation) break;
       await new Promise((resolve) => setTimeout(resolve, Math.min(50, deadline - Date.now())));
     }
     return settled();
   };
+  process.on('SIGINT', onInterrupt);
+  process.on('SIGTERM', onTerminate);
+  process.on('exit', stopGroup);
   try {
     markClaimChildPending(claim);
     try {
@@ -103,12 +121,9 @@ export async function reconcileSimSlim({
         } catch {}
       }
     }
-    if (!(await waitUntil(Date.now() + timeoutMs))) {
-      if (child.pid !== undefined && identity && inspectProcessIdentity(identity) === 'same') {
-        try {
-          process.kill(-child.pid, 'SIGKILL');
-        } catch {}
-      }
+    const completed = await waitUntil(Date.now() + timeoutMs, true);
+    if (cancellation || !completed) {
+      stopGroup();
       const stopped = await waitUntil(Date.now() + cleanupMs);
       const detail = lines.length ? ` ${lines.join(' | ')}` : '';
       const recovery = stopped
@@ -116,12 +131,10 @@ export async function reconcileSimSlim({
         : `Its process group could not be confirmed stopped. The claim remains at ${claim.path}. ` +
           `Inspect the SimSlim process group ${child.pid ?? 'unknown'} before retrying. ` +
           `Only when nothing is using it, remove the claim: ${claimRemoveCommand(claim.path)}`;
-      throw Object.assign(
-        new Error(`SimSlim ${action} exceeded ${Math.round(timeoutMs / 1000)}s. ${recovery}${detail}`),
-        {
-          code: 'ETIMEDOUT',
-        },
-      );
+      const reason = cancellation ? `interrupted by ${cancellation}` : `exceeded ${Math.round(timeoutMs / 1000)}s`;
+      const message = `SimSlim ${action} ${reason}. ${recovery}${detail}`;
+      if (cancellation) out(message);
+      throw Object.assign(new Error(message), { code: cancellation ? 'EINTR' : 'ETIMEDOUT' });
     }
   } finally {
     if (!child || settled()) releaseClaim(claim);
@@ -130,6 +143,10 @@ export async function reconcileSimSlim({
       child.stderr?.destroy?.();
       child.unref();
     }
+    process.off('SIGINT', onInterrupt);
+    process.off('SIGTERM', onTerminate);
+    process.off('exit', stopGroup);
+    if (cancellation) process.exit(cancellation === 'SIGINT' ? 130 : 143);
   }
 
   stdout.flush();

--- a/packages/stim-cli/src/exec.ts
+++ b/packages/stim-cli/src/exec.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, type SpawnOptions, execFileSync, execSync, spawn } f
 
 interface ExecOptions {
   timeoutMs?: number;
+  killSignal?: NodeJS.Signals;
   cwd?: string;
   env?: Record<string, string>;
   omitEnv?: readonly string[];
@@ -18,23 +19,25 @@ export interface Executor {
 const MAX_BUFFER = 64 * 1024 * 1024;
 
 const defaultExecutor: Executor = {
-  run(cmd, { timeoutMs, cwd } = {}) {
+  run(cmd, { timeoutMs, killSignal, cwd } = {}) {
     const opts: Parameters<typeof execSync>[1] = {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       maxBuffer: MAX_BUFFER,
     };
     if (timeoutMs) opts.timeout = timeoutMs;
+    if (killSignal) opts.killSignal = killSignal;
     if (cwd) opts.cwd = cwd;
     return String(execSync(cmd, opts)).trim();
   },
-  runFile(file, args = [], { timeoutMs, cwd, env, omitEnv } = {}) {
+  runFile(file, args = [], { timeoutMs, killSignal, cwd, env, omitEnv } = {}) {
     const opts: Parameters<typeof execFileSync>[2] = {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       maxBuffer: MAX_BUFFER,
     };
     if (timeoutMs) opts.timeout = timeoutMs;
+    if (killSignal) opts.killSignal = killSignal;
     if (cwd) opts.cwd = cwd;
     if (env || omitEnv?.length) {
       const childEnv = { ...process.env, ...env };

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1366,8 +1366,8 @@ THE POOL: WHICH DEVICE AN ID-LESS \`--device\` PICKS
   Stim applied the profile. Stim never changes an unowned or remote simulator.
   Each SimSlim operation has a 12-minute outer deadline, including discovery.
   This cap also applies when SimSlim's own timeout is increased. On timeout,
-  Stim attempts to stop only its verified process group, then waits up to
-  10 seconds to confirm termination.
+  Ctrl-C, or SIGTERM, Stim attempts to stop only its verified process group, then waits up to
+  10 seconds to confirm termination before returning or exiting.
   An unconfirmed process group keeps its claim and blocks another reconciliation;
   inspect the named processes before removing the exact claim in the error.
   The simulator's managed settings record is retained, so retrying reconciles an

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1364,13 +1364,26 @@ THE POOL: WHICH DEVICE AN ID-LESS \`--device\` PICKS
   profile is a fast no-op on later launches. The settings persist across normal
   shutdowns and reboots. Removing the setting restores stock services when
   Stim applied the profile. Stim never changes an unowned or remote simulator.
+  Each SimSlim operation has a 12-minute outer deadline, including discovery.
+  This cap also applies when SimSlim's own timeout is increased. On timeout,
+  Stim attempts to stop only its verified process group, then waits up to
+  10 seconds to confirm termination.
+  An unconfirmed process group keeps its claim and blocks another reconciliation;
+  inspect the named processes before removing the exact claim in the error.
+  The simulator's managed settings record is retained, so retrying reconciles an
+  interrupted apply or restore. Stim does not assume partial changes rolled back.
   Doctor recommends this setup but never installs SimSlim or applies a profile.
   Profile schema and service tradeoffs: https://github.com/MobAI-App/simslim
 
 HOST MEMORY PRESSURE AND STALLED SIMULATORS
   Booted and a working screenshot do not prove that simulator processes can
   start. Stim checks a bounded process spawn before install and bounds local
-  simulator launch operations. A timeout is not proof of an app crash or OOM.
+  simulator launch operations. Simulator discovery waits up to 30 seconds,
+  boot (including the initial boot request) up to 10 minutes, and app installation
+  up to 5 minutes. Process termination confirmation can take another 10 seconds;
+  a final boot-state query can take 30 seconds. Opening the Simulator app after
+  boot is best-effort and takes at most 5 seconds. A timeout is not proof of an
+  app crash or OOM.
   Doctor and failure diagnostics report macOS memory pressure when available;
   a failed query remains unknown. Existing swap or low free RAM alone is not
   enough to diagnose pressure.

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -104,10 +104,13 @@ export function parseSimctlList(
 }
 
 export function listAllIosSims({
-  timeoutMs,
+  timeoutMs = 30000,
   includeUnavailable = false,
 }: { timeoutMs?: number; includeUnavailable?: boolean } = {}): IosSimRecord[] {
-  const out = getExecutor().run('xcrun simctl list devices --json', { timeoutMs });
+  const out = getExecutor().runFile('xcrun', ['simctl', 'list', 'devices', '--json'], {
+    timeoutMs,
+    killSignal: 'SIGKILL',
+  });
   return parseSimctlList(out, { includeUnavailable });
 }
 
@@ -187,11 +190,29 @@ async function awaitBootstatus(udid: string, attemptMs: number): Promise<void> {
   const attempt = new Promise<'timeout'>((resolve) => {
     timer = setTimeout(() => resolve('timeout'), attemptMs);
   });
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
   const result = await Promise.race([waitForChild(child), attempt]);
   clearTimeout(timer);
   reader.flush();
   if (result === 'timeout') {
-    child.kill('SIGKILL');
+    try {
+      child.kill('SIGKILL');
+    } catch {}
+    const stopped = await Promise.race([
+      exited.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), 10000);
+      }),
+    ]);
+    clearTimeout(timer);
+    if (!stopped) {
+      child.stdout?.destroy?.();
+      child.stderr?.destroy?.();
+      child.unref();
+      throw new Error(
+        `Timed out waiting for simctl bootstatus ${udid}; its process could not be confirmed stopped. Inspect pid ${child.pid ?? 'unknown'} before retrying.`,
+      );
+    }
     throw bootstatusTimeout(udid);
   }
   if (result.error) throw result.error;
@@ -208,12 +229,12 @@ export async function bootIosSim(
   }: { timeoutMs?: number; attemptMs?: number } = {},
 ): Promise<void> {
   const exec = getExecutor();
+  const deadline = Date.now() + timeoutMs;
   try {
-    exec.run(`xcrun simctl boot ${udid}`);
+    exec.runFile('xcrun', ['simctl', 'boot', udid], { timeoutMs, killSignal: 'SIGKILL' });
   } catch (e) {
     if (!String((e as Error)?.message || e).includes('Booted')) throw e;
   }
-  const deadline = Date.now() + timeoutMs;
   // `simctl bootstatus -b` blocks until the boot finishes, and a first boot on a
   // CPU-starved host (a CI runner sharing cores with xcodebuild) can legitimately
   // outlast one attempt (#128).
@@ -242,7 +263,7 @@ export async function bootIosSim(
       throw new Error(`Simulator ${udid} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`);
     }
   }
-  exec.runQuiet('open -a Simulator');
+  exec.runFileQuiet('open', ['-a', 'Simulator'], { timeoutMs: 5000, killSignal: 'SIGKILL' });
 }
 
 export function shutdownIosSim(udid: string): void {
@@ -251,7 +272,10 @@ export function shutdownIosSim(udid: string): void {
 
 export function listIosDeviceTypes(): IosDeviceType[] {
   const exec = getExecutor();
-  const out = exec.run('xcrun simctl list devicetypes --json');
+  const out = exec.runFile('xcrun', ['simctl', 'list', 'devicetypes', '--json'], {
+    timeoutMs: 30000,
+    killSignal: 'SIGKILL',
+  });
   const data = JSON.parse(out) as { devicetypes?: Array<{ identifier: string; name: string }> };
   return (data.devicetypes || []).map((dt) => ({
     identifier: dt.identifier,
@@ -495,7 +519,10 @@ export function deleteParkedIosSim(udid: string): void {
 }
 
 export function listIosRuntimes(): IosRuntime[] {
-  const out = getExecutor().run('xcrun simctl list runtimes --json');
+  const out = getExecutor().runFile('xcrun', ['simctl', 'list', 'runtimes', '--json'], {
+    timeoutMs: 30000,
+    killSignal: 'SIGKILL',
+  });
   const data = JSON.parse(out) as {
     runtimes?: Array<{
       identifier: string;


### PR DESCRIPTION
## Description

Local iOS discovery, the initial boot request, installation, and the outer SimSlim wait can block without a Stim deadline. SimSlim 0.8's own ten-minute apply deadline starts [after device discovery](https://github.com/MobAI-App/simslim/blob/09fc9cbbca35db5230e6d571a0a366fe6876266e/cmd/simslim/main.go#L754-L764), so upgrading alone does not cover the gap. The earlier host-pressure incident’s cause remains unconfirmed.

## Solution

Bound discovery to 30 seconds, boot to ten minutes including its initial request, installation to five minutes, and SimSlim to twelve minutes including discovery. Opening the Simulator app after boot is best-effort with a five-second bound. Direct simctl invocations opt into hard termination; other executor callers keep their existing defaults. A timed-out bootstatus child must exit before Stim surveys or retries.

SimSlim records its owned process group in a per-simulator claim. A deadline, Ctrl-C, or SIGTERM triggers identity-verified group termination with a ten-second confirmation bound; unconfirmed termination keeps the claim and blocks another reconciliation. An immediate CLI exit attempts verified group termination without releasing the claim. The simulator's managed-settings record survives interruption so retry can reconcile partial changes.

## Test plan

- Controlled Node processes prove hard timeout waits for actual exit, Ctrl-C/SIGTERM exit with 130/143, and an immediate CLI exit leaves no surviving child. Confirmed group cleanup precedes claim release; a surviving descendant after its leader exits retains the claim and blocks a second reconciliation.
- Regressions cover initial boot consuming the shared budget, bootstatus waiting for actual exit before survey, and an install timeout stopping before dev-client preparation with host recovery guidance.
- On one disposable iPhone 17 / iOS 26.5 simulator, real discovery, boot, install, and Expo launch passed: local cache hit, `launched: true`, healthy UI, empty error logs. Exact stop/remove cleanup completed and preserved all pre-existing simulator IDs. The bounded direct-argv Simulator opener also succeeded. No SimSlim profile was applied.

Fixes #754
