### PR TITLE
test: slim generated iOS QA fixtures

### DIFF
--- a/.github/workflows/e2e-native.yml
+++ b/.github/workflows/e2e-native.yml
@@ -112,6 +112,9 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Install SimSlim for generated iOS fixtures
+        run: brew install mobai-app/tap/simslim
+
       - name: Install (workspace root)
         run: pnpm install --frozen-lockfile
 

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -102,6 +102,17 @@ The cache runner performs these checks before seeding its disposable Gradle
 home. Worktree names include a digest of the run directory, so separate runs
 use different device names and do not recover a previous run's AVD by name.
 
+Generated iOS fixtures use the committed
+[`simslim-profile.json`](../test/e2e/native/simslim-profile.json) to reduce
+background services while running several simulators. Install the prerequisite
+with `brew install mobai-app/tap/simslim`; CI does this automatically. The profile
+keeps App Store/push/media, web/universal links, connectivity, diagnostics, and
+miscellaneous system services. It disables widgets, Siri, search, account sync,
+PIM, family, health, photos, bundled apps, and messaging, which these blank-app
+scenarios do not exercise. Review the profile when adding feature-specific QA.
+Supplied `--app-dir` projects retain their own settings. Stock simulator boot
+and memory behavior require a separate run against a project without a profile.
+
 ### The simulator pool suite
 
 `test/e2e/native/run-pool-e2e.mjs` runs on iOS. With a pool bound of one, it

--- a/test/e2e/native-worktrees.e2e.js
+++ b/test/e2e/native-worktrees.e2e.js
@@ -150,9 +150,11 @@ test('the disposable Expo iOS fixture prepares matching Pods before committing i
   const workDir = scratch(t);
   const tools = join(workDir, 'tools');
   mkdirSync(tools);
-  const npm = join(tools, 'npm');
-  writeFileSync(npm, '#!/bin/sh\nexit 0\n');
-  chmodSync(npm, 0o755);
+  for (const name of ['npm', 'simslim']) {
+    const tool = join(tools, name);
+    writeFileSync(tool, '#!/bin/sh\nexit 0\n');
+    chmodSync(tool, 0o755);
+  }
   const init = join(workDir, 'init.mjs');
   writeFileSync(
     init,
@@ -161,6 +163,7 @@ import { join } from 'node:path';
 const app = process.argv[2];
 mkdirSync(app);
 writeFileSync(join(app, 'package.json'), '{"name":"fixture"}\\n');
+writeFileSync(join(app, '.stim.json'), JSON.stringify({ios:{deviceType:'iPhone 17'},android:{systemImage:'keep-image'}}));
 `,
   );
   const previousInit = process.env.STIM_E2E_EXPO_INIT;
@@ -195,4 +198,11 @@ writeFileSync(join(app, 'package.json'), '{"name":"fixture"}\\n');
   assert.equal(git(app, 'status', '--porcelain'), '');
   assert.equal(git(app, 'show', 'HEAD:package.json'), '{"name":"prepared-fixture"}');
   assert.equal(git(app, 'ls-files', 'ios'), '');
+  const settings = JSON.parse(git(app, 'show', 'HEAD:.stim.json'));
+  assert.equal(settings.ios.deviceType, 'iPhone 17');
+  assert.equal(settings.android.systemImage, 'keep-image');
+  assert.equal(
+    git(app, 'show', `HEAD:${settings.ios.simslimProfile}`),
+    readFileSync(new URL('./native/simslim-profile.json', import.meta.url), 'utf8').trim(),
+  );
 });

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -1,5 +1,14 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -107,6 +116,7 @@ function withDir(tmplStr, appDir) {
 }
 
 export function createFixture({ framework, platform, workDir, h }) {
+  if (platform === 'ios') h.requireTool('simslim', ['--version']);
   const appDir = join(workDir, 'app');
   const cmd = FIXTURE_COMMANDS[framework](appDir);
   h.log(`creating ${framework} fixture: ${cmd.map(quote).join(' ')}`);
@@ -158,6 +168,15 @@ export function createFixture({ framework, platform, workDir, h }) {
     h.log('preparing the disposable Expo iOS fixture and Pods before its initial commit');
     h.sh('npx', ['--no-install', 'expo', 'prebuild', '--platform', 'ios'], { cwd: appDir, timeout: 20 * 60 * 1000 });
     assertMatchingPods(appDir);
+  }
+
+  if (platform === 'ios') {
+    const settingsPath = join(appDir, '.stim.json');
+    const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf8')) : {};
+    settings.ios = { ...settings.ios, simslimProfile: '.stim-simslim.json' };
+    copyFileSync(new URL('./simslim-profile.json', import.meta.url), join(appDir, '.stim-simslim.json'));
+    writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+    h.log('generated iOS fixture uses the native QA SimSlim profile');
   }
 
   gitInitWithRemote({ appDir, workDir, framework, h });

--- a/test/e2e/native/simslim-profile.json
+++ b/test/e2e/native/simslim-profile.json
@@ -1,0 +1,6 @@
+{
+  "name": "stim-native-qa",
+  "description": "Blank React Native and Expo fixtures: preserve app services, networking, connectivity and diagnostics while reducing unrelated background work.",
+  "except": ["store", "web", "connectivity", "telemetry", "other"],
+  "keep": []
+}


### PR DESCRIPTION
## Description

Generated native iOS fixtures run several stock simulators without using Stim's existing SimSlim support. Concurrent stock simulators showed memory pressure locally. Fixes #784.

## Solution

Give generated iOS fixtures an explicit SimSlim profile and install SimSlim in iOS CI. The profile disables background features the blank-app scenarios do not test, retaining networking and diagnostic services. Supplied `--app-dir` projects retain their own configuration.

This exercises the same full suites on slimmed simulators. It does not establish that memory pressure caused the hosted readiness failures or provide stock-service QA coverage; the QA guide records that distinction and requires reviewing the profile when scenarios grow.

## Test plan

Format, lint, build, typecheck, knip, runtime checks, 4,297 unit tests (one skipped), and 84 E2E tests passed. A fresh owned iOS 26.5 simulator passed profile apply, reboot, exact SimSlim verification, and Stim readiness; centralized teardown removed it afterward. After integration with the slot stack and readiness fixes, bare and Expo iOS loop/cache suites passed locally using the generated profile. Both pool suites passed in [hosted QA](https://github.com/appandflow/stim/actions/runs/34714685868). A separate stock bare iOS pool run also passed locally.
