### PR TITLE
feat: run multiple devices per workspace with named slots

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -178,3 +178,22 @@ Update programmatic imports from `stim-cli/cache-manifest` to
 `stim/cache-manifest`. The `@stim-cli/*` packages keep their names.
 
 MIT License.
+
+### Multiple devices in one workspace
+
+Use a stable slot name for each simulator, emulator, or physical device. Slots
+can use identical models and all share the workspace's Metro server and build
+cache. Omit `--slot` to reuse your existing default device.
+
+```sh
+stim ios --slot phone
+stim ios --slot tablet --device-type "iPad Pro 13-inch (M4)"
+stim ios --slot hardware --device <udid>
+stim logs --slot tablet --source device
+stim stop --slot tablet
+```
+
+`stim status` shows every slot. Plain `stim stop` stops the whole workspace;
+`--slot` preserves the shared server and other devices. `stim reload ios` or
+`stim reload android` can reload multiple connected devices. Read
+`stim guide lifecycle options` for launch verification and recycling behavior.

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -3068,8 +3068,9 @@ describe('launch verification', () => {
     expect(text).toMatch(/Do not run `stim android` unless native inputs changed or the app process exits/);
   });
 
-  test('a native process exit recommends another platform run instead of a Metro reload', async () => {
+  test.each(['default', 'phone'])('a native process exit recommends the same slot (%s)', async (slot) => {
     const h = harness({
+      slot,
       verifyLaunched: async () => ({
         fatal: true,
         processAlive: false,
@@ -3079,7 +3080,7 @@ describe('launch verification', () => {
     const result = await h.run();
     expect(result.ok).toBe(false);
     expect(h.stderr.join('\n')).toContain("adb -s 'emulator-5584' shell am force-stop 'com.example.app'");
-    expect(h.stderr.join('\n')).toMatch(/run `stim android` again.*Metro reload cannot recover/);
+    expect(h.stderr.join('\n')).toContain(`run \`stim android${slot === 'default' ? '' : ` --slot ${slot}`}\` again`);
   });
 
   test.each([

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -469,7 +469,7 @@ function harness(overrides = {}) {
         ...options,
         ensureDevice: async (args) => {
           const device = await ensureDevice(args);
-          if (device.owned) setDevice(root, 'android', device);
+          if (device.owned) setDevice(root, 'android', device, args.slot);
           return device;
         },
       }),
@@ -5798,4 +5798,15 @@ describe('EAS development builds', () => {
     expect(await run()).toMatchObject({ ok: false, error: { code: 'STIM_BAD_ARG' } });
     expect(resolveEasDevelopmentBuild).not.toHaveBeenCalled();
   });
+});
+
+test('a named Android run scopes allocation, launch verification and collector startup', async () => {
+  const h = harness({ slot: 'phone', json: true });
+  const result = await h.run();
+  expect(result.ok).toBe(true);
+  expect(h.calls.ensureDevice[0]).toMatchObject({ slot: 'phone' });
+  expect(h.calls.verify[0]).toMatchObject({ slot: 'phone' });
+  expect(h.calls.spawn.some((call) => call.args.includes('--slot') && call.args.includes('phone'))).toBe(true);
+  const facts = JSON.parse(h.stdout.at(-1)!);
+  expect(facts.slot).toBe('phone');
 });

--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5701,7 +5701,7 @@ describe('EAS development builds', () => {
     );
   }
 
-  test('installs the EAS APK on the owned emulator with the reserved Metro port, without a local build', async () => {
+  test.each(['default', 'phone'])('installs the EAS APK in slot %s without a local build', async (slot) => {
     expoProject();
     const path = fakeApk();
     const resolveEasDevelopmentBuild = vi.fn<
@@ -5715,6 +5715,7 @@ describe('EAS development builds', () => {
     }));
     const { run, calls, stdout } = harness({
       json: true,
+      slot,
       easProfile: 'development',
       resolveEasDevelopmentBuild,
       resolveDevClientScheme: () => 'exp+fixture',
@@ -5725,6 +5726,7 @@ describe('EAS development builds', () => {
     expect(resolveEasDevelopmentBuild).toHaveBeenCalledWith(
       expect.objectContaining({ platform: 'android', profile: 'development' }),
     );
+    expect(calls.ensureDevice[0]).toMatchObject(slot === 'default' ? {} : { slot });
     expect(calls.install[0]).toMatchObject({ apkPath: path, serial: 'emulator-5584' });
     expect(calls.launch[0]).toMatchObject({ metroPort: 8082, devClientScheme: 'exp+fixture' });
     expect(JSON.parse(stdout[0]!)).toMatchObject({

--- a/packages/stim-cli/src/__tests__/device-command.test.ts
+++ b/packages/stim-cli/src/__tests__/device-command.test.ts
@@ -491,12 +491,12 @@ describe('the command surface', () => {
 
     const lock = device.commands.find((command) => command.name() === 'lock');
     assert(lock);
-    expect(lock.options.map((option) => option.long).toSorted()).toEqual(['--for', '--json', '--wait']);
+    expect(lock.options.map((option) => option.long).toSorted()).toEqual(['--for', '--json', '--slot', '--wait']);
     expect(lock.usage()).toMatch(/<platform> \[id\]/);
 
     const unlock = device.commands.find((command) => command.name() === 'unlock');
     assert(unlock);
-    expect(unlock.options.map((option) => option.long)).toEqual(['--json']);
+    expect(unlock.options.map((option) => option.long)).toEqual(['--slot', '--json']);
     expect(unlock.usage()).toMatch(/\[platform\]/);
   });
 

--- a/packages/stim-cli/src/__tests__/engine-app-install.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-app-install.test.ts
@@ -2629,3 +2629,24 @@ test('a simulator install timeout fails before dev-client preparation and gives 
   expect(exec.options[0]).toEqual({ timeoutMs: 300000, killSignal: 'SIGKILL' });
   expect(exec.calls.some((args) => args.includes('defaults'))).toBe(false);
 });
+
+test.each(['default', 'phone'])('slot %s cannot borrow a sibling or unattributed bundle success', async (slot) => {
+  const clock = fakeClock();
+  const result = await verifyLaunch({
+    slot,
+    since: clock.at(),
+    timeoutMs: 100,
+    pollMs: 25,
+    stabilityMs: 0,
+    now: clock.now,
+    sleep: clock.sleep,
+    readRecords: () => [
+      { ts: clock.at(), event: 'bundle_build_done' },
+      { ts: clock.at(), event: 'bundle_build_done', slot: 'tablet' },
+    ],
+    readDeviceRecords: () => [],
+    readClientRecords: () => [],
+  });
+  expect(result.verified).toBe(false);
+  expect(result.timedOut).toBe(true);
+});

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1,3 +1,4 @@
+import { deviceSlotPlatforms } from '../device-slots.ts';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1796,38 +1797,44 @@ describe('ensureOwnedDevice: android', () => {
     }
   });
 
-  test('same-label workspaces receive distinct owned AVDs without touching the existing owner', async () => {
-    const other = projectDir();
-    const root = projectDir();
-    try {
-      setDevice(other, 'android', { avdName: 'stim-app', consolePort: 5554, owned: true });
-      const existing = getProject(other)?.platforms?.android;
-      const { run, spawn, exec } = androidExecutor({ avds: ['stim-app'] });
-      setExecutor(exec);
-      const result = await ensureOwnedDevice({
-        platform: 'android',
-        project: getProject(root),
-        projectPath: root,
-        label: 'app',
-        settings: {},
-      });
-      expect(result.avdName).toMatch(/^stim-app-[a-f0-9]{8}$/);
-      expect(result.consolePort).toBe(5556);
-      expect(getProject(root)?.platforms?.android).toMatchObject({
-        avdName: result.avdName,
-        owned: true,
-      });
-      expect(getProject(other)?.platforms?.android).toEqual(existing);
-      expect(run.filter((cmd) => /create avd/.test(cmd))).toHaveLength(1);
-      expect(run.some((cmd) => /delete avd| -s emulator-5554 /.test(cmd))).toBe(false);
-      expect(spawn).toHaveLength(1);
-      expect(spawn[0]?.args).toContain(result.avdName);
-      expect(spawn[0]?.args).not.toContain('stim-app');
-    } finally {
-      rmSync(other, { recursive: true, force: true });
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+  test.each([false, true])(
+    'AVD name collisions preserve the existing owner (same workspace: %s)',
+    async (sameWorkspace) => {
+      const root = projectDir();
+      const other = sameWorkspace ? root : projectDir();
+      const existingName = sameWorkspace ? 'stim-app-PHONE' : 'stim-app';
+      const slot = sameWorkspace ? 'phone' : 'default';
+      try {
+        setDevice(other, 'android', { avdName: existingName, consolePort: 5554, owned: true });
+        const existing = getProject(other)?.platforms?.android;
+        const { run, spawn, exec } = androidExecutor({ avds: [existingName] });
+        setExecutor(exec);
+        const result = await ensureOwnedDevice({
+          platform: 'android',
+          slot,
+          project: getProject(root),
+          projectPath: root,
+          label: 'app',
+          settings: {},
+        });
+        expect(result.avdName).toMatch(sameWorkspace ? /^stim-app-phone-[a-f0-9]{8}$/ : /^stim-app-[a-f0-9]{8}$/);
+        expect(result.consolePort).toBe(5556);
+        expect(deviceSlotPlatforms(getProject(root), slot)?.android).toMatchObject({
+          avdName: result.avdName,
+          owned: true,
+        });
+        expect(getProject(other)?.platforms?.android).toEqual(existing);
+        expect(run.filter((cmd) => /create avd/.test(cmd))).toHaveLength(1);
+        expect(run.some((cmd) => /delete avd| -s emulator-5554 /.test(cmd))).toBe(false);
+        expect(spawn).toHaveLength(1);
+        expect(spawn[0]?.args).toContain(result.avdName);
+        expect(spawn[0]?.args).not.toContain('stim-app');
+      } finally {
+        rmSync(other, { recursive: true, force: true });
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   test('an AVD claimed by another project during creation errors instead of being hijacked', async () => {
     const other = projectDir();
@@ -2258,4 +2265,55 @@ test('capacity counts named Android slots and only exempts the selected live slo
   };
   expect(deviceCapacityRefusal({ ...args, slot: 'phone' })).toBeNull();
   expect(deviceCapacityRefusal({ ...args, slot: 'tablet' })?.code).toBe('STIM_AT_CAPACITY');
+});
+
+test('identical simulator models have distinct slot assignments and reuse the selected slot', async () => {
+  const root = projectDir();
+  const { exec } = iosExecutor([]);
+  let next = 0;
+  setExecutor({
+    ...exec,
+    run(command) {
+      return command.includes('simctl create') ? `SLOT-${++next}` : exec.run(command);
+    },
+  });
+  try {
+    const devices = [];
+    for (const slot of ['default', 'phone', 'second-phone']) {
+      const device = await ensureOwnedDevice({
+        platform: 'ios',
+        projectPath: root,
+        project: getProject(root),
+        label: 'same',
+        settings: {},
+        slot,
+      });
+      await device.booting?.done;
+      devices.push(device);
+    }
+    expect(new Set(devices.map((device) => device.deviceUdid)).size).toBe(3);
+    expect(new Set(devices.map((device) => device.deviceName)).size).toBe(3);
+    const listed = devices.map((device) => ({
+      udid: device.deviceUdid!,
+      name: device.deviceName!,
+      state: 'Booted',
+      isAvailable: true,
+      deviceTypeIdentifier: TYPE_17_PRO.identifier,
+    }));
+    setExecutor(iosExecutor(listed).exec);
+    const repeated = await ensureOwnedDevice({
+      platform: 'ios',
+      projectPath: root,
+      project: getProject(root),
+      label: 'same',
+      settings: {},
+      slot: 'phone',
+    });
+    expect(repeated.deviceUdid).toBe(devices[1]!.deviceUdid);
+    expect(deviceSlotPlatforms(getProject(root), 'second-phone')?.ios?.deviceUdid).toBe(devices[2]!.deviceUdid);
+    expect(getProject(root)?.platforms?.ios?.deviceUdid).toBe(devices[0]!.deviceUdid);
+    expect(next).toBe(3);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -486,3 +486,11 @@ test('EAS guidance routes agents to the profile and preserves the paid-build aut
   expect(eas).toContain('npx eas-cli device:create');
   expect(eas).toMatch(/Registration, signing changes and cloud builds need session authorization/);
 });
+
+test('slot selection and shared Metro behavior are discoverable in operational guidance', () => {
+  expect(renderTopic('agent')).toContain('--slot <name>');
+  expect(renderSection('lifecycle', 'options')).toContain('--slot <name>');
+  expect(renderTopic('logs')).toContain('--slot <name>');
+  expect(renderTopic('cleanup')).toContain('stop --slot <name>');
+  expect(renderSection('lifecycle', 'options')).toContain('not a single-slot reload');
+});

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -5869,3 +5869,16 @@ describe('EAS development builds', () => {
     expect(resolveEasDevelopmentBuild).not.toHaveBeenCalled();
   });
 });
+
+test('a named iOS run scopes allocation, launch verification, collector and build records', async () => {
+  reserve();
+  const result = await run({ json: true, slot: 'tablet' });
+  expect(result.exitCode).toBe(null);
+  expect(parseFirst(result.logs).slot).toBe('tablet');
+  expect(result.calls.args.ensureOwnedDevice).toMatchObject({ slot: 'tablet' });
+  expect(result.calls.args.replaceCollector).toMatchObject({ slot: 'tablet' });
+  expect(result.calls.args.verifyLaunch).toMatchObject({ slot: 'tablet' });
+  const records = parseNdjsonText(readFileSync(join(workspaceLogsDir(root), 'build-ios:tablet.ndjson'), 'utf8'));
+  expect(records.length).toBeGreaterThan(0);
+  expect(records.every((record) => record.slot === 'tablet')).toBe(true);
+});

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -5785,7 +5785,7 @@ describe('EAS development builds', () => {
     for (const step of ['installIosDeviceApp', 'sealAppForDevice', 'buildIos']) expect(calls.order).not.toContain(step);
   });
 
-  test('installs the EAS artifact against the reserved Metro port without entering the local build pipeline', async () => {
+  test.each(['default', 'tablet'])('installs the EAS artifact in slot %s without a local build', async (slot) => {
     reserve();
     const path = join(root, 'Eas.app');
     const resolveEasDevelopmentBuild = vi.fn<NonNullable<IosDeps['resolveEasDevelopmentBuild']>>(async () => ({
@@ -5796,7 +5796,7 @@ describe('EAS development builds', () => {
       cacheHit: 'remote' as const,
     }));
     const { logs, calls } = await run(
-      { json: true, easProfile: 'development-simulator' },
+      { json: true, slot, easProfile: 'development-simulator' },
       {
         detectIsExpo: () => true,
         resolveEasDevelopmentBuild,
@@ -5807,6 +5807,7 @@ describe('EAS development builds', () => {
     expect(resolveEasDevelopmentBuild).toHaveBeenCalledWith(
       expect.objectContaining({ profile: 'development-simulator', platform: 'ios' }),
     );
+    expect(calls.args.ensureOwnedDevice).toMatchObject(slot === 'default' ? {} : { slot });
     expect(calls.args.installIosApp.appPath).toBe(path);
     expect(calls.args.launchIosApp).toMatchObject({ metroPort: 8082, devClientScheme: 'exp+fixture' });
     expect(parseFirst(logs)).toMatchObject({

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -993,10 +993,10 @@ describe('launch verification', () => {
     expect(text).not.toMatch(/NSBundle/);
   });
 
-  test('a launch that does not verify still prints every error it collected', async () => {
+  test.each(['default', 'phone'])('an unverified launch reports errors and its recovery slot (%s)', async (slot) => {
     reserve();
     const { errs, exitCode } = await run(
-      {},
+      { slot },
       {
         verifyLaunch: async () => ({
           fatal: true,
@@ -1008,7 +1008,7 @@ describe('launch verification', () => {
     );
     expect(exitCode).toBe(1);
     expect(errs.join('\n')).toMatch(/attention client lost event tag/);
-    expect(errs.join('\n')).toMatch(/run `stim ios` again.*Metro reload cannot restart an exited app/);
+    expect(errs.join('\n')).toContain(`run \`stim ios${slot === 'default' ? '' : ` --slot ${slot}`}\` again`);
     expect(errs.join('\n')).toContain('about a minute or longer');
     expect(errs.join('\n')).toContain('Run `stim logs --errors` again');
   });

--- a/packages/stim-cli/src/__tests__/logs-query.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-query.test.ts
@@ -584,3 +584,17 @@ describe('incremental tailing', () => {
     expect(r.state.offset).toBe(7);
   });
 });
+
+test('a sibling launch marker does not hide errors from the selected slot', () => {
+  writeLog('build-ios:phone.ndjson', [
+    { ts: 1, src: 'build', marker: true, slot: 'phone' },
+    { ts: 2, src: 'build', level: 'error', msg: 'phone failed', slot: 'phone' },
+  ]);
+  writeLog('build-ios:tablet.ndjson', [
+    { ts: 3, src: 'build', marker: true, slot: 'tablet' },
+    { ts: 4, src: 'build', level: 'error', msg: 'tablet failed', slot: 'tablet' },
+  ]);
+  expect(queryLogs({ dir, errorsOnly: true }).map((record) => record.msg)).toEqual(['phone failed', 'tablet failed']);
+  expect(queryLogs({ dir, slot: 'phone', errorsOnly: true }).map((record) => record.msg)).toEqual(['phone failed']);
+  expect(queryLogs({ dir, slot: 'tablet', errorsOnly: true }).map((record) => record.msg)).toEqual(['tablet failed']);
+});

--- a/packages/stim-cli/src/__tests__/reload-command.test.ts
+++ b/packages/stim-cli/src/__tests__/reload-command.test.ts
@@ -422,3 +422,21 @@ test('reload plain output reports a request and retains the target facts', async
   expect(lines[0]).toContain('8082');
   expect(lines[0]).toContain('stim logs --errors');
 });
+
+test('multiple live slots of the same platform use one platform reload', async () => {
+  const calls: unknown[] = [];
+  const result = await runReload({
+    root: '/project',
+    deps: reloadDeps({
+      getProject: () => ({ ...project, deviceSlots: { phone: { ios: { deviceUdid: 'U2', owned: true } } } }),
+      readLaunches: () => ({ ios: iosLaunch, 'ios:phone': { ...iosLaunch, deviceId: 'U2' } }),
+      resolveIos: (udid) => ({ sim: { udid, name: `stim-${udid}`, state: 'Booted' } }) as never,
+      reloadMetro: async (port, options) => {
+        calls.push([port, options]);
+        return { ok: true, peers: 2, targets: 2 };
+      },
+    }),
+  });
+  expect(result.ok).toBe(true);
+  expect(calls).toEqual([[8082, { role: 'ios', appId: iosLaunch.appId }]]);
+});

--- a/packages/stim-cli/src/__tests__/reload-command.test.ts
+++ b/packages/stim-cli/src/__tests__/reload-command.test.ts
@@ -440,3 +440,34 @@ test('multiple live slots of the same platform use one platform reload', async (
   expect(result.ok).toBe(true);
   expect(calls).toEqual([[8082, { role: 'ios', appId: iosLaunch.appId }]]);
 });
+
+test.each([true, false])(
+  'a default release or old-port launch does not block a Debug sibling (release: %s)',
+  async (release) => {
+    const result = await runReload({
+      root: '/project',
+      platform: 'ios',
+      deps: reloadDeps({
+        getProject: () => ({ ...project, deviceSlots: { phone: { ios: { deviceUdid: 'U2', owned: true } } } }),
+        readLaunches: () => ({
+          ios: { ...iosLaunch, release, metroPort: release ? null : 8083 },
+          'ios:phone': { ...iosLaunch, deviceId: 'U2' },
+        }),
+        resolveIos: (udid) => ({ sim: { udid, name: `stim-${udid}`, state: 'Booted' } }) as never,
+      }),
+    });
+    expect(result).toMatchObject({ ok: true, facts: { deviceId: 'U2', metroPort: 8082 } });
+  },
+);
+
+test('a stopped named slot keeps its slot in the reload recovery command', async () => {
+  const result = await runReload({
+    root: '/project',
+    deps: reloadDeps({
+      getProject: () => ({ ...project, deviceSlots: { phone: { ios: { deviceUdid: 'U1', owned: true } } } }),
+      readLaunches: () => ({ 'ios:phone': iosLaunch }),
+      iosProcess: () => null,
+    }),
+  });
+  expect(result).toMatchObject({ ok: false, error: { remedy: 'Run `stim ios --slot phone` to launch it.' } });
+});

--- a/packages/stim-cli/src/__tests__/sim-pool.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-pool.test.ts
@@ -89,7 +89,7 @@ test('selection is exact by model and runtime and oldest first', () => {
 });
 
 test('overflow eviction removes the oldest records regardless of insertion order', () => {
-  const third = { ...second, udid: 'THIRD', parkedAt: '2026-09-01T12:00:00.000Z' };
+  const third = { ...second, deviceTypeIdentifier: 'ipad-pro', udid: 'THIRD', parkedAt: '2026-09-01T12:00:00.000Z' };
   const result = evictOverflow([third, first, second], 1);
   expect(result.keep.map((record) => record.udid)).toEqual(['THIRD']);
   expect(result.evicted.map((record) => record.udid)).toEqual(['FIRST', 'SECOND']);
@@ -253,4 +253,14 @@ test('pool transfers refuse to overwrite or clear another device in the same slo
   ).toBeNull();
   expect(getProject(path)?.deviceSlots?.phone?.ios?.deviceUdid).toBe(second.udid);
   expect(readParked('ios')).toEqual([first]);
+});
+
+test('a rare tablet is evicted by later phone parking under the shared platform cap', () => {
+  const root = '/tmp/rare-model';
+  const tablet = { ...first, deviceTypeIdentifier: 'ipad-pro' };
+  upsertProject(root, {});
+  setDevice(root, 'ios', { owned: true, deviceUdid: tablet.udid }, 'tablet');
+  expect(parkSim({ platform: 'ios', projectPath: root, slot: 'tablet', record: tablet, max: 1 })).toEqual([]);
+  setDevice(root, 'ios', { owned: true, deviceUdid: second.udid }, 'phone');
+  expect(parkSim({ platform: 'ios', projectPath: root, slot: 'phone', record: second, max: 1 })).toEqual([tablet]);
 });

--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -1267,3 +1267,40 @@ test('stop visits all device slots and reports a named-slot failure without skip
   expect(result.outcomes.device['ios:tablet']?.status).toBe('shut-down');
   expect(result.outcomes.device['ios:external']?.status).toBe('skipped');
 });
+
+test('stopping a slot preserves sibling collectors, leases and the shared server', async () => {
+  const phone = { pid: 111, processToken: 'phone' };
+  const tablet = { pid: 222, processToken: 'tablet' };
+  writeFileSync(
+    workspaceStateFile(tmpRoot),
+    JSON.stringify({
+      collectors: { 'ios:phone': phone, 'ios:tablet': tablet },
+      supervisor: { pid: 333, processToken: 'metro' },
+    }),
+  );
+  takeLease({ root: tmpRoot, platform: 'ios', slot: 'phone', id: 'PHONE-HW', kind: 'declared', durationMs: 60000 });
+  takeLease({ root: tmpRoot, platform: 'ios', slot: 'tablet', id: 'TABLET-HW', kind: 'declared', durationMs: 60000 });
+  const { calls, opts } = seams({
+    root: tmpRoot,
+    project: {
+      metroPort: 8083,
+      platforms: { ios: { deviceUdid: 'DEFAULT', owned: true } },
+      deviceSlots: {
+        phone: { ios: { deviceUdid: 'PHONE', owned: true } },
+        tablet: { ios: { deviceUdid: 'TABLET', owned: true } },
+      },
+    },
+    collectors: undefined,
+    isAlive: () => true,
+  });
+  const result = await runStop({ ...opts, slot: 'phone' });
+  expect(result.ok).toBe(true);
+  expect(calls.collectorSignals).toEqual([111]);
+  expect(calls.teardowns.map((call) => ('udid' in call ? call.udid : call.avd))).toEqual(['PHONE']);
+  expect(calls.signals).toEqual([]);
+  expect(calls.freed).toEqual([]);
+  expect(readCollectorState(tmpRoot)).toEqual({ 'ios:tablet': tablet });
+  expect(readSupervisorState(tmpRoot)?.pid).toBe(333);
+  expect(listLeaseFiles().map((entry) => entry.id)).toEqual(['TABLET-HW']);
+  expect(result.outcomes.port).toMatchObject({ status: 'kept', port: 8083 });
+});

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -1,4 +1,6 @@
 import { isEasBuildFailure, resolveEasDevelopmentBuild } from '../engine/eas-build.ts';
+import { deviceSlotKey, validateDeviceSlot } from '../device-slots.ts';
+import { withWorkspaceProcessLock } from '../engine/workspace-process-lock.ts';
 import { parkedMaxSetting } from '../sim-pool.ts';
 import {
   resolveOptimizations,
@@ -218,6 +220,7 @@ export { formatDuration, phaseLine, shortHash } from '../command-output.ts';
 
 interface AndroidCommandOptions {
   easProfile?: string;
+  slot?: string;
   json?: boolean;
   metroCheck?: boolean;
   buildCache?: boolean;
@@ -274,6 +277,7 @@ export function registerAndroid(program: Command): void {
       '--eas-profile <name>',
       'Download a matching EAS development build; on a miss, print the build command without running it',
     )
+    .option('--slot <name>', 'Reusable device slot within this workspace (default: default)', validateDeviceSlot)
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
     .option(
       '--no-metro-check',
@@ -321,19 +325,26 @@ export function registerAndroid(program: Command): void {
         process.exit(1);
         return;
       }
-      const result = await runAndroid({
-        root,
-        json: Boolean(opts.json),
-        metroCheck: opts.metroCheck !== false,
-        useBuildCache: opts.buildCache !== false,
-        variant: opts.variant ?? null,
-        easProfile: opts.easProfile,
-        systemImage: opts.systemImage ?? null,
-        remoteDevice: opts.remote ?? null,
-        device: opts.device ?? null,
-        wait: opts.wait,
-        waitConflict: waitFlagConflict(process.argv),
-      });
+      const result = await withWorkspaceProcessLock(
+        workspaceDir(root),
+        'native-run',
+        () =>
+          runAndroid({
+            root,
+            slot: opts.slot,
+            easProfile: opts.easProfile,
+            json: Boolean(opts.json),
+            metroCheck: opts.metroCheck !== false,
+            useBuildCache: opts.buildCache !== false,
+            variant: opts.variant ?? null,
+            systemImage: opts.systemImage ?? null,
+            remoteDevice: opts.remote ?? null,
+            device: opts.device ?? null,
+            wait: opts.wait,
+            waitConflict: waitFlagConflict(process.argv),
+          }),
+        { external: true, waitMs: 30 * 60_000 },
+      );
       if (!result.ok) process.exit(1);
     });
 }
@@ -341,6 +352,7 @@ export function registerAndroid(program: Command): void {
 interface RunAndroidOptions {
   easProfile?: string;
   resolveEasDevelopmentBuild?: typeof resolveEasDevelopmentBuild;
+  slot?: string;
   root: string;
   json?: boolean;
   metroCheck?: boolean;
@@ -589,6 +601,22 @@ function resolveRunAndroidOptions(
   };
 }
 
+function androidSlotOptions(options: RunAndroidOptions) {
+  const base = resolveRunAndroidOptions(options);
+  const slot = validateDeviceSlot(options.slot);
+  if (slot === 'default') return base;
+  return {
+    ...base,
+    ensureDevice: (args: Parameters<typeof base.ensureDevice>[0]) => base.ensureDevice({ ...args, slot }),
+    checkCapacity: (args: Parameters<typeof base.checkCapacity>[0]) => base.checkCapacity({ ...args, slot }),
+    selectPool: (args: Parameters<typeof base.selectPool>[0]) => base.selectPool({ ...args, slot }),
+    acquireLease: (args: Parameters<typeof base.acquireLease>[0]) => base.acquireLease({ ...args, slot }),
+    makeRunLease: (args: Parameters<typeof base.makeRunLease>[0]) => base.makeRunLease({ ...args, slot }),
+    writeLaunch: ((projectRoot, platform, record) =>
+      base.writeLaunch(projectRoot, platform, record, slot)) as typeof base.writeLaunch,
+  };
+}
+
 export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOptions): Promise<RunAndroidResult> {
   let {
     root,
@@ -671,7 +699,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     now,
     out,
     emit,
-  } = resolveRunAndroidOptions(options);
+  } = androidSlotOptions(options);
+  const slot = validateDeviceSlot(options.slot);
   const started = now();
   const startedAt = new Date(started).toISOString();
   const projectProblem = appProjectProblem(root);
@@ -695,8 +724,8 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
     return { ok: false, error: { code, message, remedy } };
   }
   const logsDir = workspaceLogsDir(root);
-  const buildLog = join(logsDir, 'build-android.ndjson');
-  const writer = createWriter(buildLog, { truncate: true });
+  const buildLog = join(logsDir, `build-${deviceSlotKey('android', slot)}.ndjson`);
+  const writer = createWriter(buildLog, { truncate: true, fields: { slot } });
 
   const record: AndroidRecord = {
     fingerprint: null,
@@ -899,6 +928,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
 
   const remoteBackend = physical ? null : (commandRemoteBackend ?? remoteAndroidSetting(settings));
   const imageRefusal = systemImageRefusal({
+    slot,
     flag: systemImageFlag,
     resolved: systemImage,
     physical,
@@ -1715,6 +1745,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
 
     try {
       return await finishAndroidRun({
+        slot,
         lease: leaseHandle,
         releaseLease,
         root,

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -1,3 +1,5 @@
+import { launchSlotScope } from '../../engine/slot-launch.ts';
+import { deviceSlotPlatforms } from '../../device-slots.ts';
 import { resetAdoptedAvd, type resolveOwnedAvdSerial, type waitForBoot } from '../../sim/android.ts';
 import type { ChildProcess } from 'node:child_process';
 import { rmSync } from 'node:fs';
@@ -64,6 +66,7 @@ import { errorDiagnostics } from '../../error-diagnostics.ts';
 
 interface VerifyAndroidRunArgs {
   root: string;
+  slot?: string;
   release: boolean;
   remoteRelease: boolean;
   remoteDevice: boolean;
@@ -86,6 +89,7 @@ interface VerifyAndroidRunArgs {
 
 async function verifyAndroidRun({
   root,
+  slot,
   release,
   remoteRelease,
   remoteDevice,
@@ -109,7 +113,7 @@ async function verifyAndroidRun({
     remoteDevice
       ? []
       : captureNativeCrashes(
-          { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
+          { root, slot, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
           logsDir,
         );
   if (remoteRelease) {
@@ -160,6 +164,7 @@ async function verifyAndroidRun({
     ? await verifyLaunched({
         timeoutMs,
         requireBundleResponse: true,
+        slot: launchSlotScope(root, slot),
         onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,
@@ -292,6 +297,7 @@ interface FinishAndroidRunArgs {
   lease: RunLease | null;
   releaseLease: () => void;
   root: string;
+  slot?: string;
   json: boolean;
   metroCheck: boolean;
   useBuildCache: boolean;
@@ -350,6 +356,7 @@ interface FinishAndroidRunArgs {
 
 async function resolveInstallSerial({
   root,
+  slot,
   device,
   physical,
   remoteDevice,
@@ -359,7 +366,7 @@ async function resolveInstallSerial({
   phase,
 }: Pick<
   FinishAndroidRunArgs,
-  'root' | 'device' | 'physical' | 'remoteDevice' | 'resolveAvdSerial' | 'waitForDeviceBoot' | 'phase'
+  'root' | 'slot' | 'device' | 'physical' | 'remoteDevice' | 'resolveAvdSerial' | 'waitForDeviceBoot' | 'phase'
 > & { serial: string }): Promise<string> {
   if (physical || remoteDevice || !device.owned || !device.avdName) return serial;
   const resolved = resolveAvdSerial(device.avdName, { timeoutMs: 5000 });
@@ -382,10 +389,10 @@ async function resolveInstallSerial({
   }
   const consolePort = Number(resolved.serial.replace(/^emulator-/, ''));
   withConfigLock(() => {
-    const current = loadConfig()?.projects?.[root]?.platforms?.android;
+    const current = deviceSlotPlatforms(loadConfig()?.projects?.[root], slot)?.android;
     if (!current?.owned || current.avdName !== device.avdName)
       throw new Error('The owned emulator assignment changed before installation.');
-    if (current.consolePort !== consolePort) setDevice(root, PLATFORM, { ...current, consolePort });
+    if (current.consolePort !== consolePort) setDevice(root, PLATFORM, { ...current, consolePort }, slot);
   });
   return resolved.serial;
 }
@@ -394,6 +401,7 @@ export async function finishAndroidRun({
   lease,
   releaseLease,
   root,
+  slot,
   json,
   metroCheck,
   useBuildCache,
@@ -477,6 +485,7 @@ export async function finishAndroidRun({
   try {
     serial = await resolveInstallSerial({
       root,
+      slot,
       device,
       physical,
       remoteDevice,
@@ -550,7 +559,7 @@ export async function finishAndroidRun({
     try {
       withConfigLock(() => {
         const config = loadConfig();
-        const current = config?.projects?.[root]?.platforms?.android;
+        const current = deviceSlotPlatforms(config?.projects?.[root], slot)?.android;
         if (!config || !current || current.avdName !== device.avdName)
           throw new Error('The adopted emulator assignment changed during installation.');
         delete current.adoptionPending;
@@ -622,7 +631,7 @@ export async function finishAndroidRun({
       });
   if (launched.failed) {
     printNativeCrashReport(
-      { root, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
+      { root, slot, platform: 'android', deviceId: serial, appId: androidPackage, since: launchedAt },
       logsDir,
       (line) => phase('launch', chalk.red(line)),
       Boolean(remoteDevice),
@@ -689,6 +698,7 @@ export async function finishAndroidRun({
     if (physical) raiseLeaseFor(0, false);
     const collectorPid = await startCollector({
       root,
+      slot,
       serial,
       packageName: androidPackage,
       spawn,
@@ -703,6 +713,7 @@ export async function finishAndroidRun({
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const { state: launchState, warning: launchWarning } = await verifyAndroidRun({
     root,
+    slot,
     release,
     remoteRelease,
     remoteDevice: Boolean(remoteDevice),
@@ -738,6 +749,7 @@ export async function finishAndroidRun({
   releaseLease();
 
   const facts = reportAndroidResult({
+    slot,
     json,
     useBuildCache,
     variant,

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -1,4 +1,4 @@
-import { launchSlotScope } from '../../engine/slot-launch.ts';
+import { launchSlotScope, nativeRunCommand } from '../../engine/slot-launch.ts';
 import { deviceSlotPlatforms } from '../../device-slots.ts';
 import { resetAdoptedAvd, type resolveOwnedAvdSerial, type waitForBoot } from '../../sim/android.ts';
 import type { ChildProcess } from 'node:child_process';
@@ -109,6 +109,7 @@ async function verifyAndroidRun({
   component = null,
   phase,
 }: VerifyAndroidRunArgs): Promise<{ state: boolean | string; warning?: string }> {
+  const runCommand = nativeRunCommand('android', slot, { physical, deviceId: serial });
   const readNativeCrashes = () =>
     remoteDevice
       ? []
@@ -213,7 +214,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `Fix the crash, then restart the app: \`adb -s ${deviceShellArg(serial)} shell am force-stop ${deviceShellArg(androidPackage)}\`, then run \`stim android\` again. A crashed Android process can remain alive behind the system crash dialog; Metro reload cannot recover it.`,
+          `Fix the crash, then restart the app: \`adb -s ${deviceShellArg(serial)} shell am force-stop ${deviceShellArg(androidPackage)}\`, then run \`${runCommand}\` again. A crashed Android process can remain alive behind the system crash dialog; Metro reload cannot recover it.`,
         ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
@@ -223,7 +224,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`${runCommand}\` unless native inputs changed or the app process exits.`,
         ),
       );
     }
@@ -247,7 +248,7 @@ async function verifyAndroidRun({
       phase(
         'remedy',
         chalk.yellow(
-          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`stim android\` unless native inputs changed or the app process exits.`,
+          `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`${runCommand}\` unless native inputs changed or the app process exits.`,
         ),
       );
     }
@@ -469,11 +470,12 @@ export async function finishAndroidRun({
   };
 
   const booted = await bootPromise;
+  const runCommand = nativeRunCommand('android', slot, { physical, deviceId: booted.serial });
   if (booted.failed) {
     const diag = noDeviceDiagnostic({
       reason: booted.reason ?? 'The emulator did not boot.',
       logFile: emuLog,
-      remedy: 'Run `stim status` to see what Stim thinks it owns; re-running `stim android` creates a fresh owned AVD.',
+      remedy: `Run \`stim status\` to see what Stim thinks it owns; re-running \`${runCommand}\` creates a fresh owned AVD.`,
       localEmulator: !physical,
     });
     return fail(NO_DEVICE, diag.message, diag.remedy, {
@@ -498,7 +500,7 @@ export async function finishAndroidRun({
     return fail(
       NO_DEVICE,
       error instanceof Error ? error.message : String(error),
-      'Run `stim status` to inspect the owned AVD, then retry `stim android`; the APK was not installed.',
+      `Run \`stim status\` to inspect the owned AVD, then retry \`${runCommand}\`; the APK was not installed.`,
     );
   }
   phase(

--- a/packages/stim-cli/src/commands/android/result.ts
+++ b/packages/stim-cli/src/commands/android/result.ts
@@ -16,6 +16,7 @@ import type { RunRecorder } from '../../engine/stats.ts';
 import { writeWorkspaceState } from '../../supervisor/state.ts';
 
 export function androidFacts({
+  slot,
   serial,
   avdName = null,
   deviceName = null,
@@ -39,6 +40,7 @@ export function androidFacts({
   durationMs,
   lease,
 }: {
+  slot?: string;
   serial?: string | null;
   avdName?: string | null;
   deviceName?: string | null;
@@ -64,6 +66,7 @@ export function androidFacts({
 }): AndroidFacts {
   return {
     platform: PLATFORM,
+    ...(slot && slot !== 'default' ? { slot } : {}),
     serial: serial ?? null,
     avdName: avdName ?? null,
     deviceName: deviceName ?? avdName ?? null,
@@ -160,6 +163,7 @@ export async function finishAndroidUpload(
 }
 
 export interface ReportAndroidResultArgs {
+  slot?: string;
   lease?: { kind: string; expiresAt: string } | null;
   json: boolean;
   useBuildCache: boolean;
@@ -187,6 +191,7 @@ export interface ReportAndroidResultArgs {
 }
 
 export function reportAndroidResult({
+  slot,
   json,
   useBuildCache,
   variant,
@@ -214,6 +219,7 @@ export function reportAndroidResult({
 }: ReportAndroidResultArgs): AndroidFacts {
   recordRun({ failed: false, cacheHit: cacheLevel(record.cacheHit), waited: waitedForBuild, durationMs });
   const facts = androidFacts({
+    slot,
     serial,
     avdName: record.avdName,
     deviceName: record.deviceName,

--- a/packages/stim-cli/src/commands/android/support.ts
+++ b/packages/stim-cli/src/commands/android/support.ts
@@ -56,18 +56,26 @@ export function resolveSystemImage(
 }
 
 export function systemImageRefusal({
+  slot,
   flag,
   resolved,
   physical,
   remoteBackend,
   listImages,
 }: {
+  slot?: string;
   flag: string | null | undefined;
   resolved: string | null;
   physical: boolean;
   remoteBackend: string | null;
   listImages: typeof listInstalledSystemImages;
 }): { code: string; message: string; remedy: string } | null {
+  if (slot && slot !== 'default' && remoteBackend)
+    return {
+      code: 'STIM_BAD_ARG',
+      message: 'Named slots currently support local simulators and physical devices.',
+      remedy: 'Use the default slot for a remote session.',
+    };
   if (typeof flag === 'string' && flag.trim() === '') {
     return {
       code: 'STIM_BAD_ARG',

--- a/packages/stim-cli/src/commands/device.ts
+++ b/packages/stim-cli/src/commands/device.ts
@@ -1,3 +1,4 @@
+import { validateDeviceSlot } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { clockTime } from '../command-output.ts';
@@ -66,12 +67,14 @@ const DEFAULT_DEPS: DeviceDeps = {
 };
 
 interface LockOptions {
+  slot?: string;
   for?: string;
   wait?: string;
   json?: boolean;
 }
 
 interface UnlockOptions {
+  slot?: string;
   json?: boolean;
 }
 
@@ -83,6 +86,7 @@ export interface DeviceFailure {
 }
 
 export interface LockFacts {
+  slot?: string;
   platform: LeasePlatform;
   id: string;
   deviceName: string | null;
@@ -97,7 +101,7 @@ export function grantLine(facts: LockFacts, durationText: string): string {
   const device = facts.deviceName ? `${facts.deviceName} (${facts.id})` : facts.id;
   return (
     `locked ${device} for ${facts.holder} until ${clockTime(facts.expiresAt)} (${durationText}). ` +
-    `Renew: stim device lock ${facts.platform} --for ${durationText}. Release: stim device unlock.`
+    `Renew: stim device lock ${facts.platform}${facts.slot ? ` --slot ${facts.slot}` : ''} --for ${durationText}. Release: stim device unlock${facts.slot ? ` --slot ${facts.slot}` : ''}.`
   );
 }
 
@@ -145,9 +149,11 @@ async function poolDevice(
   deadline: number,
   root: string,
   d: DeviceDeps,
+  slot?: string,
 ): Promise<ResolvedDevice | DeviceFailure> {
   const isEmulator = memoizeEmulatorProbe(d.probeEmulatorSerial);
   const pooled = await d.selectFromPool({
+    ...(slot ? { slot } : {}),
     root,
     platform,
     idLabel,
@@ -249,11 +255,12 @@ export async function runLock(
 
   const device = idArg
     ? resolveDevice(platform, idArg, d)
-    : await poolDevice(platform, idLabel, wait.seconds, deadline, root, d);
+    : await poolDevice(platform, idLabel, wait.seconds, deadline, root, d, opts.slot);
   if (isFailure(device)) return report(device);
 
   for (;;) {
     const outcome = await d.waitForDevice({
+      ...(opts.slot ? { slot: opts.slot } : {}),
       root,
       platform,
       id: device.id,
@@ -272,6 +279,7 @@ export async function runLock(
 
     const taken = d.takeLease(
       {
+        ...(opts.slot ? { slot: opts.slot } : {}),
         root,
         platform,
         id: device.id,
@@ -292,6 +300,7 @@ export async function runLock(
     if (taken.status === 'held') continue;
 
     const facts: LockFacts = {
+      ...(taken.lease.slot ? { slot: taken.lease.slot } : {}),
       platform,
       id: taken.lease.id,
       deviceName: taken.lease.deviceName,
@@ -339,7 +348,7 @@ export async function runUnlock(
     });
   }
 
-  const released = d.releaseLeases(root, { platform }, d.io);
+  const released = d.releaseLeases(root, { platform, ...(opts.slot ? { slot: opts.slot } : {}) }, d.io);
   if (released.length === 0) {
     d.note(
       chalk.dim(
@@ -374,6 +383,7 @@ export function registerDevice(program: Command, deps: Partial<DeviceDeps> = {})
       '--wait <seconds>',
       'How long to wait for a device another workspace holds, before refusing with STIM_DEVICE_BUSY (default 60, 0 refuses at once)',
     )
+    .option('--slot <name>', 'Use this workspace device slot', validateDeviceSlot)
     .option('--json', 'print the lease as JSON on stdout')
     .action(async (platform: string, id: string | undefined, opts: LockOptions) => {
       const result = await runLock(platform, id, opts, deps);
@@ -384,6 +394,7 @@ export function registerDevice(program: Command, deps: Partial<DeviceDeps> = {})
     .command('unlock')
     .argument('[platform]', 'ios or android; without one, every lease this workspace holds is released')
     .description('Release the device lease or leases this workspace holds. Releasing nothing is not an error.')
+    .option('--slot <name>', 'Use this workspace device slot', validateDeviceSlot)
     .option('--json', 'print the released leases as JSON on stdout')
     .action(async (platform: string | undefined, opts: UnlockOptions) => {
       const result = await runUnlock(platform, opts, deps);

--- a/packages/stim-cli/src/commands/ios.ts
+++ b/packages/stim-cli/src/commands/ios.ts
@@ -1,5 +1,8 @@
 import { easDeviceBuildRemedy, isEasBuildFailure } from '../engine/eas-build.ts';
+import { deviceSlotKey, validateDeviceSlot } from '../device-slots.ts';
+import { withWorkspaceProcessLock } from '../engine/workspace-process-lock.ts';
 import { rmSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   resolveOptimizations,
   artifactCachePolicy,
@@ -163,6 +166,7 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
       '--eas-profile <name>',
       'Download a matching EAS development build; on a miss, print the build command without running it',
     )
+    .option('--slot <name>', 'Reusable device slot within this workspace (default: default)', validateDeviceSlot)
     .option('--json', 'Emit the facts as a single JSON line on stdout; every other line goes to stderr')
     .option(
       '--scheme <name>',
@@ -212,7 +216,11 @@ export function registerIos(program: Command, deps: Partial<IosDeps> = {}): void
       "Install on a phone another workspace leases instead of waiting: this run takes no lease and, when both workspaces build the same app id, the install terminates the holder's running app. Only with --device.",
     )
     .action(async (opts: IosCommandOptions) => {
-      await runIos({ ...opts, waitConflict: waitFlagConflict(process.argv) }, deps);
+      const root = (deps.findProjectRoot ?? DEFAULT_DEPS.findProjectRoot)(process.cwd());
+      const run = () => runIos({ ...opts, waitConflict: waitFlagConflict(process.argv) }, deps);
+      if (!root) await run();
+      else
+        await withWorkspaceProcessLock(workspaceDir(root), 'native-run', run, { external: true, waitMs: 30 * 60_000 });
     });
 }
 
@@ -231,8 +239,35 @@ function explicitSchemeRefusal(root: string, scheme: string | undefined, isExpo:
   return d.resolveScheme(project, { scheme }).error ?? null;
 }
 
+function iosSlotLogFile(root: string, slot: string): string {
+  return slot === 'default'
+    ? buildLogFile(root)
+    : join(workspaceLogsDir(root), `build-${deviceSlotKey('ios', slot)}.ndjson`);
+}
+
+function iosSlotDeps(d: IosDeps, slot: string): IosDeps {
+  if (slot !== 'default') {
+    const base = d;
+    d = {
+      ...base,
+      ensureOwnedDevice: (args) => base.ensureOwnedDevice({ ...args, slot }),
+      checkDeviceCapacity: (args) => base.checkDeviceCapacity({ ...args, slot }),
+      selectFromPool: (args) => base.selectFromPool({ ...args, slot }),
+      acquireRunLease: (args) => base.acquireRunLease({ ...args, slot }),
+      runLease: (args) => base.runLease({ ...args, slot }),
+      replaceCollector: (args) => base.replaceCollector({ ...args, slot }),
+      stopPreviousCollector: (args) => base.stopPreviousCollector({ ...args, slot }),
+      clearIosAdoptionPending: (root) => base.clearIosAdoptionPending(root, slot),
+      writeWorkspaceLaunch: (root, platform, record) => base.writeWorkspaceLaunch(root, platform, record, slot),
+      createWriter: (file, options) => base.createWriter(file, { ...options, fields: { slot } }),
+    };
+  }
+  return d;
+}
+
 async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> = {}): Promise<IosFacts | null> {
-  let d: typeof DEFAULT_DEPS = { ...DEFAULT_DEPS, ...overrides };
+  const slot = validateDeviceSlot(opts.slot);
+  let d = iosSlotDeps({ ...DEFAULT_DEPS, ...overrides }, slot);
   const json = Boolean(opts.json);
   const metroCheck = opts.metroCheck !== false;
   let useBuildCache = opts.buildCache !== false;
@@ -280,7 +315,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   }
 
   const logsDir = workspaceLogsDir(root);
-  const logFile = buildLogFile(root);
+  const logFile = iosSlotLogFile(root, slot);
   let writer = null as NdjsonWriter | null;
   const logWriter = () => (writer ||= d.createWriter(logFile, { truncate: true }));
 
@@ -483,6 +518,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
   if (schemeRefusal) return fail(schemeRefusal);
   const remoteBackend = physical ? null : (opts.remote ?? remoteIosSetting(settings));
   const modelRefusal = deviceModelRefusal({
+    slot,
     deviceTypeFlag: opts.deviceType,
     runtimeFlag: opts.runtime,
     deviceType,
@@ -1426,6 +1462,7 @@ async function runIos(opts: IosCommandOptions = {}, overrides: Partial<IosDeps> 
 
     try {
       return await finishIosRun({
+        slot,
         d,
         root,
         json,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -1,3 +1,4 @@
+import { launchSlotScope } from '../../engine/slot-launch.ts';
 import { basename } from 'node:path';
 import { rmSync } from 'node:fs';
 import chalk from 'chalk';
@@ -53,6 +54,7 @@ import { errorDiagnostics } from '../../error-diagnostics.ts';
 
 interface VerifyIosRunArgs {
   root: string;
+  slot?: string;
   appPath: string | null;
   d: IosDeps;
   release: boolean;
@@ -92,6 +94,7 @@ function missingCrashReportHint({
 
 async function verifyIosRun({
   root,
+  slot,
   appPath,
   d,
   release,
@@ -118,7 +121,7 @@ async function verifyIosRun({
     remoteDevice
       ? []
       : captureNativeCrashes(
-          { root, platform: 'ios', deviceId: udid, appId: bundleId, since: launchedAt, appPath, physical },
+          { root, slot, platform: 'ios', deviceId: udid, appId: bundleId, since: launchedAt, appPath, physical },
           logsDir,
         );
   const deviceProcess = (): boolean | null => {
@@ -176,6 +179,7 @@ async function verifyIosRun({
   const verification: VerifyLaunchResultLike = metroCheck
     ? await d.verifyLaunch({
         requireBundleResponse: true,
+        slot: launchSlotScope(root, slot),
         onReadinessPending: () => phase('readiness', 'waiting for app readiness (up to 30s after bundle load)'),
         logsDir,
         since: launchedAt,
@@ -332,6 +336,7 @@ function reportLaunchErrors(errors: LaunchErrorRecord[], note: (line: string) =>
 interface FinishIosRunArgs {
   d: IosDeps;
   root: string;
+  slot?: string;
   json: boolean;
   release: boolean;
   configuration: string | null;
@@ -379,6 +384,7 @@ interface FinishIosRunArgs {
 function cleanAdoptedIosApps({
   d,
   root,
+  slot,
   udid,
   bundleId,
   phase,
@@ -386,6 +392,7 @@ function cleanAdoptedIosApps({
 }: {
   d: IosDeps;
   root: string;
+  slot?: string;
   udid: string;
   bundleId: string | null;
   phase: (name: unknown, text: string) => void;
@@ -396,7 +403,7 @@ function cleanAdoptedIosApps({
     phase('install', `removed ${swept.removed.join(', ')}, left by the previous workspace`);
   }
   if (swept.listed && swept.failed.length === 0) {
-    d.clearIosAdoptionPending(root);
+    d.clearIosAdoptionPending(root, slot);
     return null;
   }
   if (!swept.listed) return 'Could not list apps left by the previous workspace.';
@@ -444,6 +451,7 @@ function recordIosReloadTarget({
 }: {
   d: IosDeps;
   root: string;
+  slot?: string;
   physical: boolean;
   remoteDevice: boolean;
   bundleId: string;
@@ -477,6 +485,7 @@ function simulatorLaunchFailureRemedy(remote: boolean, udid: string, bundleId: s
 export async function finishIosRun({
   d,
   root,
+  slot,
   json,
   release,
   configuration,
@@ -608,6 +617,7 @@ export async function finishIosRun({
     });
     const collector = await d.replaceCollector({
       root,
+      slot,
       udid,
       bundleId: bundleId!,
       appName,
@@ -628,7 +638,10 @@ export async function finishIosRun({
       bundleId: bundleId!,
       appName: appName ?? bundleId!,
       collectorPid: collector.pid,
-      readRecords: () => readCollectorRecords(logsDir).filter((entry) => Number(entry.ts) >= launchedAt),
+      readRecords: () =>
+        readCollectorRecords(logsDir).filter(
+          (entry) => Number(entry.ts) >= launchedAt && (entry.slot ?? 'default') === (slot ?? 'default'),
+        ),
     });
     if (started.failed || !started.pid) {
       return fail({
@@ -697,7 +710,8 @@ export async function finishIosRun({
 
     dropSwapDir();
 
-    if (!remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
+    if (!remoteDevice)
+      await d.replaceCollector({ root, slot, udid, bundleId: bundleId!, appName, appExecutable, note });
     const launchTimer = stepTimer(d.now);
     launchedAt = d.now();
     logWriter().write({
@@ -726,7 +740,7 @@ export async function finishIosRun({
     });
     if (launched?.failed) {
       printNativeCrashReport(
-        { root, platform: 'ios', deviceId: udid, appId: bundleId!, since: launchedAt, appPath },
+        { root, slot, platform: 'ios', deviceId: udid, appId: bundleId!, since: launchedAt, appPath },
         logsDir,
         (line) => note(chalk.red(phaseLine('launch', line))),
         Boolean(remoteDevice),
@@ -744,6 +758,7 @@ export async function finishIosRun({
   recordIosReloadTarget({
     d,
     root,
+    slot,
     physical,
     remoteDevice: Boolean(remoteDevice),
     bundleId: bundleId!,
@@ -764,11 +779,12 @@ export async function finishIosRun({
         (launched?.mode === 'openurl' || launched?.mode === 'payload-url' ? ' (expo-dev-client)' : ''),
   });
 
-  if (remoteDevice) await d.replaceCollector({ root, udid, bundleId: bundleId!, appName, appExecutable, note });
+  if (remoteDevice) await d.replaceCollector({ root, slot, udid, bundleId: bundleId!, appName, appExecutable, note });
 
   if (physical) raiseLeaseFor(release ? RELEASE_VERIFY_WAIT_MS : DEBUG_VERIFY_STEP_MS, false);
   const { state: launchState, warning: launchWarning } = await verifyIosRun({
     root,
+    slot,
     appPath,
     d,
     release,
@@ -814,6 +830,7 @@ export async function finishIosRun({
   const facts = reportIosResult({
     d,
     root,
+    slot,
     json,
     release,
     configuration,

--- a/packages/stim-cli/src/commands/ios/launch.ts
+++ b/packages/stim-cli/src/commands/ios/launch.ts
@@ -1,4 +1,4 @@
-import { launchSlotScope } from '../../engine/slot-launch.ts';
+import { launchSlotScope, nativeRunCommand } from '../../engine/slot-launch.ts';
 import { basename } from 'node:path';
 import { rmSync } from 'node:fs';
 import chalk from 'chalk';
@@ -117,6 +117,7 @@ async function verifyIosRun({
   remoteDevice,
   metroOrigin,
 }: VerifyIosRunArgs): Promise<{ state: boolean | string; warning?: string }> {
+  const runCommand = nativeRunCommand('ios', slot, { physical, deviceId: udid });
   const readNativeCrashes = () =>
     remoteDevice
       ? []
@@ -229,7 +230,10 @@ async function verifyIosRun({
     if (nativeFatal || verification.processAlive === false) {
       note(
         chalk.yellow(
-          phaseLine('remedy', 'Fix the crash, then run `stim ios` again. A Metro reload cannot restart an exited app.'),
+          phaseLine(
+            'remedy',
+            `Fix the crash, then run \`${runCommand}\` again. A Metro reload cannot restart an exited app.`,
+          ),
         ),
       );
     } else if (verification.processAlive === true && metroPort !== null) {
@@ -243,7 +247,7 @@ async function verifyIosRun({
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. ${deliveryFailed ? 'Check the Metro logs and device connection, then' : 'Fix the JavaScript or TypeScript error, then'} ${reloadRemedy} Do not run \`${runCommand}\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );
@@ -268,7 +272,7 @@ async function verifyIosRun({
         chalk.yellow(
           phaseLine(
             'remedy',
-            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`stim ios\` unless native inputs changed or the app process exits.`,
+            `The native app is still running. Fix the JavaScript or TypeScript error; Fast Refresh should apply the edit. If the error screen remains, ${reloadRemedy} Do not run \`${runCommand}\` unless native inputs changed or the app process exits.`,
           ),
         ),
       );
@@ -529,6 +533,7 @@ export async function finishIosRun({
   releaseLease,
   recordRun,
 }: FinishIosRunArgs): Promise<IosFacts | null> {
+  const runCommand = nativeRunCommand('ios', slot, { physical, deviceId: udid });
   let bundleId = initialBundleId;
   let leaseWarned = false;
   const raiseLeaseFor = (boundMs: number, beforeInstall: boolean): FailArgs | null => {
@@ -562,7 +567,7 @@ export async function finishIosRun({
     return fail({
       code: booted?.code || 'STIM_NO_DEVICE',
       message: booted?.reason || 'The owned simulator could not be booted.',
-      remedy: booted?.remedy || 'Run `stim ios` again to re-establish an owned simulator for this workspace.',
+      remedy: booted?.remedy || `Run \`${runCommand}\` again to re-establish an owned simulator for this workspace.`,
     });
   }
   const deviceOutcome = physical ? 'connected' : `${device?.adopted ? 'adopted' : 'booted'} ${bootDuration()}`;
@@ -669,7 +674,7 @@ export async function finishIosRun({
         return fail({
           code: 'STIM_INSTALL_FAILED',
           message: `${cleanupFailure} Stim kept the adoption cleanup pending and did not install or launch the app.`,
-          remedy: 'Run `stim ios` again after simulator tooling is responsive.',
+          remedy: `Run \`${runCommand}\` again after simulator tooling is responsive.`,
           build: { ...buildFailure, appPath, bundleId },
         });
       }

--- a/packages/stim-cli/src/commands/ios/result.ts
+++ b/packages/stim-cli/src/commands/ios/result.ts
@@ -56,6 +56,7 @@ export function lastBuildRecord({
 }
 
 export function iosFacts({
+  slot,
   udid,
   deviceName,
   deviceType = null,
@@ -78,6 +79,7 @@ export function iosFacts({
   webPreviewUrl = null,
   lease,
 }: {
+  slot?: string;
   udid: string;
   deviceName?: string | null;
   deviceType?: string | null;
@@ -102,6 +104,7 @@ export function iosFacts({
 }): IosFacts {
   return {
     platform: PLATFORM,
+    ...(slot && slot !== 'default' ? { slot } : {}),
     udid,
     deviceName: deviceName ?? null,
     deviceType: deviceType ?? null,
@@ -168,6 +171,7 @@ export async function finishIosUpload(
 }
 
 export interface ReportIosResultArgs {
+  slot?: string;
   d: IosDeps;
   root: string;
   json: boolean;
@@ -201,6 +205,7 @@ export interface ReportIosResultArgs {
 }
 
 export function reportIosResult({
+  slot,
   d,
   root,
   json,
@@ -252,6 +257,7 @@ export function reportIosResult({
   closeWriter();
 
   const facts = iosFacts({
+    slot,
     udid,
     deviceName: device?.deviceName ?? null,
     deviceType: device?.deviceType,

--- a/packages/stim-cli/src/commands/ios/support.ts
+++ b/packages/stim-cli/src/commands/ios/support.ts
@@ -71,6 +71,7 @@ export function resolveRuntime(
 }
 
 export function deviceModelRefusal({
+  slot,
   deviceTypeFlag,
   runtimeFlag,
   deviceType,
@@ -79,6 +80,7 @@ export function deviceModelRefusal({
   remoteBackend,
   listRuntimes,
 }: {
+  slot?: string;
   deviceTypeFlag: string | undefined;
   runtimeFlag: string | undefined;
   deviceType: string | null;
@@ -87,6 +89,12 @@ export function deviceModelRefusal({
   remoteBackend: RemoteDeviceBackend | null;
   listRuntimes: typeof listIosRuntimes;
 }): { code: string; message: string; remedy: string } | null {
+  if (slot && slot !== 'default' && remoteBackend)
+    return {
+      code: 'STIM_BAD_ARG',
+      message: 'Named slots currently support local simulators and physical devices.',
+      remedy: 'Use the default slot for a remote session.',
+    };
   if (typeof deviceTypeFlag === 'string' && deviceTypeFlag.trim() === '') {
     return {
       code: 'STIM_BAD_ARG',

--- a/packages/stim-cli/src/commands/ios/types.ts
+++ b/packages/stim-cli/src/commands/ios/types.ts
@@ -66,6 +66,7 @@ export interface VerifyLaunchResultLike {
 }
 
 export interface IosCommandOptions {
+  slot?: string;
   json?: boolean;
   metroCheck?: boolean;
   buildCache?: boolean;

--- a/packages/stim-cli/src/commands/logs.ts
+++ b/packages/stim-cli/src/commands/logs.ts
@@ -1,3 +1,4 @@
+import { validateDeviceSlot } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { ChalkInstance } from 'chalk';
 import type { Command } from 'commander';
@@ -108,6 +109,7 @@ const LEVEL_COLOURS: Record<string, ChalkInstance> = {
 };
 
 interface LogsOptions {
+  slot?: string;
   source?: string | string[];
   level?: string;
   since?: string;
@@ -124,6 +126,7 @@ export default function logsCommand(program: Command): void {
     .description(
       "Query this workspace's merged NDJSON log timeline (bundler, client, device, build). Prints and exits; nothing matching is a successful, empty result. Use --follow to stream.",
     )
+    .option('--slot <name>', 'Only records attributed to this device slot', validateDeviceSlot)
     .option('--source <s...>', 'Only these sources: metro, client, device, build, or all')
     .option('--level <l>', `Minimum level: ${LEVELS.join(', ')}`)
     .option('--since <d>', 'Only records newer than this, e.g. 30s, 5m, 2h')
@@ -175,6 +178,7 @@ export default function logsCommand(program: Command): void {
       }
 
       const query = {
+        slot: opts.slot,
         dir,
         sources,
         minLevel,
@@ -239,6 +243,7 @@ export default function logsCommand(program: Command): void {
       }
 
       const criteria = buildCriteria({
+        slot: opts.slot,
         sources,
         minLevel,
         since: opts.since,

--- a/packages/stim-cli/src/commands/reload.ts
+++ b/packages/stim-cli/src/commands/reload.ts
@@ -1,3 +1,4 @@
+import { nativeRunCommand } from '../engine/slot-launch.ts';
 import { deviceSlotPlatforms, parseDeviceSlotKey } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { Command } from 'commander';
@@ -36,6 +37,7 @@ interface ReloadFailure {
 type ReloadResult = { ok: true; facts: ReloadFacts } | { ok: false; error: ReloadFailure };
 
 interface LiveTarget {
+  slot: string;
   platform: ReloadPlatform;
   record: WorkspaceLaunchRecord;
   deviceName: string;
@@ -78,7 +80,12 @@ function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function processFailure(platform: ReloadPlatform, record: WorkspaceLaunchRecord, d: ReloadDeps): ReloadFailure | null {
+function processFailure(
+  platform: ReloadPlatform,
+  record: WorkspaceLaunchRecord,
+  d: ReloadDeps,
+  slot = 'default',
+): ReloadFailure | null {
   const process =
     platform === 'ios' ? d.iosProcess(record.deviceId, record.appId) : d.androidProcess(record.deviceId, record.appId);
   if (process === undefined) {
@@ -96,7 +103,7 @@ function processFailure(platform: ReloadPlatform, record: WorkspaceLaunchRecord,
     return failure(
       'STIM_RELOAD_STOPPED',
       `${record.appId} is not running on ${record.deviceId}.`,
-      `Run \`stim ${platform}\` to launch it.`,
+      `Run \`${nativeRunCommand(platform, slot)}\` to launch it.`,
     );
   }
   return null;
@@ -107,7 +114,9 @@ function inspectTarget(
   record: WorkspaceLaunchRecord,
   project: ProjectRecord,
   d: ReloadDeps,
+  slot = 'default',
 ): LiveTarget | TargetFailure {
+  const runCommand = nativeRunCommand(platform, slot);
   if (platform === 'ios') {
     const configured = project.platforms?.ios;
     if (!configured?.owned || configured.deviceUdid !== record.deviceId) {
@@ -116,7 +125,7 @@ function inspectTarget(
         error: failure(
           'STIM_RELOAD_UNOWNED',
           `The recorded iOS launch on ${record.deviceId} is not this workspace's current owned simulator.`,
-          "Run `stim ios` to launch the app on this workspace's owned simulator.",
+          `Run \`${runCommand}\` to launch the app on this workspace's owned simulator.`,
         ),
       };
     }
@@ -139,13 +148,13 @@ function inspectTarget(
         error: failure(
           'STIM_RELOAD_STOPPED',
           `The recorded iOS app is not running on a booted owned simulator.`,
-          'Run `stim ios` to boot, install, and launch it.',
+          `Run \`${runCommand}\` to boot, install, and launch it.`,
         ),
       };
     }
-    const stopped = processFailure(platform, record, d);
+    const stopped = processFailure(platform, record, d, slot);
     if (stopped) return { platform, error: stopped };
-    return { platform, record, deviceName: resolved.sim.name };
+    return { platform, slot, record, deviceName: resolved.sim.name };
   }
 
   const configured = project.platforms?.android;
@@ -155,7 +164,7 @@ function inspectTarget(
       error: failure(
         'STIM_RELOAD_UNOWNED',
         `The recorded Android launch on ${record.deviceId} is not this workspace's current owned emulator.`,
-        "Run `stim android` to launch the app on this workspace's owned emulator.",
+        `Run \`${runCommand}\` to launch the app on this workspace's owned emulator.`,
       ),
     };
   }
@@ -178,13 +187,13 @@ function inspectTarget(
       error: failure(
         'STIM_RELOAD_STOPPED',
         `The recorded Android app is not running on this workspace's owned emulator.`,
-        'Run `stim android` to boot, install, and launch it.',
+        `Run \`${runCommand}\` to boot, install, and launch it.`,
       ),
     };
   }
-  const stopped = processFailure(platform, record, d);
+  const stopped = processFailure(platform, record, d, slot);
   if (stopped) return { platform, error: stopped };
-  return { platform, record, deviceName: configured.avdName };
+  return { platform, slot, record, deviceName: configured.avdName };
 }
 
 function isTargetFailure(value: LiveTarget | TargetFailure): value is TargetFailure {
@@ -213,7 +222,13 @@ export async function runReload({
     const parsed = parseDeviceSlotKey(key);
     if (!parsed || (platform && parsed.platform !== platform)) return [];
     return [
-      inspectTarget(parsed.platform, record, { ...project, platforms: deviceSlotPlatforms(project, parsed.slot) }, d),
+      inspectTarget(
+        parsed.platform,
+        record,
+        { ...project, platforms: deviceSlotPlatforms(project, parsed.slot) },
+        d,
+        parsed.slot,
+      ),
     ];
   });
   const live = inspected.filter((target): target is LiveTarget => !isTargetFailure(target));
@@ -242,14 +257,15 @@ export async function runReload({
     };
   }
 
-  const target = live[0]!;
+  const target =
+    live.find((candidate) => !candidate.record.release && candidate.record.metroPort === project.metroPort) ?? live[0]!;
   if (target.record.release) {
     return {
       ok: false,
       error: failure(
         'STIM_RELOAD_RELEASE',
         `${target.record.appId} was launched with an embedded release bundle.`,
-        `Run \`stim ${target.platform}\` with a Debug configuration or variant before reloading JavaScript.`,
+        `Run \`${nativeRunCommand(target.platform, target.slot)}\` with a Debug configuration or variant before reloading JavaScript.`,
       ),
     };
   }
@@ -275,12 +291,12 @@ export async function runReload({
       ),
     };
   }
-  const stopped = processFailure(target.platform, target.record, d);
+  const stopped = processFailure(target.platform, target.record, d, target.slot);
   if (stopped) return { ok: false, error: stopped };
 
   const reloaded = await d.reloadMetro(port, { role: target.platform, appId: target.record.appId });
   if (!reloaded.ok) {
-    const stoppedAfterMetro = processFailure(target.platform, target.record, d);
+    const stoppedAfterMetro = processFailure(target.platform, target.record, d, target.slot);
     if (stoppedAfterMetro) return { ok: false, error: stoppedAfterMetro };
     const snapshot = `agent-device snapshot -i --platform ${target.platform} --${target.platform === 'ios' ? 'udid' : 'serial'} ${target.record.deviceId}`;
     const relaunch = `agent-device open ${target.record.appId} --platform ${target.platform} --${target.platform === 'ios' ? 'udid' : 'serial'} ${target.record.deviceId} --metro-port ${port} --relaunch`;

--- a/packages/stim-cli/src/commands/reload.ts
+++ b/packages/stim-cli/src/commands/reload.ts
@@ -1,3 +1,4 @@
+import { deviceSlotPlatforms, parseDeviceSlotKey } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { phaseLine } from '../command-output.ts';
@@ -208,14 +209,16 @@ export async function runReload({
     };
   }
   const launches = d.readLaunches(root);
-  const platforms: ReloadPlatform[] = platform ? [platform] : ['ios', 'android'];
-  const inspected = platforms.flatMap((candidate) => {
-    const record = launches[candidate];
-    return record ? [inspectTarget(candidate, record, project, d)] : [];
+  const inspected = Object.entries(launches).flatMap(([key, record]) => {
+    const parsed = parseDeviceSlotKey(key);
+    if (!parsed || (platform && parsed.platform !== platform)) return [];
+    return [
+      inspectTarget(parsed.platform, record, { ...project, platforms: deviceSlotPlatforms(project, parsed.slot) }, d),
+    ];
   });
   const live = inspected.filter((target): target is LiveTarget => !isTargetFailure(target));
 
-  if (live.length > 1) {
+  if (new Set(live.map((target) => target.platform)).size > 1) {
     return {
       ok: false,
       error: failure(

--- a/packages/stim-cli/src/commands/status.ts
+++ b/packages/stim-cli/src/commands/status.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from '../device-slots.ts';
 import chalk from 'chalk';
 import { existsSync } from 'fs';
 import { totalmem } from 'os';
@@ -91,6 +92,16 @@ export default function statusCommand(program: Command): void {
               metro: metro as unknown as MetroFacts | null,
               worktrees: worktrees as unknown as WorktreeFacts[],
               simsAvailable,
+              androidRuntimes: Object.fromEntries(
+                projectDeviceSlots(proj)
+                  .slice(1)
+                  .map(({ slot, platforms }) => [
+                    slot,
+                    platforms.android?.owned && platforms.android.avdName
+                      ? readAndroidRuntime(platforms.android.avdName)
+                      : null,
+                  ]),
+              ),
               androidRuntime:
                 proj.platforms?.android?.owned && proj.platforms.android.avdName
                   ? readAndroidRuntime(proj.platforms.android.avdName)
@@ -176,20 +187,30 @@ export default function statusCommand(program: Command): void {
           const errs = n > 0 ? chalk.yellow(` (${n} error${n === 1 ? '' : 's'} since the last marker)`) : '';
           console.log(chalk.dim(`  logs: ${state.logs.dir}`) + errs);
         }
-        if (state.ios) {
-          const booted =
-            state.ios.state === 'Booted' ? chalk.green('booted') : chalk.dim(state.ios.state.toLowerCase());
-          const owned = state.ios.owned ? chalk.dim(' (owned)') : '';
-          console.log(`  ios: ${chalk.cyan(state.ios.name ?? state.ios.udid)} ${booted}${owned}`);
-        }
-        if (state.android) {
-          const kind = state.android.physical ? chalk.dim('(physical)') : chalk.dim('(emulator)');
-          const observed = state.android.state
-            ? ` ${state.android.state}${state.android.serial ? ` (${state.android.serial})` : ''}`
-            : '';
-          console.log(
-            `  android: ${chalk.cyan(state.android.name)} ${kind}${observed}${state.android.owned ? chalk.dim(' (owned)') : ''}`,
-          );
+        for (const deviceState of [
+          { slot: 'default', ios: state.ios, android: state.android },
+          ...(state.slots ?? []),
+        ]) {
+          const slotLabel = deviceState.slot === 'default' ? '' : ` [${deviceState.slot}]`;
+          if (deviceState.ios) {
+            const booted =
+              deviceState.ios.state === 'Booted'
+                ? chalk.green('booted')
+                : chalk.dim(deviceState.ios.state.toLowerCase());
+            const owned = deviceState.ios.owned ? chalk.dim(' (owned)') : '';
+            console.log(
+              `  ios${slotLabel}: ${chalk.cyan(deviceState.ios.name ?? deviceState.ios.udid)} ${booted}${owned}`,
+            );
+          }
+          if (deviceState.android) {
+            const kind = deviceState.android.physical ? chalk.dim('(physical)') : chalk.dim('(emulator)');
+            const observed = deviceState.android.state
+              ? ` ${deviceState.android.state}${deviceState.android.serial ? ` (${deviceState.android.serial})` : ''}`
+              : '';
+            console.log(
+              `  android${slotLabel}: ${chalk.cyan(deviceState.android.name)} ${kind}${observed}${deviceState.android.owned ? chalk.dim(' (owned)') : ''}`,
+            );
+          }
         }
         for (const w of state.warnings) console.log(chalk.yellow(`  ! ${w}`));
       }

--- a/packages/stim-cli/src/commands/stop.ts
+++ b/packages/stim-cli/src/commands/stop.ts
@@ -1,4 +1,6 @@
-import { projectDeviceSlots } from '../device-slots.ts';
+import { withWorkspaceProcessLock } from '../engine/workspace-process-lock.ts';
+import { workspaceDir } from '../paths.ts';
+import { deviceSlotPlatforms, parseDeviceSlotKey, projectDeviceSlots, validateDeviceSlot } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { phaseLine, plural, releasedLeaseFact } from '../command-output.ts';
@@ -209,7 +211,52 @@ function defaultTeardownRemoteSession(
   return endRecordedSession({ root, sessionId, easBin: resolveEasCliBin(root)?.file ?? null });
 }
 
-export async function runStop({
+type StopArgs = Parameters<typeof stopWorkspace>[0];
+
+export async function runStop(options: StopArgs & { slot?: string }): ReturnType<typeof stopWorkspace> {
+  if (options.slot === undefined) return stopWorkspace(options);
+  const slot = validateDeviceSlot(options.slot);
+  const root = options.root;
+  const project = options.project === undefined ? getProject(root) : options.project;
+  const records = options.collectors === undefined ? readCollectorState(root) : options.collectors;
+  const collectors = Object.fromEntries(
+    Object.entries(records ?? {}).filter(([key]) => parseDeviceSlotKey(key)?.slot === slot),
+  );
+  const result = await stopWorkspace({
+    ...options,
+    project: project
+      ? {
+          ...project,
+          platforms: deviceSlotPlatforms(project, slot),
+          deviceSlots: undefined,
+          supervisor: undefined,
+          metroPort: null,
+        }
+      : null,
+    state: null,
+    collectors,
+    remoteDevice: null,
+    metroTunnel: null,
+    clearCollectors: (projectRoot, expected) =>
+      withWorkspaceStateLock(projectRoot, () => {
+        clearCollectorState(projectRoot, expected);
+        return !Object.keys(readCollectorState(projectRoot)).some((key) => parseDeviceSlotKey(key)?.slot === slot);
+      }),
+    clearState: () => true,
+    clearRegistration: async () => true,
+    releaseLeases: (projectRoot) => releaseWorkspaceLeases(projectRoot, { slot }),
+  });
+  result.outcomes.port = {
+    status: 'kept',
+    port: project?.metroPort ?? null,
+    reason: 'The workspace server is shared by all slots.',
+  };
+  result.outcomes.metro = { status: 'skipped', reason: 'The workspace server is shared by all slots.' };
+  result.summary = summarize(root, result.outcomes, result.ok);
+  return result;
+}
+
+async function stopWorkspace({
   root,
   project = undefined,
   state = undefined,
@@ -739,6 +786,7 @@ async function defaultClearRegistration(root: string, expected?: ProcessRecord |
 }
 
 interface StopOptions {
+  slot?: string;
   json?: boolean;
 }
 
@@ -748,6 +796,7 @@ export default function stopCommand(program: Command): void {
     .description(
       "The inverse of `start`: halt this workspace's supervisor, shut the owned device down (never deleted), and free the reserved port. Non-destructive -- the device stays assigned, so coming back costs a boot. Acts on the current workspace.",
     )
+    .option('--slot <name>', 'Stop only this device slot, keeping the shared server running', validateDeviceSlot)
     .option('--json', 'print the per-step outcomes as JSON')
     .action(async (opts: StopOptions) => {
       const root = findProjectRoot(process.cwd());
@@ -756,7 +805,12 @@ export default function stopCommand(program: Command): void {
         process.exit(1);
       }
 
-      const { ok, outcomes, summary } = await runStop({ root });
+      const { ok, outcomes, summary } = await withWorkspaceProcessLock(
+        workspaceDir(root),
+        'native-run',
+        () => runStop({ root, slot: opts.slot }),
+        { external: true, waitMs: 30 * 60_000 },
+      );
 
       if (opts.json) {
         console.log(JSON.stringify({ root, ok, ...outcomes }));

--- a/packages/stim-cli/src/device-slots.ts
+++ b/packages/stim-cli/src/device-slots.ts
@@ -2,7 +2,7 @@ import type { DeviceRecord, PlatformRecords, ProjectRecord } from './types.ts';
 
 const DEFAULT_DEVICE_SLOT = 'default';
 
-export function validateDeviceSlot(slot: string): string {
+export function validateDeviceSlot(slot: string = 'default'): string {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(slot) || ['constructor', 'prototype', '__proto__'].includes(slot)) {
     const error = new Error(
       'A device slot must be 1-64 letters, digits, underscores or hyphens, starting with a letter or digit.',

--- a/packages/stim-cli/src/engine/app-install.ts
+++ b/packages/stim-cli/src/engine/app-install.ts
@@ -831,6 +831,7 @@ function nativeLaunchFailure({
 }
 
 export async function verifyLaunch({
+  slot,
   logsDir,
   since,
   metroPort = null,
@@ -849,6 +850,7 @@ export async function verifyLaunch({
   now = Date.now,
   sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
 }: {
+  slot?: string;
   logsDir?: string;
   since?: number | string;
   metroPort?: number | string | null;
@@ -881,12 +883,18 @@ export async function verifyLaunch({
   let runtimeStartedAt: number | null = null;
   let nextCrashCheck = startedAt + 1000;
   while (true) {
-    const metroRecords = read().filter((record) => after(record, since));
+    const metroRecords = read().filter(
+      (record) => after(record, since) && (slot === undefined || record.slot === slot),
+    );
     const bundleRecords = metroRecords.filter(
       (record) => !requireBundleResponse || String(record.event).startsWith('bundle_response_'),
     );
-    const deviceRecords = readDevice().filter((record) => after(record, since));
-    const clientRecords = readClient().filter((record) => after(record, since));
+    const deviceRecords = readDevice().filter(
+      (record) => after(record, since) && (slot === undefined || (record.slot ?? 'default') === slot),
+    );
+    const clientRecords = readClient().filter(
+      (record) => after(record, since) && (slot === undefined || record.slot === slot),
+    );
     if (now() >= nextCrashCheck) {
       nextCrashCheck = now() + 2000;
       const crash = nativeLaunchFailure({

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -145,6 +145,7 @@ export async function ensureOwnedDevice({
   platform,
   project,
   projectPath,
+  slot,
   settingsRoot = projectPath,
   label = ownedDeviceLabel(projectPath),
   settings,
@@ -160,6 +161,7 @@ export async function ensureOwnedDevice({
   platform: string;
   project?: ProjectRecord | null;
   projectPath: string;
+  slot?: string;
   settingsRoot?: string;
   label?: string;
   settings: DeviceSettings;
@@ -170,11 +172,13 @@ export async function ensureOwnedDevice({
   teardownAvd?: typeof teardownOwnedAvd;
   reconcileIosSimulator?: typeof reconcileSimSlim;
 } & EmulatorLogging): Promise<OwnedDeviceRecord> {
-  const record = (project?.platforms?.[platform] as OwnedDeviceRecord | undefined) ?? null;
+  if (slot && slot !== 'default') label = `${label}-${slot}`;
+  const record = (deviceSlotPlatforms(project, slot)?.[platform] as OwnedDeviceRecord | undefined) ?? null;
   if (platform === 'ios') {
     return ensureOwnedIosDevice({
       record,
       projectPath,
+      slot,
       settingsRoot,
       label,
       settings,
@@ -187,6 +191,7 @@ export async function ensureOwnedDevice({
   return ensureOwnedAndroidDevice({
     record,
     projectPath,
+    slot,
     settingsRoot,
     label,
     settings,
@@ -203,6 +208,7 @@ export async function ensureOwnedDevice({
 async function ensureOwnedIosDevice({
   record,
   projectPath,
+  slot,
   settingsRoot,
   label,
   settings,
@@ -213,6 +219,7 @@ async function ensureOwnedIosDevice({
 }: {
   record: OwnedDeviceRecord | null;
   projectPath: string;
+  slot?: string;
   settingsRoot: string;
   label: string;
   settings: DeviceSettings;
@@ -264,6 +271,7 @@ async function ensureOwnedIosDevice({
           return configureOwnedIosSim({
             record: updated,
             projectPath,
+            slot,
             profile: simslimProfile,
             out,
             reconcileIosSimulator,
@@ -298,12 +306,12 @@ async function ensureOwnedIosDevice({
       }
     }
     withConfigLock(() => {
-      const current = loadConfig()?.projects?.[projectPath]?.platforms?.ios;
+      const current = deviceSlotPlatforms(loadConfig()?.projects?.[projectPath], slot)?.ios;
       if (!current) return;
       if (current.deviceUdid !== record.deviceUdid || current.owned !== record.owned) {
         throw new Error('The simulator assignment changed during recovery. Run `stim ios` again.');
       }
-      clearDevice(projectPath, 'ios');
+      clearDevice(projectPath, 'ios', slot);
     });
   }
 
@@ -314,7 +322,7 @@ async function ensureOwnedIosDevice({
 
   const adopted =
     parkedMaxSetting('ios').max > 0
-      ? await withIosDeviceNameLock(() => takeParkedIosSim({ projectPath, label, choice, out }))
+      ? await withIosDeviceNameLock(() => takeParkedIosSim({ projectPath, slot, label, choice, out }))
       : null;
   if (adopted) {
     out(chalk.dim(phaseLine('device', `booting ${adopted.deviceName} (${adopted.deviceUdid})`)));
@@ -323,6 +331,7 @@ async function ensureOwnedIosDevice({
       await configureOwnedIosSim({
         record: adopted,
         projectPath,
+        slot,
         profile: simslimProfile,
         out,
         reconcileIosSimulator,
@@ -334,7 +343,7 @@ async function ensureOwnedIosDevice({
   const created = await withIosDeviceNameLock(() => {
     const suffix = ownedIosNameSuffix(label, { model: choice.deviceType, runtime: choice.runtime }, projectPath);
     const result = createOwnedIosSim(label, { suffix }, choice);
-    setDevice(projectPath, 'ios', { deviceUdid: result.udid, owned: true, deviceName: result.name });
+    setDevice(projectPath, 'ios', { deviceUdid: result.udid, owned: true, deviceName: result.name }, slot);
     return result;
   });
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
@@ -342,6 +351,7 @@ async function ensureOwnedIosDevice({
     configureOwnedIosSim({
       record: newRecord,
       projectPath,
+      slot,
       profile: simslimProfile,
       out,
       reconcileIosSimulator,
@@ -403,11 +413,13 @@ type AdoptedRecord = OwnedDeviceRecord & { deviceUdid: string; deviceName: strin
 
 function takeParkedIosSim({
   projectPath,
+  slot,
   label,
   choice,
   out,
 }: {
   projectPath: string;
+  slot?: string;
   label: string;
   choice: IosCreationChoice;
   out: Notify;
@@ -463,7 +475,7 @@ function takeParkedIosSim({
       ...(parked.simslimManaged ? { simslimManaged: true } : {}),
       ...(parked.cacheKey ? { parkedCacheKey: parked.cacheKey } : {}),
     };
-    if (!adoptParked({ platform: 'ios', projectPath, udid: parked.udid, device })) continue;
+    if (!adoptParked({ platform: 'ios', projectPath, slot, udid: parked.udid, device })) continue;
     try {
       renameIosSim(parked.udid, name);
     } catch {}
@@ -472,10 +484,10 @@ function takeParkedIosSim({
   return null;
 }
 
-export function clearIosAdoptionPending(projectPath: string): void {
+export function clearIosAdoptionPending(projectPath: string, slot = 'default'): void {
   withConfigLock(() => {
     const cfg = loadConfig();
-    const ios = cfg?.projects?.[projectPath]?.platforms?.ios;
+    const ios = deviceSlotPlatforms(cfg?.projects?.[projectPath], slot)?.ios;
     if (!cfg || !ios?.adoptionPending) return;
     delete ios.adopted;
     delete ios.adoptionPending;
@@ -487,12 +499,14 @@ export function clearIosAdoptionPending(projectPath: string): void {
 async function configureOwnedIosSim({
   record,
   projectPath,
+  slot,
   profile,
   out,
   reconcileIosSimulator,
 }: {
   record: OwnedDeviceRecord & { deviceUdid: string };
   projectPath: string;
+  slot?: string;
   profile: string | null;
   out: Notify;
   reconcileIosSimulator: typeof reconcileSimSlim;
@@ -504,7 +518,7 @@ async function configureOwnedIosSim({
   const previouslyManaged = Boolean(record.simslimManaged);
   if (profile && !record.simslimManaged) {
     const pending = { ...record, simslimManaged: true };
-    setDevice(projectPath, 'ios', pending);
+    setDevice(projectPath, 'ios', pending, slot);
     record = pending;
   }
   const result = await reconcileIosSimulator({
@@ -516,15 +530,21 @@ async function configureOwnedIosSim({
   const updated = { ...record };
   if (result.managed) updated.simslimManaged = true;
   else delete updated.simslimManaged;
-  setDevice(projectPath, 'ios', updated);
+  setDevice(projectPath, 'ios', updated, slot);
   return updated;
 }
 
-function findOtherProjectOwningAvd(avdName: string, projectPath: string): string | null {
+function findOtherProjectOwningAvd(avdName: string, projectPath: string, selectedSlot = 'default'): string | null {
   const cfg = loadConfig();
   for (const [path, proj] of Object.entries(cfg?.projects || {})) {
-    if (path === projectPath) continue;
-    if (projectDeviceSlots(proj).some(({ platforms }) => platforms.android?.avdName === avdName)) return path;
+    if (
+      projectDeviceSlots(proj).some(
+        ({ slot, platforms }) =>
+          (path !== projectPath || slot !== selectedSlot) &&
+          platforms.android?.avdName?.toLowerCase() === avdName.toLowerCase(),
+      )
+    )
+      return path;
   }
   return null;
 }
@@ -541,6 +561,7 @@ export class AvdRecoveryError extends Error {
 async function ensureOwnedAndroidDevice({
   record,
   projectPath,
+  slot,
   settingsRoot,
   label,
   settings,
@@ -554,6 +575,7 @@ async function ensureOwnedAndroidDevice({
 }: {
   record: OwnedDeviceRecord | null;
   projectPath: string;
+  slot?: string;
   settingsRoot: string;
   label: string;
   settings: DeviceSettings;
@@ -572,7 +594,7 @@ async function ensureOwnedAndroidDevice({
         `Owned AVD ${record.avdName} has incomplete setup and could not be deleted (${cleanup.reason || cleanup.status}). Fix the cause, then retry; Stim kept the device record for cleanup.`,
       );
     }
-    clearDevice(projectPath, 'android');
+    clearDevice(projectPath, 'android', slot);
     record = null;
   }
   if (record?.avdName) {
@@ -601,7 +623,7 @@ async function ensureOwnedAndroidDevice({
           owned: true,
           deviceName: record.deviceName ?? record.avdName,
         };
-        setDevice(projectPath, 'android', updated);
+        setDevice(projectPath, 'android', updated, slot);
         return { ...updated, systemImage: ownedAvdSystemImage(record.avdName) };
       } else if (!resolved.missing) {
         out(
@@ -614,6 +636,7 @@ async function ensureOwnedAndroidDevice({
             avdName: record.avdName,
             metadata: record,
             projectPath,
+            slot,
             deviceName: record.deviceName,
             out,
             logFile,
@@ -688,11 +711,12 @@ async function ensureOwnedAndroidDevice({
         poolConfiguration: configuration,
         adoptionPending: true,
       };
-      if (!adoptParked({ platform: 'android', projectPath, udid: parked.udid, device: adopted })) continue;
+      if (!adoptParked({ platform: 'android', projectPath, slot, udid: parked.udid, device: adopted })) continue;
       return {
         ...(await bootOwnedAvdOnFreshPort({
           avdName: parked.name,
           projectPath,
+          slot,
           metadata: adopted,
           out,
           logFile,
@@ -707,23 +731,28 @@ async function ensureOwnedAndroidDevice({
   let fresh = false;
   try {
     created = withConfigLock(() => {
-      const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
+      const current = deviceSlotPlatforms(loadConfig()?.projects?.[projectPath], slot)?.android;
       if (current?.avdName && current.avdName !== record?.avdName) {
         throw new Error(`Another Stim run assigned AVD ${current.avdName} to this workspace. Retry to use it.`);
       }
       if (
         readParked('android').some((entry) => entry.name === ownedAvdName(label)) ||
-        findOtherProjectOwningAvd(ownedAvdName(label), projectPath)
+        findOtherProjectOwningAvd(ownedAvdName(label), projectPath, slot)
       )
         label = `${label}-${randomUUID().slice(0, 8)}`;
       const result = createOwnedAvd(label, { systemImage: flags.systemImage || settings.android?.systemImage });
-      setDevice(projectPath, 'android', {
-        avdName: result.avdName,
-        owned: true,
-        deviceName: result.avdName,
-        setupIncomplete: true,
-        poolConfiguration: configuration,
-      });
+      setDevice(
+        projectPath,
+        'android',
+        {
+          avdName: result.avdName,
+          owned: true,
+          deviceName: result.avdName,
+          setupIncomplete: true,
+          poolConfiguration: configuration,
+        },
+        slot,
+      );
       return result;
     });
     fresh = true;
@@ -743,14 +772,14 @@ async function ensureOwnedAndroidDevice({
           if (readParked('android').some((entry) => entry.name === avdName)) {
             throw new Error(`AVD ${avdName} was parked by another Stim run. Retry to adopt it safely.`, { cause: e });
           }
-          const owner = findOtherProjectOwningAvd(avdName, projectPath);
+          const owner = findOtherProjectOwningAvd(avdName, projectPath, slot);
           if (owner) {
             throw new Error(
               `AVD ${avdName} already exists and is owned by another project (${owner}). Retry to allocate a distinct owned emulator.`,
               { cause: e },
             );
           }
-          const current = loadConfig()?.projects?.[projectPath]?.platforms?.android;
+          const current = deviceSlotPlatforms(loadConfig()?.projects?.[projectPath], slot)?.android;
           if (current?.avdName) {
             const state = current.setupIncomplete ? 'has incomplete setup' : 'was registered';
             throw new Error(
@@ -774,7 +803,7 @@ async function ensureOwnedAndroidDevice({
             deviceName: avdName,
             ...(resolved.serial ? { consolePort: Number(resolved.serial.replace(/^emulator-/, '')) } : {}),
           };
-          setDevice(projectPath, 'android', recovered);
+          setDevice(projectPath, 'android', recovered, slot);
           return { ...recovered, systemImage: ownedAvdSystemImage(avdName), serial: resolved.serial };
         });
       } catch (error) {
@@ -800,7 +829,7 @@ async function ensureOwnedAndroidDevice({
     } catch (error) {
       const cleanup = teardownAvd(created.avdName, { del: true, owner: { projectPath } });
       const kept = cleanup.status === 'failed' || cleanup.status === 'skipped';
-      if (!kept) clearDevice(projectPath, 'android');
+      if (!kept) clearDevice(projectPath, 'android', slot);
       const orphan = kept
         ? ` The owned AVD remains tracked for cleanup (${cleanup.reason || cleanup.status}); fix the cause, then retry or run \`stim gc --delete\`.`
         : '';
@@ -815,6 +844,7 @@ async function ensureOwnedAndroidDevice({
       avdName: created.avdName,
       metadata: fresh ? { poolConfiguration: configuration } : undefined,
       projectPath,
+      slot,
       deviceName: created.avdName,
       out,
       logFile,
@@ -836,11 +866,19 @@ export interface AndroidConsolePortClaim {
 export function claimAndroidConsolePort(
   {
     projectPath,
+    slot,
     avdName,
     deviceName,
     livePorts = [],
     metadata,
-  }: { projectPath: string; avdName: string; deviceName?: string; livePorts?: number[]; metadata?: OwnedDeviceRecord },
+  }: {
+    projectPath: string;
+    slot?: string;
+    avdName: string;
+    deviceName?: string;
+    livePorts?: number[];
+    metadata?: OwnedDeviceRecord;
+  },
   {
     lock = withConfigLock,
     recordedPorts = () => allConsolePortsAndSerials().androidConsolePorts,
@@ -861,7 +899,7 @@ export function claimAndroidConsolePort(
       owned: true,
       deviceName: deviceName ?? avdName,
     };
-    record(projectPath, 'android', claim);
+    record(projectPath, 'android', claim, slot);
     return claim;
   });
 }
@@ -878,6 +916,7 @@ async function bootOwnedAvdOnFreshPort({
   avdName,
   metadata,
   projectPath,
+  slot,
   deviceName,
   out,
   logFile = null,
@@ -886,11 +925,13 @@ async function bootOwnedAvdOnFreshPort({
   avdName: string;
   metadata?: OwnedDeviceRecord;
   projectPath: string;
+  slot?: string;
   deviceName?: string;
   out: Notify;
 } & EmulatorLogging): Promise<OwnedDeviceRecord> {
   const claim = claimAndroidConsolePort({
     projectPath,
+    slot,
     avdName,
     deviceName,
     livePorts: liveAndroidConsolePorts(),
@@ -914,7 +955,7 @@ async function bootOwnedAvdOnFreshPort({
     }
     return { ...claim, serial };
   } catch (error) {
-    releaseAndroidConsolePort(projectPath, claim.consolePort);
+    releaseAndroidConsolePort(projectPath, claim.consolePort, slot);
     throw error;
   }
 }

--- a/packages/stim-cli/src/engine/slot-launch.ts
+++ b/packages/stim-cli/src/engine/slot-launch.ts
@@ -1,0 +1,12 @@
+import { fileLeaseIo } from './device-lease.ts';
+import { getProject } from '../config.ts';
+import { readWorkspaceState } from '../supervisor/state.ts';
+
+export function launchSlotScope(root: string, slot = 'default'): string | undefined {
+  if (slot !== 'default') return slot;
+  if (Object.keys(getProject(root)?.deviceSlots ?? {}).length) return slot;
+  const state = readWorkspaceState(root);
+  if (Object.keys({ ...state?.collectors, ...fileLeaseIo.readHolder(root) }).some((key) => key.includes(':')))
+    return slot;
+  return undefined;
+}

--- a/packages/stim-cli/src/engine/slot-launch.ts
+++ b/packages/stim-cli/src/engine/slot-launch.ts
@@ -1,3 +1,4 @@
+import { deviceShellArg } from './app-install.ts';
 import { fileLeaseIo } from './device-lease.ts';
 import { getProject } from '../config.ts';
 import { readWorkspaceState } from '../supervisor/state.ts';
@@ -9,4 +10,12 @@ export function launchSlotScope(root: string, slot = 'default'): string | undefi
   if (Object.keys({ ...state?.collectors, ...fileLeaseIo.readHolder(root) }).some((key) => key.includes(':')))
     return slot;
   return undefined;
+}
+
+export function nativeRunCommand(
+  platform: 'ios' | 'android',
+  slot = 'default',
+  { physical, deviceId }: { physical?: boolean; deviceId?: string } = {},
+): string {
+  return `stim ${platform}${slot === 'default' ? '' : ` --slot ${slot}`}${physical && deviceId ? ` --device ${deviceShellArg(deviceId)}` : ''}`;
 }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -26,6 +26,15 @@ branch that is not the default one -- only once the repository has at least
 one linked worktree, so read it from inside the worktree. A single-checkout
 session is never told that its own branch is a problem.
 
+MULTIPLE DEVICES
+
+Use ios/android --slot <name> to retain multiple devices in one workspace,
+including several of the same model. Reuse the same slot name on subsequent
+runs. Read guide lifecycle options for the complete slot workflow. Use the
+reported device ID for UI interaction. All slots share Metro; reload can reach
+multiple devices, and a shared bundle request does not prove a slot launched.
+Use stop --slot <name> for one slot, or plain stop for the whole workspace.
+
 NORMAL WORKFLOW
 
 Work in the current checkout by default. When the task needs another branch or

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -2,7 +2,16 @@ import type { GuideTopic } from './types.ts';
 
 const cleanup: GuideTopic = {
   summary: 'Where simulators come from, and how they get reclaimed',
-  preamble: () => `CLEANUP AND DISK
+  preamble: () => `DEVICE SLOTS
+
+Cleanup enumerates every slot. stop --slot <name> keeps the shared server and
+other slots; plain stop and worktree remove handle the whole workspace.
+An upgrade retains existing device assignments as the default slot. Do not
+wipe state to upgrade: it records ownership needed for safe teardown. Use the
+same slot-aware CLI for all commands while named assignments exist; older
+versions cannot reliably manage their assignments.
+
+CLEANUP AND DISK
 
 WHAT RECLAIMS AN OWNED DEVICE
   stim worktree remove    parks eligible owned simulators and emulators

--- a/packages/stim-cli/src/guide/facts.ts
+++ b/packages/stim-cli/src/guide/facts.ts
@@ -3,7 +3,13 @@ import type { GuideTopic } from './types.ts';
 const facts: GuideTopic = {
   summary:
     'The --json payloads: `start`, `ios`, `android`, `reload`, `stop`, `status`, `doctor`, `device lock`/`unlock`, and the error contract',
-  preamble: () => `FACTS CONTRACT
+  preamble: () => `SLOTS
+Named ios/android runs add slot to their JSON facts. Default-run fields remain
+compatible. status adds a slots array per environment with each named slot's
+ios/android device facts; top-level ios/android still describe default.
+Named collector, lease-holder, and launch keys use platform:slot internally.
+
+FACTS CONTRACT
 
 \`start\`, \`ios\`, \`android\`, \`reload\`, \`stop\`, \`status\`, \`stats\`, \`doctor\`,
 and \`device lock\`/\`device unlock\` each print exactly ONE line of JSON on

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -932,19 +932,51 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
         'every flag per command, Android variants and flavors, the per-run simulator model, runtime and system image',
       body: () => `THE OPTION SURFACE, IN FULL
   start           --json --wait <seconds> --remote --reset-cache
-  ios             --json --no-metro-check --no-build-cache --scheme <name> --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
-  android         --json --no-metro-check --no-build-cache --variant <name> --system-image <id> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
+  ios             --slot <name> --json --no-metro-check --no-build-cache --scheme <name> --configuration <name> --device-type <name> --runtime <version> --device [udid] --wait <seconds> --no-wait --remote <proxy|eas>
+  android         --slot <name> --json --no-metro-check --no-build-cache --variant <name> --system-image <id> --device [serial] --wait <seconds> --no-wait --remote <proxy|eas>
   reload          [ios|android] --json
-  device          lock <ios|android> [id] --for <duration> --wait <seconds> --json;
-                  unlock [ios|android] --json
-  logs            --source --level --since --grep --tail --follow --errors --json
-  stop            --json
+  device          lock <ios|android> [id] --slot <name> --for <duration> --wait <seconds> --json;
+                  unlock [ios|android] --slot <name> --json
+  logs            --slot <name> --source --level --since --grep --tail --follow --errors --json
+  stop            --slot <name> --json
   status          --json          (already machine-wide)
   stats           --json          (this project and machine-wide)
   doctor          --json --fix --platform <ios|android>
                                   (--platform keeps shared checks and filters native findings)
   gc              --delete --older-than <days> --cache <name|all>
   worktree warm    --refresh; remove [path] --force
+
+  DEVICE SLOTS
+  Use --slot <name> on ios or android to keep any number of simulators,
+  emulators, or physical devices in the same workspace. Names are reusable
+  identities, not models: two slots can request identical models. A slot has
+  one target per platform. Omitting the flag selects default and preserves
+  the workspace's existing assignment.
+
+    stim ios --slot phone
+    stim ios --slot tablet --device-type "iPad Pro 13-inch (M4)"
+    stim ios --slot hardware --device <udid>
+    stim android --slot second-phone
+    stim logs --slot tablet --source device
+    stim stop --slot tablet
+
+  All slots share this workspace's Metro server and build cache. Native CLI
+  runs serialize workspace mutations; a waiting run can wait up to 30 minutes.
+  Named slots support local devices; remote sessions use the default slot.
+  Names use 1-64 letters, digits, underscores or hyphens, starting with a letter
+  or digit. Reserved object-property names are refused.
+
+  stop --slot shuts down that slot's owned devices and releases its leases,
+  retaining Metro and sibling slots. Plain stop handles the whole workspace.
+  status reports named devices under slots and counts their memory. Device
+  caps count every slot. Recycling uses the same model/runtime-matched pool
+  for every slot, with one shared cap per platform and oldest-first eviction.
+
+  Metro cannot reliably identify a particular simulator's bundle request.
+  When slots coexist, a shared bundle event is not proof that a particular
+  slot launched: Debug launch can report unverified. Check the reported device
+  directly. Release verification still checks its process. reload ios/android
+  addresses matching Metro peers across slots; it is not a single-slot reload.
 
   That is the whole surface today, and it is deliberately small. It can grow
   when a flag is genuinely the best answer -- but project-specific knowledge

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -18,7 +18,13 @@ one dim note on STDERR reading \`No matching log records in <logs dir>\`
 (human mode only -- \`--json\` prints nothing at all, on either stream).
 The only exit-1 paths are a malformed query and no project.
 
+Device collectors and build records carry their named slot. Use --slot phone
+for that slot's timeline; its launch marker cannot hide a sibling's errors.
+Untagged legacy records belong to default. Metro/client records are shared and
+usually untagged: use an unfiltered workspace query to inspect those errors.
+
 FLAGS
+  --slot <name>   only this slot's records (default includes untagged records)
   --source <s...>  metro, client, device, build (one or more), or all. An
                    unknown value is REJECTED rather than quietly matching
                    nothing.

--- a/packages/stim-cli/src/logs-query.ts
+++ b/packages/stim-cli/src/logs-query.ts
@@ -22,6 +22,7 @@ interface MarkerWindow {
 }
 
 export interface QueryCriteria {
+  slot?: string;
   includeNativeCrashes?: boolean;
   sources?: string[];
   minLevel?: string;
@@ -78,6 +79,7 @@ export function markerWindow(records: NdjsonRecord[]): MarkerWindow {
 
 export function recordMatches(record: NdjsonRecord | null | undefined, criteria: QueryCriteria = {}): boolean {
   if (!record) return false;
+  if (criteria.slot !== undefined && (record.slot ?? 'default') !== criteria.slot) return false;
   const { sources, minLevel, grep, sinceTs, errorsOnly, markerTs, bundleMarkerTs } = criteria;
 
   if (
@@ -115,6 +117,7 @@ export function recordMatches(record: NdjsonRecord | null | undefined, criteria:
 }
 
 export function buildCriteria({
+  slot,
   sources,
   minLevel,
   since,
@@ -124,6 +127,7 @@ export function buildCriteria({
   bundleMarkerTs,
   now,
 }: {
+  slot?: string;
   sources?: string[];
   minLevel?: string;
   since?: string | null;
@@ -134,6 +138,7 @@ export function buildCriteria({
   now?: number;
 } = {}): QueryCriteria {
   const criteria: QueryCriteria = {
+    ...(slot === undefined ? {} : { slot }),
     errorsOnly: Boolean(errorsOnly),
     includeNativeCrashes: Boolean(errorsOnly && !sources?.length),
   };
@@ -257,7 +262,19 @@ function includeBareErrorContext(
   return sortByTs([...matched, ...renderedContext]);
 }
 
+function launchMarkersBySlot(records: NdjsonRecord[]): Map<unknown, number> {
+  const markers = new Map<unknown, number>();
+  for (const record of records) {
+    if (record.marker !== true || record.src === 'metro') continue;
+    const ts = tsOf(record);
+    const slot = record.slot ?? 'default';
+    if (ts !== null && ts > (markers.get(slot) ?? -Infinity)) markers.set(slot, ts);
+  }
+  return markers;
+}
+
 export function queryLogs({
+  slot,
   dir,
   sources,
   minLevel,
@@ -268,6 +285,7 @@ export function queryLogs({
   errorContext,
   now,
 }: {
+  slot?: string;
   dir?: string;
   sources?: string[];
   minLevel?: string;
@@ -278,11 +296,14 @@ export function queryLogs({
   errorContext?: boolean;
   now?: number;
 } = {}): NdjsonRecord[] {
-  const all = readLogRecords(dir as string);
+  const all = readLogRecords(dir as string).filter(
+    (record) => slot === undefined || (record.slot ?? 'default') === slot,
+  );
   if (all.length === 0) return [];
 
   const { launchTs, bundleTs } = errorsOnly ? markerWindow(all) : { launchTs: null, bundleTs: null };
   const criteria = buildCriteria({
+    slot,
     sources,
     minLevel,
     since,
@@ -293,7 +314,16 @@ export function queryLogs({
     bundleMarkerTs: bundleTs === null ? undefined : bundleTs,
   });
 
-  let matched = all.filter((r) => recordMatches(r, criteria));
+  const slotMarkers = launchMarkersBySlot(all);
+  let matched = all.filter((record) =>
+    recordMatches(record, {
+      ...criteria,
+      markerTs:
+        record.src === 'metro' || record.src === 'client'
+          ? criteria.markerTs
+          : slotMarkers.get(record.slot ?? 'default'),
+    }),
+  );
   if (typeof tail === 'number' && tail >= 0 && matched.length > tail) {
     matched = matched.slice(matched.length - tail);
   }

--- a/packages/stim-cli/src/native-crash.ts
+++ b/packages/stim-cli/src/native-crash.ts
@@ -1,3 +1,4 @@
+import { deviceSlotKey, deviceSlotPlatforms } from './device-slots.ts';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -18,6 +19,7 @@ export const IOS_CRASH_REPORT_RETRY =
   'iOS crash reports can take about a minute or longer to appear. Run `stim logs --errors` again for the native stack.';
 
 interface CrashTarget {
+  slot?: string;
   root?: string;
   platform: 'ios' | 'android';
   deviceId: string;
@@ -399,9 +401,10 @@ export function captureNativeCrashes(target: CrashTarget, logsDir: string): Ndjs
     }
   } catch {}
   for (const record of records) {
+    if (target.slot && target.slot !== 'default') record.slot = target.slot;
     try {
       const key = createHash('sha256')
-        .update(JSON.stringify([record.deviceId, record.incident ?? record.deviceTs, record.rawReport]))
+        .update(JSON.stringify([record.slot, record.deviceId, record.incident ?? record.deviceTs, record.rawReport]))
         .digest('hex');
       writeDiagnosticOnce(join(logsDir, `native-crash-${key}.ndjson`), `${JSON.stringify(record)}\n`);
     } catch {}
@@ -422,9 +425,15 @@ export function printNativeCrashReport(
 export function captureWorkspaceCrashes(root: string, logsDir: string): void {
   const attempts = readLogRecords(logsDir).filter((record) => record.event === 'launch_attempt');
   const launches = readWorkspaceLaunches(root);
-  for (const platform of ['ios', 'android'] as const) {
+  const latest = new Map<string, NdjsonRecord>();
+  for (const attempt of attempts) {
+    if (attempt.platform === 'ios' || attempt.platform === 'android')
+      latest.set(deviceSlotKey(attempt.platform, String(attempt.slot ?? 'default')), attempt);
+  }
+  for (const [key, attempt] of latest) {
+    const platform = attempt.platform as 'ios' | 'android';
+    const slot = String(attempt.slot ?? 'default');
     try {
-      const attempt = attempts.findLast((record) => record.platform === platform);
       if (!attempt || attempt.remote) continue;
       const { deviceId, appId } = attempt;
       const since = attempt.ts;
@@ -437,7 +446,7 @@ export function captureWorkspaceCrashes(root: string, logsDir: string): void {
       )
         continue;
       if (attempt.physical) {
-        const holder = fileLeaseIo.readHolder(root)[platform];
+        const holder = fileLeaseIo.readHolder(root)[key];
         const lease = parseLease(fileLeaseIo.readLease(deviceLeasePath(platform, deviceId)));
         if (
           holder?.id !== deviceId ||
@@ -453,7 +462,7 @@ export function captureWorkspaceCrashes(root: string, logsDir: string): void {
         )
           continue;
       } else {
-        const launch = launches[platform];
+        const launch = launches[key];
         if (
           !launch ||
           launch.deviceId !== deviceId ||
@@ -461,7 +470,7 @@ export function captureWorkspaceCrashes(root: string, logsDir: string): void {
           Date.parse(launch.launchedAt) !== since
         )
           continue;
-        const configured = getProject(root)?.platforms?.[platform];
+        const configured = deviceSlotPlatforms(getProject(root), slot)?.[platform];
         if (!configured?.owned) continue;
         if (platform === 'ios' && configured.deviceUdid !== deviceId) continue;
         if (platform === 'android') {
@@ -473,6 +482,7 @@ export function captureWorkspaceCrashes(root: string, logsDir: string): void {
       captureNativeCrashes(
         {
           root,
+          slot,
           platform,
           deviceId,
           appId,

--- a/packages/stim-cli/src/ndjson.ts
+++ b/packages/stim-cli/src/ndjson.ts
@@ -61,7 +61,10 @@ export function formatNdjsonLine(record: unknown): string | null {
   }
 }
 
-export function createNdjsonWriter(file: string, { truncate = false }: { truncate?: boolean } = {}): NdjsonWriter {
+export function createNdjsonWriter(
+  file: string,
+  { truncate = false, fields = {} }: { truncate?: boolean; fields?: Record<string, unknown> } = {},
+): NdjsonWriter {
   let fd: number | null = null;
   let freshFile = truncate;
   let written = 0;
@@ -80,7 +83,7 @@ export function createNdjsonWriter(file: string, { truncate = false }: { truncat
       dropped += 1;
       return false;
     }
-    const line = formatNdjsonLine(stamp(record));
+    const line = formatNdjsonLine({ ...stamp(record), ...fields });
     if (line === null) {
       dropped += 1;
       lastError = new TypeError('record could not be serialized to JSON');

--- a/packages/stim-cli/src/status.ts
+++ b/packages/stim-cli/src/status.ts
@@ -1,3 +1,4 @@
+import { projectDeviceSlots } from './device-slots.ts';
 import { clockTime, formatElapsed, plural } from './command-output.ts';
 import type { ProjectRecord } from './config.ts';
 import type { LeaseFileEntry } from './engine/device-lease.ts';
@@ -45,6 +46,7 @@ export interface AndroidRuntimeFacts {
 }
 
 export interface EnvironmentState {
+  slots?: { slot: string; ios: EnvironmentState['ios']; android: EnvironmentState['android'] }[];
   path: string;
   live: boolean;
   memoryMb: number;
@@ -93,6 +95,7 @@ export function environmentState(
     worktrees = [],
     simsAvailable = true,
     androidRuntime = null,
+    androidRuntimes = {},
     supervisor = null,
     logs = null,
   }: {
@@ -101,6 +104,7 @@ export function environmentState(
     worktrees?: WorktreeFacts[];
     simsAvailable?: boolean;
     androidRuntime?: AndroidRuntimeFacts | null;
+    androidRuntimes?: Record<string, AndroidRuntimeFacts | null>;
     supervisor?: SupervisorFacts | null;
     logs?: LogsFacts | null;
   } = {},
@@ -112,7 +116,7 @@ export function environmentState(
   const simBooted = Boolean(sim && sim.state === 'Booted');
   const metroRunning = Boolean(metro?.metro);
   const androidDetected = androidRuntime ? Boolean(androidRuntime.serial) : Boolean(android?.serial);
-  const live = simBooted || metroRunning || androidDetected;
+  let live = simBooted || metroRunning || androidDetected;
 
   let memoryMb = 0;
   if (simBooted) memoryMb += IOS_SIM_MB;
@@ -143,8 +147,21 @@ export function environmentState(
     warnings.push(`stale supervisor record for ${project.__path}`);
   }
 
+  const slots: NonNullable<EnvironmentState['slots']> = [];
+  for (const { slot, platforms } of projectDeviceSlots(project).slice(1)) {
+    const deviceState = environmentState(
+      { ...project, platforms, deviceSlots: undefined },
+      { simsByUdid, simsAvailable, metro, androidRuntime: androidRuntimes[slot] },
+    );
+    slots.push({ slot, ios: deviceState.ios, android: deviceState.android });
+    memoryMb += deviceState.memoryMb - (metroRunning ? METRO_MB : 0);
+    live ||= deviceState.live;
+    warnings.push(...deviceState.warnings.map((warning) => `${slot}: ${warning}`));
+  }
+
   return {
     path: project.__path,
+    ...(slots.length ? { slots } : {}),
     live,
     memoryMb,
     warnings,
@@ -242,6 +259,7 @@ export function unprovisionedWorktrees(worktrees: WorktreeFacts[], projectPaths:
 }
 
 export interface DeviceLeaseState {
+  slot?: string;
   path: string;
   platform: string;
   id: string | null;
@@ -263,6 +281,7 @@ export function deviceLeaseStates(
     return {
       path: entry.path,
       platform: entry.platform,
+      ...(lease?.slot ? { slot: lease.slot } : {}),
       id: entry.id,
       deviceName: lease?.deviceName ?? null,
       holder: lease?.holder ?? null,
@@ -279,7 +298,7 @@ export function deviceLeaseLines(states: readonly DeviceLeaseState[], now: numbe
   if (states.length === 0) return [];
   const lines = [`Device leases (${states.length}):`];
   for (const state of states) {
-    const device = `${state.platform} ${state.id ?? state.path}${state.deviceName ? ` (${state.deviceName})` : ''}`;
+    const device = `${state.platform}${state.slot ? ` [${state.slot}]` : ''} ${state.id ?? state.path}${state.deviceName ? ` (${state.deviceName})` : ''}`;
     if (!state.parsed || state.expiresAt === null) {
       lines.push(`  ${device} -- unreadable lease file, so nothing may take the device: ${state.path}`);
       continue;

--- a/packages/stim-cli/src/types.ts
+++ b/packages/stim-cli/src/types.ts
@@ -120,6 +120,7 @@ interface RunLeaseFacts {
 }
 
 export interface IosFacts {
+  slot?: string;
   platform: string;
   udid: string;
   deviceName: string | null;
@@ -145,6 +146,7 @@ export interface IosFacts {
 }
 
 export interface AndroidFacts {
+  slot?: string;
   platform: string;
   serial: string | null;
   avdName: string | null;

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -239,14 +239,19 @@ export function createCleanupTracker({ h, platform, processExitTimeoutMs = 5000 
   }
 
   function recordWorkspace(cwd) {
-    let device;
+    let assignments = [];
     try {
       const config = JSON.parse(readFileSync(join(h.env.STIM_HOME, 'config.json'), 'utf-8'));
-      device = config.projects?.[resolve(cwd)]?.platforms?.[platform];
+      const project = config.projects?.[resolve(cwd)];
+      assignments = [project?.platforms, ...Object.values(project?.deviceSlots ?? {})].map(
+        (platforms) => platforms?.[platform],
+      );
     } catch (error) {
       if (error.code !== 'ENOENT') throw error;
     }
-    if (device?.owned === true) recordBuild({ udid: device.deviceUdid, avdName: device.avdName });
+    for (const device of assignments) {
+      if (device?.owned === true) recordBuild({ udid: device.deviceUdid, avdName: device.avdName });
+    }
 
     let state;
     try {

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -94,11 +94,62 @@ async function main() {
 
   cleanup.recordWorkspace(wt2);
   cli(['stop'], { cwd: wt2 });
+  verifyDeviceSlots(wt1, build1);
   cleanup.recordWorkspace(wt1);
   cli(['stop'], { cwd: wt1 });
   worktreeRemove(wt2);
   worktreeRemove(wt1);
   await verifyCleanup({ h, cleanup, appDir, created });
+}
+
+function verifyDeviceSlots(cwd, original) {
+  banner('named slots: distinct devices, cached installs, reuse and scoped stop');
+  const deviceId = (facts) => (PLATFORM === 'ios' ? facts.udid : facts.avdName);
+  const runSlot = (slot, flags = []) => {
+    const facts = cliJson([PLATFORM, '--slot', slot, ...flags, '--json'], { cwd, timeout: 40 * 60 * 1000 });
+    cleanup.recordBuild(facts);
+    cleanup.recordWorkspace(cwd);
+    assert(facts.slot === slot, `launch facts did not identify ${slot}`);
+    assert(facts.cacheHit === 'local' || facts.cacheHit === 'remote', `slot ${slot} did not reuse the native build`);
+    const records = cli(['logs', '--slot', slot, '--source', 'build', '--json'], { cwd })
+      .stdout.trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert(records.length && records.every((record) => record.slot === slot), `build records escaped slot ${slot}`);
+    return facts;
+  };
+  const second = runSlot('second');
+  assert(deviceId(second) !== deviceId(original), 'two same-model slots shared a device');
+  const repeated = runSlot('second');
+  assert(deviceId(repeated) === deviceId(second), 'repeated slot did not reuse its device');
+  const flags = [];
+  if (PLATFORM === 'ios') {
+    const types = JSON.parse(
+      sh('xcrun', ['simctl', 'list', 'devicetypes', '--json'], { timeout: 30000 }).stdout,
+    ).devicetypes;
+    const tablet = types.findLast((type) => type.name.startsWith('iPad Pro'));
+    assert(tablet, 'native slot QA requires an installed iPad device type');
+    flags.push('--device-type', tablet.name);
+  }
+  const third = runSlot('third', flags);
+  assert(new Set([original, second, third].map(deviceId)).size === 3, 'three slots did not get distinct devices');
+  const status = () =>
+    cliJson(['status', '--json'], { cwd }).environments.find((environment) => environment.path === cwd);
+  const before = status();
+  assert(before?.slots?.length === 2, 'status omitted named slots');
+  const stopped = cliJson(['stop', '--slot', 'second', '--json'], { cwd });
+  assert(stopped.ok && stopped.port.status === 'kept', 'slot stop failed or released the shared port');
+  const after = status();
+  assert(after?.metro?.running && after.metro.port === before.metro.port, 'slot stop disturbed Metro');
+  const sibling = after.slots.find((slot) => slot.slot === 'third');
+  assert(
+    PLATFORM === 'ios' ? sibling?.ios?.state === 'Booted' : sibling?.android?.serial === third.serial,
+    'slot stop disturbed its sibling',
+  );
+  const resumed = runSlot('second');
+  assert(deviceId(resumed) === deviceId(second), 'stopped slot lost its assignment');
+  log('SLOT PROOF: three assignments, reuse, cache hits, attributed logs and isolated stop.');
 }
 
 function worktreeCreate(name, sourceDir) {

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -125,11 +125,16 @@ function verifyDeviceSlots(cwd, original) {
   assert(deviceId(repeated) === deviceId(second), 'repeated slot did not reuse its device');
   const flags = [];
   if (PLATFORM === 'ios') {
-    const types = JSON.parse(
-      sh('xcrun', ['simctl', 'list', 'devicetypes', '--json'], { timeout: 30000 }).stdout,
-    ).devicetypes;
-    const tablet = types.findLast((type) => type.name.startsWith('iPad Pro'));
-    assert(tablet, 'native slot QA requires an installed iPad device type');
+    const inventory = JSON.parse(sh('xcrun', ['simctl', 'list', '--json'], { timeout: 30000 }).stdout);
+    const supported = new Set(
+      inventory.runtimes
+        .filter((runtime) => runtime.isAvailable && runtime.identifier.includes('.iOS-'))
+        .flatMap((runtime) => runtime.supportedDeviceTypes.map((type) => type.identifier)),
+    );
+    const tablet = inventory.devicetypes.find(
+      (type) => type.name.startsWith('iPad Pro') && supported.has(type.identifier),
+    );
+    assert(tablet, 'native slot QA requires an iPad device type supported by an available iOS runtime');
     flags.push('--device-type', tablet.name);
   }
   const third = runSlot('third', flags);


### PR DESCRIPTION
## Description

Each platform currently has one device assignment per workspace. Testing on an iPhone, an iPad, and hardware needs independent targets that subsequent commands can reuse.

## Solution

Add `--slot <name>` to local iOS/Android runs, including physical devices and multiple simulators of the same model. Existing assignments remain in the default slot. Slots share Metro and build caches; native CLI runs serialize workspace mutations to protect shared build output.

Logs and status identify slots. `stop --slot` preserves Metro and sibling devices; workspace cleanup handles every slot.

Limits to review:
- Shared Metro requests cannot verify an individual simulator launch when slots coexist; Debug may report `unverified`.
- Reload remains platform-wide, and named remote sessions are unsupported.
- Upgrades retain ownership state. Use a slot-aware CLI consistently while named assignments exist.

Depends on #769, above #767 and #764.

## Test plan

Regression coverage includes allocation, reuse, scoped cleanup, leases, log markers, launch attribution, default-state compatibility, and EAS-downloaded builds in default and named slots.

The combined slot stack and QA fixes passed the full loop and cache suites for bare React Native and Expo on both platforms. iOS ran locally on the 16 GB Mac; all four Android jobs passed in the [hosted matrix](https://github.com/appandflow/stim/actions/runs/34713741980). Both iOS pool suites also passed [hosted QA](https://github.com/appandflow/stim/actions/runs/34714685868).

Both iOS loops exercised three distinct simulators (two iPhones and an iPad), reuse, cache hits, attributed logs, scoped stop/resume, and complete cleanup. Each iOS cache suite passed all seven applicable checks, including one build shared by two racing workspaces. The initial failures led to readiness fixes in #779, Android cleanup fixes in #780, and selecting an iPad supported by an available runtime in this PR.

Physical-device installs were not exercised on hardware. Lease and command behavior have regression coverage. The earlier full hosted run contains iOS failures; the passing sign-off combines its Android jobs with the final local iOS loops/caches and hosted pool run.

Fixes #770.



