### PR TITLE
feat: store named device slots independently

### DIFF
--- a/packages/stim-cli/src/__tests__/config.test.ts
+++ b/packages/stim-cli/src/__tests__/config.test.ts
@@ -461,3 +461,47 @@ test('a negative or garbage value reads as unlimited', () => {
     maxDevices: 0,
   });
 });
+
+test('named device slots preserve default assignments and release only their own console ports', () => {
+  const root = liveProjectDir('slots');
+  upsertProject(root, {});
+  setDevice(root, 'ios', { deviceUdid: 'default-ios', owned: true });
+  setDevice(root, 'android', { avdName: 'stim-first', consolePort: 5554, owned: true }, 'first');
+  setDevice(root, 'android', { avdName: 'stim-second', consolePort: 5556, owned: true }, 'second');
+  setDevice(root, 'ios', { deviceUdid: 'first-ios', owned: true }, 'first');
+  expect(getProject(root)?.platforms?.ios?.deviceUdid).toBe('default-ios');
+  expect(allConsolePortsAndSerials().androidConsolePorts).toEqual([5554, 5556]);
+  expect(releaseAndroidConsolePort(root, 5556, 'first')).toBe(false);
+  expect(releaseAndroidConsolePort(root, 5554, 'first')).toBe(true);
+  expect(allConsolePortsAndSerials().androidConsolePorts).toEqual([5556]);
+  clearDevice(root, 'android', 'first');
+  expect(getProject(root)?.deviceSlots?.first).toEqual({ ios: { deviceUdid: 'first-ios', owned: true } });
+  clearDevice(root, 'ios', 'first');
+  expect(getProject(root)?.deviceSlots?.first).toBeUndefined();
+  expect(getProject(root)?.deviceSlots?.second?.android?.avdName).toBe('stim-second');
+  clearDevice(root, 'android', 'second');
+  expect(getProject(root)?.deviceSlots).toBeUndefined();
+  expect(getProject(root)?.platforms?.ios?.deviceUdid).toBe('default-ios');
+});
+
+test('slot registry rejects unsafe names without mutating assignments', () => {
+  const root = liveProjectDir('invalid-slots');
+  upsertProject(root, {});
+  const before = loadConfig();
+  for (const slot of ['', '../phone', '__proto__', 'constructor', 'prototype', 'a'.repeat(65)]) {
+    expect(() => setDevice(root, 'ios', { deviceUdid: 'test' }, slot)).toThrow(/device slot/);
+  }
+  expect(loadConfig()).toEqual(before);
+});
+
+test('slot registry supports arbitrary numbers of identical model assignments', () => {
+  const root = liveProjectDir('many-slots');
+  upsertProject(root, {});
+  for (let i = 0; i < 20; i++) {
+    setDevice(root, 'ios', { deviceUdid: `udid-${i}`, deviceName: 'same model', owned: true }, `phone-${i}`);
+  }
+  expect(Object.keys(getProject(root)?.deviceSlots ?? {})).toHaveLength(20);
+  clearDevice(root, 'ios', 'phone-8');
+  expect(getProject(root)?.deviceSlots?.['phone-9']?.ios?.deviceUdid).toBe('udid-9');
+  expect(Object.keys(getProject(root)?.deviceSlots ?? {})).toHaveLength(19);
+});

--- a/packages/stim-cli/src/config.ts
+++ b/packages/stim-cli/src/config.ts
@@ -1,3 +1,4 @@
+import { assignSlotDevice, deviceSlotPlatforms, projectDeviceSlots, removeSlotDevice } from './device-slots.ts';
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
@@ -165,23 +166,22 @@ export function claimMetroPort(projectPath: string, port: number): number | null
   });
 }
 
