### PR TITLE
feat: isolate device slot runtime state

### DIFF
--- a/packages/stim-cli/src/__tests__/collector-run.test.ts
+++ b/packages/stim-cli/src/__tests__/collector-run.test.ts
@@ -626,9 +626,11 @@ describe('the android collector, spawned for real against a fake adb', { timeout
     await exited(child);
   });
 
-  test('a SIGTERM during the pid wait still clears the registration', async () => {
+  test('a SIGTERM during the pid wait clears a named-slot registration', async () => {
     writeShim('adb', 'exit 1\n');
     const child = spawnCollector([
+      '--slot',
+      'phone',
       '--platform',
       'android',
       '--root',
@@ -638,7 +640,7 @@ describe('the android collector, spawned for real against a fake adb', { timeout
       '--package',
       'com.example.app',
     ]);
-    await until(() => readCollectors(root).android, { label: 'the android registration' });
+    await until(() => readCollectors(root)['android:phone'], { label: 'the android registration' });
     process.kill(childPid(child), 'SIGTERM');
     expect(await exited(child)).toEqual({ code: 0, signal: null });
     expect('collectors' in (state() || {})).toBe(false);
@@ -943,4 +945,44 @@ describe('the collector never signals a pid it does not own', () => {
       process.kill = origKill;
     }
   });
+});
+
+test('named collectors attribute their output and finish without unregistering a sibling', async () => {
+  const streams = [makeChildProcess({ pid: 3132 }), makeChildProcess({ pid: 3133 })];
+  const handles = [];
+  for (const [index, slot] of ['phone', 'tablet'].entries()) {
+    const handle = await runCollector({
+      platform: 'android',
+      root,
+      slot,
+      serial: slot,
+      packageName: 'com.example.app',
+      resolvePid: async () => ({ ok: true, pid: 3132 + index }),
+      resolveClockOffset: () => 0,
+      startStream: () => streams[index]!,
+      pidOf: () => 3132 + index,
+      pidWatchMs: 60_000,
+      attachSignals: false,
+      onExit: () => {},
+    });
+    assert(handle);
+    handles.push(handle);
+  }
+  try {
+    expect(Object.keys(readCollectors(root))).toEqual(['android:phone', 'android:tablet']);
+    streams[0]!.stdout!.emit('data', ' 1788902582.542 I/ReactNativeJS( 3132): phone-output\n');
+    streams[1]!.stdout!.emit('data', ' 1788902582.542 I/ReactNativeJS( 3133): tablet-output\n');
+    expect(
+      deviceLog()
+        .filter((r) => String(r.msg).endsWith('-output'))
+        .map((r) => [r.slot, r.deviceId]),
+    ).toEqual([
+      ['phone', 'phone'],
+      ['tablet', 'tablet'],
+    ]);
+    handles[0]!.finish(0, 'info', 'done', 'collector_stopped');
+    expect(Object.keys(readCollectors(root))).toEqual(['android:tablet']);
+  } finally {
+    for (const handle of handles) handle.finish(0, 'info', 'done', 'collector_stopped');
+  }
 });

--- a/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease-run.test.ts
@@ -492,3 +492,25 @@ describe('releasing what the run took', () => {
     expect(h.holders.get(ROOT)?.ios?.kind).toBe('declared');
   });
 });
+
+test('run leases in different slots coexist and a guard releases only its own slot', async () => {
+  const h = harness();
+  const phone = await acquire(h, { slot: 'phone' });
+  const tablet = await acquire(h, { slot: 'tablet', id: 'TABLET' });
+  assert(phone.status === 'leased' && tablet.status === 'leased');
+  const handle = runLease({
+    root: ROOT,
+    platform: 'ios',
+    slot: 'tablet',
+    kind: tablet.kind,
+    expiresAt: tablet.expiresAt,
+    io: h.io,
+  });
+  expect(handle.raise(120_000).ok).toBe(true);
+  handle.release();
+  expect(Object.keys(h.holders.get(ROOT) ?? {})).toEqual(['ios:phone']);
+  expect(h.read()?.slot).toBe('phone');
+  const duplicate = await acquire(h, { slot: 'duplicate', waitSeconds: 0 });
+  assert(duplicate.status === 'refused');
+  expect(duplicate.refusal.code).toBe('STIM_DEVICE_BUSY');
+});

--- a/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device-lease.test.ts
@@ -21,7 +21,7 @@ import {
   type LeaseIo,
   type WorkspaceLeases,
 } from '../engine/device-lease.ts';
-import { writeWorkspaceState } from '../supervisor/state.ts';
+import { readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
 
 const ROOT_A = '/worktree/a';
 const ROOT_B = '/worktree/b';
@@ -462,6 +462,25 @@ describe('the real file protocol', { timeout: 30_000 }, () => {
     writeFileSync(join(scratch, name), '');
   }
 
+  test('concurrent slots preserve both workspace holder tokens', async () => {
+    const racer = script(
+      'slot-race.mjs',
+      [
+        `const { takeLease } = await import(${JSON.stringify(LEASE_URL)});`,
+        ...barrier('slots-go'),
+        'console.log(JSON.stringify(takeLease({ root: process.argv[2], platform: "ios", slot: process.argv[3], id: process.argv[3], kind: "run" })));',
+      ].join('\n'),
+    );
+    const root = join(scratch, 'shared');
+    const runs = [runNode(racer, [root, 'phone']), runNode(racer, [root, 'tablet'])];
+    release('slots-go');
+    const answers = (await Promise.all(runs)).map((r) => JSON.parse(r.stdout.trim()));
+    expect(answers.map((r) => r.status)).toEqual(['taken', 'taken']);
+    const holders = readWorkspaceState(root)?.deviceLeases as WorkspaceLeases;
+    expect(Object.keys(holders).toSorted()).toEqual(['ios:phone', 'ios:tablet']);
+    for (const result of answers) expect(holders[`ios:${result.lease.slot}`]?.token).toBe(result.lease.token);
+  });
+
   test('two processes racing for one free device leave exactly one holder', async () => {
     const racer = script(
       'racer.mjs',
@@ -572,4 +591,23 @@ describe('the real file protocol', { timeout: 30_000 }, () => {
     expect(releaseWorkspaceLeases(join(scratch, 'a')).map((r) => r.id)).toEqual([UDID]);
     expect(listLeaseFiles()).toEqual([]);
   });
+});
+
+test('named leases coexist, renew independently and release only the requested slot', () => {
+  const phone = takeLease({ root: ROOT_A, platform: 'ios', slot: 'phone', id: 'PHONE', kind: 'declared' });
+  const tablet = takeLease({ root: ROOT_A, platform: 'ios', slot: 'tablet', id: 'TABLET', kind: 'run' });
+  expect(phone.status).toBe('taken');
+  expect(tablet.status).toBe('taken');
+  expect(
+    listLeaseFiles()
+      .map(({ lease }) => lease?.slot)
+      .toSorted(),
+  ).toEqual(['phone', 'tablet']);
+  expect(takeLease({ root: ROOT_A, platform: 'ios', slot: 'duplicate', id: 'PHONE', kind: 'run' }).status).toBe('held');
+  expect(raiseLease({ root: ROOT_A, platform: 'ios', slot: 'phone', minMs: 600_000 }).status).toBe('raised');
+  expect(releaseRunLease({ root: ROOT_A, platform: 'ios', slot: 'tablet' })?.id).toBe('TABLET');
+  expect(listLeaseFiles().map(({ lease }) => lease?.id)).toEqual(['PHONE']);
+  expect(releaseWorkspaceLeases(ROOT_A, { slot: 'tablet' })).toEqual([]);
+  expect(releaseWorkspaceLeases(ROOT_A).map(({ id }) => id)).toEqual(['PHONE']);
+  expect(listLeaseFiles()).toEqual([]);
 });

--- a/packages/stim-cli/src/__tests__/workspace-launch-state.test.ts
+++ b/packages/stim-cli/src/__tests__/workspace-launch-state.test.ts
@@ -80,3 +80,19 @@ test('stop clears launch eligibility with the supervisor record', () => {
   expect(readWorkspaceLaunches(root)).toEqual({});
   expect(readWorkspaceState(root)).toBeNull();
 });
+
+test('launches in named slots coexist with default launches and share the supervisor', () => {
+  writeWorkspaceState(root, { supervisor: { pid: 42 } });
+  writeWorkspaceLaunch(root, 'ios', launch('app', 'DEFAULT'));
+  writeWorkspaceLaunch(root, 'ios', launch('app', 'PHONE'), 'phone');
+  writeWorkspaceLaunch(root, 'ios', launch('app', 'TABLET'), 'tablet');
+  writeWorkspaceLaunch(root, 'ios', launch('app', 'PHONE-RELAUNCH'), 'phone');
+  expect(Object.entries(readWorkspaceLaunches(root)).map(([key, value]) => [key, value.deviceId])).toEqual([
+    ['ios', 'DEFAULT'],
+    ['ios:phone', 'PHONE-RELAUNCH'],
+    ['ios:tablet', 'TABLET'],
+  ]);
+  expect(readWorkspaceState(root)?.supervisor).toEqual({ pid: 42 });
+  expect(() => writeWorkspaceLaunch(root, 'ios', launch('app', 'INVALID'), '../phone')).toThrow(/device slot/);
+  expect(Object.keys(readWorkspaceLaunches(root))).toHaveLength(3);
+});

--- a/packages/stim-cli/src/collector/run.ts
+++ b/packages/stim-cli/src/collector/run.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey, validateDeviceSlot } from '../device-slots.ts';
 import type { ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
@@ -22,6 +23,7 @@ import {
 export const PLATFORMS: string[] = ['ios', 'android'];
 
 export interface ParsedCollectorArgs {
+  slot?: string;
   platform?: string;
   root?: string;
   udid?: string;
@@ -36,6 +38,7 @@ export interface ParsedCollectorArgs {
 }
 
 export function parseArgs(argv: string[]): ParsedCollectorArgs {
+  let slot: string | undefined;
   let platform: string | undefined;
   let root: string | undefined;
   let udid: string | undefined;
@@ -48,6 +51,16 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
   let payloadUrl: string | null = null;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
+    if (arg === '--slot') {
+      slot = argv[++i];
+      if (!slot) return { error: '--slot needs a name.' };
+      try {
+        validateDeviceSlot(slot);
+      } catch (error) {
+        return { error: String((error as Error).message) };
+      }
+      continue;
+    }
     if (arg === '--platform') {
       platform = argv[++i];
       continue;
@@ -109,7 +122,19 @@ export function parseArgs(argv: string[]): ParsedCollectorArgs {
   if (payloadUrl && !physical) {
     return { error: '--payload-url only applies to --physical, which launches the app itself.' };
   }
-  return { platform, root, udid, bundleId, appName, appExecutable, serial, packageName, physical, payloadUrl };
+  return {
+    platform,
+    root,
+    udid,
+    bundleId,
+    appName,
+    appExecutable,
+    serial,
+    packageName,
+    physical,
+    payloadUrl,
+    ...(slot ? { slot } : {}),
+  };
 }
 
 import { readCollectors, registerCollector, unregisterCollector } from './state.ts';
@@ -117,6 +142,7 @@ import { captureProcessToken } from '../process-identity.ts';
 export { readCollectors, registerCollector, unregisterCollector };
 
 export interface RunCollectorOptions {
+  slot?: string;
   platform: string;
   root: string;
   udid?: string | null;
@@ -193,6 +219,7 @@ function startMessage({
 }
 
 export async function runCollector({
+  slot = 'default',
   platform,
   root,
   udid = null,
@@ -215,6 +242,8 @@ export async function runCollector({
   attachSignals = true,
   stderr = (line: string) => console.error(line),
 }: RunCollectorOptions): Promise<RunCollectorHandle | null> {
+  const key = deviceSlotKey(platform, slot);
+  const attribution = slot === 'default' ? {} : { slot, deviceId: udid ?? serial };
   const writer = createNdjsonWriter(join(workspaceLogsDir(root), 'device.ndjson'));
   const startedAt = new Date(now()).toISOString();
   const processToken = captureProcessToken(process.pid);
@@ -234,6 +263,7 @@ export async function runCollector({
     watcher?.stop();
     if (physical && captured === 0 && !signalled) {
       writer.write({
+        ...attribution,
         src: 'device',
         platform,
         level: 'warn',
@@ -241,9 +271,9 @@ export async function runCollector({
         msg: `the device console produced no output for ${bundleId}; devicectl only connects the app's streams when it starts the app, and os_log below the info level never reaches them`,
       });
     }
-    writer.write({ src: 'device', platform, level, event, msg });
+    writer.write({ ...attribution, src: 'device', platform, level, event, msg });
     try {
-      unregisterCollector(root, platform, process.pid, processToken);
+      unregisterCollector(root, key, process.pid, processToken);
     } catch {}
     const closed = writer.close();
     if (closed.dropped > 0) {
@@ -267,7 +297,7 @@ export async function runCollector({
   }
 
   try {
-    registerCollector(root, platform, { pid: process.pid, processToken, startedAt });
+    registerCollector(root, key, { ...attribution, pid: process.pid, processToken, startedAt });
   } catch (err) {
     stderr(`Stim collector: could not record the collector in ${root}: ${describe(err)}`);
     finish(1, 'error', 'Could not persist collector identity', 'collector_failed');
@@ -287,6 +317,7 @@ export async function runCollector({
   }
 
   writer.write({
+    ...attribution,
     src: 'device',
     platform,
     level: 'info',
@@ -309,6 +340,7 @@ export async function runCollector({
     const clockOffsetMs = platform === 'android' ? resolveClockOffset(serial as string, { now }) : null;
     if (platform === 'android') {
       writer.write({
+        ...attribution,
         src: 'device',
         platform,
         level: clockOffsetMs === null ? 'warn' : 'debug',
@@ -324,7 +356,7 @@ export async function runCollector({
       const record = parse(line, { now, clockOffsetMs });
       if (!record) return;
       captured++;
-      writer.write({ ...record, platform });
+      writer.write({ ...attribution, ...record, platform });
     };
     const spawned = startStream
       ? startStream({ platform, udid, appName, appExecutable, bundleId, serial, physical, payloadUrl, pid: streamPid })
@@ -343,6 +375,7 @@ export async function runCollector({
             const text = String(line).trimEnd();
             if (text.trim()) {
               writer.write({
+                ...attribution,
                 src: 'device',
                 platform,
                 level: 'debug',
@@ -391,6 +424,7 @@ export async function runCollector({
     killChild(child);
     child = null;
     writer.write({
+      ...attribution,
       src: 'device',
       platform,
       level: 'info',

--- a/packages/stim-cli/src/commands/android/collector.ts
+++ b/packages/stim-cli/src/commands/android/collector.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey } from '../../device-slots.ts';
 import { join } from 'node:path';
 import type { ChildProcess } from 'node:child_process';
 import { mkdirSync, openSync } from 'node:fs';
@@ -14,8 +15,8 @@ function collectorEntry(): string {
   return spawnEntry('collector-run');
 }
 
-export function collectorLogFile(root: string): string {
-  return join(workspaceLogsDir(root), `collector-${PLATFORM}.log`);
+export function collectorLogFile(root: string, slot = 'default'): string {
+  return join(workspaceLogsDir(root), `collector-${deviceSlotKey(PLATFORM, slot)}.log`);
 }
 
 const COLLECTOR_EXIT_WAIT_MS = 2000;
@@ -26,6 +27,7 @@ export function killPreviousCollector(
   root: string,
   {
     platform = PLATFORM,
+    slot = 'default',
     kill = (pid: number, signal: NodeJS.Signals) => process.kill(pid, signal),
     collectors = null,
     verify = verifyCollectorOwnership,
@@ -33,6 +35,7 @@ export function killPreviousCollector(
     note = (_line: string) => {},
   }: {
     platform?: string;
+    slot?: string;
     kill?: (pid: number, signal: NodeJS.Signals) => boolean;
     collectors?: Record<string, { pid?: number }> | null;
     verify?: typeof verifyCollectorOwnership;
@@ -40,10 +43,10 @@ export function killPreviousCollector(
     note?: (line: string) => void;
   } = {},
 ): number | null {
-  const record = (collectors ?? readCollectors(root))?.[platform] as { pid?: number } | undefined;
+  const record = (collectors ?? readCollectors(root))?.[deviceSlotKey(platform, slot)] as { pid?: number } | undefined;
   const pid = Number(record?.pid);
   if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return null;
-  const ownership = verify({ pid, platform, root, isAlive, expected: record });
+  const ownership = verify({ pid, platform: deviceSlotKey(platform, slot), root, isAlive, expected: record });
   if (ownership.status === 'gone') return null;
   if (ownership.status === 'unverified') {
     note(
@@ -63,6 +66,7 @@ export function killPreviousCollector(
 
 export async function startCollector({
   root,
+  slot = 'default',
   serial,
   packageName,
   spawn,
@@ -74,6 +78,7 @@ export async function startCollector({
   out,
 }: {
   root: string;
+  slot?: string;
   serial?: string;
   packageName: string;
   spawn: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => ChildProcess;
@@ -85,6 +90,7 @@ export async function startCollector({
   out: (line: string) => void;
 }): Promise<number | null> {
   const previousPid = killPreviousCollector(root, {
+    slot,
     kill,
     isAlive: alive,
     verify,
@@ -100,14 +106,25 @@ export async function startCollector({
   let stdio: 'ignore' | (number | 'ignore')[] = 'ignore';
   try {
     mkdirSync(workspaceLogsDir(root), { recursive: true });
-    const fd = openSync(collectorLogFile(root), 'a');
+    const fd = openSync(collectorLogFile(root, slot), 'a');
     stdio = ['ignore', fd, fd];
   } catch {}
 
   try {
     const child = spawn(
       process.execPath,
-      [collectorEntry(), '--platform', PLATFORM, '--root', root, '--serial', serial!, '--package', packageName],
+      [
+        collectorEntry(),
+        '--platform',
+        PLATFORM,
+        '--root',
+        root,
+        ...(slot === 'default' ? [] : ['--slot', slot]),
+        '--serial',
+        serial!,
+        '--package',
+        packageName,
+      ],
       {
         cwd: root,
         detached: true,

--- a/packages/stim-cli/src/commands/ios/collector.ts
+++ b/packages/stim-cli/src/commands/ios/collector.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey } from '../../device-slots.ts';
 import { join } from 'node:path';
 import type { ChildProcess } from 'node:child_process';
 import { mkdirSync, openSync } from 'node:fs';
@@ -11,8 +12,8 @@ import { pidExists } from '../../metro.ts';
 import { sleep } from '../native-runtime.ts';
 import { getExecutor } from '../../exec.ts';
 
-function collectorLogFile(root: string): string {
-  return join(workspaceLogsDir(root), `collector-${PLATFORM}.log`);
+function collectorLogFile(root: string, slot: string): string {
+  return join(workspaceLogsDir(root), `collector-${deviceSlotKey(PLATFORM, slot)}.log`);
 }
 
 export function collectorEntry(): string {
@@ -25,6 +26,7 @@ const COLLECTOR_POLL_MS = 25;
 
 interface ReplaceCollectorArgs {
   root: string;
+  slot?: string;
   udid: string;
   bundleId: string;
   appName?: string | null;
@@ -46,6 +48,7 @@ interface ReplaceCollectorArgs {
 // collector before it installs, rather than as part of starting its own.
 export async function stopPreviousCollector({
   root,
+  slot = 'default',
   kill = (pid, signal) => process.kill(pid, signal),
   alive = pidExists,
   readState = readWorkspaceState,
@@ -54,6 +57,7 @@ export async function stopPreviousCollector({
   note = (_line: string) => {},
 }: {
   root: string;
+  slot?: string;
   kill?: (pid: number, signal: NodeJS.Signals) => boolean;
   alive?: (pid: number) => boolean;
   readState?: typeof readWorkspaceState;
@@ -61,12 +65,20 @@ export async function stopPreviousCollector({
   waitMs?: number;
   note?: (line: string) => void;
 }): Promise<{ killed: number | null }> {
-  const previous = (readState(root)?.collectors as Record<string, { pid?: number }> | undefined)?.[PLATFORM] || null;
+  const previous =
+    (readState(root)?.collectors as Record<string, { pid?: number }> | undefined)?.[deviceSlotKey(PLATFORM, slot)] ||
+    null;
   const previousPid = Number(previous?.pid) || null;
   let killed: number | null = null;
 
   if (previousPid) {
-    const ownership = verify({ pid: previousPid, platform: PLATFORM, root, isAlive: alive, expected: previous });
+    const ownership = verify({
+      pid: previousPid,
+      platform: deviceSlotKey(PLATFORM, slot),
+      root,
+      isAlive: alive,
+      expected: previous,
+    });
     if (ownership.status === 'ours') {
       try {
         kill(previousPid, 'SIGTERM');
@@ -97,6 +109,7 @@ export async function stopPreviousCollector({
 
 export async function replaceCollector({
   root,
+  slot = 'default',
   udid,
   bundleId,
   appName,
@@ -111,9 +124,10 @@ export async function replaceCollector({
   waitMs = COLLECTOR_EXIT_WAIT_MS,
   note = (_line: string) => {},
 }: ReplaceCollectorArgs): Promise<{ killed: number | null; pid: number | null }> {
-  const { killed } = await stopPreviousCollector({ root, kill, alive, readState, verify, waitMs, note });
+  const { killed } = await stopPreviousCollector({ root, slot, kill, alive, readState, verify, waitMs, note });
 
   const args = [collectorEntry(), '--platform', PLATFORM, '--root', root, '--udid', udid, '--bundle', bundleId];
+  if (slot !== 'default') args.push('--slot', slot);
   if (appName) args.push('--app-name', appName);
   if (appExecutable) args.push('--app-executable', appExecutable);
   if (physical) args.push('--physical');
@@ -122,7 +136,7 @@ export async function replaceCollector({
   let stdio: 'ignore' | (number | 'ignore')[] = 'ignore';
   try {
     mkdirSync(workspaceLogsDir(root), { recursive: true });
-    const fd = openSync(collectorLogFile(root), 'a');
+    const fd = openSync(collectorLogFile(root, slot), 'a');
     stdio = ['ignore', fd, fd];
   } catch {}
 

--- a/packages/stim-cli/src/device-slots.ts
+++ b/packages/stim-cli/src/device-slots.ts
@@ -2,7 +2,7 @@ import type { DeviceRecord, PlatformRecords, ProjectRecord } from './types.ts';
 
 const DEFAULT_DEVICE_SLOT = 'default';
 
-function validateDeviceSlot(slot: string): string {
+export function validateDeviceSlot(slot: string): string {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(slot) || ['constructor', 'prototype', '__proto__'].includes(slot)) {
     const error = new Error(
       'A device slot must be 1-64 letters, digits, underscores or hyphens, starting with a letter or digit.',
@@ -63,4 +63,22 @@ export function removeSlotDevice(project: ProjectRecord, platform: string, slot:
     delete project.deviceSlots![slot];
     if (Object.keys(project.deviceSlots!).length === 0) delete project.deviceSlots;
   }
+}
+
+export function deviceSlotKey(platform: string, slot = 'default'): string {
+  validateDeviceSlot(slot);
+  if (platform !== 'ios' && platform !== 'android') throw new Error(`Unknown device platform: ${platform}`);
+  return slot === 'default' ? platform : `${platform}:${slot}`;
+}
+
+export function parseDeviceSlotKey(key: string): { platform: 'ios' | 'android'; slot: string } | null {
+  const [platform, slot = 'default', extra] = key.split(':');
+  if ((platform !== 'ios' && platform !== 'android') || extra !== undefined) return null;
+  try {
+    validateDeviceSlot(slot);
+  } catch {
+    return null;
+  }
+  if (key !== deviceSlotKey(platform, slot)) return null;
+  return { platform, slot };
 }

--- a/packages/stim-cli/src/engine/device-lease-run.ts
+++ b/packages/stim-cli/src/engine/device-lease-run.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey } from '../device-slots.ts';
 import { clockTime, formatElapsed } from '../command-output.ts';
 import { VERIFY_TIMEOUT_MS } from './app-install.ts';
 import { APP_READINESS_TIMEOUT_MS } from './app-readiness.ts';
@@ -193,12 +194,14 @@ export interface RunLease {
 export function runLease({
   root,
   platform,
+  slot = 'default',
   kind,
   expiresAt,
   io = fileLeaseIo,
 }: {
   root: string;
   platform: LeasePlatform;
+  slot?: string;
   kind: LeaseKind | null;
   expiresAt: string | null;
   io?: LeaseIo;
@@ -211,7 +214,7 @@ export function runLease({
       if (handle.kind === null || handle.lost) {
         return { ok: !handle.lost, holder: null, expiresAt: handle.expiresAt };
       }
-      const result = raiseLease({ root, platform, minMs: leaseStepMs(boundMs) }, io);
+      const result = raiseLease({ root, platform, slot, minMs: leaseStepMs(boundMs) }, io);
       if (result.status === 'raised') {
         handle.expiresAt = result.lease.expiresAt;
         return { ok: true, holder: result.lease.holder, expiresAt: result.lease.expiresAt };
@@ -222,7 +225,7 @@ export function runLease({
     },
     release() {
       if (handle.kind === null) return;
-      releaseRunLease({ root, platform }, io);
+      releaseRunLease({ root, platform, slot }, io);
     },
     facts() {
       if (handle.kind === null || handle.lost || handle.expiresAt === null) return null;
@@ -279,6 +282,7 @@ export type LeaseWaitOutcome =
 export async function waitForDevice({
   root,
   platform,
+  slot = 'default',
   id,
   idLabel,
   waitSeconds,
@@ -294,6 +298,7 @@ export async function waitForDevice({
 }: {
   root: string;
   platform: LeasePlatform;
+  slot?: string;
   id: string;
   idLabel: string;
   waitSeconds: number;
@@ -313,7 +318,7 @@ export async function waitForDevice({
     const current = parseLease(raw);
     if (raw !== null && !current) return { status: 'refused', refusal: unreadableRefusal(path) };
     if (!current || leaseIsExpired(current, now())) return { status: 'free' };
-    if (current.holder === root) return { status: 'ours', lease: current };
+    if (current.holder === root && (current.slot ?? 'default') === slot) return { status: 'ours', lease: current };
     if (noWait) {
       for (const line of bypassLines(current, now(), appIdMatch(appId, holderAppId(current.holder)))) warn(line);
       return { status: 'bypassed', lease: current };
@@ -332,6 +337,7 @@ export async function waitForDevice({
 export async function acquireRunLease({
   root,
   platform,
+  slot = 'default',
   id,
   deviceName = null,
   idLabel,
@@ -347,6 +353,7 @@ export async function acquireRunLease({
 }: {
   root: string;
   platform: LeasePlatform;
+  slot?: string;
   id: string;
   deviceName?: string | null;
   idLabel: string;
@@ -360,7 +367,7 @@ export async function acquireRunLease({
   warn?: (line: string) => void;
   io?: LeaseIo;
 }): Promise<AcquireRunLeaseResult> {
-  const recorded = io.readHolder(root)[platform];
+  const recorded = io.readHolder(root)[deviceSlotKey(platform, slot)];
   let held = recorded;
   if (recorded && recorded.id !== id) {
     const other = parseLease(io.readLease(deviceLeasePath(platform, recorded.id)));
@@ -378,7 +385,7 @@ export async function acquireRunLease({
     const current = parseLease(io.readLease(path));
     const mine = current && held && current.token === held.token ? { lease: current, record: held } : null;
     if (mine && (mine.record.kind === 'run' || !leaseIsExpired(mine.lease, now()))) {
-      const raised = raiseLease({ root, platform, minMs: leaseStepMs(installBoundMs) }, io);
+      const raised = raiseLease({ root, platform, slot, minMs: leaseStepMs(installBoundMs) }, io);
       if (raised.status === 'raised') {
         return { status: 'leased', kind: mine.record.kind, expiresAt: raised.lease.expiresAt };
       }
@@ -387,6 +394,7 @@ export async function acquireRunLease({
     const outcome = await waitForDevice({
       root,
       platform,
+      slot,
       id,
       idLabel,
       waitSeconds,
@@ -405,7 +413,7 @@ export async function acquireRunLease({
     if (outcome.status === 'ours') return { status: 'refused', refusal: untokenedRefusal(outcome.lease, now()) };
 
     const taken = takeLease(
-      { root, platform, id, deviceName, kind: 'run', durationMs: leaseStepMs(installBoundMs) },
+      { root, platform, slot, id, deviceName, kind: 'run', durationMs: leaseStepMs(installBoundMs) },
       io,
     );
     if (taken.status === 'unreadable') return { status: 'refused', refusal: unreadableRefusal(taken.path) };

--- a/packages/stim-cli/src/engine/device-lease.ts
+++ b/packages/stim-cli/src/engine/device-lease.ts
@@ -1,9 +1,15 @@
+import { deviceSlotKey, parseDeviceSlotKey, validateDeviceSlot } from '../device-slots.ts';
 import { randomBytes } from 'node:crypto';
 import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getConfigDir } from '../config.ts';
 import { withDirLock } from '../dir-lock.ts';
-import { clearWorkspaceStateKeys, readWorkspaceState, writeWorkspaceState } from '../supervisor/state.ts';
+import {
+  clearWorkspaceStateKeys,
+  readWorkspaceState,
+  withWorkspaceStateLock,
+  writeWorkspaceState,
+} from '../supervisor/state.ts';
 import { segment } from './build-lock.ts';
 
 export const LEASE_VERSION = 1;
@@ -20,6 +26,7 @@ export type LeaseKind = 'declared' | 'run';
 
 export interface DeviceLease {
   version: number;
+  slot?: string;
   platform: LeasePlatform;
   id: string;
   deviceName: string | null;
@@ -35,9 +42,10 @@ export interface WorkspaceLeaseRecord {
   kind: LeaseKind;
 }
 
-export type WorkspaceLeases = Partial<Record<LeasePlatform, WorkspaceLeaseRecord>>;
+export type WorkspaceLeases = Record<string, WorkspaceLeaseRecord>;
 
 export interface LeaseIo {
+  withHolderLock?: <T>(root: string, fn: () => T) => T;
   now: () => number;
   readLease: (path: string) => string | null;
   writeLease: (path: string, text: string) => void;
@@ -65,6 +73,7 @@ export function deviceLeaseLockPath(platform: string, id: string): string {
 }
 
 export const fileLeaseIo: LeaseIo = {
+  withHolderLock: withWorkspaceStateLock,
   now: () => Date.now(),
   readLease(path) {
     try {
@@ -130,8 +139,17 @@ export function parseLease(raw: string | null): DeviceLease | null {
   const token = text(entry.token);
   const expiresAt = text(entry.expiresAt);
   if (!id || !holder || !token || !expiresAt || !Number.isFinite(Date.parse(expiresAt))) return null;
+  if (entry.slot !== undefined) {
+    if (typeof entry.slot !== 'string') return null;
+    try {
+      validateDeviceSlot(entry.slot);
+    } catch {
+      return null;
+    }
+  }
   return {
     version: LEASE_VERSION,
+    ...(typeof entry.slot === 'string' ? { slot: entry.slot } : {}),
     platform: entry.platform,
     id,
     deviceName: text(entry.deviceName),
@@ -146,7 +164,7 @@ export function parseWorkspaceLeases(value: unknown): WorkspaceLeases {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   const leases: WorkspaceLeases = {};
   for (const [platform, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (!isPlatform(platform) || !entry || typeof entry !== 'object') continue;
+    if (!parseDeviceSlotKey(platform) || !entry || typeof entry !== 'object') continue;
     const record = entry as Record<string, unknown>;
     const id = text(record.id);
     const token = text(record.token);
@@ -216,6 +234,7 @@ export function takeLease(
   {
     root,
     platform,
+    slot = 'default',
     id,
     deviceName = null,
     kind,
@@ -223,6 +242,7 @@ export function takeLease(
   }: {
     root: string;
     platform: LeasePlatform;
+    slot?: string;
     id: string;
     deviceName?: string | null;
     kind: LeaseKind;
@@ -230,51 +250,62 @@ export function takeLease(
   },
   io: LeaseIo = fileLeaseIo,
 ): TakeLeaseResult {
-  const previous = io.readHolder(root)[platform];
-  if (previous && previous.id !== id) releaseHeld(root, platform, previous, io);
-  for (const entry of listLeaseFiles(io)) {
-    const other = entry.lease;
-    if (!other || other.platform !== platform || other.holder !== root || other.id === id) continue;
-    releaseByRoot(root, platform, other.id, io);
-  }
-
-  const declared = previous?.kind === 'declared' && previous.id === id;
-  const path = deviceLeasePath(platform, id);
-  const result = io.withLeaseLock(deviceLeaseLockPath(platform, id), (): TakeLeaseResult => {
-    const now = io.now();
-    const raw = io.readLease(path);
-    const current = parseLease(raw);
-    if (raw !== null && !current) return { status: 'unreadable', path };
-    const asked = now + durationMs;
-    if (current && !leaseIsExpired(current, now)) {
-      if (current.holder !== root) return { status: 'held', lease: current };
-      const floor = declared && kind === 'run' ? Math.max(asked, Date.parse(current.expiresAt)) : asked;
-      const kept = {
-        ...current,
-        deviceName: deviceName ?? current.deviceName,
-        expiresAt: new Date(floor).toISOString(),
-      };
-      return { status: 'set', lease: writeLease(kept, io) };
+  return withHolderLock(io, root, () => {
+    const key = deviceSlotKey(platform, slot);
+    const previous = io.readHolder(root)[key];
+    if (previous && previous.id !== id) releaseHeld(root, platform, previous, io, slot);
+    for (const entry of listLeaseFiles(io)) {
+      const other = entry.lease;
+      if (
+        !other ||
+        other.platform !== platform ||
+        other.holder !== root ||
+        (other.slot ?? 'default') !== slot ||
+        other.id === id
+      )
+        continue;
+      releaseByRoot(root, platform, other.id, io);
     }
-    const expiresAt = new Date(asked).toISOString();
-    const granted: DeviceLease = {
-      version: LEASE_VERSION,
-      platform,
-      id,
-      deviceName,
-      holder: root,
-      token: randomBytes(12).toString('hex'),
-      grantedAt: new Date(now).toISOString(),
-      expiresAt,
-    };
-    return { status: 'taken', lease: writeLease(granted, io) };
-  });
 
-  if (result.status === 'taken' || result.status === 'set') {
-    const recorded = result.status === 'set' && declared ? 'declared' : kind;
-    io.writeHolder(root, { ...io.readHolder(root), [platform]: { id, token: result.lease.token, kind: recorded } });
-  }
-  return result;
+    const declared = previous?.kind === 'declared' && previous.id === id;
+    const path = deviceLeasePath(platform, id);
+    const result = io.withLeaseLock(deviceLeaseLockPath(platform, id), (): TakeLeaseResult => {
+      const now = io.now();
+      const raw = io.readLease(path);
+      const current = parseLease(raw);
+      if (raw !== null && !current) return { status: 'unreadable', path };
+      const asked = now + durationMs;
+      if (current && !leaseIsExpired(current, now)) {
+        if (current.holder !== root || (current.slot ?? 'default') !== slot) return { status: 'held', lease: current };
+        const floor = declared && kind === 'run' ? Math.max(asked, Date.parse(current.expiresAt)) : asked;
+        const kept = {
+          ...current,
+          deviceName: deviceName ?? current.deviceName,
+          expiresAt: new Date(floor).toISOString(),
+        };
+        return { status: 'set', lease: writeLease(kept, io) };
+      }
+      const expiresAt = new Date(asked).toISOString();
+      const granted: DeviceLease = {
+        version: LEASE_VERSION,
+        ...(slot === 'default' ? {} : { slot }),
+        platform,
+        id,
+        deviceName,
+        holder: root,
+        token: randomBytes(12).toString('hex'),
+        grantedAt: new Date(now).toISOString(),
+        expiresAt,
+      };
+      return { status: 'taken', lease: writeLease(granted, io) };
+    });
+
+    if (result.status === 'taken' || result.status === 'set') {
+      const recorded = result.status === 'set' && declared ? 'declared' : kind;
+      io.writeHolder(root, { ...io.readHolder(root), [key]: { id, token: result.lease.token, kind: recorded } });
+    }
+    return result;
+  });
 }
 
 export type RaiseLeaseResult =
@@ -283,10 +314,10 @@ export type RaiseLeaseResult =
   | { status: 'lost'; lease: DeviceLease | null };
 
 export function raiseLease(
-  { root, platform, minMs }: { root: string; platform: LeasePlatform; minMs: number },
+  { root, platform, slot = 'default', minMs }: { root: string; platform: LeasePlatform; slot?: string; minMs: number },
   io: LeaseIo = fileLeaseIo,
 ): RaiseLeaseResult {
-  const record = io.readHolder(root)[platform];
+  const record = io.readHolder(root)[deviceSlotKey(platform, slot)];
   if (!record) return { status: 'none' };
   const path = deviceLeasePath(platform, record.id);
   return io.withLeaseLock(deviceLeaseLockPath(platform, record.id), (): RaiseLeaseResult => {
@@ -315,7 +346,9 @@ function releaseHeld(
   platform: LeasePlatform,
   record: WorkspaceLeaseRecord,
   io: LeaseIo,
+  slot = 'default',
 ): DeviceLease | null {
+  const key = deviceSlotKey(platform, slot);
   const path = deviceLeasePath(platform, record.id);
   const released = io.withLeaseLock(deviceLeaseLockPath(platform, record.id), (): DeviceLease | null => {
     const current = parseLease(io.readLease(path));
@@ -324,8 +357,8 @@ function releaseHeld(
     return current;
   });
   const held = io.readHolder(root);
-  if (held[platform]?.token === record.token) {
-    delete held[platform];
+  if (held[key]?.token === record.token) {
+    delete held[key];
     io.writeHolder(root, held);
   }
   return released;
@@ -342,34 +375,40 @@ function releaseByRoot(root: string, platform: LeasePlatform, id: string, io: Le
 }
 
 export function releaseRunLease(
-  { root, platform }: { root: string; platform: LeasePlatform },
+  { root, platform, slot = 'default' }: { root: string; platform: LeasePlatform; slot?: string },
   io: LeaseIo = fileLeaseIo,
 ): ReleasedLease | null {
-  const record = io.readHolder(root)[platform];
-  if (!record || record.kind !== 'run') return null;
-  const released = releaseHeld(root, platform, record, io);
-  return released ? summarize(released) : null;
+  return withHolderLock(io, root, () => {
+    const record = io.readHolder(root)[deviceSlotKey(platform, slot)];
+    if (!record || record.kind !== 'run') return null;
+    const released = releaseHeld(root, platform, record, io, slot);
+    return released ? summarize(released) : null;
+  });
 }
 
 export function releaseWorkspaceLeases(
   root: string,
-  { platform = null }: { platform?: LeasePlatform | null } = {},
+  { platform = null, slot = null }: { platform?: LeasePlatform | null; slot?: string | null } = {},
   io: LeaseIo = fileLeaseIo,
 ): ReleasedLease[] {
-  const released: ReleasedLease[] = [];
-  for (const [name, record] of Object.entries(io.readHolder(root))) {
-    if (!isPlatform(name) || (platform && name !== platform)) continue;
-    const lease = releaseHeld(root, name, record, io);
-    if (lease) released.push(summarize(lease));
-  }
-  for (const entry of listLeaseFiles(io)) {
-    const lease = entry.lease;
-    if (!lease || lease.holder !== root) continue;
-    if (platform && lease.platform !== platform) continue;
-    const byRoot = releaseByRoot(root, lease.platform, lease.id, io);
-    if (byRoot) released.push(summarize(byRoot));
-  }
-  return released;
+  return withHolderLock(io, root, () => {
+    const released: ReleasedLease[] = [];
+    for (const [name, record] of Object.entries(io.readHolder(root))) {
+      const parsed = parseDeviceSlotKey(name);
+      if (!parsed || (platform && parsed.platform !== platform) || (slot !== null && parsed.slot !== slot)) continue;
+      const lease = releaseHeld(root, parsed.platform, record, io, parsed.slot);
+      if (lease) released.push(summarize(lease));
+    }
+    for (const entry of listLeaseFiles(io)) {
+      const lease = entry.lease;
+      if (!lease || lease.holder !== root) continue;
+      if (platform && lease.platform !== platform) continue;
+      if (slot !== null && (lease.slot ?? 'default') !== slot) continue;
+      const byRoot = releaseByRoot(root, lease.platform, lease.id, io);
+      if (byRoot) released.push(summarize(byRoot));
+    }
+    return released;
+  });
 }
 
 export function removeExpiredLease(entry: LeaseFileEntry, io: LeaseIo = fileLeaseIo): boolean {
@@ -429,4 +468,8 @@ export function selectPoolDevice({
     holders.push({ id: lease.id, holder: lease.holder, expiresAt: lease.expiresAt });
   }
   return { status: 'busy', holders };
+}
+
+function withHolderLock<T>(io: LeaseIo, root: string, fn: () => T): T {
+  return io.withHolderLock ? io.withHolderLock(root, fn) : fn();
 }

--- a/packages/stim-cli/src/engine/device-pool.ts
+++ b/packages/stim-cli/src/engine/device-pool.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey } from '../device-slots.ts';
 import {
   deviceLeasePath,
   fileLeaseIo,
@@ -32,8 +33,9 @@ export function heldPoolId(
   platform: LeasePlatform,
   now: number,
   io: LeaseIo = fileLeaseIo,
+  slot = 'default',
 ): string | null {
-  const record = io.readHolder(root)[platform];
+  const record = io.readHolder(root)[deviceSlotKey(platform, slot)];
   if (!record) return null;
   const lease = parseLease(io.readLease(deviceLeasePath(platform, record.id)));
   if (!lease || lease.token !== record.token || leaseIsExpired(lease, now)) return null;
@@ -122,6 +124,7 @@ function poolBusyRefusal(
 export async function selectFromPool({
   root,
   platform,
+  slot = 'default',
   idLabel,
   list,
   noCandidates,
@@ -135,6 +138,7 @@ export async function selectFromPool({
 }: {
   root: string;
   platform: LeasePlatform;
+  slot?: string;
   idLabel: string;
   list: () => PoolCandidate[];
   noCandidates: () => PoolRefusalText;
@@ -146,7 +150,7 @@ export async function selectFromPool({
   warn?: (line: string) => void;
   io?: LeaseIo;
 }): Promise<PoolResult> {
-  const held = heldPoolId(root, platform, now(), io);
+  const held = heldPoolId(root, platform, now(), io, slot);
   const until = deadline ?? now() + waitSeconds * 1000;
   let lastLine: number | null = null;
 

--- a/packages/stim-cli/src/reclaim.ts
+++ b/packages/stim-cli/src/reclaim.ts
@@ -41,7 +41,7 @@ async function reapCollectors(
     if (ownership.status === 'gone') continue;
     if (ownership.status === 'unverified') {
       const name = `${platform} log collector (pid ${pid})`;
-      const platformLabel = platform === 'android' ? 'android' : 'ios';
+      const platformLabel = platform.split(':')[0] === 'android' ? 'android' : 'ios';
       const entry: SkippedDevice = {
         platform: platformLabel,
         name,
@@ -58,7 +58,7 @@ async function reapCollectors(
       if ((error as NodeJS.ErrnoException).code === 'ESRCH') continue;
     }
     const entry: SkippedDevice = {
-      platform: platform === 'android' ? 'android' : 'ios',
+      platform: platform.split(':')[0] === 'android' ? 'android' : 'ios',
       name: `${platform} log collector (pid ${pid})`,
       reason: 'Collector exit could not be confirmed; keeping its ownership record.',
     };

--- a/packages/stim-cli/src/supervisor/state.ts
+++ b/packages/stim-cli/src/supervisor/state.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey, parseDeviceSlotKey } from '../device-slots.ts';
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { withDirLock } from '../dir-lock.ts';
@@ -13,7 +14,7 @@ export interface WorkspaceState {
   supervisor?: Record<string, unknown>;
   collectors?: Record<string, unknown>;
   lastBuild?: Record<string, unknown>;
-  launches?: Partial<Record<WorkspaceLaunchPlatform, WorkspaceLaunchRecord>>;
+  launches?: Record<string, WorkspaceLaunchRecord>;
   remoteDevice?: Record<string, unknown>;
   metroTunnel?: Record<string, unknown>;
   [key: string]: unknown;
@@ -105,23 +106,27 @@ function parseWorkspaceLaunchRecord(value: unknown): WorkspaceLaunchRecord | nul
   return record as WorkspaceLaunchRecord;
 }
 
-export function readWorkspaceLaunches(root: string): Partial<Record<WorkspaceLaunchPlatform, WorkspaceLaunchRecord>> {
+export function readWorkspaceLaunches(root: string): Record<string, WorkspaceLaunchRecord> {
   const launches = readWorkspaceState(root)?.launches;
   if (!launches || typeof launches !== 'object' || Array.isArray(launches)) return {};
-  const ios = parseWorkspaceLaunchRecord(launches.ios);
-  const android = parseWorkspaceLaunchRecord(launches.android);
-  return { ...(ios ? { ios } : {}), ...(android ? { android } : {}) };
+  const records: Record<string, WorkspaceLaunchRecord> = {};
+  for (const [key, value] of Object.entries(launches)) {
+    const record = parseWorkspaceLaunchRecord(value);
+    if (parseDeviceSlotKey(key) && record) records[key] = record;
+  }
+  return records;
 }
 
 export function writeWorkspaceLaunch(
   root: string,
   platform: WorkspaceLaunchPlatform,
   record: WorkspaceLaunchRecord,
+  slot = 'default',
 ): void {
   withWorkspaceStateLock(root, () => {
     const state = readWorkspaceState(root) ?? {};
     const launches = state.launches && typeof state.launches === 'object' ? state.launches : {};
-    replaceWorkspaceState(root, { ...state, launches: { ...launches, [platform]: record } });
+    replaceWorkspaceState(root, { ...state, launches: { ...launches, [deviceSlotKey(platform, slot)]: record } });
   });
 }
 


### PR DESCRIPTION
## Description

Multiple devices in one workspace need independent launch records, native collectors, and physical-device lease tokens. Platform-only runtime keys let the next device replace the previous one.

Depends on #767. Fixes #766.

## Solution

Give named slots their own runtime keys while preserving existing default keys and lease files. Lease operations lock the workspace holder update and isolate acquisition, renewal, and release by slot. Two slots cannot take the same live device lease.

Collectors register and stop by slot and attach the slot and device identity to named-slot log records. The supervisor remains shared. This is runtime plumbing; public `--slot` integration, targeted queries/reload, and user guidance remain for the next layer.

## Test plan

All 4,262 unit tests and 84 end-to-end tests pass, including a real two-process lease race, collector cleanup, log attribution, and independent slot state. Native device-tool arguments are unchanged.
