### PR TITLE
test: check CoreSimulator before native fixture setup

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -98,6 +98,9 @@ Native runners check their environment before preparing the fixture. Android
 requires `ANDROID_HOME` or `ANDROID_SDK_ROOT` pointing to an existing SDK
 directory, even when the app has `android/local.properties`. iOS requires a
 UTF-8 locale; set `LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8` when needed.
+Its preflight also checks CoreSimulator inventory with a five-minute deadline
+before fixture setup. This read-only check initializes the service without
+booting devices; a failure identifies the command before any app build starts.
 The cache runner performs these checks before seeding its disposable Gradle
 home. Worktree names include a digest of the run directory, so separate runs
 use different device names and do not recover a previous run's AVD by name.

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -66,6 +66,8 @@ export function preflight(h, platform) {
     if (process.platform !== 'darwin') h.die('ios variant requires macOS + Xcode; this is not a macOS host.', 2);
     h.requireTool('xcrun', ['--version']);
     h.requireTool('xcodebuild', ['-version']);
+    h.log('checking CoreSimulator inventory before fixture setup (up to 5 minutes)');
+    h.sh('xcrun', ['simctl', 'list', '--json'], { timeout: 5 * 60 * 1000 });
   } else {
     const sdk = h.env.ANDROID_HOME || h.env.ANDROID_SDK_ROOT;
     assert(sdk, 'Native Android tests require ANDROID_HOME or ANDROID_SDK_ROOT pointing to the Android SDK.');


### PR DESCRIPTION
## Description

Native iOS QA currently verifies Xcode versions, then prepares an app before discovering that CoreSimulator cannot answer its first inventory query. This wasted setup work in the hosted Expo pool and cache runs, even with normal memory pressure. Fixes #786.

## Solution

Check the simulator inventory during iOS preflight with a five-minute deadline. The read-only query initializes and verifies CoreSimulator before fixture setup; it does not boot a device or change the CLI's timeouts. A failure names the command at the prerequisite boundary.

## Test plan

Format, lint, build, typecheck, knip, runtime checks, 4,297 unit tests (one skipped), and 84 E2E tests passed. The actual iOS preflight passed against local Xcode. The subsequent [hosted bare and Expo iOS pool run](https://github.com/appandflow/stim/actions/runs/34714685868) passed with this preflight. This is successful cold-runner evidence, not proof that every simulator stall is fixed.
