### PR TITLE
feat: include every device slot in workspace cleanup

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -824,7 +824,8 @@ describe('ensureOwnedDevice: ios', () => {
     const root = projectDir();
     const name = 'stim-app (iPhone 17 Pro 26.2)';
     try {
-      if (source === 'parked')
+      if (source === 'parked') {
+        setDevice(root, 'ios', { deviceUdid: 'OTHER', owned: true });
         parkSim({
           platform: 'ios',
           projectPath: root,
@@ -838,6 +839,7 @@ describe('ensureOwnedDevice: ios', () => {
             simslimManaged: false,
           },
         });
+      }
       const { exec } = iosExecutor(
         source === 'unavailable' ? [{ udid: 'OTHER', name, state: 'Shutdown', isAvailable: false }] : [],
       );
@@ -854,6 +856,7 @@ describe('ensureOwnedDevice: ios', () => {
     const root = projectDir();
     process.env.STIM_POOL_IOS_PARKED_MAX = '3';
     try {
+      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true });
       parkSim({
         platform: 'ios',
         projectPath: root,
@@ -920,6 +923,7 @@ describe('ensureOwnedDevice: ios', () => {
     process.env.STIM_POOL_IOS_PARKED_MAX = '3';
     const output: string[] = [];
     try {
+      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true });
       parkSim({
         platform: 'ios',
         projectPath: root,
@@ -969,6 +973,7 @@ describe('ensureOwnedDevice: ios', () => {
     const root = projectDir();
     process.env.STIM_POOL_IOS_PARKED_MAX = '3';
     try {
+      setDevice(root, 'ios', { deviceUdid: 'GONE', owned: true });
       parkSim({
         platform: 'ios',
         projectPath: root,
@@ -2224,4 +2229,25 @@ describe('ensureOwnedDevice: the requested model against the sim this workspace 
       rmSync(root, { recursive: true, force: true });
     }
   });
+});
+
+test('capacity counts named Android slots and only exempts the selected live slot', () => {
+  const project = {
+    platforms: { android: { avdName: 'stim-default', consolePort: 5554, owned: true } },
+    deviceSlots: { phone: { android: { avdName: 'stim-phone', consolePort: 5556, owned: true } } },
+  };
+  const args = {
+    platform: 'android',
+    project,
+    max: 2,
+    adb: makeAdbDevices({
+      emulators: [
+        { serial: 'emulator-5554', consolePort: 5554 },
+        { serial: 'emulator-5556', consolePort: 5556 },
+      ],
+    }),
+    config: makeConfig({ projects: { '/w/x': project } }),
+  };
+  expect(deviceCapacityRefusal({ ...args, slot: 'phone' })).toBeNull();
+  expect(deviceCapacityRefusal({ ...args, slot: 'tablet' })?.code).toBe('STIM_AT_CAPACITY');
 });

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -852,71 +852,79 @@ describe('ensureOwnedDevice: ios', () => {
     }
   });
 
-  test.each([false, true])('adopts and resets a matching parked simulator (name collision: %s)', async (collision) => {
-    const root = projectDir();
-    process.env.STIM_POOL_IOS_PARKED_MAX = '3';
-    try {
-      setDevice(root, 'ios', { deviceUdid: 'U1', owned: true });
-      parkSim({
-        platform: 'ios',
-        projectPath: root,
-        max: 3,
-        record: {
-          udid: 'U1',
-          name: 'stim-parked (iPhone 17 Pro 26.2) u1',
-          deviceTypeIdentifier: TYPE_17_PRO.identifier,
-          runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
-          parkedAt: '2026-09-01T10:00:00.000Z',
-          simslimManaged: false,
-          cacheKey: 'fingerprint-debug-sim',
-        },
-      });
-      const devices = [
-        {
-          udid: 'U1',
-          name: 'stim-parked (iPhone 17 Pro 26.2) u1',
-          state: 'Shutdown',
-          isAvailable: true,
-          deviceTypeIdentifier: TYPE_17_PRO.identifier,
-        },
-      ];
-      if (collision)
-        devices.push({
-          udid: 'OTHER',
-          name: 'stim-app (iPhone 17 Pro 26.2)',
-          state: 'Booted',
-          isAvailable: true,
-          deviceTypeIdentifier: TYPE_17_PRO.identifier,
+  test.each([
+    { collision: false, stale: false },
+    { collision: true, stale: false },
+    { collision: false, stale: true },
+  ])(
+    'adopts a matching parked simulator (collision: $collision, stale assignment: $stale)',
+    async ({ collision, stale }) => {
+      const root = projectDir();
+      process.env.STIM_POOL_IOS_PARKED_MAX = '3';
+      try {
+        setDevice(root, 'ios', { deviceUdid: 'U1', owned: true });
+        parkSim({
+          platform: 'ios',
+          projectPath: root,
+          max: 3,
+          record: {
+            udid: 'U1',
+            name: 'stim-parked (iPhone 17 Pro 26.2) u1',
+            deviceTypeIdentifier: TYPE_17_PRO.identifier,
+            runtimeIdentifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2',
+            parkedAt: '2026-09-01T10:00:00.000Z',
+            simslimManaged: false,
+            cacheKey: 'fingerprint-debug-sim',
+          },
         });
-      const name = `stim-app (iPhone 17 Pro 26.2)${collision ? ` ${workspaceId(root)}` : ''}`;
-      const { run, files, exec } = iosExecutor(devices);
-      setExecutor(exec);
-      const device = await ensureOwnedDevice({
-        platform: 'ios',
-        project: getProject(root),
-        projectPath: root,
-        label: 'app',
-        settings: {},
-      });
-      expect(device).toMatchObject({
-        deviceUdid: 'U1',
-        deviceName: name,
-        adopted: true,
-        adoptionPending: true,
-        parkedCacheKey: 'fingerprint-debug-sim',
-      });
-      expect(readParked('ios')).toEqual([]);
-      expect(run).toContain('xcrun simctl boot U1');
-      expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', name]);
-      expect(files.some((call) => call.includes('privacy'))).toBe(false);
-      await device.booting?.done;
-      expect(files).toContainEqual(['xcrun', 'simctl', 'privacy', 'U1', 'reset', 'all']);
-      expect(files).toContainEqual(['xcrun', 'simctl', 'keychain', 'U1', 'reset']);
-    } finally {
-      delete process.env.STIM_POOL_IOS_PARKED_MAX;
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+        const devices = [
+          {
+            udid: 'U1',
+            name: 'stim-parked (iPhone 17 Pro 26.2) u1',
+            state: 'Shutdown',
+            isAvailable: true,
+            deviceTypeIdentifier: TYPE_17_PRO.identifier,
+          },
+        ];
+        if (collision)
+          devices.push({
+            udid: 'OTHER',
+            name: 'stim-app (iPhone 17 Pro 26.2)',
+            state: 'Booted',
+            isAvailable: true,
+            deviceTypeIdentifier: TYPE_17_PRO.identifier,
+          });
+        if (stale) setDevice(root, 'ios', { deviceUdid: 'MISSING', owned: true });
+        const name = `stim-app (iPhone 17 Pro 26.2)${collision ? ` ${workspaceId(root)}` : ''}`;
+        const { run, files, exec } = iosExecutor(devices);
+        setExecutor(exec);
+        const device = await ensureOwnedDevice({
+          platform: 'ios',
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+        });
+        expect(device).toMatchObject({
+          deviceUdid: 'U1',
+          deviceName: name,
+          adopted: true,
+          adoptionPending: true,
+          parkedCacheKey: 'fingerprint-debug-sim',
+        });
+        expect(readParked('ios')).toEqual([]);
+        expect(run).toContain('xcrun simctl boot U1');
+        expect(files).toContainEqual(['xcrun', 'simctl', 'rename', 'U1', name]);
+        expect(files.some((call) => call.includes('privacy'))).toBe(false);
+        await device.booting?.done;
+        expect(files).toContainEqual(['xcrun', 'simctl', 'privacy', 'U1', 'reset', 'all']);
+        expect(files).toContainEqual(['xcrun', 'simctl', 'keychain', 'U1', 'reset']);
+      } finally {
+        delete process.env.STIM_POOL_IOS_PARKED_MAX;
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   test('keeps a parked record renamed away from Stim ownership and creates a fresh simulator', async () => {
     const root = projectDir();

--- a/packages/stim-cli/src/__tests__/gc.test.ts
+++ b/packages/stim-cli/src/__tests__/gc.test.ts
@@ -3168,3 +3168,28 @@ test('a kept lease file alone is not something to reclaim', () => {
   expect(lines).toMatch(/Nothing to reclaim/);
   expect(lines).toMatch(/Device lease files kept \(1\)/);
 });
+
+test('GC preserves named-slot references on unavailable volumes and identifies stale records by slot', () => {
+  const config = makeConfig({
+    projects: {
+      '/Volumes/offline/app': {
+        platforms: { ios: { deviceUdid: 'DEFAULT', owned: true } },
+        deviceSlots: {
+          phone: { ios: { deviceUdid: 'PHONE', owned: true } },
+          tablet: { ios: { deviceUdid: 'TABLET', owned: true } },
+          emulator: { android: { avdName: 'stim-extra', owned: true } },
+        },
+      },
+    },
+  });
+  const sims = ['DEFAULT', 'PHONE', 'TABLET'].map((udid) => makeIosSim({ udid, name: `stim-${udid}` }));
+  const result = findOrphanedDevices({ config, sims, avds: ['stim-extra'], isMounted: () => false });
+  expect(result.orphaned).toEqual([]);
+  expect(result.kept).toHaveLength(4);
+  const stale = findStaleDeviceRecords({ config, sims: sims.slice(0, 1), avds: [] });
+  expect(stale.map(({ slot, id }) => [slot, id])).toEqual([
+    ['phone', 'PHONE'],
+    ['tablet', 'TABLET'],
+    ['emulator', 'stim-extra'],
+  ]);
+});

--- a/packages/stim-cli/src/__tests__/reclaim.test.ts
+++ b/packages/stim-cli/src/__tests__/reclaim.test.ts
@@ -102,10 +102,11 @@ test('reclaimProject keeps the config entry when an owned device delete fails', 
     spawn: () => {},
   });
   upsertProject('/proj', { metroPort: 8082 });
-  setDevice('/proj', 'ios', { deviceUdid: 'U1', owned: true });
+  setDevice('/proj', 'ios', { deviceUdid: 'U1', owned: true }, 'phone');
 
   const result = await reclaimProject('/proj', { deleteOwnedDevices: true });
   expect(result.keptEntry).toBe(true);
+  expect(getProject('/proj')?.deviceSlots?.phone?.ios?.deviceUdid).toBe('U1');
   expect(result.deletedDevices.length).toBe(0);
   expect(result.failedDevices[0]?.reason).toMatch(/Unable to delete device/);
   expect(getProject('/proj')).toBeTruthy();

--- a/packages/stim-cli/src/__tests__/sim-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-pool.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getProject, loadConfig, upsertProject } from '../config.ts';
+import { getProject, loadConfig, setDevice, upsertProject } from '../config.ts';
 import {
   DEFAULT_PARKED_MAX,
   adoptParked,
@@ -109,6 +109,7 @@ test('overflow records stay claimed until deletion succeeds', () => {
     platforms: { ios: { deviceUdid: first.udid, deviceName: 'stim-project', owned: true } },
   });
   parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 1 });
+  setDevice('/tmp/project', 'ios', { deviceUdid: second.udid, owned: true });
   expect(parkSim({ platform: 'ios', projectPath: '/tmp/project', record: second, max: 1 })).toEqual([first]);
   expect(
     readParked('ios')
@@ -187,6 +188,7 @@ test('a live deletion claim blocks adoption beyond the ordinary lock stale windo
 
 test('adoption takes a pool record and creates the owned project claim in one persisted update', () => {
   upsertProject('/tmp/project', { platforms: {} });
+  setDevice('/tmp/project', 'ios', { deviceUdid: first.udid, owned: true });
   parkSim({ platform: 'ios', projectPath: '/tmp/project', record: first, max: 3 });
   const device = {
     deviceUdid: first.udid,
@@ -207,4 +209,48 @@ test('malformed and non-Stim pool records are ignored', () => {
     parked: { ios: [{ ...first, name: 'My iPhone' }, { nope: true }, first] },
   };
   expect(readParked('ios', { config }).map((record) => record.udid)).toEqual(['FIRST']);
+});
+
+test('parking and adopting a named slot preserve its default and sibling assignments', () => {
+  const device = { deviceUdid: first.udid, owned: true };
+  upsertProject('/tmp/project', {
+    platforms: { ios: { deviceUdid: 'DEFAULT', owned: true } },
+    deviceSlots: {
+      phone: { ios: device },
+      tablet: { ios: { deviceUdid: 'TABLET', owned: true } },
+    },
+  });
+  parkSim({ platform: 'ios', projectPath: '/tmp/project', slot: 'phone', record: first, max: 3 });
+  expect(getProject('/tmp/project')?.deviceSlots?.phone).toBeUndefined();
+  expect(getProject('/tmp/project')?.platforms?.ios?.deviceUdid).toBe('DEFAULT');
+  expect(getProject('/tmp/project')?.deviceSlots?.tablet?.ios?.deviceUdid).toBe('TABLET');
+  expect(
+    adoptParked({ platform: 'ios', projectPath: '/tmp/project', slot: 'second-phone', udid: first.udid, device }),
+  ).toEqual(first);
+  expect(readParked('ios')).toEqual([]);
+  expect(getProject('/tmp/project')?.deviceSlots?.['second-phone']?.ios?.deviceUdid).toBe(first.udid);
+  expect(getProject('/tmp/project')?.platforms?.ios?.deviceUdid).toBe('DEFAULT');
+});
+
+test('pool transfers refuse to overwrite or clear another device in the same slot', () => {
+  const path = '/tmp/project';
+  upsertProject(path, {});
+  setDevice(path, 'ios', { deviceUdid: first.udid, owned: true }, 'phone');
+  expect(() => parkSim({ platform: 'ios', projectPath: path, slot: 'phone', record: second, max: 3 })).toThrow(
+    /assignment changed/,
+  );
+  expect(readParked('ios')).toEqual([]);
+  parkSim({ platform: 'ios', projectPath: path, slot: 'phone', record: first, max: 3 });
+  setDevice(path, 'ios', { deviceUdid: second.udid, owned: true }, 'phone');
+  expect(
+    adoptParked({
+      platform: 'ios',
+      projectPath: path,
+      slot: 'phone',
+      udid: first.udid,
+      device: { deviceUdid: first.udid, owned: true },
+    }),
+  ).toBeNull();
+  expect(getProject(path)?.deviceSlots?.phone?.ios?.deviceUdid).toBe(second.udid);
+  expect(readParked('ios')).toEqual([first]);
 });

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -1243,3 +1243,27 @@ test('stop --json prints exactly one line of JSON on stdout', async () => {
   expect(typeof payload.root).toBe('string');
   expect(typeof payload.ok).toBe('boolean');
 });
+
+test('stop visits all device slots and reports a named-slot failure without skipping siblings', async () => {
+  const visited: string[] = [];
+  const { opts } = seams({
+    project: {
+      platforms: { ios: { deviceUdid: 'DEFAULT', owned: true } },
+      deviceSlots: {
+        phone: { ios: { deviceUdid: 'PHONE', owned: true } },
+        tablet: { ios: { deviceUdid: 'TABLET', owned: true } },
+        external: { ios: { deviceUdid: 'USER', owned: false } },
+      },
+    },
+    teardownIos: (udid: string) => {
+      visited.push(udid);
+      return udid === 'PHONE' ? { status: 'failed', reason: 'busy' } : { status: 'torn-down', label: udid };
+    },
+  });
+  const result = await runStop(opts);
+  expect(visited).toEqual(['DEFAULT', 'PHONE', 'TABLET']);
+  expect(result.ok).toBe(false);
+  expect(result.outcomes.device['ios:phone']?.status).toBe('failed');
+  expect(result.outcomes.device['ios:tablet']?.status).toBe('shut-down');
+  expect(result.outcomes.device['ios:external']?.status).toBe('skipped');
+});

--- a/packages/stim-cli/src/commands/gc/devices.ts
+++ b/packages/stim-cli/src/commands/gc/devices.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from '../../device-slots.ts';
 import { existsSync } from 'fs';
 import { isAbsolute } from 'path';
 import chalk from 'chalk';
@@ -16,6 +17,7 @@ export interface StaleProjectDevice {
   id: string;
   name: string;
   project: string;
+  slot?: string;
   idleDays: number;
   bytes?: number;
 }
@@ -24,6 +26,7 @@ export interface StaleDeviceRecord {
   kind: 'ios' | 'android';
   id: string;
   project: string;
+  slot?: string;
   owned: boolean;
 }
 
@@ -95,13 +98,15 @@ export function findOrphanedDevices({
   for (const [path, proj] of Object.entries(config?.projects || {})) {
     if (dead.has(path)) continue;
     const mounted = isMounted ? isMounted(path) : true;
-    const ios = proj?.platforms?.ios;
-    if (ios?.deviceUdid) {
-      referenced.set(ios.deviceUdid, { path, mounted });
-    }
-    const android = proj?.platforms?.android;
-    if (android?.avdName) {
-      referenced.set(android.avdName, { path, mounted });
+    for (const { platforms } of projectDeviceSlots(proj)) {
+      const ios = platforms.ios;
+      if (ios?.deviceUdid) {
+        referenced.set(ios.deviceUdid, { path, mounted });
+      }
+      const android = platforms.android;
+      if (android?.avdName) {
+        referenced.set(android.avdName, { path, mounted });
+      }
     }
   }
   for (const sim of readParked('ios', { config })) {
@@ -170,19 +175,29 @@ export function findStaleProjectDevices({
     if (!Number.isFinite(touched) || touched >= cutoff) continue;
     const idleDays = Math.floor((now - touched) / DAY_MS);
 
-    const ios = proj?.platforms?.ios;
-    if (ios?.owned && ios.deviceUdid && liveSims.has(ios.deviceUdid)) {
-      stale.push({
-        kind: 'ios',
-        id: ios.deviceUdid,
-        name: liveSims.get(ios.deviceUdid) as string,
-        project: path,
-        idleDays,
-      });
-    }
-    const android = proj?.platforms?.android;
-    if (android?.owned && android.avdName && liveAvds.has(android.avdName)) {
-      stale.push({ kind: 'android', id: android.avdName, name: android.avdName, project: path, idleDays });
+    for (const { slot, platforms } of projectDeviceSlots(proj)) {
+      const ios = platforms.ios;
+      if (ios?.owned && ios.deviceUdid && liveSims.has(ios.deviceUdid)) {
+        stale.push({
+          kind: 'ios',
+          id: ios.deviceUdid,
+          name: liveSims.get(ios.deviceUdid) as string,
+          project: path,
+          ...(slot === 'default' ? {} : { slot }),
+          idleDays,
+        });
+      }
+      const android = platforms.android;
+      if (android?.owned && android.avdName && liveAvds.has(android.avdName)) {
+        stale.push({
+          kind: 'android',
+          id: android.avdName,
+          name: android.avdName,
+          project: path,
+          idleDays,
+          ...(slot === 'default' ? {} : { slot }),
+        });
+      }
     }
   }
   return stale;
@@ -211,13 +226,27 @@ export function findStaleDeviceRecords({
   for (const [path, proj] of Object.entries(config?.projects || {})) {
     if (dead.has(path)) continue;
 
-    const ios = proj?.platforms?.ios;
-    if (simsChecked && ios?.deviceUdid && !liveSims.has(ios.deviceUdid)) {
-      stale.push({ kind: 'ios', id: ios.deviceUdid, project: path, owned: Boolean(ios.owned) });
-    }
-    const android = proj?.platforms?.android;
-    if (avdsChecked && android?.avdName && !liveAvds.has(android.avdName)) {
-      stale.push({ kind: 'android', id: android.avdName, project: path, owned: Boolean(android.owned) });
+    for (const { slot, platforms } of projectDeviceSlots(proj)) {
+      const ios = platforms.ios;
+      if (simsChecked && ios?.deviceUdid && !liveSims.has(ios.deviceUdid)) {
+        stale.push({
+          kind: 'ios',
+          id: ios.deviceUdid,
+          project: path,
+          ...(slot === 'default' ? {} : { slot }),
+          owned: Boolean(ios.owned),
+        });
+      }
+      const android = platforms.android;
+      if (avdsChecked && android?.avdName && !liveAvds.has(android.avdName)) {
+        stale.push({
+          kind: 'android',
+          id: android.avdName,
+          project: path,
+          ...(slot === 'default' ? {} : { slot }),
+          owned: Boolean(android.owned),
+        });
+      }
     }
   }
   return stale;
@@ -453,13 +482,13 @@ export function deleteProjectDevices(
   for (const d of staleDevices) {
     const status = reap(d);
     if (status === 'torn-down' || status === 'missing') {
-      clearDevice(d.project, d.kind);
+      clearDevice(d.project, d.kind, d.slot);
       console.log(chalk.dim(`  cleared the ${d.kind} record for ${d.project}`));
     }
   }
 
   for (const r of staleDeviceRecords) {
-    clearDevice(r.project, r.kind);
+    clearDevice(r.project, r.kind, r.slot);
     console.log(chalk.green(`Cleared the ${r.kind} record for ${r.project} (${r.id} is not on this machine)`));
   }
 

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { phaseLine, plural, releasedLeaseFact } from '../command-output.ts';
@@ -173,6 +174,7 @@ interface DeviceOutcomeEntry {
 }
 
 interface DeviceOutcome {
+  [key: string]: DeviceOutcomeEntry | null | undefined;
   ios: DeviceOutcomeEntry | null;
   android: DeviceOutcomeEntry | null;
   remote?: DeviceOutcomeEntry | null;
@@ -377,7 +379,7 @@ export async function runStop({
     report(chalk.dim(phaseLine('device', 'left alone (something is still running)')));
   } else {
     outcomes.device = shutDownDevices(proj, { teardownIos, teardownAvd, report });
-    if ([outcomes.device.ios, outcomes.device.android].some((device) => device?.status === 'failed')) ok = false;
+    if (Object.values(outcomes.device).some((device) => device?.status === 'failed')) ok = false;
   }
 
   const remote = remoteDevice === undefined ? readRemoteSession(root) : remoteDevice;
@@ -629,38 +631,41 @@ function shutDownDevices(
 ): DeviceOutcome {
   const device: DeviceOutcome = { ios: null, android: null };
 
-  const ios = project?.platforms?.ios;
-  const iosUdid = ios?.deviceUdid as string | undefined;
-  const iosName = ios?.deviceName as string | undefined;
-  if (iosUdid) {
-    if (!ios?.owned) {
-      device.ios = {
-        status: 'skipped',
-        kind: 'not-owned',
-        label: iosUdid,
-        reason: 'Stim does not own this device',
-      };
-      report(chalk.dim(phaseLine('device', `${iosUdid} is not Stim-owned, leaving it running`)));
-    } else {
-      device.ios = reportDevice(iosUdid, teardownIos(iosUdid, { del: false, label: iosName }), report);
+  for (const { slot, platforms } of projectDeviceSlots(project)) {
+    const iosKey = slot === 'default' ? 'ios' : `ios:${slot}`;
+    const androidKey = slot === 'default' ? 'android' : `android:${slot}`;
+    const ios = platforms.ios;
+    const iosUdid = ios?.deviceUdid as string | undefined;
+    const iosName = ios?.deviceName as string | undefined;
+    if (iosUdid) {
+      if (!ios?.owned) {
+        device[iosKey] = {
+          status: 'skipped',
+          kind: 'not-owned',
+          label: iosUdid,
+          reason: 'Stim does not own this device',
+        };
+        report(chalk.dim(phaseLine('device', `${iosUdid} is not Stim-owned, leaving it running`)));
+      } else {
+        device[iosKey] = reportDevice(iosUdid, teardownIos(iosUdid, { del: false, label: iosName }), report);
+      }
+    }
+
+    const android = platforms.android;
+    if (android?.avdName) {
+      if (!android.owned) {
+        device[androidKey] = {
+          status: 'skipped',
+          kind: 'not-owned',
+          label: android.avdName,
+          reason: 'Stim does not own this device',
+        };
+        report(chalk.dim(phaseLine('device', `${android.avdName} is not Stim-owned, leaving it running`)));
+      } else {
+        device[androidKey] = reportDevice(android.avdName, teardownAvd(android.avdName, { del: false }), report);
+      }
     }
   }
-
-  const android = project?.platforms?.android;
-  if (android?.avdName) {
-    if (!android.owned) {
-      device.android = {
-        status: 'skipped',
-        kind: 'not-owned',
-        label: android.avdName,
-        reason: 'Stim does not own this device',
-      };
-      report(chalk.dim(phaseLine('device', `${android.avdName} is not Stim-owned, leaving it running`)));
-    } else {
-      device.android = reportDevice(android.avdName, teardownAvd(android.avdName, { del: false }), report);
-    }
-  }
-
   return device;
 }
 
@@ -698,10 +703,7 @@ function summarize(root: string, outcomes: StopOutcomes, ok: boolean): string {
   if (outcomes.metro.status === 'not-managed') parts.push(`external server on port ${outcomes.metro.port} left alone`);
   if (outcomes.metro.status === 'refused') parts.push(`port ${outcomes.metro.port} refused`);
   if (outcomes.metro.status === 'failed') parts.push(`port ${outcomes.metro.port} could not be freed`);
-  const devicesByPlatform: [string, DeviceOutcomeEntry | null][] = [
-    ['ios', outcomes.device.ios],
-    ['android', outcomes.device.android],
-  ];
+  const devicesByPlatform = Object.entries(outcomes.device).filter(([key]) => key !== 'remote');
   for (const [platform, o] of devicesByPlatform) {
     if (!o) continue;
     if (o.status === 'shut-down') parts.push(`${platform} ${o.label} shut down`);

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -1,3 +1,4 @@
+import { deviceSlotPlatforms, projectDeviceSlots } from '../device-slots.ts';
 import chalk from 'chalk';
 import { randomUUID } from 'node:crypto';
 import { phaseLine } from '../command-output.ts';
@@ -358,8 +359,10 @@ function ownedIosNameSuffix(label: string, model: SimModel, projectPath: string,
       .map((sim) => sim.name),
   );
   for (const project of Object.values(loadConfig()?.projects ?? {})) {
-    const record = project.platforms?.ios;
-    if (record?.deviceUdid !== udid && record?.deviceName) names.add(record.deviceName);
+    for (const { platforms } of projectDeviceSlots(project)) {
+      const record = platforms.ios;
+      if (record?.deviceUdid !== udid && record?.deviceName) names.add(record.deviceName);
+    }
   }
   for (const parked of readParked('ios')) {
     if (parked.udid !== udid) names.add(parked.name);
@@ -513,7 +516,7 @@ function findOtherProjectOwningAvd(avdName: string, projectPath: string): string
   const cfg = loadConfig();
   for (const [path, proj] of Object.entries(cfg?.projects || {})) {
     if (path === projectPath) continue;
-    if (proj?.platforms?.android?.avdName === avdName) return path;
+    if (projectDeviceSlots(proj).some(({ platforms }) => platforms.android?.avdName === avdName)) return path;
   }
   return null;
 }
@@ -930,14 +933,16 @@ export function liveOwnedDeviceCount({
   }
   const livePorts = new Set(adbEmulators.map((e) => e.consolePort));
   for (const proj of Object.values(config?.projects || {})) {
-    const android = proj?.platforms?.android;
-    if (
-      android?.owned &&
-      android.avdName &&
-      typeof android.consolePort === 'number' &&
-      livePorts.has(android.consolePort)
-    ) {
-      count++;
+    for (const { platforms } of projectDeviceSlots(proj)) {
+      const android = platforms.android;
+      if (
+        android?.owned &&
+        android.avdName &&
+        typeof android.consolePort === 'number' &&
+        livePorts.has(android.consolePort)
+      ) {
+        count++;
+      }
     }
   }
   return count;
@@ -946,16 +951,18 @@ export function liveOwnedDeviceCount({
 function workspaceHasLiveDevice({
   platform,
   project,
+  slot = 'default',
   sims = [],
   adbEmulators = [],
 }: Partial<{
   platform: string;
   project: ProjectRecord | null;
+  slot: string;
   sims: SimRecord[];
   adbEmulators: EmulatorRecord[];
 }> = {}) {
   if (!platform) return false;
-  const record = project?.platforms?.[platform];
+  const record = deviceSlotPlatforms(project, slot)?.[platform];
   if (!record) return false;
   if (platform === 'ios') {
     return sims.some((s) => s.udid === record.deviceUdid && s.state === 'Booted');
@@ -966,6 +973,7 @@ function workspaceHasLiveDevice({
 export function deviceCapacityRefusal({
   platform,
   project,
+  slot = 'default',
   max,
   sims = [],
   adb = null,
@@ -973,6 +981,7 @@ export function deviceCapacityRefusal({
 }: Partial<{
   platform: string;
   project: ProjectRecord | null;
+  slot: string;
   max: number;
   sims: SimRecord[];
   adb: AdbDevices | null;
@@ -980,7 +989,7 @@ export function deviceCapacityRefusal({
 }> = {}): CapacityRefusal | null {
   if (!max || max <= 0) return null;
   const adbEmulators = adb?.emulators || [];
-  if (workspaceHasLiveDevice({ platform, project, sims, adbEmulators })) return null;
+  if (workspaceHasLiveDevice({ platform, project, slot, sims, adbEmulators })) return null;
   const count = liveOwnedDeviceCount({ sims, adbEmulators, config });
   if (count < max) return null;
   return {
@@ -993,6 +1002,7 @@ export function deviceCapacityRefusal({
 export function checkDeviceCapacity({
   platform,
   project,
+  slot = 'default',
   max,
   sims = listAllIosSims,
   adb = listAdbDevices,
@@ -1000,6 +1010,7 @@ export function checkDeviceCapacity({
 }: Partial<{
   platform: string;
   project: ProjectRecord | null;
+  slot: string;
   max: number;
   sims: SimRecord[] | (() => SimRecord[]);
   adb: AdbDevices | (() => AdbDevices);
@@ -1018,7 +1029,7 @@ export function checkDeviceCapacity({
   try {
     cfg = typeof config === 'function' ? config() : (config ?? null);
   } catch {}
-  return deviceCapacityRefusal({ platform, project, max, sims: simList, adb: adbRes, config: cfg });
+  return deviceCapacityRefusal({ platform, project, slot, max, sims: simList, adb: adbRes, config: cfg });
 }
 
 export function deviceTypeMismatch(

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -297,6 +297,14 @@ async function ensureOwnedIosDevice({
         return record;
       }
     }
+    withConfigLock(() => {
+      const current = loadConfig()?.projects?.[projectPath]?.platforms?.ios;
+      if (!current) return;
+      if (current.deviceUdid !== record.deviceUdid || current.owned !== record.owned) {
+        throw new Error('The simulator assignment changed during recovery. Run `stim ios` again.');
+      }
+      clearDevice(projectPath, 'ios');
+    });
   }
 
   const choice = resolveIosCreation({

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from './device-slots.ts';
 import { type ProjectRecord, getProject, removeProject } from './config.ts';
 import { existsSync, rmSync } from 'node:fs';
 import { resolveProjectMetro, killMetroTree, pidExists } from './metro.ts';
@@ -164,11 +165,13 @@ interface SkippedDevice {
 
 export function describeDereferenced(project: ProjectRecord | null): string[] {
   const devices: string[] = [];
-  const ios = project?.platforms?.ios;
-  if (ios?.deviceUdid) devices.push(`ios sim ${ios.deviceUdid}`);
-  const android = project?.platforms?.android;
-  if (android?.avdName) devices.push(`android avd ${android.avdName}`);
-  else if (android?.serial) devices.push(`android device ${android.serial}`);
+  for (const { platforms } of projectDeviceSlots(project)) {
+    const ios = platforms.ios;
+    if (ios?.deviceUdid) devices.push(`ios sim ${ios.deviceUdid}`);
+    const android = platforms.android;
+    if (android?.avdName) devices.push(`android avd ${android.avdName}`);
+    else if (android?.serial) devices.push(`android device ${android.serial}`);
+  }
   return devices;
 }
 
@@ -178,7 +181,12 @@ export function parkedIosCacheKey(lastBuild: unknown): string | null {
   return build.platform === 'ios' && typeof build.cacheKey === 'string' ? build.cacheKey : null;
 }
 
-function parkRequest(project: ProjectRecord | null, projectPath: string): ParkRequest | undefined {
+function parkRequest(
+  project: ProjectRecord | null,
+  projectPath: string,
+  slot: string,
+  simslimManaged: boolean,
+): ParkRequest | undefined {
   const { max, error } = parkedMaxSetting('ios');
   if (error || max <= 0) return undefined;
   const cacheKey = parkedIosCacheKey(readWorkspaceState(projectPath)?.lastBuild);
@@ -187,7 +195,8 @@ function parkRequest(project: ProjectRecord | null, projectPath: string): ParkRe
     max,
     bundleId: typeof project?.bundleId === 'string' ? project.bundleId : null,
     cacheKey,
-    simslimManaged: Boolean(project?.platforms?.ios?.simslimManaged),
+    simslimManaged,
+    slot,
   };
 }
 
@@ -210,65 +219,67 @@ function reclaimOwnedDevices(
   const skippedDevices: SkippedDevice[] = [];
   const failedDevices: SkippedDevice[] = [];
 
-  const ios = project?.platforms?.ios;
-  if (ios?.owned && ios.deviceUdid) {
-    const udid = ios.deviceUdid as string;
-    const label = (ios.deviceName as string | undefined) || udid;
-    const r = teardownOwnedIosSim(udid, {
-      del: true,
-      label,
-      ...(park ? { park: parkRequest(project, projectPath) } : {}),
-    });
-    if (r.parkFallback) poolNotes.push(`could not park ${label}: ${r.parkFallback} -- deleted it instead`);
-    for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
-    if (r.parked) {
-      parkedDevices.push(r.parked);
-      evictedDevices.push(...(r.evicted ?? []));
-    } else if (r.status === 'torn-down') deletedDevices.push(r.label as string);
-    if (r.status === 'skipped') {
-      skippedDevices.push({ platform: 'ios', name: label, udid, reason: `${r.reason} -- not touched` });
-    } else if (r.status === 'failed') {
-      const entry: SkippedDevice = { platform: 'ios', name: label, udid, reason: `teardown failed: ${r.reason}` };
-      skippedDevices.push(entry);
-      failedDevices.push(entry);
+  for (const { slot, platforms } of projectDeviceSlots(project)) {
+    const ios = platforms.ios;
+    if (ios?.owned && ios.deviceUdid) {
+      const udid = ios.deviceUdid as string;
+      const label = (ios.deviceName as string | undefined) || udid;
+      const r = teardownOwnedIosSim(udid, {
+        del: true,
+        label,
+        ...(park ? { park: parkRequest(project, projectPath, slot, Boolean(ios.simslimManaged)) } : {}),
+      });
+      if (r.parkFallback) poolNotes.push(`could not park ${label}: ${r.parkFallback} -- deleted it instead`);
+      for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
+      if (r.parked) {
+        parkedDevices.push(r.parked);
+        evictedDevices.push(...(r.evicted ?? []));
+      } else if (r.status === 'torn-down') deletedDevices.push(r.label as string);
+      if (r.status === 'skipped') {
+        skippedDevices.push({ platform: 'ios', name: label, udid, reason: `${r.reason} -- not touched` });
+      } else if (r.status === 'failed') {
+        const entry: SkippedDevice = { platform: 'ios', name: label, udid, reason: `teardown failed: ${r.reason}` };
+        skippedDevices.push(entry);
+        failedDevices.push(entry);
+      }
+    }
+
+    const android = platforms.android;
+    if (android?.owned && android.avdName) {
+      const bound = parkedMaxSetting('android');
+      const r = teardownOwnedAvd(android.avdName, {
+        del: true,
+        owner: { projectPath },
+        ...(park && !bound.error && bound.max > 0
+          ? {
+              park: {
+                projectPath,
+                slot,
+                max: bound.max,
+                configuration: typeof android.poolConfiguration === 'string' ? android.poolConfiguration : undefined,
+              },
+            }
+          : {}),
+      });
+      if (r.parkFallback) poolNotes.push(`could not park ${android.avdName}: ${r.parkFallback} -- deleted it instead`);
+      for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
+      if (r.parked) {
+        parkedDevices.push(r.parked);
+        evictedDevices.push(...(r.evicted ?? []));
+      } else if (r.status === 'torn-down') deletedDevices.push(android.avdName);
+      else if (r.status === 'skipped') {
+        skippedDevices.push({ platform: 'android', name: android.avdName, reason: `${r.reason} -- not touched` });
+      } else if (r.status === 'failed') {
+        const entry: SkippedDevice = {
+          platform: 'android',
+          name: android.avdName,
+          reason: `teardown failed: ${r.reason}`,
+        };
+        skippedDevices.push(entry);
+        failedDevices.push(entry);
+      }
     }
   }
-
-  const android = project?.platforms?.android;
-  if (android?.owned && android.avdName) {
-    const bound = parkedMaxSetting('android');
-    const r = teardownOwnedAvd(android.avdName, {
-      del: true,
-      owner: { projectPath },
-      ...(park && !bound.error && bound.max > 0
-        ? {
-            park: {
-              projectPath,
-              max: bound.max,
-              configuration: typeof android.poolConfiguration === 'string' ? android.poolConfiguration : undefined,
-            },
-          }
-        : {}),
-    });
-    if (r.parkFallback) poolNotes.push(`could not park ${android.avdName}: ${r.parkFallback} -- deleted it instead`);
-    for (const failure of r.evictionFailures ?? []) poolNotes.push(failure);
-    if (r.parked) {
-      parkedDevices.push(r.parked);
-      evictedDevices.push(...(r.evicted ?? []));
-    } else if (r.status === 'torn-down') deletedDevices.push(android.avdName);
-    else if (r.status === 'skipped') {
-      skippedDevices.push({ platform: 'android', name: android.avdName, reason: `${r.reason} -- not touched` });
-    } else if (r.status === 'failed') {
-      const entry: SkippedDevice = {
-        platform: 'android',
-        name: android.avdName,
-        reason: `teardown failed: ${r.reason}`,
-      };
-      skippedDevices.push(entry);
-      failedDevices.push(entry);
-    }
-  }
-
   return { deletedDevices, parkedDevices, evictedDevices, poolNotes, skippedDevices, failedDevices };
 }
 

--- a/packages/stim-cli/src/sim-pool.ts
+++ b/packages/stim-cli/src/sim-pool.ts
@@ -1,3 +1,4 @@
+import { assignSlotDevice, deviceSlotPlatforms, removeSlotDevice } from './device-slots.ts';
 import { randomUUID } from 'node:crypto';
 import { ensureConfig, loadConfig, saveConfig, withConfigLock } from './config.ts';
 import type { Config, DeviceRecord } from './types.ts';
@@ -149,26 +150,27 @@ export function evictOverflow<T extends ParkedRecord>(records: readonly T[], max
 export function parkSim<P extends PoolPlatform>({
   platform,
   projectPath,
+  slot = 'default',
   record,
   max,
 }: {
   platform: P;
   projectPath: string;
+  slot?: string;
   record: PoolRecords[P];
   max: number;
 }): PoolRecords[P][] {
   return withConfigLock(() => {
     const cfg = ensureConfig();
-    if (platform === 'android') {
-      const current = cfg.projects[projectPath]?.platforms?.android;
-      if (!current?.owned || current.avdName !== record.udid)
-        throw new Error('The emulator assignment changed before parking.');
-    }
+    const current = deviceSlotPlatforms(cfg.projects[projectPath], slot)?.[platform];
+    const currentId = platform === 'ios' ? current?.deviceUdid : current?.avdName;
+    if (!current?.owned || currentId !== record.udid)
+      throw new Error(`The ${platform === 'ios' ? 'simulator' : 'emulator'} assignment changed before parking.`);
     const kept = readParked(platform, { config: cfg }).filter((r) => r.udid !== record.udid);
     const { keep, evicted } = evictOverflow([...kept, record], max);
     writeParked(cfg, platform, [...keep, ...evicted]);
-    const platforms = cfg.projects?.[projectPath]?.platforms;
-    if (platforms) delete platforms[platform];
+    const project = cfg.projects[projectPath];
+    if (project) removeSlotDevice(project, platform, slot);
     saveConfig(cfg);
     return evicted;
   });
@@ -177,11 +179,13 @@ export function parkSim<P extends PoolPlatform>({
 export function adoptParked<P extends PoolPlatform>({
   platform,
   projectPath,
+  slot = 'default',
   udid,
   device,
 }: {
   platform: P;
   projectPath: string;
+  slot?: string;
   udid: string;
   device: DeviceRecord;
 }): PoolRecords[P] | null {
@@ -190,7 +194,7 @@ export function adoptParked<P extends PoolPlatform>({
     const records = readParked(platform, { config: cfg });
     const taken = records.find((r) => r.udid === udid);
     if (!taken || taken.deletionClaim !== undefined) return null;
-    if (platform === 'android' && cfg.projects[projectPath]?.platforms?.android) return null;
+    if (deviceSlotPlatforms(cfg.projects[projectPath], slot)?.[platform]) return null;
     writeParked(
       cfg,
       platform,
@@ -198,8 +202,7 @@ export function adoptParked<P extends PoolPlatform>({
     );
     const project = cfg.projects[projectPath];
     if (!project) throw new Error(`Project not registered: ${projectPath}`);
-    project.platforms = project.platforms || {};
-    project.platforms[platform] = device;
+    assignSlotDevice(project, platform, device, slot);
     saveConfig(cfg);
     return taken;
   });

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from './device-slots.ts';
 import { randomUUID } from 'node:crypto';
 import { lstatSync, renameSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -51,6 +52,7 @@ export interface TeardownOutcome {
 }
 
 export interface ParkRequest {
+  slot?: string;
   projectPath: string;
   max: number;
   bundleId?: string | null;
@@ -111,7 +113,7 @@ function parkOwnedIosSim(udid: string, park: ParkRequest): { record: ParkedSim; 
     ...(park.bundleId ? { bundleId: park.bundleId } : {}),
     ...(park.cacheKey ? { cacheKey: park.cacheKey } : {}),
   };
-  const evicted = parkSim({ platform: 'ios', projectPath: park.projectPath, record, max: park.max });
+  const evicted = parkSim({ platform: 'ios', projectPath: park.projectPath, slot: park.slot, record, max: park.max });
   return { record, evicted };
 }
 
@@ -178,14 +180,11 @@ function removeOrphanedAvdDirectory(candidate: OrphanedAvdDirectory, owner?: Avd
     const config = loadConfig();
     if (!config) throw new Error('Cannot verify AVD references without a Stim config; the data was kept.');
     for (const [projectPath, project] of Object.entries(config.projects)) {
-      if (project.platforms?.android?.avdName !== candidate.name) continue;
-      if (
-        !owner ||
-        !('projectPath' in owner) ||
-        owner.projectPath !== projectPath ||
-        !project.platforms.android.owned
-      ) {
-        throw new Error(`AVD ${candidate.name} is referenced by ${projectPath}; its data was kept.`);
+      for (const { platforms } of projectDeviceSlots(project)) {
+        if (platforms.android?.avdName !== candidate.name) continue;
+        if (!owner || !('projectPath' in owner) || owner.projectPath !== projectPath || !platforms.android.owned) {
+          throw new Error(`AVD ${candidate.name} is referenced by ${projectPath}; its data was kept.`);
+        }
       }
     }
     if (
@@ -290,6 +289,7 @@ export function teardownOwnedAvd(
           const evicted = parkSim({
             platform: 'android',
             projectPath: park.projectPath,
+            slot: park.slot,
             max: park.max,
             record: {
               udid: avdName,


### PR DESCRIPTION
## Description

Devices in named slots must stay claimed during GC and participate in workspace stop/removal. Reading only the default assignment would leave devices running or mistake them for orphans.

Depends on #764. Fixes #763.

## Solution

Enumerate every slot for cleanup, ownership references, simulator-name reservations, and device capacity. Stop retains its default outcomes and reports named outcomes by platform and slot; a named-device failure fails the overall stop while allowing sibling cleanup.

Pool transfers operate on the selected slot under the config lock. Parking verifies its current device identity, and adoption refuses an occupied slot. Failed teardown keeps the project claim for a later cleanup attempt. Public launch selection follows in another layer of the stack.

## Test plan

Regression tests cover slot-aware GC, cleanup continuing after failures, safe pool transfers, and device capacity. Native tool arguments are unchanged.
