### PR TITLE
test: stop idle workspaces before the native cache race

### DIFF
--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -541,6 +541,7 @@ async function main() {
     return c.pass(`gc reports ${expected.length} live cache(s) with sizes and calls none of them garbage`);
   });
 
+  stopWorkspace(wt1);
   stopWorkspace(wt2);
 
   let raceOutcome = null;


### PR DESCRIPTION
## Description

The native cache suite keeps its first simulator and Metro running after their checks finish, while starting two more workspaces for the build race. This adds avoidable load on small runners; the recent hosted iOS cache failure recorded sustained memory pressure.

## Solution

Stop both completed warm-up workspaces before starting the two racers. Keep every cache assertion, the concurrent single-flight check, and final cleanup verification. This changes only the test harness.

## Test plan

The full bare iOS cache suite passed all seven applicable checks on the combined slot stack: both warm-up workspaces stopped before the race, exactly one racer built, the other reused its artifact, and cleanup passed. All 33 host-memory samples were normal during the eight-minute run. Blocking CI is green; the [full hosted matrix](https://github.com/appandflow/stim/actions/runs/34716978286) is running on the integrated final tree.

Fixes #788.

