### PR TITLE
test: allow larger iOS runners for manual native QA

### DIFF
--- a/.github/workflows/e2e-native.yml
+++ b/.github/workflows/e2e-native.yml
@@ -46,6 +46,11 @@ on:
         type: choice
         default: loop
         options: [loop, caches, pool, all]
+      ios_runner:
+        description: 'iOS runner: standard is free for public repos; large is billed'
+        type: choice
+        default: standard
+        options: [standard, large]
   pull_request:
     # `labeled` is what makes "add the label to run it" work; the others let a
     # push to an already-labeled PR re-run. The `if:` on each job is the actual
@@ -67,7 +72,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-native'))
-    runs-on: macos-latest
+    runs-on: ${{ inputs.ios_runner == 'large' && 'macos-latest-xlarge' || 'macos-latest' }}
     # The caches suite adds a second cold compile (the single-flight race) plus a
     # third cache-hit build, so it needs headroom the loop suite never did.
     timeout-minutes: ${{ matrix.suite == 'caches' && 120 || 60 }}

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -242,6 +242,19 @@ Two workflows under `.github/workflows/`:
   the cross-run cache path is itself exercised; build logs
   (`build-*.ndjson`) are uploaded as artifacts on failure.
 
+Manual dispatches can select `ios_runner=large` to use the 14 GB ARM64
+`macos-latest-xlarge` runner when simulator workloads need more memory:
+
+```bash
+gh workflow run e2e-native.yml --ref <branch> -f suite=all -f ios_runner=large
+```
+
+The default is `standard` (`macos-latest`); scheduled and PR runs also use
+standard runners. Android and the selected suite matrix are unchanged.
+[Larger macOS runners](https://docs.github.com/en/actions/reference/runners/larger-runners)
+are [billed per job-minute](https://docs.github.com/en/billing/reference/actions-runner-pricing),
+including in public repositories. Confirm the run budget before choosing `large`.
+
 ### Assumptions a reviewer must confirm
 
 - The `macos-latest` runner image ships the Xcode that `latest-stable` selects,


### PR DESCRIPTION
## Description

Native iOS QA needs a way to test suspected host-capacity failures with more memory without moving every scheduled run onto a paid runner.

## Solution

Add a manual `ios_runner` choice. `standard` remains the default; only `large` selects GitHub's 14 GB ARM64 runner. Scheduled and PR runs retain the standard runner, and the full suite matrix is unchanged. Larger runners are [billed even for public repositories](https://docs.github.com/en/billing/reference/actions-runner-pricing); the QA guide makes that choice explicit.

## Test plan

Verify workflow syntax through GitHub's PR evaluation and run the repository checks. The paid runner has not been dispatched: after budget approval, run the combined native matrix with `ios_runner=large` and verify the actual runner, suite results, and memory artifacts.

Fixes #790.
