### PR TITLE
test: capture host memory during native iOS QA

### DIFF
--- a/.github/workflows/e2e-native.yml
+++ b/.github/workflows/e2e-native.yml
@@ -137,6 +137,11 @@ jobs:
         if: matrix.suite == 'loop'
         run: echo "STIM_E2E_WARM_CACHE=$([ -n \"$(ls -A \"$STIM_BUILD_CACHE\" 2>/dev/null)\" ] && echo 1 || echo 0)" >> "$GITHUB_ENV"
 
+      - name: Monitor host memory during iOS QA
+        run: |
+          node test/e2e/native/monitor-macos-memory.mjs > "$GITHUB_WORKSPACE/ios-memory.jsonl" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/stim-memory-monitor.pid"
+
       - name: Loop suite (ios, ${{ matrix.framework }})
         if: matrix.suite == 'loop'
         # --keep leaves the temp worktrees in place on this ephemeral runner so
@@ -160,6 +165,22 @@ jobs:
       - name: Simulator pool suite (ios, ${{ matrix.framework }})
         if: matrix.suite == 'pool'
         run: node test/e2e/native/run-pool-e2e.mjs --framework ${{ matrix.framework }} --keep --home "$TMPDIR/stim-cli-pool-home"
+
+      - name: Stop host memory monitor
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/stim-memory-monitor.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/stim-memory-monitor.pid")" 2>/dev/null || true
+          fi
+
+      - name: Upload iOS host memory diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-memory-ios-${{ matrix.framework }}-${{ matrix.suite }}
+          path: ios-memory.jsonl
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload the cache-suite summary
         # `always()`: a FAILING cache run is exactly when the per-check evidence

--- a/.github/workflows/e2e-native.yml
+++ b/.github/workflows/e2e-native.yml
@@ -138,6 +138,7 @@ jobs:
         run: echo "STIM_E2E_WARM_CACHE=$([ -n \"$(ls -A \"$STIM_BUILD_CACHE\" 2>/dev/null)\" ] && echo 1 || echo 0)" >> "$GITHUB_ENV"
 
       - name: Monitor host memory during iOS QA
+        continue-on-error: true
         run: |
           node test/e2e/native/monitor-macos-memory.mjs > "$GITHUB_WORKSPACE/ios-memory.jsonl" 2>&1 &
           echo "$!" > "$RUNNER_TEMP/stim-memory-monitor.pid"
@@ -167,6 +168,7 @@ jobs:
         run: node test/e2e/native/run-pool-e2e.mjs --framework ${{ matrix.framework }} --keep --home "$TMPDIR/stim-cli-pool-home"
 
       - name: Stop host memory monitor
+        continue-on-error: true
         if: always()
         run: |
           if [ -f "$RUNNER_TEMP/stim-memory-monitor.pid" ]; then
@@ -174,6 +176,7 @@ jobs:
           fi
 
       - name: Upload iOS host memory diagnostics
+        continue-on-error: true
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/test/e2e/native/monitor-macos-memory.mjs
+++ b/test/e2e/native/monitor-macos-memory.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+while (true) {
+  const sample = { time: new Date().toISOString() };
+  for (const [name, file, args] of [
+    ['host', '/usr/sbin/sysctl', ['hw.memsize', 'vm.swapusage', 'vm.loadavg', 'kern.memorystatus_vm_pressure_level']],
+    ['pages', '/usr/bin/vm_stat', []],
+  ]) {
+    const result = spawnSync(file, args, {
+      encoding: 'utf8',
+      timeout: 2000,
+      killSignal: 'SIGKILL',
+      maxBuffer: 64 * 1024,
+    });
+    sample[name] = {
+      output: result.stdout ?? '',
+      error: result.error?.message ?? result.stderr ?? '',
+      status: result.status,
+    };
+  }
+  process.stdout.write(`${JSON.stringify(sample)}\n`);
+  await sleep(15000);
+}


### PR DESCRIPTION
## Description

Native iOS QA can time out during simulator readiness without enough evidence to tell whether host memory pressure contributed. Fixes #782.

## Solution

Record macOS memory pressure, swap, load, and VM counters every 15 seconds during each iOS suite, and upload the timeline on success or failure. Each diagnostic command has a two-second timeout, and telemetry failures stay advisory. This preserves all suites and their pass/fail results; it does not change simulator settings.

## Test plan

Ran the sampler against real macOS tools and verified parseable output with pressure, swap, and page counters, then terminated it. Format, lint, build, typecheck, knip, runtime checks, 4,297 unit tests (one skipped), and 84 E2E tests passed. Node 22/24 and published-runtime CI passed. Artifact collection is being exercised in https://github.com/appandflow/stim/actions/runs/34713127656.

