### PR TITLE
docs: show command reminders in note boxes

### DIFF
--- a/website/docs/agent-skills.md
+++ b/website/docs/agent-skills.md
@@ -4,8 +4,12 @@ sidebar_position: 4
 description: 'Install the small Stim workflow skill for coding agents'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Install the bundled skill from the repository:
 

--- a/website/docs/android-cas.md
+++ b/website/docs/android-cas.md
@@ -101,8 +101,14 @@ assertion failures stop the script. All fixture data remains available.
 ## Application integration
 
 After building the Stim checkout, use its CLI with a disposable React Native/Expo
-worktree and a private `STIM_HOME`. Commands use `stim`; replace it with
+worktree and a private `STIM_HOME`.
+
+:::note[Command examples]
+
+Commands use `stim`; replace it with
 `npx stim` if it is not installed globally.
+
+:::
 
 For persistent selection, merge this into `$STIM_HOME/config.json` (default
 `~/.stim/config.json`). The same `optimizations` object in `.stim.json` can

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -6,8 +6,12 @@ description: 'How Stim keeps worktree builds warm'
 
 import StimTabs from '@site/src/components/StimTabs';
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Stim shares four types of work across projects and git worktrees:
 

--- a/website/docs/build-optimizations.md
+++ b/website/docs/build-optimizations.md
@@ -5,8 +5,12 @@ description: 'Control native artifact reuse, compiler caches, PCH, and Metro cac
 
 import StimTabs from '@site/src/components/StimTabs';
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Stim enables build optimizations by default. Use the `optimizations` settings to
 disable individual layers when debugging or to opt into experimental compiler

--- a/website/docs/cache-packages.md
+++ b/website/docs/cache-packages.md
@@ -4,8 +4,12 @@ sidebar_position: 5
 description: 'Optional npm packages for builds that run outside Stim'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Stim supplies its own cache arguments when it runs Metro and native builds. A
 project does not need these packages for `stim start`, `stim ios`, or

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -6,8 +6,12 @@ description: 'Every Stim command and option'
 
 import StimTabs from '@site/src/components/StimTabs';
 
+:::note[Command examples]
+
 Commands use `stim`. If Stim is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Run `stim <command> --help` for parser help. Run `stim guide` for the full
 reference that ships with the installed version.

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -6,8 +6,12 @@ description: 'A supervised Metro server and a queryable launch timeline'
 
 import StimTabs from '@site/src/components/StimTabs';
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 `stim start` reserves a port for the workspace and starts its React Native or
 Expo dev server under a detached supervisor. The command exits only after the

--- a/website/docs/eas-builds.md
+++ b/website/docs/eas-builds.md
@@ -6,8 +6,12 @@ description: 'Download a compatible EAS build and run it with Stim'
 import StimTabs from '@site/src/components/StimTabs';
 import PromptBox from '@site/src/components/PromptBox';
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 If your Expo project builds with EAS, Stim can download a matching development
 build and run it on a simulator, emulator, or connected phone. EAS supplies the

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -4,8 +4,12 @@ sidebar_position: 3
 description: 'Owned devices, physical-device leases, and cleanup'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Stim creates and records its local simulators and emulators. Their names start
 with `stim-`. It never creates, boots, or deletes a simulator or emulator that

--- a/website/docs/requirements.md
+++ b/website/docs/requirements.md
@@ -4,8 +4,12 @@ sidebar_position: 3
 description: 'Local and optional remote requirements'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 ## All projects
 

--- a/website/docs/settings.md
+++ b/website/docs/settings.md
@@ -4,8 +4,12 @@ sidebar_position: 2
 description: 'Project, repository, machine, and environment settings'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Most projects need no settings. Use `stim guide settings` for descriptions that
 match the installed version.

--- a/website/docs/why.md
+++ b/website/docs/why.md
@@ -4,8 +4,12 @@ sidebar_position: 1
 description: 'Fast, isolated React Native environments for coding agents'
 ---
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 Stim gives each coding agent a complete React Native environment. Each project
 or git worktree gets a reserved Metro port and an owned simulator or emulator.

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -6,8 +6,12 @@ description: 'Parallel worktrees that share expensive build caches'
 
 import StimTabs from '@site/src/components/StimTabs';
 
+:::note[Command examples]
+
 Commands use `stim`. If it is not installed globally, replace `stim` with
 `npx stim`.
+
+:::
 
 ## Create with Git
 


### PR DESCRIPTION
## Description

The repeated `stim`/`npx stim` reminder looks like primary page content. Wrap it in a note box so it reads as supporting guidance.

## Solution

Use Docusaurus's built-in “Command examples” note on all 13 affected pages, preserving the command wording. No custom styles or components.

## Test plan

Verified every note at desktop and mobile widths, with no overflow or browser errors. Checked the EAS page in light and dark themes.

| Before | After |
| --- | --- |
| ![Plain command reminder](https://github.com/user-attachments/assets/b4e61c4a-212a-4a04-b440-920102c0b19c) | ![Command examples note box](https://github.com/user-attachments/assets/840bed34-4ca5-4621-a6f3-244188863df6) |

Fixes #771
