### PR TITLE
docs: shorten EAS prompts and clarify profile selection

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -474,11 +474,12 @@ test('the settings guide documents every configurable optimization', () => {
   }
 });
 
-test('EAS guidance routes agents to the profile and preserves the paid-build authorization boundary', () => {
+test('EAS guidance requires profile clarification when needed and authorization for paid builds', () => {
   const agent = renderTopic('agent');
   expect(agent).toContain('stim guide lifecycle eas');
   const eas = renderSection('lifecycle', 'eas');
   expect(eas).toContain('--eas-profile');
+  expect(eas).toMatch(/no\s+compatible profile or the choice is ambiguous, ask the user/);
   expect(eas).toContain('fingerprint:generate uploads fingerprint metadata');
   expect(eas).toMatch(/session authorizes the potentially billable/);
   expect(eas).toContain('STIM_EAS_BUILD_MISSING');

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -83,9 +83,10 @@ them. It preserves source, custom launcher settings, and the shared ccache.
   stim start
   stim ios                             # or: stim android
 
-For a project using EAS development builds, select the agreed profile with
+For a project using EAS development builds, read stim guide lifecycle eas to
+select a profile from eas.json for the requested target, then run
 stim ios --eas-profile <name> or stim android --eas-profile <name>.
-Read stim guide lifecycle eas before using this path. A miss stops with
+Ask the user if the profile choice is ambiguous. A miss stops with
 STIM_EAS_BUILD_MISSING and an EAS build command. Run that command only when the
 session authorizes the potentially billable build, then retry Stim. The
 presence of eas.json does not select EAS or authorize building.

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -202,6 +202,15 @@ android.gradleCommand must be a single :app:assemble<Variant>Debug task producin
 an APK. Install eas-cli and authenticate with eas login
 or EXPO_TOKEN. The Expo app must already be linked to the intended EAS project.
 
+Use the profile the user names. Otherwise inspect eas.json, including extends
+and platform overrides, for the requested platform, simulator or physical
+device, and app variant or environment. Choose a profile only when those
+requirements identify one compatible development profile. If there is no
+compatible profile or the choice is ambiguous, ask the user. Profile names
+alone do not establish compatibility. Confirm the resolved settings with
+npx eas-cli config --platform <ios|android> --profile <name> --json --non-interactive.
+Pass the selected name to --eas-profile; the CLI does not infer it.
+
 Stim delegates profile inheritance, environment resolution and fingerprinting
 to EAS CLI. fingerprint:generate uploads fingerprint metadata to EAS. It does
 not start a native build. EAS access is needed even when the artifact is

--- a/website/docs/eas-builds.md
+++ b/website/docs/eas-builds.md
@@ -17,7 +17,7 @@ loading their own JavaScript from Metro.
 
 ## Ask your agent
 
-Replace `ios-simulator` with your project's EAS profile name:
+Name the platform and target you want:
 
 <PromptBox
 title="Run an EAS development build"
@@ -26,12 +26,14 @@ com.appandflow.trailhead · ready · EAS build · errors clean`}
 
 >
 
-{`Use Stim to run this app on an iOS simulator with the EAS profile ios-simulator. Reuse a compatible build. If none matches, show me the EAS build command and ask before starting a cloud build. Check the app logs for errors after launch.`}
+{`Run the app on an iOS simulator using an EAS build.`}
 </PromptBox>
 
-The response is illustrative. For Android, ask for an Android emulator and name
-its profile. For hardware, ask for your connected iPhone or Android phone and
-use a device-compatible profile.
+The response is illustrative. Ask for an Android emulator or connected phone to
+change the target. With the Stim skill installed, the agent can inspect
+`eas.json` and choose a compatible development profile. If none fits or several
+remain plausible, it should ask. You can also name a profile for a specific app
+variant. New cloud builds still require your authorization.
 
 ## Choose a profile
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -80,7 +80,7 @@ com.appandflow.trailhead · ready · cache hit · 58.8s · errors clean`}
     response={`Trailhead launched on stim-trailhead (iPhone 17 / iOS 26.5).
 com.appandflow.trailhead · ready · EAS build · errors clean`}
   >
-    {`Use Stim to run this app on an iOS simulator with the EAS profile ios-simulator. Reuse a compatible build. If none matches, show me the EAS build command and ask before starting a cloud build. Check the app logs for errors after launch.`}
+    {`Run the app on an iOS simulator using an EAS build.`}
   </PromptBox>
   <PromptBox
     title="Run on a connected phone"
@@ -122,9 +122,10 @@ Before and After recordings captured; named assertion passed; PR opened with the
   </PromptBox>
 </PromptGrid>
 
-The EAS prompt assumes an `ios-simulator` profile. Replace it with your
-project's profile name; see [EAS development builds](./eas-builds.md) for setup,
-Android and device examples, and build-miss behavior.
+The agent can choose a compatible EAS profile for the requested target. It
+should ask if none fits or the choice is ambiguous. See
+[EAS development builds](./eas-builds.md) for setup, Android and device examples,
+and build-miss behavior.
 
 ## Run work in parallel
 


### PR DESCRIPTION
## Description

The EAS example makes users name a profile and repeat workflow instructions. The agent can select a profile when the requested target and app variant identify one compatible development profile.

## Solution

Use “Run the app on an iOS simulator using an EAS build” on both website pages. The version-matched guide tells agents to inspect inherited profile settings, confirm them with EAS CLI, and ask when none fits or several remain plausible. The CLI still requires an explicit profile, and cloud builds still require authorization.

## Test plan

Verified the exact copied prompt and example response on both pages, plus mobile layout. Rendered the built CLI guide and extended its existing contract test to cover missing or ambiguous profiles.

| Before | After |
| --- | --- |
| ![Detailed EAS prompt](https://github.com/user-attachments/assets/25956daf-ae60-4541-a5ea-3515a01f0e36) | ![Compact EAS prompt](https://github.com/user-attachments/assets/b4ee9714-2284-4d65-b89b-9c7435ba6ac1) |

Fixes #774
