### PR TITLE
test: resolve the Android SDK emulator during native cleanup

### DIFF
--- a/test/e2e/native-cleanup.e2e.js
+++ b/test/e2e/native-cleanup.e2e.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
@@ -264,8 +264,32 @@ for (const [platform, tool] of [
   });
 }
 
+for (const setting of ['ANDROID_HOME', 'ANDROID_SDK_ROOT']) {
+  test(`native cleanup finds the emulator through ${setting} without PATH`, (t) => {
+    const home = mkdtempSync(join(tmpdir(), 'stim-native-sdk-'));
+    t.after(() => rmSync(home, { recursive: true, force: true }));
+    const executable = join(home, 'sdk with spaces', 'emulator', 'emulator');
+    mkdirSync(dirname(executable), { recursive: true });
+    writeFileSync(
+      executable,
+      `#!${process.execPath}\nif (process.argv[2] !== '-list-avds') process.exit(2);\nconsole.log('stim-owned\\nuser-avd');\n`,
+    );
+    chmodSync(executable, 0o755);
+    const h = createHarness({
+      env: { STIM_HOME: home, PATH: '', [setting]: join(home, 'sdk with spaces') },
+      cliPath: '/unused',
+      label: 'sdk-inspection',
+    });
+    const cleanup = createCleanupTracker({ h, platform: 'android' });
+    cleanup.recordBuild({ avdName: 'stim-owned' });
+    assert.deepEqual(cleanup.remainingDevices(), ['stim-owned']);
+    rmSync(executable);
+    assert.throws(() => cleanup.remainingDevices(), /could not inspect .*emulator:.*ENOENT/);
+  });
+}
+
 test('missing executables remain inspection failures with allowFail enabled', async () => {
-  const h = createHarness({ env: { ...process.env, PATH: '' }, cliPath: '/unused', label: 'missing-inspection' });
+  const h = createHarness({ env: { PATH: '' }, cliPath: '/unused', label: 'missing-inspection' });
   const result = h.sh('stim-native-cleanup-unavailable-tool', [], { allowFail: true });
   assert.equal(result.code, 1);
   assert.match(result.stderr, /ENOENT/);

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -274,7 +274,13 @@ export function createCleanupTracker({ h, platform, processExitTimeoutMs = 5000 
         ? Object.values(JSON.parse(inspect(h, 'xcrun', ['simctl', 'list', 'devices', '--json'])).devices)
             .flat()
             .map((device) => device.udid)
-        : inspect(h, 'emulator', ['-list-avds'])
+        : inspect(
+            h,
+            h.env.ANDROID_HOME || h.env.ANDROID_SDK_ROOT
+              ? join(h.env.ANDROID_HOME || h.env.ANDROID_SDK_ROOT, 'emulator', 'emulator')
+              : 'emulator',
+            ['-list-avds'],
+          )
             .split('\n')
             .map((name) => name.trim());
     return ids.filter((id) => devices.has(id));


### PR DESCRIPTION
## Description

Android native QA completes its work but fails final device enumeration with `emulator ENOENT`: the SDK executable is installed outside PATH (#777).

## Solution

Resolve the emulator from `ANDROID_HOME` or `ANDROID_SDK_ROOT`, matching the native harness's SDK selection. Keep enumeration failures fatal so missing tools cannot hide leaked AVDs.

## Test plan

Exercise cleanup with an SDK path containing spaces and an empty PATH, through both SDK variables; verify a missing executable still fails. Run the actual SDK emulator with an empty PATH, then run the Bare and Expo Android native suites.

Fixes #777.
