### PR TITLE
fix: probe iOS readiness with a simulator-native executable

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -98,7 +98,7 @@ describe('ensureBooted: ios', () => {
     });
     expect(commands.filter((c) => c.includes('simctl boot')).length).toBe(0);
     expect(commands.some((c) => c.includes('simctl bootstatus'))).toBe(false);
-    expect(probes).toEqual([['xcrun', 'simctl', 'spawn', 'U1', '/usr/bin/true', { timeoutMs: 30000 }]]);
+    expect(probes).toEqual([['xcrun', 'simctl', 'spawn', 'U1', 'launchctl', 'list', { timeoutMs: 30000 }]]);
   });
 
   test.each([false, true])('refuses a simulator that cannot spawn a process after boot (joined=%s)', async (joined) => {
@@ -323,7 +323,7 @@ describe('ensureBooted: ios', () => {
     });
     expect(result).toEqual({ ok: true, udid: 'U1' });
     expect(finished).toBe(true);
-    expect(commands).toEqual(['xcrun simctl spawn U1 /usr/bin/true']);
+    expect(commands).toEqual(['xcrun simctl spawn U1 launchctl list']);
   });
 
   test('reports the failure of the boot this run started, before anything is installed', async () => {

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -686,18 +686,21 @@ test('bootIosSim re-enters bootstatus after a timed-out attempt while the sim is
   expect(quiet).toContain('open -a Simulator');
 });
 
-test('bootIosSim treats a timed-out attempt as success when the sim reports Booted', async () => {
-  const { spawned } = bootstatusExecutor(['hang'], () => bootSimList('Booted'));
+test('bootIosSim waits for bootstatus even when a timed-out attempt reports Booted', async () => {
+  const { spawned } = bootstatusExecutor(['hang', { exitCode: 0 }], () => bootSimList('Booted'));
   await bootIosSim('UDID-A', { attemptMs: 20 });
-  expect(spawned.length).toBe(1);
+  expect(spawned.length).toBe(2);
 });
 
-test('bootIosSim names the udid and the wait when the deadline expires while Booting', async () => {
-  bootstatusExecutor(['hang'], () => bootSimList('Booting'));
-  await expect(bootIosSim('UDID-A', { timeoutMs: 1200, attemptMs: 300 })).rejects.toThrow(
-    /UDID-A did not finish booting within 1s/,
-  );
-});
+test.each(['Booting', 'Booted'])(
+  'bootIosSim names the udid and the wait when the deadline expires while %s',
+  async (state) => {
+    bootstatusExecutor(['hang'], () => bootSimList(state));
+    await expect(bootIosSim('UDID-A', { timeoutMs: 1200, attemptMs: 300 })).rejects.toThrow(
+      /UDID-A did not finish booting within 1s/,
+    );
+  },
+);
 
 test('bootIosSim reports a sim that vanished from the device list', async () => {
   bootstatusExecutor(['hang'], () => JSON.stringify({ devices: {} }));
@@ -764,6 +767,10 @@ test('bootstatus does not survey or retry until its timed-out child has actually
     },
     runFileQuiet: () => '',
     spawn() {
+      if (events.includes('survey')) {
+        events.push('retry');
+        return makeExitingChild();
+      }
       const child = makeChildProcess();
       child.kill = () => {
         events.push('signal');
@@ -777,7 +784,7 @@ test('bootstatus does not survey or retry until its timed-out child has actually
     },
   });
   await bootIosSim('UDID-A', { attemptMs: 10 });
-  expect(events).toEqual(['signal', 'exit', 'survey']);
+  expect(events).toEqual(['signal', 'exit', 'survey', 'retry']);
 });
 
 test('bootstatus refuses a retry when termination cannot be confirmed within the cleanup bound', async () => {

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -1140,7 +1140,8 @@ async function ensureIosBooted({
   if (!udid) return { failed: true, reason: 'No iOS simulator is recorded for this project.' };
   const ready = (): BootResult => {
     try {
-      getExecutor().runFile('xcrun', ['simctl', 'spawn', udid, '/usr/bin/true'], { timeoutMs: 30000 });
+      // Apple simctl spawn searches the device PATH for bare names; absolute paths use the host root.
+      getExecutor().runFile('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'list'], { timeoutMs: 30000 });
       return { ok: true, udid };
     } catch (error) {
       return {

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -533,8 +533,8 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   and \`adb devices\`, then retry after any other run finishes. Keep the AVD and
   its process locks while its state is unverified.
   On iOS a slow first boot is waited out for up to ten minutes while the
-  simulator still reports Booting -- a long silent wait on a loaded machine
-  is patience, not a hang. The failure names the udid and the wait.
+  simulator reports Booting or Booted but bootstatus has not completed.
+  Booted alone does not end that wait. The failure names the udid and the wait.
   After boot, a process-spawn probe must finish within 30 seconds before
   installation. If it fails, the refusal includes observed host memory pressure
   when available. Free memory before retrying under pressure; see

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -254,9 +254,8 @@ export async function bootIosSim(
     } catch {
       state = undefined;
     }
-    if (state === 'Booted') break;
     const waited = Math.round((timeoutMs - Math.max(0, deadline - Date.now())) / 1000);
-    if (state !== 'Booting' && state !== undefined) {
+    if (state !== 'Booting' && state !== 'Booted' && state !== undefined) {
       throw new Error(`Simulator ${udid} reports "${state ?? 'missing'}" after ${waited}s of boot wait.`);
     }
     if (deadline - Date.now() <= 0) {


### PR DESCRIPTION
## Description

Healthy iOS simulators can fail Stim's readiness gate because `/usr/bin/true` resolves to a macOS binary. Native QA reports an incompatible-platform error after a successful build (#776).

## Solution

Run `simctl spawn <udid> launchctl list` instead. Apple’s `simctl help spawn` specifies that bare names search the device PATH, while absolute paths refer to the host root. This retains the bounded process-spawn check introduced in [#753](https://github.com/appandflow/stim/commit/62404f7824), which catches simulators that report Booted but cannot start a process.

The retry loop also waits for successful bootstatus completion after a timed-out attempt, even when the device reports Booted. The [slow-boot recovery in #129](https://github.com/appandflow/stim/commit/91900c46046eb14fbba7ce9bbcd992184d613ae5) intentionally retries within ten minutes, but its Booted shortcut can finish that wait before simulator startup completes. The overall deadline remains bounded.

## Test plan

The old host-binary probe failed and the new simulator-native probe passed on a real Stim-owned simulator. Failure-path regression tests passed. With the device-slot stack, bare and Expo iOS loop/cache suites passed locally, and both pool suites passed locally and in [hosted QA](https://github.com/appandflow/stim/actions/runs/34714685868). All local test-owned devices were cleaned up.

Fixes #776.