-export function setDevice(projectPath: string, platform: string, deviceFields: DeviceRecord): void {
+export function setDevice(projectPath: string, platform: string, deviceFields: DeviceRecord, slot = 'default'): void {
   requireAbsoluteProjectPath(projectPath);
   withConfigLock(() => {
     const cfg = ensureConfig();
     if (!cfg.projects[projectPath]) {
       throw new Error(`Project not registered: ${projectPath}`);
     }
-    cfg.projects[projectPath].platforms = cfg.projects[projectPath].platforms || {};
-    cfg.projects[projectPath].platforms[platform] = deviceFields;
+    assignSlotDevice(cfg.projects[projectPath], platform, deviceFields, slot);
     saveConfig(cfg);
   });
 }
 
-export function releaseAndroidConsolePort(projectPath: string, consolePort: number): boolean {
+export function releaseAndroidConsolePort(projectPath: string, consolePort: number, slot = 'default'): boolean {
   return withConfigLock(() => {
     const cfg = loadConfig();
-    const android = cfg?.projects?.[projectPath]?.platforms?.android;
+    const android = deviceSlotPlatforms(cfg?.projects?.[projectPath], slot)?.android;
     if (!cfg || !android || android.consolePort !== consolePort) return false;
     delete android.consolePort;
     saveConfig(cfg);
@@ -189,11 +189,12 @@ export function releaseAndroidConsolePort(projectPath: string, consolePort: numb
   });
 }
 
-export function clearDevice(projectPath: string, platform: string): void {
+export function clearDevice(projectPath: string, platform: string, slot = 'default'): void {
   withConfigLock(() => {
     const cfg = loadConfig();
-    if (!cfg?.projects?.[projectPath]?.platforms) return;
-    delete cfg.projects[projectPath].platforms[platform];
+    const project = cfg?.projects?.[projectPath];
+    if (!cfg || !project) return;
+    removeSlotDevice(project, platform, slot);
     saveConfig(cfg);
   });
 }
@@ -400,12 +401,14 @@ export function allConsolePortsAndSerials({
   if (!cfg) return result;
   for (const [path, proj] of Object.entries(cfg.projects || {})) {
     if (!existsSync(path) && isMounted(path)) continue;
-    const android = proj.platforms?.android;
-    if (typeof android?.consolePort === 'number') {
-      result.androidConsolePorts.push(android.consolePort);
-    }
-    if (android?.serial && !android.avdName) {
-      result.androidPhysicalSerials.push(android.serial);
+    for (const { platforms } of projectDeviceSlots(proj)) {
+      const android = platforms.android;
+      if (typeof android?.consolePort === 'number') {
+        result.androidConsolePorts.push(android.consolePort);
+      }
+      if (android?.serial && !android.avdName) {
+        result.androidPhysicalSerials.push(android.serial);
+      }
     }
   }
   return result;

--- a/packages/stim-cli/src/device-slots.ts
+++ b/packages/stim-cli/src/device-slots.ts
@@ -1,0 +1,66 @@
+import type { DeviceRecord, PlatformRecords, ProjectRecord } from './types.ts';
+
+const DEFAULT_DEVICE_SLOT = 'default';
+
+function validateDeviceSlot(slot: string): string {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(slot) || ['constructor', 'prototype', '__proto__'].includes(slot)) {
+    const error = new Error(
+      'A device slot must be 1-64 letters, digits, underscores or hyphens, starting with a letter or digit.',
+    );
+    Object.assign(error, { code: 'STIM_BAD_ARG' });
+    throw error;
+  }
+  return slot;
+}
+
+export function deviceSlotPlatforms(
+  project: ProjectRecord | null | undefined,
+  slot: string = DEFAULT_DEVICE_SLOT,
+): PlatformRecords | undefined {
+  validateDeviceSlot(slot);
+  if (slot === DEFAULT_DEVICE_SLOT) return project?.platforms;
+  return project?.deviceSlots && Object.hasOwn(project.deviceSlots, slot) ? project.deviceSlots[slot] : undefined;
+}
+
+export function projectDeviceSlots(
+  project: ProjectRecord | null | undefined,
+): { slot: string; platforms: PlatformRecords }[] {
+  const slots = [{ slot: DEFAULT_DEVICE_SLOT, platforms: project?.platforms ?? {} }];
+  for (const [slot, platforms] of Object.entries(project?.deviceSlots ?? {})) {
+    validateDeviceSlot(slot);
+    if (slot === DEFAULT_DEVICE_SLOT)
+      throw new Error('The default device slot must use the existing platforms record.');
+    if (!platforms || typeof platforms !== 'object' || Array.isArray(platforms))
+      throw new Error(`Invalid device slot record: ${slot}`);
+    slots.push({ slot, platforms });
+  }
+  return slots;
+}
+
+export function assignSlotDevice(
+  project: ProjectRecord,
+  platform: string,
+  device: DeviceRecord,
+  slot: string = DEFAULT_DEVICE_SLOT,
+): void {
+  validateDeviceSlot(slot);
+  if (platform !== 'ios' && platform !== 'android') throw new Error(`Unknown device platform: ${platform}`);
+  if (slot === DEFAULT_DEVICE_SLOT) {
+    project.platforms = { ...project.platforms, [platform]: device };
+  } else {
+    project.deviceSlots = {
+      ...project.deviceSlots,
+      [slot]: { ...deviceSlotPlatforms(project, slot), [platform]: device },
+    };
+  }
+}
+
+export function removeSlotDevice(project: ProjectRecord, platform: string, slot: string = DEFAULT_DEVICE_SLOT): void {
+  const platforms = deviceSlotPlatforms(project, slot);
+  if (!platforms) return;
+  delete platforms[platform];
+  if (slot !== DEFAULT_DEVICE_SLOT && Object.keys(platforms).length === 0) {
+    delete project.deviceSlots![slot];
+    if (Object.keys(project.deviceSlots!).length === 0) delete project.deviceSlots;
+  }
+}

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -33,7 +33,7 @@ interface AndroidDeviceRecord {
 
 export type DeviceRecord = IosDeviceRecord | AndroidDeviceRecord;
 
-interface PlatformRecords {
+export interface PlatformRecords {
   ios?: IosDeviceRecord;
   android?: AndroidDeviceRecord;
   [platform: string]: DeviceRecord | undefined;
@@ -42,6 +42,7 @@ interface PlatformRecords {
 export interface ProjectRecord {
   metroPort?: number | null;
   platforms?: PlatformRecords;
+  deviceSlots?: Record<string, PlatformRecords>;
   supervisor?: SupervisorRecord;
   settings?: SettingsObject;
   worktreeRoot?: boolean;


### PR DESCRIPTION
## Description

A workspace currently has one owned device record per platform. Multi-device support needs independently addressable assignments before launch commands can accept the approved `--slot` selector.

## Solution

Add named-slot registry storage and slot-aware assignment, removal, and Android console-port reservation. Existing `platforms` records remain the default slot, so existing device claims need no rewrite. Slot names are validated before writes, and removing the last device in a named slot removes the empty slot.

This is the storage layer of the multi-device stack. Launch commands do not expose named slots yet; lifecycle enumeration and runtime integration follow in dependent PRs.

Fixes #761.

## Test plan

Registry tests exercise 20 same-model assignments, independent slot removal and port release, preservation of default devices, and rejection of unsafe names without changing the registry. These state transitions are the validation for this internal layer; no native tool invocation changes.
