### PR TITLE
feat: download compatible EAS development builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,13 @@ Do not infer and rebuild commands from project scripts. Bare React Native hosts
 Metro from the project's dependencies. Expo runs its fixed start command. iOS
 and Android use fixed `xcodebuild` and Gradle arguments.
 
+The explicit `ios|android --eas-profile <name>` path downloads a compatible
+completed EAS development build instead of compiling locally. Delegate profile
+resolution and fingerprinting to fixed EAS CLI invocations. Keep EAS cache
+identity separate from local native builds. A miss prints the EAS build command;
+Stim never starts a cloud build. This path targets simulators/emulators only
+and preserves Stim device ownership, Metro and launch semantics.
+
 The supported build selectors are `ios --scheme <name>`, `ios --configuration <name>`, and
 `android --variant <name>`. `ios --device-type <name>`, `ios --runtime
 <version>`, and `android --system-image <id>` select the model and version of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,10 +234,12 @@ and Android use fixed `xcodebuild` and Gradle arguments.
 
 The explicit `ios|android --eas-profile <name>` path downloads a compatible
 completed EAS development build instead of compiling locally. Delegate profile
-resolution and fingerprinting to fixed EAS CLI invocations. Keep EAS cache
-identity separate from local native builds. A miss prints the EAS build command;
-Stim never starts a cloud build. This path targets simulators/emulators only
-and preserves Stim device ownership, Metro and launch semantics.
+resolution, fingerprinting and artifact caching to fixed EAS CLI invocations.
+Coordinate downloads by EAS project and build ID. A miss prints the EAS build
+command; Stim never starts a cloud build. Physical devices use the existing
+lease and iOS provisioning gates. EAS device failures print EAS registration
+and rebuild remedies; they never register devices or change signing accounts.
+Preserve Stim device ownership, Metro and launch semantics.
 
 The supported build selectors are `ios --scheme <name>`, `ios --configuration <name>`, and
 `android --variant <name>`. `ios --device-type <name>`, `ios --runtime

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -77,6 +77,14 @@ Stim builds or restores the app, installs it, launches it, and checks launch
 readiness. Plain output streams progress and reports the complete result. Use
 `--json` when a script needs structured data.
 
+To use an existing EAS development build, run `stim ios --eas-profile ios-simulator`
+or `stim android --eas-profile development` with your project's profile name.
+The profile must be an internal development build; iOS requires `ios.simulator: true`.
+Stim downloads a matching native build and connects it to the workspace's Metro.
+On a miss it stops and prints the EAS build command, which may incur charges;
+it never triggers the build automatically. See `stim guide lifecycle eas` for
+setup, environment handling, and cache behavior.
+
 Use `stim ios --scheme "App Staging"` when a project has several shared Xcode
 app schemes. Combine it with `--configuration Release` if needed. Without the
 flag, Stim keeps its automatic scheme selection. Explicit schemes use separate

--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -79,8 +79,11 @@ readiness. Plain output streams progress and reports the complete result. Use
 
 To use an existing EAS development build, run `stim ios --eas-profile ios-simulator`
 or `stim android --eas-profile development` with your project's profile name.
-The profile must be an internal development build; iOS requires `ios.simulator: true`.
+The profile must be an internal development build. Add `--device` for a connected
+phone; iOS requires `ios.simulator: true` for a simulator and false for a phone.
 Stim downloads a matching native build and connects it to the workspace's Metro.
+EAS CLI manages the downloaded artifact cache. An iOS provisioning failure
+points to EAS device registration and rebuild commands.
 On a miss it stops and prints the EAS build command, which may incur charges;
 it never triggers the build automatically. See `stim guide lifecycle eas` for
 setup, environment handling, and cache behavior.

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5758,9 +5758,44 @@ describe('EAS development builds', () => {
     for (const list of [calls.ensureDevice, calls.booted, calls.install, calls.build]) expect(list).toHaveLength(0);
   });
 
+  test('installs the EAS APK on a physical device without creating or building an emulator', async () => {
+    expoProject();
+    const path = fakeApk();
+    const { run, calls } = harness({
+      device: 'RFCR7081Q9L',
+      easProfile: 'development',
+      listDevices: () => ({ emulators: [], physical: [{ serial: 'RFCR7081Q9L' }], unhealthy: [] }),
+      deviceModel: () => 'SM-G996W',
+      isEmulatorDevice: () => false,
+      resolveEasDevelopmentBuild: async () => ({
+        ok: true,
+        path,
+        fingerprint: 'eas-fingerprint',
+        cacheKey: 'eas-key',
+        cacheHit: 'remote',
+      }),
+    });
+    expect((await run()).ok).toBe(true);
+    expect(calls.install[0]).toMatchObject({ apkPath: path, serial: 'RFCR7081Q9L' });
+    for (const list of [calls.ensureDevice, calls.booted, calls.build, calls.fingerprint]) expect(list).toHaveLength(0);
+  });
+
   test('conflicting local selectors refuse before querying EAS', async () => {
     expoProject();
     const { run } = harness({ easProfile: 'development', variant: 'debug' });
     expect(await run()).toMatchObject({ ok: false, error: { code: 'STIM_BAD_ARG' } });
+  });
+
+  test.each([
+    { device: '' },
+    { device: true, remoteDevice: 'eas' as const },
+    { device: true, wait: 'invalid' },
+    { device: true, systemImage: '' },
+  ])('invalid device options refuse before EAS uploads or downloads: %j', async (options) => {
+    expoProject();
+    const resolveEasDevelopmentBuild = vi.fn<() => Promise<null>>(async () => null);
+    const { run } = harness({ ...options, easProfile: 'development', resolveEasDevelopmentBuild });
+    expect(await run()).toMatchObject({ ok: false, error: { code: 'STIM_BAD_ARG' } });
+    expect(resolveEasDevelopmentBuild).not.toHaveBeenCalled();
   });
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5690,3 +5690,77 @@ describe('Metro prefetch', () => {
     },
   );
 });
+
+describe('EAS development builds', () => {
+  function expoProject() {
+    writeFileSync(join(root, 'app.json'), JSON.stringify({ expo: { name: 'Fixture', slug: 'fixture' } }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'app', dependencies: { expo: '55.0.0', 'react-native': '0.83.0' } }),
+    );
+  }
+
+  test('installs the EAS APK on the owned emulator with the reserved Metro port, without a local build', async () => {
+    expoProject();
+    const path = fakeApk();
+    const resolveEasDevelopmentBuild = vi.fn<
+      NonNullable<NonNullable<Parameters<typeof runAndroid>[0]>['resolveEasDevelopmentBuild']>
+    >(async () => ({
+      ok: true as const,
+      path,
+      fingerprint: 'eas-fingerprint',
+      cacheKey: 'eas-key',
+      cacheHit: 'remote' as const,
+    }));
+    const { run, calls, stdout } = harness({
+      json: true,
+      easProfile: 'development',
+      resolveEasDevelopmentBuild,
+      resolveDevClientScheme: () => 'exp+fixture',
+      resolveSettingsFor: () => ({ android: { variant: 'productionRelease' } }),
+    });
+    const result = await run();
+    expect(result.ok).toBe(true);
+    expect(resolveEasDevelopmentBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'android', profile: 'development' }),
+    );
+    expect(calls.install[0]).toMatchObject({ apkPath: path, serial: 'emulator-5584' });
+    expect(calls.launch[0]).toMatchObject({ metroPort: 8082, devClientScheme: 'exp+fixture' });
+    expect(JSON.parse(stdout[0]!)).toMatchObject({
+      fingerprint: 'eas-fingerprint',
+      cacheKey: 'eas-key',
+      cacheHit: 'remote',
+      launched: true,
+    });
+    for (const list of [
+      calls.fingerprint,
+      calls.resolveCached,
+      calls.loadProvider,
+      calls.prebuild,
+      calls.build,
+      calls.uploadRemoteBuild,
+    ])
+      expect(list).toHaveLength(0);
+  });
+
+  test('a miss refuses before creating an emulator or compiling locally', async () => {
+    expoProject();
+    const { run, calls } = harness({
+      easProfile: 'development',
+      resolveEasDevelopmentBuild: async () => ({
+        ok: false,
+        code: 'STIM_EAS_BUILD_MISSING',
+        message: 'No match',
+        remedy: 'Run the approved EAS command.',
+      }),
+    });
+    expect(await run()).toMatchObject({ ok: false, error: { code: 'STIM_EAS_BUILD_MISSING' } });
+    for (const list of [calls.ensureDevice, calls.booted, calls.install, calls.build]) expect(list).toHaveLength(0);
+  });
+
+  test('conflicting local selectors refuse before querying EAS', async () => {
+    expoProject();
+    const { run } = harness({ easProfile: 'development', variant: 'debug' });
+    expect(await run()).toMatchObject({ ok: false, error: { code: 'STIM_BAD_ARG' } });
+  });
+});

--- a/packages/stim-cli/src/__tests__/eas-build.test.ts
+++ b/packages/stim-cli/src/__tests__/eas-build.test.ts
@@ -44,11 +44,13 @@ function fixture({
   builds = [build],
   config = {},
   failCommand = '',
+  projectFromEnv = false,
 }: {
   platform?: 'ios' | 'android';
   builds?: unknown;
   config?: Record<string, unknown>;
   failCommand?: string;
+  projectFromEnv?: boolean;
 } = {}) {
   const calls: string[][] = [];
   setExecutor({
@@ -71,9 +73,11 @@ function fixture({
             appConfig: { extra: { eas: { projectId } } },
           });
         case 'fingerprint:generate':
+          if (projectFromEnv && options.env?.APP_VARIANT !== 'development')
+            throw new Error('Fingerprint would be uploaded to the wrong project');
           return JSON.stringify({ hash: fingerprint, sources: [] });
         case 'build:list':
-          return JSON.stringify(builds);
+          return JSON.stringify(projectFromEnv && options.env?.APP_VARIANT !== 'development' ? [] : builds);
         case 'build:download': {
           const path = join(options.env.TMPDIR, platform === 'ios' ? 'App.app' : 'App.apk');
           if (platform === 'ios') mkdirSync(path);
@@ -175,6 +179,29 @@ test('changed profile settings do not reuse a previous artifact', async () => {
   if (!first?.ok || !second?.ok) throw new Error('Expected downloads');
   expect(second.cacheKey).not.toBe(first.cacheKey);
   expect(second.cacheHit).toBe('remote');
+});
+
+test('a profile that selects a different EAS project fingerprints and downloads from that project', async () => {
+  const { resolve } = fixture({ config: { env: { APP_VARIANT: 'development' } }, projectFromEnv: true });
+  expect(await resolve()).toMatchObject({ ok: true, cacheHit: 'remote' });
+});
+
+test.each([
+  { platform: 'ios' as const, config: { buildConfiguration: 'Release' } },
+  { platform: 'android' as const, config: { gradleCommand: ':app:assembleRelease' } },
+  { platform: 'android' as const, config: { gradleCommand: ':app:bundleDebug' } },
+])('refuses incompatible development profile overrides: %j', async ({ platform, config }) => {
+  const { resolve, calls } = fixture({ platform, config });
+  expect(await resolve()).toMatchObject({ ok: false, code: 'STIM_BAD_ARG' });
+  expect(calls.map((call) => call[0])).toEqual(['config']);
+});
+
+test.each([
+  { platform: 'ios' as const, config: { buildConfiguration: 'Debug' } },
+  { platform: 'android' as const, config: { gradleCommand: ':app:assembleDevelopmentDebug' } },
+])('accepts explicit development profile overrides: %j', async ({ platform, config }) => {
+  const { resolve } = fixture({ platform, config, builds: [{ ...build, platform: platform.toUpperCase() }] });
+  expect(await resolve()).toMatchObject({ ok: true, cacheHit: 'remote' });
 });
 
 test('disabled local caching leaves the downloaded artifact available for installation', async () => {

--- a/packages/stim-cli/src/__tests__/eas-build.test.ts
+++ b/packages/stim-cli/src/__tests__/eas-build.test.ts
@@ -1,0 +1,208 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { vi } from 'vitest';
+import { easOptionRefusal, resolveEasDevelopmentBuild, selectEasBuild } from '../engine/eas-build.ts';
+import * as locks from '../engine/build-lock.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
+
+const fingerprint = 'a'.repeat(40);
+const projectId = 'project-1';
+const profile = 'development';
+const target = { platform: 'ios' as const, profile, fingerprint, projectId };
+const build = {
+  id: 'build-1',
+  status: 'FINISHED',
+  platform: 'IOS',
+  buildProfile: profile,
+  fingerprint: { hash: fingerprint },
+  project: { id: projectId },
+  isForIosSimulator: true,
+  distribution: 'INTERNAL',
+  artifacts: { applicationArchiveUrl: 'https://example.com/app.tar.gz' },
+};
+let home: string;
+let root: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'stim-eas-test-'));
+  root = join(home, 'project');
+  mkdirSync(root);
+  process.env.STIM_HOME = home;
+  vi.spyOn(locks, 'acquireBuildLock').mockReturnValue({ acquired: true });
+  vi.spyOn(locks, 'releaseBuildLock').mockReturnValue(true);
+});
+afterEach(() => {
+  resetExecutor();
+  vi.restoreAllMocks();
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.STIM_HOME;
+});
+
+function fixture({
+  platform = 'ios',
+  builds = [build],
+  config = {},
+  failCommand = '',
+}: {
+  platform?: 'ios' | 'android';
+  builds?: unknown;
+  config?: Record<string, unknown>;
+  failCommand?: string;
+} = {}) {
+  const calls: string[][] = [];
+  setExecutor({
+    runQuiet: () => '/eas',
+    runFile: (file, args, options) => {
+      if (file === 'cp') {
+        cpSync(args.at(-2), args.at(-1), { recursive: true });
+        return '';
+      }
+      expect(file).toBe('/eas');
+      expect(options.cwd).toBe(root);
+      expect(args).toContain('--json');
+      expect(args).toContain('--non-interactive');
+      calls.push(args);
+      if (args[0] === failCommand) throw new Error('private environment value');
+      switch (args[0]) {
+        case 'config':
+          return JSON.stringify({
+            buildProfile: { developmentClient: true, distribution: 'internal', simulator: true, ...config },
+            appConfig: { extra: { eas: { projectId } } },
+          });
+        case 'fingerprint:generate':
+          return JSON.stringify({ hash: fingerprint, sources: [] });
+        case 'build:list':
+          return JSON.stringify(builds);
+        case 'build:download': {
+          const path = join(options.env.TMPDIR, platform === 'ios' ? 'App.app' : 'App.apk');
+          if (platform === 'ios') mkdirSync(path);
+          else writeFileSync(path, 'apk bytes');
+          return JSON.stringify({ path });
+        }
+        default:
+          throw new Error(`Unexpected EAS command ${args[0]}`);
+      }
+    },
+  });
+  const resolve = (cache = { read: true, write: true }) =>
+    resolveEasDevelopmentBuild({ root, platform, profile, cache, note: () => {} });
+  return { calls, resolve };
+}
+
+test.each([
+  { status: 'ERRORED' },
+  { platform: 'ANDROID' },
+  { buildProfile: 'production' },
+  { fingerprint: { hash: 'b'.repeat(40) } },
+  { project: { id: 'another-project' } },
+  { isForIosSimulator: false },
+  { artifacts: {} },
+])('does not select an incompatible EAS artifact: %j', (change) => {
+  expect(selectEasBuild([{ ...build, ...change }], target)).toBeNull();
+});
+
+test.each(['ios', 'android'] as const)(
+  'downloads the matching %s build, then reuses its local artifact',
+  async (platform) => {
+    const { resolve, calls } = fixture({ platform, builds: [{ ...build, platform: platform.toUpperCase() }] });
+    const first = await resolve();
+    expect(first).toMatchObject({ ok: true, cacheHit: 'remote', fingerprint });
+    if (!first?.ok) throw new Error(JSON.stringify(first));
+    expect(existsSync(first.path)).toBe(true);
+    expect(first.cacheKey).toMatch(/^eas-/);
+    expect(calls.find((call) => call[0] === 'fingerprint:generate')).toContain('--build-profile');
+    expect(calls.find((call) => call[0] === 'build:list')).toEqual([
+      'build:list',
+      '--platform',
+      platform,
+      '--build-profile',
+      profile,
+      '--fingerprint-hash',
+      fingerprint,
+      '--status',
+      'finished',
+      ...(platform === 'ios' ? ['--simulator'] : ['--distribution', 'internal']),
+      '--limit',
+      '1',
+      '--json',
+      '--non-interactive',
+    ]);
+    expect(calls.find((call) => call[0] === 'build:download')).toEqual([
+      'build:download',
+      '--build-id',
+      'build-1',
+      '--json',
+      '--non-interactive',
+    ]);
+    expect(await resolve()).toEqual({ ...first, cacheHit: 'local' });
+    expect(calls.filter((call) => call[0] === 'build:download')).toHaveLength(1);
+  },
+);
+
+test('a miss gives a build command without running it', async () => {
+  const { resolve, calls } = fixture({ builds: [] });
+  const result = await resolve();
+  expect(result).toMatchObject({ ok: false, code: 'STIM_EAS_BUILD_MISSING' });
+  if (result?.ok !== false) throw new Error('Expected a miss');
+  expect(result.remedy).toContain('npx eas-cli build --platform ios --profile development');
+  expect(result.remedy).toContain('charges');
+  expect(calls.map((call) => call[0])).toEqual(['config', 'fingerprint:generate', 'build:list']);
+  expect(locks.releaseBuildLock).toHaveBeenCalled();
+});
+
+test.each(['config', 'fingerprint:generate', 'build:list', 'build:download'])(
+  'a failed %s is not a cache miss and does not expose command output',
+  async (failCommand) => {
+    const result = await fixture({ failCommand }).resolve();
+    expect(result).toMatchObject({ ok: false, code: 'STIM_EAS_UNAVAILABLE' });
+    expect(JSON.stringify(result)).not.toContain('private environment value');
+  },
+);
+
+test.each([{ developmentClient: false }, { distribution: 'store' }, { simulator: false }])(
+  'rejects a profile that cannot produce simulator development builds: %j',
+  async (config) => {
+    const { resolve, calls } = fixture({ config });
+    expect(await resolve()).toMatchObject({ ok: false, code: 'STIM_BAD_ARG' });
+    expect(calls.map((call) => call[0])).toEqual(['config']);
+  },
+);
+
+test('changed profile settings do not reuse a previous artifact', async () => {
+  const first = await fixture().resolve();
+  const second = await fixture({ config: { env: { APP_VARIANT: 'another' } } }).resolve();
+  if (!first?.ok || !second?.ok) throw new Error('Expected downloads');
+  expect(second.cacheKey).not.toBe(first.cacheKey);
+  expect(second.cacheHit).toBe('remote');
+});
+
+test('disabled local caching leaves the downloaded artifact available for installation', async () => {
+  const { resolve } = fixture();
+  const result = await resolve({ read: false, write: false });
+  if (!result?.ok) throw new Error(JSON.stringify(result));
+  expect(existsSync(result.path)).toBe(true);
+  expect(result.path).toContain('eas-downloads');
+});
+
+test('a held claim prevents downloading or storing an artifact', async () => {
+  const { resolve, calls } = fixture();
+  vi.mocked(locks.acquireBuildLock).mockReturnValue({
+    path: '/claim',
+    held: { pid: 12, projectRoot: root, startedAt: null, logFile: null },
+  });
+  expect(await resolve()).toMatchObject({ ok: false, code: 'STIM_EAS_UNAVAILABLE' });
+  expect(calls.map((call) => call[0])).toEqual(['config', 'fingerprint:generate']);
+});
+
+test.each([
+  { physical: true },
+  { isExpo: false },
+  { buildSelector: 'Release' },
+  { buildCache: false },
+  { profile: '' },
+])('refuses incompatible EAS options before side effects: %j', (change) => {
+  expect(easOptionRefusal({ profile, isExpo: true, physical: false, ...change })).toMatchObject({
+    code: 'STIM_BAD_ARG',
+  });
+});

--- a/packages/stim-cli/src/__tests__/eas-build.test.ts
+++ b/packages/stim-cli/src/__tests__/eas-build.test.ts
@@ -1,10 +1,11 @@
-import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { vi } from 'vitest';
 import { easOptionRefusal, resolveEasDevelopmentBuild, selectEasBuild } from '../engine/eas-build.ts';
 import * as locks from '../engine/build-lock.ts';
 import { resetExecutor, setExecutor } from '../exec.ts';
+import { ClaimUnavailableError } from '../ownership-claim.ts';
 
 const fingerprint = 'a'.repeat(40);
 const projectId = 'project-1';
@@ -45,21 +46,19 @@ function fixture({
   config = {},
   failCommand = '',
   projectFromEnv = false,
+  physical = false,
 }: {
   platform?: 'ios' | 'android';
   builds?: unknown;
   config?: Record<string, unknown>;
   failCommand?: string;
   projectFromEnv?: boolean;
+  physical?: boolean;
 } = {}) {
   const calls: string[][] = [];
   setExecutor({
     runQuiet: () => '/eas',
     runFile: (file, args, options) => {
-      if (file === 'cp') {
-        cpSync(args.at(-2), args.at(-1), { recursive: true });
-        return '';
-      }
       expect(file).toBe('/eas');
       expect(options.cwd).toBe(root);
       expect(args).toContain('--json');
@@ -69,7 +68,7 @@ function fixture({
       switch (args[0]) {
         case 'config':
           return JSON.stringify({
-            buildProfile: { developmentClient: true, distribution: 'internal', simulator: true, ...config },
+            buildProfile: { developmentClient: true, distribution: 'internal', simulator: !physical, ...config },
             appConfig: { extra: { eas: { projectId } } },
           });
         case 'fingerprint:generate':
@@ -79,9 +78,10 @@ function fixture({
         case 'build:list':
           return JSON.stringify(projectFromEnv && options.env?.APP_VARIANT !== 'development' ? [] : builds);
         case 'build:download': {
-          const path = join(options.env.TMPDIR, platform === 'ios' ? 'App.app' : 'App.apk');
-          if (platform === 'ios') mkdirSync(path);
-          else writeFileSync(path, 'apk bytes');
+          const path = join(home, 'eas-run-cache', `${args[2]}.${platform === 'ios' ? 'app' : 'apk'}`);
+          mkdirSync(join(home, 'eas-run-cache'), { recursive: true });
+          if (platform === 'ios') mkdirSync(path, { recursive: true });
+          else if (!existsSync(path)) writeFileSync(path, 'apk bytes');
           return JSON.stringify({ path });
         }
         default:
@@ -89,8 +89,7 @@ function fixture({
       }
     },
   });
-  const resolve = (cache = { read: true, write: true }) =>
-    resolveEasDevelopmentBuild({ root, platform, profile, cache, note: () => {} });
+  const resolve = () => resolveEasDevelopmentBuild({ root, platform, profile, physical, note: () => {} });
   return { calls, resolve };
 }
 
@@ -107,13 +106,14 @@ test.each([
 });
 
 test.each(['ios', 'android'] as const)(
-  'downloads the matching %s build, then reuses its local artifact',
+  'uses the matching %s artifact from EAS CLI without copying or deleting it',
   async (platform) => {
     const { resolve, calls } = fixture({ platform, builds: [{ ...build, platform: platform.toUpperCase() }] });
     const first = await resolve();
     expect(first).toMatchObject({ ok: true, cacheHit: 'remote', fingerprint });
     if (!first?.ok) throw new Error(JSON.stringify(first));
     expect(existsSync(first.path)).toBe(true);
+    expect(first.path).toBe(realpathSync(join(home, 'eas-run-cache', `build-1.${platform === 'ios' ? 'app' : 'apk'}`)));
     expect(first.cacheKey).toMatch(/^eas-/);
     expect(calls.find((call) => call[0] === 'fingerprint:generate')).toContain('--build-profile');
     expect(calls.find((call) => call[0] === 'build:list')).toEqual([
@@ -139,8 +139,8 @@ test.each(['ios', 'android'] as const)(
       '--json',
       '--non-interactive',
     ]);
-    expect(await resolve()).toEqual({ ...first, cacheHit: 'local' });
-    expect(calls.filter((call) => call[0] === 'build:download')).toHaveLength(1);
+    expect(await resolve()).toEqual(first);
+    expect(calls.filter((call) => call[0] === 'build:download')).toHaveLength(2);
   },
 );
 
@@ -173,12 +173,13 @@ test.each([{ developmentClient: false }, { distribution: 'store' }, { simulator:
   },
 );
 
-test('changed profile settings do not reuse a previous artifact', async () => {
+test('a newly signed build uses a new identity even when its native fingerprint is unchanged', async () => {
   const first = await fixture().resolve();
-  const second = await fixture({ config: { env: { APP_VARIANT: 'another' } } }).resolve();
+  const second = await fixture({ builds: [{ ...build, id: 'build-2' }] }).resolve();
   if (!first?.ok || !second?.ok) throw new Error('Expected downloads');
   expect(second.cacheKey).not.toBe(first.cacheKey);
   expect(second.cacheHit).toBe('remote');
+  expect(second.path).not.toBe(first.path);
 });
 
 test('a profile that selects a different EAS project fingerprints and downloads from that project', async () => {
@@ -204,12 +205,20 @@ test.each([
   expect(await resolve()).toMatchObject({ ok: true, cacheHit: 'remote' });
 });
 
-test('disabled local caching leaves the downloaded artifact available for installation', async () => {
-  const { resolve } = fixture();
-  const result = await resolve({ read: false, write: false });
-  if (!result?.ok) throw new Error(JSON.stringify(result));
-  expect(existsSync(result.path)).toBe(true);
-  expect(result.path).toContain('eas-downloads');
+test.each(['ios', 'android'] as const)('resolves a physical %s development build', async (platform) => {
+  const { resolve, calls } = fixture({
+    physical: true,
+    platform,
+    builds: [{ ...build, isForIosSimulator: false, platform: platform.toUpperCase() }],
+  });
+  expect(await resolve()).toMatchObject({ ok: true, cacheHit: 'remote' });
+  const list = calls.find((call) => call[0] === 'build:list');
+  expect(list).toContain('--distribution');
+  expect(list).not.toContain('--simulator');
+});
+
+test('a simulator build is not selected for an iOS device', () => {
+  expect(selectEasBuild([build], { ...target, physical: true })).toBeNull();
 });
 
 test('a held claim prevents downloading or storing an artifact', async () => {
@@ -219,17 +228,26 @@ test('a held claim prevents downloading or storing an artifact', async () => {
     held: { pid: 12, projectRoot: root, startedAt: null, logFile: null },
   });
   expect(await resolve()).toMatchObject({ ok: false, code: 'STIM_EAS_UNAVAILABLE' });
-  expect(calls.map((call) => call[0])).toEqual(['config', 'fingerprint:generate']);
+  expect(calls.map((call) => call[0])).toEqual(['config', 'fingerprint:generate', 'build:list']);
 });
 
-test.each([
-  { physical: true },
-  { isExpo: false },
-  { buildSelector: 'Release' },
-  { buildCache: false },
-  { profile: '' },
-])('refuses incompatible EAS options before side effects: %j', (change) => {
-  expect(easOptionRefusal({ profile, isExpo: true, physical: false, ...change })).toMatchObject({
-    code: 'STIM_BAD_ARG',
+test('a failed device claim preserves the original device selection in its retry guidance', async () => {
+  const { resolve } = fixture({ physical: true, builds: [{ ...build, isForIosSimulator: false }] });
+  vi.mocked(locks.acquireBuildLock).mockImplementation(() => {
+    throw new ClaimUnavailableError('identity unavailable');
   });
+  const result = await resolve();
+  expect(result).toMatchObject({ ok: false, code: 'STIM_CLAIM_UNAVAILABLE' });
+  if (result?.ok !== false) throw new Error('Expected a refusal');
+  expect(result.remedy).toContain('retry the same Stim command');
+  expect(result.remedy).not.toContain('--device');
 });
+
+test.each([{ isExpo: false }, { buildSelector: 'Release' }, { buildCache: false }, { profile: '' }])(
+  'refuses incompatible EAS options before side effects: %j',
+  (change) => {
+    expect(easOptionRefusal({ profile, isExpo: true, ...change })).toMatchObject({
+      code: 'STIM_BAD_ARG',
+    });
+  },
+);

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -483,4 +483,6 @@ test('EAS guidance routes agents to the profile and preserves the paid-build aut
   expect(eas).toMatch(/session authorizes the potentially billable/);
   expect(eas).toContain('STIM_EAS_BUILD_MISSING');
   expect(eas).toContain('STIM_EAS_UNAVAILABLE');
+  expect(eas).toContain('npx eas-cli device:create');
+  expect(eas).toMatch(/Registration, signing changes and cloud builds need session authorization/);
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -217,7 +217,7 @@ test('the errors topic documents every code the build commands and the iOS signi
   ];
   const sources = [
     ...commandFiles.map((file) => readFileSync(new URL(`../commands/${file}`, import.meta.url), 'utf-8')),
-    ...['engine/ios-profile.ts', 'engine/ios-signing.ts'].map((f) =>
+    ...['engine/ios-profile.ts', 'engine/ios-signing.ts', 'engine/eas-build.ts'].map((f) =>
       readFileSync(new URL(`../${f}`, import.meta.url), 'utf-8'),
     ),
   ].join('\n');
@@ -472,4 +472,15 @@ test('the settings guide documents every configurable optimization', () => {
   for (const key of Object.keys(OPTIMIZATION_SHAPES)) {
     expect(body).toContain(key);
   }
+});
+
+test('EAS guidance routes agents to the profile and preserves the paid-build authorization boundary', () => {
+  const agent = renderTopic('agent');
+  expect(agent).toContain('stim guide lifecycle eas');
+  const eas = renderSection('lifecycle', 'eas');
+  expect(eas).toContain('--eas-profile');
+  expect(eas).toContain('fingerprint:generate uploads fingerprint metadata');
+  expect(eas).toMatch(/session authorizes the potentially billable/);
+  expect(eas).toContain('STIM_EAS_BUILD_MISSING');
+  expect(eas).toContain('STIM_EAS_UNAVAILABLE');
 });

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -5715,3 +5715,78 @@ describe('optimization configuration', () => {
     expect(calls.args.storeBuild.key).toMatch(/opt-/);
   });
 });
+
+describe('EAS development builds', () => {
+  test('installs the EAS artifact against the reserved Metro port without entering the local build pipeline', async () => {
+    reserve();
+    const path = join(root, 'Eas.app');
+    const resolveEasDevelopmentBuild = vi.fn<NonNullable<IosDeps['resolveEasDevelopmentBuild']>>(async () => ({
+      ok: true as const,
+      path,
+      fingerprint: 'eas-fingerprint',
+      cacheKey: 'eas-key',
+      cacheHit: 'remote' as const,
+    }));
+    const { logs, calls } = await run(
+      { json: true, easProfile: 'development-simulator' },
+      {
+        detectIsExpo: () => true,
+        resolveEasDevelopmentBuild,
+        devClientScheme: () => 'exp+fixture',
+        resolveSettings: () => ({ ios: { configuration: 'Release' } }),
+      },
+    );
+    expect(resolveEasDevelopmentBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ profile: 'development-simulator', platform: 'ios' }),
+    );
+    expect(calls.args.installIosApp.appPath).toBe(path);
+    expect(calls.args.launchIosApp).toMatchObject({ metroPort: 8082, devClientScheme: 'exp+fixture' });
+    expect(parseFirst(logs)).toMatchObject({
+      fingerprint: 'eas-fingerprint',
+      cacheKey: 'eas-key',
+      cacheHit: 'remote',
+      launched: true,
+    });
+    for (const step of [
+      'fingerprintProject',
+      'resolveBuild',
+      'loadProjectProvider',
+      'runPrebuild',
+      'runPodInstall',
+      'buildIos',
+      'uploadRemote',
+    ]) {
+      expect(calls.order).not.toContain(step);
+    }
+  });
+
+  test('a missing EAS build refuses before creating or booting a simulator', async () => {
+    reserve();
+    const { logs, calls } = await run(
+      { json: true, easProfile: 'development' },
+      {
+        detectIsExpo: () => true,
+        resolveEasDevelopmentBuild: async () => ({
+          ok: false,
+          code: 'STIM_EAS_BUILD_MISSING',
+          message: 'No match',
+          remedy: 'Run the approved EAS build command.',
+        }),
+      },
+    );
+    expect(parseFirst(logs)).toMatchObject({ code: 'STIM_EAS_BUILD_MISSING' });
+    expect(calls.order).not.toContain('ensureOwnedDevice');
+    expect(calls.order).not.toContain('buildIos');
+    expect(calls.order).not.toContain('installIosApp');
+  });
+
+  test('conflicting local selectors refuse before querying EAS', async () => {
+    const { logs } = await run(
+      { json: true, easProfile: 'development', configuration: 'Release' },
+      {
+        detectIsExpo: () => true,
+      },
+    );
+    expect(parseFirst(logs)).toMatchObject({ code: 'STIM_BAD_ARG' });
+  });
+});

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -5717,6 +5717,74 @@ describe('optimization configuration', () => {
 });
 
 describe('EAS development builds', () => {
+  async function runEasDevice(overrides: Partial<IosDeps> = {}) {
+    reserve();
+    const udid = '00008030-001A2B3C4D5E802E';
+    return run(
+      { json: true, device: udid, easProfile: 'development-device' },
+      {
+        detectIsExpo: () => true,
+        listIosDevices: () => [
+          {
+            udid,
+            name: 'Test Phone',
+            bootState: 'booted',
+            developerModeStatus: 'enabled',
+            pairingState: 'paired',
+            transportType: 'wired',
+          },
+        ],
+        resolveEasDevelopmentBuild: async () => ({
+          ok: true,
+          path: join(root, 'Eas.app'),
+          fingerprint: 'eas-fingerprint',
+          cacheKey: 'eas-device-key',
+          cacheHit: 'remote',
+        }),
+        devClientScheme: () => 'exp+fixture',
+        ...overrides,
+      },
+    );
+  }
+
+  test('installs an EAS device app after the provisioning gate without modifying its signature', async () => {
+    const { logs, calls } = await runEasDevice();
+    expect(calls.args.gateProfileForDevice).toMatchObject({
+      appPath: join(root, 'Eas.app'),
+      udid: '00008030-001A2B3C4D5E802E',
+    });
+    expect(calls.args.installIosDeviceApp).toMatchObject({
+      appPath: join(root, 'Eas.app'),
+      udid: '00008030-001A2B3C4D5E802E',
+    });
+    expect(calls.order.indexOf('gateProfileForDevice')).toBeLessThan(calls.order.indexOf('installIosDeviceApp'));
+    expect(parseFirst(logs)).toMatchObject({ launched: true, cacheHit: 'remote' });
+    for (const step of ['sealAppForDevice', 'buildIos', 'ensureOwnedDevice']) expect(calls.order).not.toContain(step);
+  });
+
+  test('an EAS provisioning refusal points to EAS registration and rebuilding', async () => {
+    const { logs, calls } = await runEasDevice({
+      gateProfileForDevice: () => ({
+        ok: false,
+        code: 'STIM_PROFILE_MISMATCH',
+        reason: 'Device is not in the profile.',
+        remedy: 'Xcode remedy.',
+      }),
+    });
+    expect(parseFirst(logs)).toMatchObject({ code: 'STIM_PROFILE_MISMATCH' });
+    expect(parseFirst(logs).remedy).toContain('npx eas-cli device:create');
+    expect(parseFirst(logs).remedy).toContain('npx eas-cli build --platform ios --profile development-device');
+    expect(parseFirst(logs).remedy).not.toContain('Xcode');
+    for (const step of ['installIosDeviceApp', 'sealAppForDevice', 'buildIos']) expect(calls.order).not.toContain(step);
+  });
+
+  test('an EAS device app without a dev-client scheme refuses instead of re-signing', async () => {
+    const { logs, calls } = await runEasDevice({ devClientScheme: () => undefined });
+    expect(parseFirst(logs)).toMatchObject({ code: 'STIM_BAD_ARG' });
+    expect(parseFirst(logs).remedy).toContain('npx expo install expo-dev-client');
+    for (const step of ['installIosDeviceApp', 'sealAppForDevice', 'buildIos']) expect(calls.order).not.toContain(step);
+  });
+
   test('installs the EAS artifact against the reserved Metro port without entering the local build pipeline', async () => {
     reserve();
     const path = join(root, 'Eas.app');
@@ -5788,5 +5856,16 @@ describe('EAS development builds', () => {
       },
     );
     expect(parseFirst(logs)).toMatchObject({ code: 'STIM_BAD_ARG' });
+  });
+
+  test('an empty simulator selector on an EAS device run refuses before EAS uploads or downloads', async () => {
+    reserve();
+    const resolveEasDevelopmentBuild = vi.fn<() => Promise<null>>(async () => null);
+    const { logs } = await run(
+      { json: true, device: true, easProfile: 'development-device', deviceType: '' },
+      { detectIsExpo: () => true, resolveEasDevelopmentBuild },
+    );
+    expect(parseFirst(logs)).toMatchObject({ code: 'STIM_BAD_ARG' });
+    expect(resolveEasDevelopmentBuild).not.toHaveBeenCalled();
   });
 });

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1,3 +1,4 @@
+import { isEasBuildFailure, resolveEasDevelopmentBuild } from '../engine/eas-build.ts';
 import { parkedMaxSetting } from '../sim-pool.ts';
 import {
   resolveOptimizations,
@@ -92,6 +93,7 @@ import {
   resolveMetroWithRetry,
   noMetroMessage,
   noMetroRemedy,
+  isPhysicalDeviceRequest,
 } from './native-runtime.ts';
 import {
   readRunEstimates,
@@ -215,6 +217,7 @@ export {
 export { formatDuration, phaseLine, shortHash } from '../command-output.ts';
 
 interface AndroidCommandOptions {
+  easProfile?: string;
   json?: boolean;
   metroCheck?: boolean;
   buildCache?: boolean;
@@ -267,6 +270,10 @@ export function registerAndroid(program: Command): void {
       "Build (or install from the shared cache), install and launch this workspace's Android app on its owned " +
         'emulator, wired to the reserved Metro port. Never starts the bundler -- run `stim start` first.',
     )
+    .option(
+      '--eas-profile <name>',
+      'Download a matching EAS development build; on a miss, print the build command without running it',
+    )
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
     .option(
       '--no-metro-check',
@@ -293,7 +300,7 @@ export function registerAndroid(program: Command): void {
     )
     .option(
       '--remote <backend>',
-      'Install and launch on a remote device with proxy or EAS. The build still happens here.',
+      'Install and launch on a remote device with proxy or EAS. Builds are local unless --eas-profile selects an existing EAS build.',
       (value) => {
         if ((REMOTE_DEVICE_BACKENDS as readonly string[]).includes(value)) return value as RemoteDeviceBackend;
         throw new InvalidArgumentError(`expected one of: ${REMOTE_DEVICE_BACKENDS.join(', ')}`);
@@ -320,6 +327,7 @@ export function registerAndroid(program: Command): void {
         metroCheck: opts.metroCheck !== false,
         useBuildCache: opts.buildCache !== false,
         variant: opts.variant ?? null,
+        easProfile: opts.easProfile,
         systemImage: opts.systemImage ?? null,
         remoteDevice: opts.remote ?? null,
         device: opts.device ?? null,
@@ -331,6 +339,8 @@ export function registerAndroid(program: Command): void {
 }
 
 interface RunAndroidOptions {
+  easProfile?: string;
+  resolveEasDevelopmentBuild?: typeof resolveEasDevelopmentBuild;
   root: string;
   json?: boolean;
   metroCheck?: boolean;
@@ -425,6 +435,8 @@ function resolveRunAndroidOptions(
     detectRemoteProviders = detectProviders,
     metroCheck = true,
     useBuildCache = true,
+    easProfile,
+    resolveEasDevelopmentBuild: resolveEasBuild = resolveEasDevelopmentBuild,
     variant: variantFlag = null,
     systemImage: systemImageFlag = null,
     device: deviceFlag = null,
@@ -506,6 +518,8 @@ function resolveRunAndroidOptions(
     detectRemoteProviders,
     metroCheck,
     useBuildCache,
+    easProfile,
+    resolveEasBuild,
     variantFlag,
     systemImageFlag,
     deviceFlag,
@@ -589,6 +603,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     detectRemoteProviders,
     metroCheck,
     useBuildCache: requestedBuildCache,
+    easProfile,
+    resolveEasBuild,
     variantFlag,
     systemImageFlag,
     deviceFlag,
@@ -832,14 +848,26 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     );
   }
   const systemImage = resolveSystemImage(systemImageFlag, settings);
-  const variant = resolveVariant(variantFlag, settings);
+  const variant = easProfile !== undefined ? 'debug' : resolveVariant(variantFlag, settings);
   const flavorRefusal = productFlavorRefusal({ flavors: readProductFlavors(root), variant });
   if (flavorRefusal) return fail(flavorRefusal.code, flavorRefusal.reason, flavorRefusal.remedy);
   const release = isReleaseVariant(variant);
   const cachePolicy = artifactCachePolicy(optimizations, requestedBuildCache, release);
   const useBuildCache = cachePolicy.read;
   const isExpo = detectIsExpo(root);
-  const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;
+  const physical = isPhysicalDeviceRequest(deviceFlag);
+  const easBuild = await resolveEasBuild({
+    root,
+    platform: PLATFORM,
+    profile: easProfile,
+    cache: cachePolicy,
+    note: out,
+    isExpo,
+    physical,
+    selectors: [variantFlag],
+    buildCache: requestedBuildCache,
+  });
+  if (isEasBuildFailure(easBuild)) return fail(easBuild.code, easBuild.message, easBuild.remedy);
   if (physical && deviceFlag === '') {
     return fail(
       'STIM_BAD_ARG',
@@ -1139,6 +1167,18 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   let apkPath: string | null = null;
 
   async function resolveInitialFingerprint(): Promise<boolean> {
+    if (easBuild?.ok) {
+      hash = storeHash = easBuild.fingerprint;
+      cacheKey = storeKey = easBuild.cacheKey;
+      apkPath = easBuild.path;
+      record.fingerprint = hash;
+      record.cacheKey = cacheKey;
+      record.cacheHit = easBuild.cacheHit;
+      record.cacheSkipped = !useBuildCache;
+      providerName = 'eas';
+      stats.setCacheKey(cacheKey);
+      return true;
+    }
     const fingerprintTimer = stepTimer(now);
     try {
       const computed = await fingerprint(root, { platform: PLATFORM });
@@ -1284,7 +1324,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       }
     }
 
-    await resolveRemoteArtifact();
+    if (!easBuild) await resolveRemoteArtifact();
 
     let waitedForBuild: WaitedForBuild | null = null;
     let releasedWait: { facts: WaitedForBuild; who: string } | null = null;
@@ -1383,7 +1423,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       return true;
     }
 
-    if (!(await waitForSharedBuild())) return phaseFailure!;
+    if (!easBuild && !(await waitForSharedBuild())) return phaseFailure!;
 
     let swapDir: string | null = null;
     let swapFellBack = false;
@@ -1619,8 +1659,10 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
       return true;
     }
 
-    await prepareCachedArtifact();
-    if (!(await buildArtifact())) return phaseFailure!;
+    if (!easBuild) {
+      await prepareCachedArtifact();
+      if (!(await buildArtifact())) return phaseFailure!;
+    }
     record.appPath = apkPath;
 
     let leaseHandle: RunLease | null = null;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -856,18 +856,6 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
   const useBuildCache = cachePolicy.read;
   const isExpo = detectIsExpo(root);
   const physical = isPhysicalDeviceRequest(deviceFlag);
-  const easBuild = await resolveEasBuild({
-    root,
-    platform: PLATFORM,
-    profile: easProfile,
-    cache: cachePolicy,
-    note: out,
-    isExpo,
-    physical,
-    selectors: [variantFlag],
-    buildCache: requestedBuildCache,
-  });
-  if (isEasBuildFailure(easBuild)) return fail(easBuild.code, easBuild.message, easBuild.remedy);
   if (physical && deviceFlag === '') {
     return fail(
       'STIM_BAD_ARG',
@@ -918,6 +906,17 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     listImages: listSystemImages,
   });
   if (imageRefusal) return fail(imageRefusal.code, imageRefusal.message, imageRefusal.remedy);
+  const easBuild = await resolveEasBuild({
+    root,
+    platform: PLATFORM,
+    profile: easProfile,
+    note: out,
+    isExpo,
+    physical,
+    selectors: [variantFlag],
+    buildCache: requestedBuildCache,
+  });
+  if (isEasBuildFailure(easBuild)) return fail(easBuild.code, easBuild.message, easBuild.remedy);
   const requestedSerial = typeof deviceFlag === 'string' ? deviceFlag : null;
   let androidPackage = detectAndroidPackage(root);
   record.bundleId = androidPackage;

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1,3 +1,4 @@
+import { isEasBuildFailure } from '../engine/eas-build.ts';
 import { rmSync } from 'node:fs';
 import {
   resolveOptimizations,
@@ -87,7 +88,7 @@ import type { NdjsonWriter } from '../ndjson.ts';
 import { workspaceDir, workspaceLogsDir } from '../paths.ts';
 import { appProjectProblem } from '../project.ts';
 import { claimFailure } from '../ownership-claim.ts';
-import { type SupervisorLike, noMetroMessage, noMetroRemedy } from './native-runtime.ts';
+import { isPhysicalDeviceRequest, type SupervisorLike, noMetroMessage, noMetroRemedy } from './native-runtime.ts';
 import {
   PLATFORM,
   buildLogFile,
@@ -158,6 +159,10 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
       "Build (or restore from the fingerprint cache), install and launch this workspace's app on its owned " +
         'simulator, wired to the reserved Metro port. Requires a running dev server (`stim start`).',
     )
+    .option(
+      '--eas-profile <name>',
+      'Download a matching EAS development build; on a miss, print the build command without running it',
+    )
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
     .option(
       '--scheme <name>',
@@ -192,7 +197,7 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
     )
     .option(
       '--remote <backend>',
-      'Install and launch on a remote device with proxy or EAS. The build still happens here.',
+      'Install and launch on a remote device with proxy or EAS. Builds are local unless --eas-profile selects an existing EAS build.',
       (value) => {
         if ((REMOTE_DEVICE_BACKENDS as readonly string[]).includes(value)) return value as RemoteDeviceBackend;
         throw new InvalidArgumentError(`expected one of: ${REMOTE_DEVICE_BACKENDS.join(', ')}`);
@@ -419,7 +424,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
     }
   }
 
-  const configuration = resolveConfiguration(opts.configuration, settings);
+  const configuration = opts.easProfile !== undefined ? null : resolveConfiguration(opts.configuration, settings);
   const buildScheme = opts.scheme;
   const release = isReleaseConfiguration(configuration);
   const cachePolicy = artifactCachePolicy(optimizations, useBuildCache, release);
@@ -429,7 +434,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   const runtime = resolveRuntime(opts.runtime, settings);
 
   const deviceFlag = opts.device;
-  const physical = deviceFlag !== null && deviceFlag !== undefined && deviceFlag !== false;
+  const physical = isPhysicalDeviceRequest(deviceFlag);
   if (physical && deviceFlag === '') {
     return fail({
       code: 'STIM_BAD_ARG',
@@ -474,6 +479,18 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   const waitSeconds = waitParsed.seconds;
 
   const isExpo = d.detectIsExpo(root);
+  const easBuild = await d.resolveEasDevelopmentBuild({
+    root,
+    platform: PLATFORM,
+    profile: opts.easProfile,
+    cache: cachePolicy,
+    note,
+    isExpo,
+    physical,
+    selectors: [opts.scheme, opts.configuration],
+    buildCache: opts.buildCache,
+  });
+  if (isEasBuildFailure(easBuild)) return fail(easBuild);
   const schemeRefusal = explicitSchemeRefusal(root, buildScheme, isExpo, d);
   if (schemeRefusal) return fail(schemeRefusal);
   const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
@@ -774,6 +791,15 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
     });
     udid = (device.deviceUdid as string | undefined) ?? (await bootPromise)?.udid ?? '';
 
+    if (easBuild?.ok) {
+      fingerprint = storeHash = easBuild.fingerprint;
+      cacheKey = storeKey = easBuild.cacheKey;
+      appPath = easBuild.path;
+      cacheHit = easBuild.cacheHit;
+      providerName = 'eas';
+      stats.setCacheKey(cacheKey);
+      return true;
+    }
     const fingerprintTimer = stepTimer(d.now);
     let computedFingerprint: string | null;
     try {
@@ -1338,10 +1364,12 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
 
   try {
     if (!(await resolveInitialFingerprint())) return null;
-    await resolveRemoteArtifact();
-    if (!(await waitForSharedBuild())) return null;
-    await prepareCachedArtifact();
-    if (!(await buildArtifact())) return null;
+    if (!easBuild) {
+      await resolveRemoteArtifact();
+      if (!(await waitForSharedBuild())) return null;
+      await prepareCachedArtifact();
+      if (!(await buildArtifact())) return null;
+    }
 
     if (physicalDevice) {
       const acquired = await d.acquireRunLease({

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1,4 +1,4 @@
-import { isEasBuildFailure } from '../engine/eas-build.ts';
+import { easDeviceBuildRemedy, isEasBuildFailure } from '../engine/eas-build.ts';
 import { rmSync } from 'node:fs';
 import {
   resolveOptimizations,
@@ -479,18 +479,6 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   const waitSeconds = waitParsed.seconds;
 
   const isExpo = d.detectIsExpo(root);
-  const easBuild = await d.resolveEasDevelopmentBuild({
-    root,
-    platform: PLATFORM,
-    profile: opts.easProfile,
-    cache: cachePolicy,
-    note,
-    isExpo,
-    physical,
-    selectors: [opts.scheme, opts.configuration],
-    buildCache: opts.buildCache,
-  });
-  if (isEasBuildFailure(easBuild)) return fail(easBuild);
   const schemeRefusal = explicitSchemeRefusal(root, buildScheme, isExpo, d);
   if (schemeRefusal) return fail(schemeRefusal);
   const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
@@ -504,6 +492,17 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
     listRuntimes: d.listIosRuntimes,
   });
   if (modelRefusal) return fail(modelRefusal);
+  const easBuild = await d.resolveEasDevelopmentBuild({
+    root,
+    platform: PLATFORM,
+    profile: opts.easProfile,
+    note,
+    isExpo,
+    physical,
+    selectors: [opts.scheme, opts.configuration],
+    buildCache: opts.buildCache,
+  });
+  if (isEasBuildFailure(easBuild)) return fail(easBuild);
   const registerProject = () => d.upsertProject(root, { bundleId: d.detectBundleId(root) ?? undefined, isExpo });
   if (remoteBackend !== 'eas') registerProject();
   const proj = d.getProject(root);
@@ -798,6 +797,22 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
       cacheHit = easBuild.cacheHit;
       providerName = 'eas';
       stats.setCacheKey(cacheKey);
+      if (physical) {
+        const gate = d.gateProfileForDevice({ appPath, udid, configuration });
+        if (!gate.ok) {
+          fail({ code: gate.code, message: gate.reason, remedy: easDeviceBuildRemedy(opts.easProfile!) });
+          return false;
+        }
+        if (!d.devClientScheme(root, appPath)) {
+          fail({
+            code: 'STIM_BAD_ARG',
+            message: 'The EAS device app has no development-client URL scheme.',
+            remedy:
+              'Install expo-dev-client with npx expo install expo-dev-client, then rebuild the EAS profile and retry.',
+          });
+          return false;
+        }
+      }
       return true;
     }
     const fingerprintTimer = stepTimer(d.now);

--- a/packages/stim-cli/src/commands/ios/dependencies.ts
+++ b/packages/stim-cli/src/commands/ios/dependencies.ts
@@ -1,4 +1,5 @@
 import { loadCacheProvider } from '@stim-cli/cache';
+import { resolveEasDevelopmentBuild } from '../../engine/eas-build.ts';
 import { fingerprintProject, resolveBuild, storeBuild, untrackedNativeFiles } from '../../build-cache.ts';
 import { getConcurrencyLimits, getProject, upsertProject } from '../../config.ts';
 import {
@@ -61,6 +62,7 @@ import { devClientScheme } from '../dev-client.ts';
 import { stopPreviousCollector, replaceCollector } from './collector.ts';
 
 export interface IosDeps {
+  resolveEasDevelopmentBuild: typeof resolveEasDevelopmentBuild;
   resolveRemoteContext: typeof resolveRemoteContext;
   ensureMetroReachable: typeof ensureMetroReachable;
   ensureRemoteBootOwned: typeof ensureRemoteBootOwned;
@@ -144,6 +146,7 @@ export interface IosDeps {
 }
 
 export const DEFAULT_DEPS: IosDeps = {
+  resolveEasDevelopmentBuild,
   findProjectRoot,
   resolveSettings,
   gitCommonDir,

--- a/packages/stim-cli/src/commands/ios/types.ts
+++ b/packages/stim-cli/src/commands/ios/types.ts
@@ -71,6 +71,7 @@ export interface IosCommandOptions {
   buildCache?: boolean;
   configuration?: string;
   scheme?: string;
+  easProfile?: string;
   deviceType?: string;
   runtime?: string;
   device?: string | boolean;

--- a/packages/stim-cli/src/commands/native-runtime.ts
+++ b/packages/stim-cli/src/commands/native-runtime.ts
@@ -136,3 +136,7 @@ export function launchOutcomeRecord({
     msg,
   };
 }
+
+export function isPhysicalDeviceRequest(flag: string | boolean | null | undefined): boolean {
+  return flag !== null && flag !== undefined && flag !== false;
+}

--- a/packages/stim-cli/src/engine/eas-build.ts
+++ b/packages/stim-cli/src/engine/eas-build.ts
@@ -1,11 +1,7 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
-import { isAbsolute, join, relative, sep } from 'node:path';
-import { resolveBuild, storeBuild } from '../build-cache.ts';
-import { register } from '../cache-manifest.ts';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { getExecutor } from '../exec.ts';
 import { claimFailure } from '../ownership-claim.ts';
-import { workspaceDir } from '../paths.ts';
 import { acquireBuildLock, releaseBuildLock } from './build-lock.ts';
 import { resolveEasCliBin } from './remote-cache.ts';
 
@@ -20,7 +16,7 @@ interface Refusal {
 
 export type EasBuildResult =
   | ({ ok: false } & Refusal)
-  | { ok: true; path: string; fingerprint: string; cacheKey: string; cacheHit: 'local' | 'remote' };
+  | { ok: true; path: string; fingerprint: string; cacheKey: string; cacheHit: 'remote' };
 
 export function isEasBuildFailure(result: EasBuildResult | null): result is { ok: false } & Refusal {
   return result?.ok === false;
@@ -29,23 +25,20 @@ export function isEasBuildFailure(result: EasBuildResult | null): result is { ok
 export function easOptionRefusal({
   profile,
   isExpo,
-  physical,
   buildSelector,
   buildCache,
 }: {
   profile?: string;
   isExpo: boolean;
-  physical: boolean;
   buildSelector?: string;
   buildCache?: boolean;
 }): Refusal | null {
   if (profile === undefined) return null;
-  if (profile.trim() && isExpo && !physical && buildSelector === undefined && buildCache !== false) return null;
+  if (profile.trim() && isExpo && buildSelector === undefined && buildCache !== false) return null;
   return {
     code: 'STIM_BAD_ARG',
-    message:
-      '--eas-profile requires an Expo project, a non-empty development profile, and a simulator or emulator target.',
-    remedy: 'Use --eas-profile <name> without --device, --scheme, --configuration, --variant, or --no-build-cache.',
+    message: '--eas-profile requires an Expo project and a non-empty development profile.',
+    remedy: 'Use --eas-profile <name> without --scheme, --configuration, --variant, or --no-build-cache.',
   };
 }
 
@@ -55,6 +48,10 @@ function object(value: unknown): JsonObject {
 
 function shellArg(value: string): string {
   return /^[a-zA-Z0-9_.-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function easDeviceBuildRemedy(profile: string): string {
+  return `If the device is not registered, run npx eas-cli device:create. With approval for cloud build costs and signing changes, run npx eas-cli build --platform ios --profile ${shellArg(profile)} to produce a build with a valid profile for this device, then retry the same Stim command.`;
 }
 
 class EasFailure extends Error {
@@ -75,7 +72,8 @@ export function selectEasBuild(
     profile,
     fingerprint,
     projectId,
-  }: { platform: Platform; profile: string; fingerprint: string; projectId: string },
+    physical = false,
+  }: { platform: Platform; profile: string; fingerprint: string; projectId: string; physical?: boolean },
 ): string | null {
   if (!Array.isArray(builds)) throw new Error('EAS build:list did not return an array.');
   for (const value of builds) {
@@ -88,7 +86,8 @@ export function selectEasBuild(
       build.buildProfile === profile &&
       object(build.fingerprint).hash === fingerprint &&
       object(build.project).id === projectId &&
-      (platform === 'ios' ? build.isForIosSimulator === true : build.distribution === 'INTERNAL') &&
+      (platform !== 'ios' || build.isForIosSimulator === !physical) &&
+      build.distribution === 'INTERNAL' &&
       typeof object(build.artifacts).applicationArchiveUrl === 'string'
     )
       return build.id;
@@ -100,7 +99,6 @@ export async function resolveEasDevelopmentBuild({
   root,
   platform,
   profile,
-  cache,
   note,
   isExpo = true,
   physical = false,
@@ -114,23 +112,18 @@ export async function resolveEasDevelopmentBuild({
   physical?: boolean;
   selectors?: (string | null | undefined)[];
   buildCache?: boolean;
-  cache: { read: boolean; write: boolean };
   note: (line: string) => void;
 }): Promise<EasBuildResult | null> {
   if (profile === undefined) return null;
   const refusal = easOptionRefusal({
     profile,
     isExpo,
-    physical,
     buildSelector: selectors.find((value) => value != null) ?? undefined,
     buildCache,
   });
   if (refusal) return { ok: false, ...refusal };
-  const retry = `stim ${platform} --eas-profile ${shellArg(profile)}`;
+  const retry = 'the same Stim command';
   const buildCommand = `npx eas-cli build --platform ${platform} --profile ${shellArg(profile)}`;
-  const scratchRoot = join(workspaceDir(root), 'eas-downloads');
-  let scratch: string | null = null;
-  let keepScratch = false;
   let lock: ReturnType<typeof acquireBuildLock> | null = null;
   try {
     const cli = resolveEasCliBin(root);
@@ -141,13 +134,13 @@ export async function resolveEasDevelopmentBuild({
         'Install eas-cli, run eas login, then retry.',
       );
     let profileEnv: Record<string, string> = {};
-    const run = (args: string[], timeoutMs = 120_000, env?: Record<string, string>): unknown => {
+    const run = (args: string[], timeoutMs = 120_000): unknown => {
       try {
         return JSON.parse(
           getExecutor().runFile(cli.file, [...args, '--json', '--non-interactive'], {
             cwd: root,
             timeoutMs,
-            env: { ...profileEnv, ...env },
+            env: profileEnv,
           }),
         );
       } catch {
@@ -168,12 +161,12 @@ export async function resolveEasDevelopmentBuild({
     if (
       buildProfile.developmentClient !== true ||
       buildProfile.distribution !== 'internal' ||
-      (platform === 'ios' && buildProfile.simulator !== true)
+      (platform === 'ios' && (buildProfile.simulator === true) !== !physical)
     ) {
       throw new EasFailure(
         'STIM_BAD_ARG',
-        `EAS profile ${profile} is not an internal development build for ${platform}.`,
-        `Set developmentClient: true and distribution: internal${platform === 'ios' ? ', with ios.simulator: true' : ''} in that eas.json profile.`,
+        `EAS profile ${profile} is not an internal development build for this ${platform} target.`,
+        `Set developmentClient: true and distribution: internal${platform === 'ios' ? `, with ios.simulator: ${!physical}` : ''} in that eas.json profile.`,
       );
     }
     if (typeof projectId !== 'string' || !projectId) {
@@ -205,25 +198,6 @@ export async function resolveEasDevelopmentBuild({
         `Run npx eas-cli fingerprint:generate --platform ${platform} --build-profile ${shellArg(profile)} to inspect the result.`,
       );
     }
-    const identity = createHash('sha256')
-      .update(JSON.stringify({ projectId, profile, buildProfile, fingerprint }))
-      .digest('hex');
-    const cacheKey = `eas-${identity}-debug-sim`;
-    const local = cache.read ? resolveBuild(platform, cacheKey) : null;
-    if (local) {
-      note(`eas   local hit ${fingerprint.slice(0, 8)}`);
-      return { ok: true, path: local, fingerprint, cacheKey, cacheHit: 'local' };
-    }
-    lock = acquireBuildLock({ platform, key: cacheKey, root });
-    if (!lock.acquired) {
-      throw new EasFailure(
-        'STIM_EAS_UNAVAILABLE',
-        `Another run holds the EAS artifact claim at ${lock.path}.`,
-        `Wait for that run to finish, then retry ${retry}.`,
-      );
-    }
-    const rechecked = cache.read ? resolveBuild(platform, cacheKey) : null;
-    if (rechecked) return { ok: true, path: rechecked, fingerprint, cacheKey, cacheHit: 'local' };
     note(`eas   looking for ${fingerprint.slice(0, 8)}`);
     const builds = run([
       'build:list',
@@ -235,11 +209,11 @@ export async function resolveEasDevelopmentBuild({
       fingerprint,
       '--status',
       'finished',
-      ...(platform === 'ios' ? ['--simulator'] : ['--distribution', 'internal']),
+      ...(platform === 'ios' && !physical ? ['--simulator'] : ['--distribution', 'internal']),
       '--limit',
       '1',
     ]);
-    const buildId = selectEasBuild(builds, { platform, profile, fingerprint, projectId });
+    const buildId = selectEasBuild(builds, { platform, profile, fingerprint, projectId, physical });
     if (!buildId) {
       throw new EasFailure(
         'STIM_EAS_BUILD_MISSING',
@@ -247,31 +221,32 @@ export async function resolveEasDevelopmentBuild({
         `A cloud build may incur charges. With approval to run it, use ${buildCommand}, then retry ${retry}.`,
       );
     }
-    mkdirSync(scratchRoot, { recursive: true });
-    register({ dir: scratchRoot, name: 'EAS downloads', prune: 'entries', note: 'downloaded development builds' });
-    scratch = mkdtempSync(join(scratchRoot, 'download-'));
-    note(`eas   downloading build ${buildId}`);
-    const result = object(run(['build:download', '--build-id', buildId], 10 * 60_000, { TMPDIR: scratch }));
+    const identity = createHash('sha256').update(JSON.stringify({ projectId, buildId })).digest('hex');
+    const cacheKey = `eas-${identity}-debug-${physical && platform === 'ios' ? 'device' : 'sim'}`;
+    lock = acquireBuildLock({ platform, key: cacheKey, root });
+    if (!lock.acquired) {
+      throw new EasFailure(
+        'STIM_EAS_UNAVAILABLE',
+        `Another run holds the EAS artifact claim at ${lock.path}.`,
+        `Wait for that run to finish, then retry ${retry}.`,
+      );
+    }
+    note(`eas   resolving artifact for build ${buildId}`);
+    const result = object(run(['build:download', '--build-id', buildId], 10 * 60_000));
     if (typeof result.path !== 'string' || !existsSync(result.path))
       throw new Error('EAS returned no downloaded artifact.');
     const path = realpathSync(result.path);
-    const within = relative(realpathSync(scratch), path);
     if (
-      isAbsolute(within) ||
-      within === '..' ||
-      within.startsWith(`..${sep}`) ||
-      (platform === 'ios'
+      platform === 'ios'
         ? !path.endsWith('.app') || !statSync(path).isDirectory()
-        : !path.endsWith('.apk') || !statSync(path).isFile())
+        : !path.endsWith('.apk') || !statSync(path).isFile()
     ) {
       throw new Error('EAS returned an unexpected artifact path or type.');
     }
-    const stored = cache.write ? storeBuild(platform, cacheKey, path) : null;
-    keepScratch = !stored;
-    note(`eas   downloaded ${fingerprint.slice(0, 8)}${stored ? ' -> stored locally' : ''}`);
-    return { ok: true, path: stored ?? path, fingerprint, cacheKey, cacheHit: 'remote' };
+    note(`eas   artifact ready ${fingerprint.slice(0, 8)}`);
+    return { ok: true, path, fingerprint, cacheKey, cacheHit: 'remote' };
   } catch (error) {
-    const claim = claimFailure(error, retry);
+    const claim = claimFailure(error, null);
     if (claim) return { ok: false, code: claim.code, message: claim.message, remedy: claim.remedy };
     if (error instanceof EasFailure)
       return { ok: false, code: error.code, message: error.message, remedy: error.remedy };
@@ -282,10 +257,6 @@ export async function resolveEasDevelopmentBuild({
       remedy: `Retry ${retry}. No cloud build was started.`,
     };
   } finally {
-    try {
-      if (scratch && !keepScratch) rmSync(scratch, { recursive: true, force: true });
-    } finally {
-      releaseBuildLock(lock);
-    }
+    releaseBuildLock(lock);
   }
 }

--- a/packages/stim-cli/src/engine/eas-build.ts
+++ b/packages/stim-cli/src/engine/eas-build.ts
@@ -140,13 +140,14 @@ export async function resolveEasDevelopmentBuild({
         'EAS CLI is not installed.',
         'Install eas-cli, run eas login, then retry.',
       );
+    let profileEnv: Record<string, string> = {};
     const run = (args: string[], timeoutMs = 120_000, env?: Record<string, string>): unknown => {
       try {
         return JSON.parse(
           getExecutor().runFile(cli.file, [...args, '--json', '--non-interactive'], {
             cwd: root,
             timeoutMs,
-            env,
+            env: { ...profileEnv, ...env },
           }),
         );
       } catch {
@@ -160,6 +161,8 @@ export async function resolveEasDevelopmentBuild({
     note(`eas   resolving profile ${profile}`);
     const config = object(run(['config', '--platform', platform, '--profile', profile]));
     const buildProfile = object(config.buildProfile);
+    // EAS build:list treats --build-profile only as a filter; project context uses the process environment.
+    profileEnv = object(buildProfile.env) as Record<string, string>;
     const appConfig = object(config.appConfig);
     const projectId = object(object(appConfig.extra).eas).projectId;
     if (
@@ -178,6 +181,19 @@ export async function resolveEasDevelopmentBuild({
         'STIM_BAD_ARG',
         'The Expo app is not linked to an EAS project.',
         'Link the intended EAS project with eas init, then retry.',
+      );
+    }
+    if (
+      platform === 'ios'
+        ? buildProfile.buildConfiguration !== undefined && buildProfile.buildConfiguration !== 'Debug'
+        : buildProfile.gradleCommand !== undefined &&
+          (typeof buildProfile.gradleCommand !== 'string' ||
+            !/^:app:assemble\w*Debug$/.test(buildProfile.gradleCommand))
+    ) {
+      throw new EasFailure(
+        'STIM_BAD_ARG',
+        `EAS profile ${profile} overrides the development build configuration.`,
+        'Use ios.buildConfiguration: Debug or an android.gradleCommand that assembles a single Debug APK, or remove the override.',
       );
     }
     note(`eas   fingerprinting ${platform} with profile ${profile}`);

--- a/packages/stim-cli/src/engine/eas-build.ts
+++ b/packages/stim-cli/src/engine/eas-build.ts
@@ -1,0 +1,275 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative, sep } from 'node:path';
+import { resolveBuild, storeBuild } from '../build-cache.ts';
+import { register } from '../cache-manifest.ts';
+import { getExecutor } from '../exec.ts';
+import { claimFailure } from '../ownership-claim.ts';
+import { workspaceDir } from '../paths.ts';
+import { acquireBuildLock, releaseBuildLock } from './build-lock.ts';
+import { resolveEasCliBin } from './remote-cache.ts';
+
+type Platform = 'ios' | 'android';
+type JsonObject = Record<string, unknown>;
+
+interface Refusal {
+  code: string;
+  message: string;
+  remedy: string;
+}
+
+export type EasBuildResult =
+  | ({ ok: false } & Refusal)
+  | { ok: true; path: string; fingerprint: string; cacheKey: string; cacheHit: 'local' | 'remote' };
+
+export function isEasBuildFailure(result: EasBuildResult | null): result is { ok: false } & Refusal {
+  return result?.ok === false;
+}
+
+export function easOptionRefusal({
+  profile,
+  isExpo,
+  physical,
+  buildSelector,
+  buildCache,
+}: {
+  profile?: string;
+  isExpo: boolean;
+  physical: boolean;
+  buildSelector?: string;
+  buildCache?: boolean;
+}): Refusal | null {
+  if (profile === undefined) return null;
+  if (profile.trim() && isExpo && !physical && buildSelector === undefined && buildCache !== false) return null;
+  return {
+    code: 'STIM_BAD_ARG',
+    message:
+      '--eas-profile requires an Expo project, a non-empty development profile, and a simulator or emulator target.',
+    remedy: 'Use --eas-profile <name> without --device, --scheme, --configuration, --variant, or --no-build-cache.',
+  };
+}
+
+function object(value: unknown): JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as JsonObject) : {};
+}
+
+function shellArg(value: string): string {
+  return /^[a-zA-Z0-9_.-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+class EasFailure extends Error {
+  readonly code: string;
+  readonly remedy: string;
+
+  constructor(code: string, message: string, remedy: string) {
+    super(message);
+    this.code = code;
+    this.remedy = remedy;
+  }
+}
+
+export function selectEasBuild(
+  builds: unknown,
+  {
+    platform,
+    profile,
+    fingerprint,
+    projectId,
+  }: { platform: Platform; profile: string; fingerprint: string; projectId: string },
+): string | null {
+  if (!Array.isArray(builds)) throw new Error('EAS build:list did not return an array.');
+  for (const value of builds) {
+    const build = object(value);
+    if (
+      typeof build.id === 'string' &&
+      build.id.length > 0 &&
+      build.status === 'FINISHED' &&
+      build.platform === platform.toUpperCase() &&
+      build.buildProfile === profile &&
+      object(build.fingerprint).hash === fingerprint &&
+      object(build.project).id === projectId &&
+      (platform === 'ios' ? build.isForIosSimulator === true : build.distribution === 'INTERNAL') &&
+      typeof object(build.artifacts).applicationArchiveUrl === 'string'
+    )
+      return build.id;
+  }
+  return null;
+}
+
+export async function resolveEasDevelopmentBuild({
+  root,
+  platform,
+  profile,
+  cache,
+  note,
+  isExpo = true,
+  physical = false,
+  selectors = [],
+  buildCache,
+}: {
+  root: string;
+  platform: Platform;
+  profile?: string;
+  isExpo?: boolean;
+  physical?: boolean;
+  selectors?: (string | null | undefined)[];
+  buildCache?: boolean;
+  cache: { read: boolean; write: boolean };
+  note: (line: string) => void;
+}): Promise<EasBuildResult | null> {
+  if (profile === undefined) return null;
+  const refusal = easOptionRefusal({
+    profile,
+    isExpo,
+    physical,
+    buildSelector: selectors.find((value) => value != null) ?? undefined,
+    buildCache,
+  });
+  if (refusal) return { ok: false, ...refusal };
+  const retry = `stim ${platform} --eas-profile ${shellArg(profile)}`;
+  const buildCommand = `npx eas-cli build --platform ${platform} --profile ${shellArg(profile)}`;
+  const scratchRoot = join(workspaceDir(root), 'eas-downloads');
+  let scratch: string | null = null;
+  let keepScratch = false;
+  let lock: ReturnType<typeof acquireBuildLock> | null = null;
+  try {
+    const cli = resolveEasCliBin(root);
+    if (!cli)
+      throw new EasFailure(
+        'STIM_EAS_UNAVAILABLE',
+        'EAS CLI is not installed.',
+        'Install eas-cli, run eas login, then retry.',
+      );
+    const run = (args: string[], timeoutMs = 120_000, env?: Record<string, string>): unknown => {
+      try {
+        return JSON.parse(
+          getExecutor().runFile(cli.file, [...args, '--json', '--non-interactive'], {
+            cwd: root,
+            timeoutMs,
+            env,
+          }),
+        );
+      } catch {
+        throw new EasFailure(
+          'STIM_EAS_UNAVAILABLE',
+          `EAS ${args[0]} failed or returned invalid JSON.`,
+          `Run npx eas-cli ${args.map(shellArg).join(' ')} to inspect the error, then retry ${retry}.`,
+        );
+      }
+    };
+    note(`eas   resolving profile ${profile}`);
+    const config = object(run(['config', '--platform', platform, '--profile', profile]));
+    const buildProfile = object(config.buildProfile);
+    const appConfig = object(config.appConfig);
+    const projectId = object(object(appConfig.extra).eas).projectId;
+    if (
+      buildProfile.developmentClient !== true ||
+      buildProfile.distribution !== 'internal' ||
+      (platform === 'ios' && buildProfile.simulator !== true)
+    ) {
+      throw new EasFailure(
+        'STIM_BAD_ARG',
+        `EAS profile ${profile} is not an internal development build for ${platform}.`,
+        `Set developmentClient: true and distribution: internal${platform === 'ios' ? ', with ios.simulator: true' : ''} in that eas.json profile.`,
+      );
+    }
+    if (typeof projectId !== 'string' || !projectId) {
+      throw new EasFailure(
+        'STIM_BAD_ARG',
+        'The Expo app is not linked to an EAS project.',
+        'Link the intended EAS project with eas init, then retry.',
+      );
+    }
+    note(`eas   fingerprinting ${platform} with profile ${profile}`);
+    const fingerprint = object(run(['fingerprint:generate', '--platform', platform, '--build-profile', profile])).hash;
+    if (typeof fingerprint !== 'string' || !/^[a-f0-9]{40,64}$/.test(fingerprint)) {
+      throw new EasFailure(
+        'STIM_EAS_UNAVAILABLE',
+        'EAS returned no valid native fingerprint.',
+        `Run npx eas-cli fingerprint:generate --platform ${platform} --build-profile ${shellArg(profile)} to inspect the result.`,
+      );
+    }
+    const identity = createHash('sha256')
+      .update(JSON.stringify({ projectId, profile, buildProfile, fingerprint }))
+      .digest('hex');
+    const cacheKey = `eas-${identity}-debug-sim`;
+    const local = cache.read ? resolveBuild(platform, cacheKey) : null;
+    if (local) {
+      note(`eas   local hit ${fingerprint.slice(0, 8)}`);
+      return { ok: true, path: local, fingerprint, cacheKey, cacheHit: 'local' };
+    }
+    lock = acquireBuildLock({ platform, key: cacheKey, root });
+    if (!lock.acquired) {
+      throw new EasFailure(
+        'STIM_EAS_UNAVAILABLE',
+        `Another run holds the EAS artifact claim at ${lock.path}.`,
+        `Wait for that run to finish, then retry ${retry}.`,
+      );
+    }
+    const rechecked = cache.read ? resolveBuild(platform, cacheKey) : null;
+    if (rechecked) return { ok: true, path: rechecked, fingerprint, cacheKey, cacheHit: 'local' };
+    note(`eas   looking for ${fingerprint.slice(0, 8)}`);
+    const builds = run([
+      'build:list',
+      '--platform',
+      platform,
+      '--build-profile',
+      profile,
+      '--fingerprint-hash',
+      fingerprint,
+      '--status',
+      'finished',
+      ...(platform === 'ios' ? ['--simulator'] : ['--distribution', 'internal']),
+      '--limit',
+      '1',
+    ]);
+    const buildId = selectEasBuild(builds, { platform, profile, fingerprint, projectId });
+    if (!buildId) {
+      throw new EasFailure(
+        'STIM_EAS_BUILD_MISSING',
+        `No compatible EAS ${platform} build exists for profile ${profile} and fingerprint ${fingerprint}.`,
+        `A cloud build may incur charges. With approval to run it, use ${buildCommand}, then retry ${retry}.`,
+      );
+    }
+    mkdirSync(scratchRoot, { recursive: true });
+    register({ dir: scratchRoot, name: 'EAS downloads', prune: 'entries', note: 'downloaded development builds' });
+    scratch = mkdtempSync(join(scratchRoot, 'download-'));
+    note(`eas   downloading build ${buildId}`);
+    const result = object(run(['build:download', '--build-id', buildId], 10 * 60_000, { TMPDIR: scratch }));
+    if (typeof result.path !== 'string' || !existsSync(result.path))
+      throw new Error('EAS returned no downloaded artifact.');
+    const path = realpathSync(result.path);
+    const within = relative(realpathSync(scratch), path);
+    if (
+      isAbsolute(within) ||
+      within === '..' ||
+      within.startsWith(`..${sep}`) ||
+      (platform === 'ios'
+        ? !path.endsWith('.app') || !statSync(path).isDirectory()
+        : !path.endsWith('.apk') || !statSync(path).isFile())
+    ) {
+      throw new Error('EAS returned an unexpected artifact path or type.');
+    }
+    const stored = cache.write ? storeBuild(platform, cacheKey, path) : null;
+    keepScratch = !stored;
+    note(`eas   downloaded ${fingerprint.slice(0, 8)}${stored ? ' -> stored locally' : ''}`);
+    return { ok: true, path: stored ?? path, fingerprint, cacheKey, cacheHit: 'remote' };
+  } catch (error) {
+    const claim = claimFailure(error, retry);
+    if (claim) return { ok: false, code: claim.code, message: claim.message, remedy: claim.remedy };
+    if (error instanceof EasFailure)
+      return { ok: false, code: error.code, message: error.message, remedy: error.remedy };
+    return {
+      ok: false,
+      code: 'STIM_EAS_UNAVAILABLE',
+      message: `Could not resolve the EAS development build: ${(error as Error).message}`,
+      remedy: `Retry ${retry}. No cloud build was started.`,
+    };
+  } finally {
+    try {
+      if (scratch && !keepScratch) rmSync(scratch, { recursive: true, force: true });
+    } finally {
+      releaseBuildLock(lock);
+    }
+  }
+}

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -83,6 +83,13 @@ them. It preserves source, custom launcher settings, and the shared ccache.
   stim start
   stim ios                             # or: stim android
 
+For a project using EAS development builds, select the agreed profile with
+stim ios --eas-profile <name> or stim android --eas-profile <name>.
+Read stim guide lifecycle eas before using this path. A miss stops with
+STIM_EAS_BUILD_MISSING and an EAS build command. Run that command only when the
+session authorizes the potentially billable build, then retry Stim. The
+presence of eas.json does not select EAS or authorize building.
+
 Read stim guide lifecycle concurrency when a build waits on another workspace
 or a build call times out. A native build can outlive a shell timeout; if the
 tool call timed out, retry the same command and follow its printed remedy if

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -89,6 +89,8 @@ Read stim guide lifecycle eas before using this path. A miss stops with
 STIM_EAS_BUILD_MISSING and an EAS build command. Run that command only when the
 session authorizes the potentially billable build, then retry Stim. The
 presence of eas.json does not select EAS or authorize building.
+Physical --device targets are supported. Follow EAS device-registration and
+rebuild remedies only when the session authorizes those account changes.
 
 Read stim guide lifecycle concurrency when a build waits on another workspace
 or a build call times out. A native build can outlive a shell timeout; if the

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -8,6 +8,24 @@ const errors: GuideTopic = {
 Every refusal from \`ios\` / \`android\` carries a stable CODE. Branch on the
 code, never on the message.`,
   sections: {
+    STIM_EAS_BUILD_MISSING: {
+      summary: 'no completed EAS development build matches; build only with session authorization',
+      body: () => `STIM_EAS_BUILD_MISSING
+  No compatible build matches the selected EAS project, profile, platform and
+  native fingerprint. No device was acquired and no local or cloud build was
+  started. The remedy prints the exact npx eas-cli build command. Check session
+  authorization for its potential cost before running it, then retry Stim.
+  See stim guide lifecycle eas.`,
+    },
+    STIM_EAS_UNAVAILABLE: {
+      summary: 'EAS lookup/download failed, or another run holds the artifact claim',
+      body: () => `STIM_EAS_UNAVAILABLE
+  EAS CLI is unavailable, a profile/fingerprint/list/download operation failed,
+  the response could not be validated, or another run holds the artifact claim.
+  Follow the printed remedy: inspect the named EAS command or retry once the
+  holder finishes. This is not proof that a build is missing. No native build
+  is started. See stim guide lifecycle eas.`,
+    },
     STIM_WORKSPACE_STATE: {
       summary: '$STIM_HOME/workspaces could not be prepared, or the digest directory belongs to another project',
       aliases: ['STIM_WORKSPACE_COLLISION'],

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -352,7 +352,10 @@ spending a build or a bundle, that the check can succeed.`,
       profile;
     - it is a development or ad hoc profile whose device list does not name
       this UDID. Register the UDID at developer.apple.com, regenerate the
-      profile, and build once from Xcode.`,
+      profile, and build once from Xcode.
+  With --eas-profile, follow the EAS device:create and build commands in the
+  refusal instead. Registration, signing changes and cloud builds need session
+  authorization. See stim guide lifecycle eas.`,
     },
     STIM_NO_SIGNING_IDENTITY: {
       summary: 'no single keychain identity resolves; ios.signingIdentitySha1 for two certificates',

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -68,8 +68,9 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
   cacheKey        the shared-build-cache key derived from it (the
                   configuration is part of it: -release-sim vs -debug-sim)
   With --eas-profile, fingerprint is computed by EAS CLI using the selected
-  profile/environment, and cacheKey is isolated from local native builds.
-  cacheHit is "remote" on download and "local" on later local reuse.
+  profile/environment, and cacheKey identifies the EAS project and build ID
+  separately from local native builds. cacheHit is "remote" for the EAS
+  source, including when EAS CLI reuses its own downloaded artifact cache.
 
   cacheHit        WHICH LEVEL answered, not a boolean:
                     "local"   this machine's shared cache (free, instant)

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -67,6 +67,10 @@ line by design (see \`guide logs\`), not this single-payload contract.`,
                   absent for automatic selection; not the app URL scheme
   cacheKey        the shared-build-cache key derived from it (the
                   configuration is part of it: -release-sim vs -debug-sim)
+  With --eas-profile, fingerprint is computed by EAS CLI using the selected
+  profile/environment, and cacheKey is isolated from local native builds.
+  cacheHit is "remote" on download and "local" on later local reuse.
+
   cacheHit        WHICH LEVEL answered, not a boolean:
                     "local"   this machine's shared cache (free, instant)
                     "remote"  the project's own Expo buildCacheProvider (a

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -184,6 +184,58 @@ TWO REPORTS, TWO QUESTIONS
   the machine, with a hit rate and an estimate of the time saved (see
   \`guide facts stats\`).`,
   sections: {
+    eas: {
+      summary: 'download a matching EAS development build; explicit profile, costs, cache and miss remedies',
+      body: () => `EAS DEVELOPMENT BUILDS
+
+  stim ios --eas-profile ios-simulator
+  stim android --eas-profile development
+
+An eas.json file does not select EAS automatically. The flag names the profile
+and selects EAS Build as the artifact source. The profile must resolve to
+"developmentClient": true and "distribution": "internal"; iOS also needs
+"ios": { "simulator": true }. Install eas-cli and authenticate with eas login
+or EXPO_TOKEN. The Expo app must already be linked to the intended EAS project.
+
+Stim delegates profile inheritance, environment resolution and fingerprinting
+to EAS CLI. fingerprint:generate uploads fingerprint metadata to EAS. It does
+not start a native build. EAS access is needed even when the artifact is
+already cached, because the current profile and fingerprint must be resolved.
+
+Stim matches the EAS project, profile, native fingerprint, platform and
+simulator/internal distribution target against a completed build. It downloads
+an iOS .app or Android .apk with EAS CLI, then uses its existing installation,
+Metro connection, log capture and launch verification on the owned device.
+The flag also works with --remote; remote EAS Simulator sessions have their
+own costs, independent of this download path. Physical --device targets and
+local --scheme, --configuration, --variant and --no-build-cache selectors
+cannot be combined with --eas-profile. Local configuration/variant defaults
+are ignored for this development-build run.
+
+Start Metro with stim start as usual. Metro uses the local workspace's
+environment; arrange the appropriate local variables before starting it.
+EAS environment resolution for native fingerprinting does not configure Metro.
+
+The EAS artifact cache is separate from local native builds and includes the
+EAS project, profile, resolved profile settings and fingerprint. A local hit
+reports cacheHit: "local"; a download reports "remote". The fingerprint fact
+is the EAS native fingerprint. Local buildCache settings control local reuse
+and storage; remoteBuildCache settings do not disable an explicitly selected
+EAS build source. Scratch downloads live under the workspace's eas-downloads
+directory and are registered for gc.
+
+On STIM_EAS_BUILD_MISSING, Stim stops before acquiring a device and prints:
+
+  npx eas-cli build --platform ios --profile ios-simulator
+
+Run that command only when the session authorizes the potentially billable
+cloud build. Once it completes, retry the same Stim command. No build-on-miss
+flag exists, and Stim never starts a cloud build or falls back to local
+compilation in this mode. Authentication, network, invalid output or download
+failures produce STIM_EAS_UNAVAILABLE, with the failed EAS command to inspect.
+If another run holds the artifact claim, wait for it to finish and retry.`,
+    },
+
     readiness: {
       summary: 'implement optional pending/ready app logs, deadlines, errors, and platform isolation',
       body: () => `OPTIONAL APP READINESS

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -190,11 +190,14 @@ TWO REPORTS, TWO QUESTIONS
 
   stim ios --eas-profile ios-simulator
   stim android --eas-profile development
+  stim ios --eas-profile development-device --device <udid>
+  stim android --eas-profile development --device <serial>
 
 An eas.json file does not select EAS automatically. The flag names the profile
 and selects EAS Build as the artifact source. The profile must resolve to
-"developmentClient": true and "distribution": "internal"; iOS also needs
-"ios": { "simulator": true }. An explicit ios.buildConfiguration must be Debug;
+"developmentClient": true and "distribution": "internal". For iOS, set
+"ios.simulator": true for a simulator, or false (or omit it) for --device.
+An explicit ios.buildConfiguration must be Debug;
 android.gradleCommand must be a single :app:assemble<Variant>Debug task producing
 an APK. Install eas-cli and authenticate with eas login
 or EXPO_TOKEN. The Expo app must already be linked to the intended EAS project.
@@ -207,24 +210,35 @@ already cached, because the current profile and fingerprint must be resolved.
 Stim matches the EAS project, profile, native fingerprint, platform and
 simulator/internal distribution target against a completed build. It downloads
 an iOS .app or Android .apk with EAS CLI, then uses its existing installation,
-Metro connection, log capture and launch verification on the owned device.
+Metro connection, log capture and launch verification on the selected device.
 The flag also works with --remote; remote EAS Simulator sessions have their
-own costs, independent of this download path. Physical --device targets and
-local --scheme, --configuration, --variant and --no-build-cache selectors
+own costs, independent of this download path. Local --scheme, --configuration,
+--variant and --no-build-cache selectors
 cannot be combined with --eas-profile. Local configuration/variant defaults
 are ignored for this development-build run.
+
+Physical devices use Stim's usual selection and lease rules. An iOS app must
+have a development-client URL scheme and a valid embedded provisioning profile
+that includes the target UDID. Stim installs the signed app without re-signing
+it. If the profile does not admit the device, the remedy points to
+npx eas-cli device:create and npx eas-cli build --platform ios --profile <name>.
+Registration, signing changes and cloud builds need session authorization.
+Run the EAS build interactively when its provisioning profile needs refreshing,
+then retry the same Stim command.
 
 Start Metro with stim start as usual. Metro uses the local workspace's
 environment; arrange the appropriate local variables before starting it.
 EAS environment resolution for native fingerprinting does not configure Metro.
 
-The EAS artifact cache is separate from local native builds and includes the
-EAS project, profile, resolved profile settings and fingerprint. A local hit
-reports cacheHit: "local"; a download reports "remote". The fingerprint fact
-is the EAS native fingerprint. Local buildCache settings control local reuse
-and storage; remoteBuildCache settings do not disable an explicitly selected
-EAS build source. Scratch downloads live under the workspace's eas-downloads
-directory and are registered for gc.
+EAS CLI caches extracted artifacts by project and build ID in its own temporary
+cache. Stim calls build:download and uses the returned artifact without making
+another cache copy. Every run queries the latest matching build, so a rebuild
+with a refreshed provisioning profile is selected even if its native fingerprint
+is unchanged. Stim coordinates concurrent downloads by project and build ID.
+cacheHit: "remote" identifies the EAS source, including when EAS CLI reuses its
+disk cache. The fingerprint fact is the EAS native fingerprint. Stim's local
+buildCache and remoteBuildCache settings do not control EAS CLI's cache.
+EAS cache files are managed by EAS CLI and are outside Stim gc.
 
 On STIM_EAS_BUILD_MISSING, Stim stops before acquiring a device and prints:
 

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -194,7 +194,9 @@ TWO REPORTS, TWO QUESTIONS
 An eas.json file does not select EAS automatically. The flag names the profile
 and selects EAS Build as the artifact source. The profile must resolve to
 "developmentClient": true and "distribution": "internal"; iOS also needs
-"ios": { "simulator": true }. Install eas-cli and authenticate with eas login
+"ios": { "simulator": true }. An explicit ios.buildConfiguration must be Debug;
+android.gradleCommand must be a single :app:assemble<Variant>Debug task producing
+an APK. Install eas-cli and authenticate with eas login
 or EXPO_TOKEN. The Expo app must already be linked to the intended EAS project.
 
 Stim delegates profile inheritance, environment resolution and fingerprinting

--- a/packages/stim-cli/src/ownership-claim.ts
+++ b/packages/stim-cli/src/ownership-claim.ts
@@ -157,21 +157,20 @@ export interface ClaimFailure {
  * states in which it holds no claim, and running the operation a claim serializes without one gives a
  * competing run no protection at all.
  */
-export function claimFailure(err: unknown, retryCommand: string): ClaimFailure | null {
+export function claimFailure(err: unknown, retryCommand: string | null): ClaimFailure | null {
+  const retry = retryCommand === null ? 'retry the same Stim command' : `run \`${retryCommand}\` again`;
   if (isClaimRefusal(err)) {
     return {
       code: CLAIM_REFUSED,
       message: err.message,
-      remedy: `Run \`${err.removeCommand}\`, then run \`${retryCommand}\` again.`,
+      remedy: `Run \`${err.removeCommand}\`, then ${retry}.`,
     };
   }
   if (isClaimUnavailable(err)) {
     return {
       code: CLAIM_UNAVAILABLE,
       message: err.message,
-      remedy:
-        'Reinstall Stim so the unique-pid native module for this platform is present, then run ' +
-        `\`${retryCommand}\` again.`,
+      remedy: `Reinstall Stim so the unique-pid native module for this platform is present, then ${retry}.`,
     };
   }
   return null;


### PR DESCRIPTION
## Description

Expo projects using EAS development builds can now select them with `stim ios --eas-profile <name>` or `stim android --eas-profile <name>`. A missing compatible build stops with the EAS command to run; Stim never starts a potentially billable cloud build or falls back to local compilation.

## Solution

EAS CLI resolves the selected profile and native fingerprint, then downloads or reuses its cached artifact. Stim coordinates downloads by EAS project/build ID and uses the returned artifact directly for its existing installation, Metro and launch checks.

Internal development builds work on simulators, emulators and connected physical devices. iOS device artifacts must admit the target UDID in a valid provisioning profile and provide a development-client URL scheme. Provisioning failures point to EAS device registration and rebuilding commands; Stim does not change signing accounts. Release profiles and local build selectors are refused.

EAS fingerprint generation uploads fingerprint metadata. Metro continues using the local environment. Both behaviors are documented in `stim guide lifecycle eas`.

## Test plan

- Live Trailhead validation: cache miss without building, then an explicitly approved [EAS simulator build](https://expo.dev/accounts/appandflow/projects/trailhead/builds/db3996ae-6218-4f9b-8f33-38d7400c9337), download and successful launch with clean logs. A repeat run reused EAS's cached artifact and skipped unchanged installation; EAS CLI confirmed `Using cached build`.
- **Hardware installation and launch remain unverified.** Physical-device tests cover signed-app provisioning gates, EAS registration/rebuild remedies, unchanged signatures, Android APK installation and argument validation before EAS calls.
- Regression coverage also exercises profile environments, Debug overrides, fingerprint/target mismatches, missing builds, failed EAS calls, download claims and retry guidance that preserves the selected device.
- All repository checks pass, including 4,297 unit tests and 84 end-to-end tests. Real EAS CLI config, fingerprint, list and download invocations were exercised against Trailhead.

Fixes #759
