### PR TITLE
fix: report simulator boot progress and memory pressure

### DIFF
--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -194,7 +194,7 @@ describe('ensureBooted: ios', () => {
     });
 
     expect(result.ok).toBeUndefined();
-    expect(result.reason).toMatch(/did not finish booting within 1s/);
+    expect(result.reason).toMatch(/simctl boot U1 timed out/);
   });
 
   test('reports boot setup failures instead of treating the Booted state as ready', async () => {
@@ -718,6 +718,7 @@ function iosExecutor(devices: SimEntry[]) {
         return '';
       },
       spawn(cmd: string, args: readonly string[] = []) {
+        if (args[1] === 'boot') run.push([cmd, ...args].join(' '));
         spawned.push([cmd, ...args].join(' '));
         return makeExitingChild();
       },
@@ -733,8 +734,11 @@ describe('ensureOwnedDevice: ios', () => {
     setExecutor({
       ...exec,
 
-      runFile(file, args = [], options) {
+      spawn(file, args = []) {
         if (file === 'xcrun' && args[1] === 'boot') events.push('boot');
+        return exec.spawn(file, args);
+      },
+      runFile(file, args = [], options) {
         if (file === '/usr/sbin/sysctl') {
           events.push('pressure');
           expect(args).toEqual(['-n', 'kern.memorystatus_vm_pressure_level']);
@@ -755,13 +759,13 @@ describe('ensureOwnedDevice: ios', () => {
         },
       });
       await device.booting?.done;
-      expect(events.filter((event) => event === 'pressure')).toHaveLength(process.platform === 'darwin' ? 1 : 0);
+      expect(events.filter((event) => event === 'pressure')).toHaveLength(process.platform === 'darwin' ? 2 : 0);
       expect(events).toContain('boot');
       const expectedEvents =
         process.platform === 'darwin'
           ? pressure === '2'
-            ? ['pressure', 'warning', 'boot']
-            : ['pressure', 'boot']
+            ? ['pressure', 'warning', 'pressure', 'boot']
+            : ['pressure', 'pressure', 'boot']
           : ['boot'];
       expect(events).toEqual(expectedEvents);
     } finally {
@@ -1225,6 +1229,7 @@ describe('ensureOwnedDevice: ios', () => {
       expect(result.owned).toBe(true);
       expect(result.created).toBe(true);
       expect(notes.some((n) => /not Stim-owned by name/i.test(n))).toBeTruthy();
+      await result.booting?.done;
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1251,7 +1256,7 @@ describe('ensureOwnedDevice: ios', () => {
         deviceName: 'stim-app (iPhone 17 Pro 26.2)',
       });
       await result.booting?.done;
-      expect(spawned).toEqual(['xcrun simctl bootstatus NEW-UDID -b']);
+      expect(spawned).toEqual(['xcrun simctl boot NEW-UDID', 'xcrun simctl bootstatus NEW-UDID -b']);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -656,6 +656,7 @@ function bootstatusExecutor(outcomes: BootstatusOutcome[], list: () => string) {
       return '';
     },
     spawn: (cmd: string, args: readonly string[] = []) => {
+      if (args[1] === 'boot') return makeExitingChild();
       spawned.push([cmd, ...args].join(' '));
       const outcome = outcomes[spawned.length - 1] ?? outcomes[outcomes.length - 1] ?? 'hang';
       if (outcome === 'hang') {
@@ -730,28 +731,28 @@ test('bootIosSim rethrows a bootstatus failure that is not a timeout', async () 
 });
 
 test('the initial boot request consumes the same deadline as bootstatus', async () => {
-  let now = 1000;
-  const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
-  let spawned = false;
+  vi.useFakeTimers();
+  const commands: string[] = [];
+  const child = makeChildProcess();
+  child.kill = () => {
+    queueMicrotask(() => child.emit('exit', null, 'SIGKILL'));
+    return true;
+  };
   setExecutor({
-    runFile(_file, args = [], options) {
-      if (args[1] === 'boot') {
-        expect(options).toEqual({ timeoutMs: 200, killSignal: 'SIGKILL' });
-        now += 250;
-        return '';
-      }
-      return bootSimList('Booting');
-    },
-    spawn() {
-      spawned = true;
-      return makeExitingChild();
+    runFile: () => '',
+    spawn: (_cmd, args) => {
+      commands.push(args.join(' '));
+      return child;
     },
   });
   try {
-    await expect(bootIosSim('UDID-A', { timeoutMs: 200 })).rejects.toThrow(/did not finish booting/);
-    expect(spawned).toBe(false);
+    const outcome = bootIosSim('UDID-A', { timeoutMs: 200 }).catch((error) => error);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(await outcome).toMatchObject({ message: expect.stringContaining('simctl boot UDID-A timed out') });
+    expect(commands).toEqual(['simctl boot UDID-A']);
   } finally {
-    clock.mockRestore();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   }
 });
 
@@ -766,7 +767,8 @@ test('bootstatus does not survey or retry until its timed-out child has actually
       return '';
     },
     runFileQuiet: () => '',
-    spawn() {
+    spawn(_cmd, args) {
+      if (args[1] === 'boot') return makeExitingChild();
       if (events.includes('survey')) {
         events.push('retry');
         return makeExitingChild();
@@ -795,7 +797,7 @@ test('bootstatus refuses a retry when termination cannot be confirmed within the
       if (args[1] === 'list') surveys++;
       return '';
     },
-    spawn: () => makeChildProcess(),
+    spawn: (_cmd, args) => (args[1] === 'boot' ? makeExitingChild() : makeChildProcess()),
   });
   try {
     const outcome = bootIosSim('UDID-A', { attemptMs: 100 }).then(
@@ -821,4 +823,47 @@ test('opening the Simulator app is bounded and best-effort after successful boot
     },
   });
   await expect(bootIosSim('UDID-A')).resolves.toBeUndefined();
+});
+
+test('boot diagnostics retain peak pressure after recovery and unknown readings, then stop sampling', async () => {
+  vi.useFakeTimers();
+  const messages: string[] = [];
+  let reads = 0;
+  const levels = ['1', '2', '', '1'];
+  const child = makeChildProcess();
+  child.kill = () => {
+    queueMicrotask(() => child.emit('exit', null, 'SIGKILL'));
+    return true;
+  };
+  setExecutor({
+    runFile: (_file, args) =>
+      args[0] === '-n' ? levels[Math.min(reads++, levels.length - 1)] : bootSimList('Booting'),
+    spawn: () => child,
+  });
+  try {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    const outcome = bootIosSim('UDID-A', {
+      timeoutMs: 45000,
+      label: 'stim-app-tablet',
+      out: (message) => messages.push(message),
+    }).catch((error) => error);
+    child.stdout?.emit('data', 'Waiting on Data Migration\n');
+    await vi.advanceTimersByTimeAsync(45000);
+    const error = await outcome;
+    expect(messages[0]).toContain('stim-app-tablet is still booting after 15s');
+    expect(messages[0]).toContain('Waiting on Data Migration');
+    expect(messages[0]).toContain('Memory pressure: warning');
+    expect(messages[0]).toContain('Boot may be delayed or stalled');
+    expect(messages[1]).toContain('Memory pressure: unknown');
+    expect(error.message).toContain('Highest observed memory pressure: warning');
+    expect(error.message).toContain('unavailable samples: 1');
+    expect(error.message).toContain('Stop unused slots in workspaces you own');
+    const count = reads;
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(reads).toBe(count);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  }
 });

--- a/packages/stim-cli/src/__tests__/sim-ios.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-ios.test.ts
@@ -867,3 +867,35 @@ test('boot diagnostics retain peak pressure after recovery and unknown readings,
     vi.restoreAllMocks();
   }
 });
+
+test('delayed boot observations report missing coverage without inventing unknown readings', async () => {
+  vi.useFakeTimers();
+  const messages: string[] = [];
+  const child = makeChildProcess();
+  child.kill = () => {
+    queueMicrotask(() => child.emit('exit', null, 'SIGKILL'));
+    return true;
+  };
+  setExecutor({
+    runFile: (_file, args) => (args[0] === '-n' ? '1' : bootSimList('Booting')),
+    spawn: () => child,
+  });
+  try {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    const outcome = bootIosSim('UDID-A', {
+      timeoutMs: 45000,
+      out: (message) => messages.push(message),
+    }).catch((error) => error);
+    vi.setSystemTime(Date.now() + 60000);
+    await vi.advanceTimersByTimeAsync(45000);
+    const error = await outcome;
+    expect(messages[0]).toContain('longest gap 75s');
+    expect(messages[0]).toContain('Pressure during gaps is unobserved');
+    expect(error.message).toContain('longest gap 75s');
+    expect(error.message).toContain('Highest observed memory pressure: normal; unavailable samples: 0');
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  }
+});

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -93,9 +93,9 @@ interface IosBoot {
   done: Promise<void>;
 }
 
-function startIosBoot(udid: string, configure: () => Promise<unknown>): IosBoot {
+function startIosBoot(udid: string, configure: () => Promise<unknown>, label: string, out: Notify): IosBoot {
   const done = (async () => {
-    await bootIosSim(udid);
+    await bootIosSim(udid, { label, out });
     await configure();
   })();
   // Node ends the process on an unhandled rejection, and `ensureBooted` -- the
@@ -274,7 +274,7 @@ async function ensureOwnedIosDevice({
         };
         if (sim.state !== 'Booted') {
           out(chalk.dim(phaseLine('device', `booting ${name} (${sim.udid})`)));
-          return { ...updated, booting: startIosBoot(sim.udid, configure), ...facts };
+          return { ...updated, booting: startIosBoot(sim.udid, configure, name, out), ...facts };
         }
         return { ...(await configure()), ...facts };
       }
@@ -309,16 +309,21 @@ async function ensureOwnedIosDevice({
       : null;
   if (adopted) {
     out(chalk.dim(phaseLine('device', `booting ${adopted.deviceName} (${adopted.deviceUdid})`)));
-    const booting = startIosBoot(adopted.deviceUdid, async () => {
-      resetAdoptedSim(adopted.deviceUdid, out);
-      await configureOwnedIosSim({
-        record: adopted,
-        projectPath,
-        profile: simslimProfile,
-        out,
-        reconcileIosSimulator,
-      });
-    });
+    const booting = startIosBoot(
+      adopted.deviceUdid,
+      async () => {
+        resetAdoptedSim(adopted.deviceUdid, out);
+        await configureOwnedIosSim({
+          record: adopted,
+          projectPath,
+          profile: simslimProfile,
+          out,
+          reconcileIosSimulator,
+        });
+      },
+      adopted.deviceName,
+      out,
+    );
     return { ...adopted, booting, deviceType: choice.deviceType, runtime: choice.runtime };
   }
 
@@ -329,14 +334,18 @@ async function ensureOwnedIosDevice({
     return result;
   });
   const newRecord = { deviceUdid: created.udid, owned: true, deviceName: created.name };
-  const booting = startIosBoot(created.udid, () =>
-    configureOwnedIosSim({
-      record: newRecord,
-      projectPath,
-      profile: simslimProfile,
-      out,
-      reconcileIosSimulator,
-    }),
+  const booting = startIosBoot(
+    created.udid,
+    () =>
+      configureOwnedIosSim({
+        record: newRecord,
+        projectPath,
+        profile: simslimProfile,
+        out,
+        reconcileIosSimulator,
+      }),
+    created.name,
+    out,
   );
   return {
     ...newRecord,
@@ -1184,7 +1193,7 @@ async function ensureIosBooted({
   out(chalk.dim(phaseLine('device', `booting ${sim.name} (${udid})`)));
   const bootDeadline = Date.now() + timeoutMs;
   try {
-    await bootIosSim(udid, { timeoutMs });
+    await bootIosSim(udid, { timeoutMs, label: sim.name, out });
   } catch (e) {
     return { failed: true, reason: `Could not boot simulator ${udid}: ${(e as Error)?.message || e}` };
   }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -61,7 +61,9 @@ For iOS Debug architecture findings, review the project's overrides and imported
 Podfile helpers using guide lifecycle options. Doctor --fix does not change them.
 For parallel iOS work, review the recommended optional SimSlim setup in
 stim guide lifecycle simslim. If simulator process startup times out, check
-host memory pressure and free memory before retrying; do not restart other
+host memory pressure and free memory before retrying. Boot progress reports
+current and highest observed pressure; a timeout does not establish OOM.
+Avoid repeated reboots under unchanged pressure; do not restart other
 workspaces' devices or close their apps without asking. That guide covers
 the recovery steps and profile tradeoffs.
 For a linked native library carrying Git metadata, add the printed .git entries to

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1465,6 +1465,9 @@ HOST MEMORY PRESSURE AND STALLED SIMULATORS
   current pressure and the highest observed pressure roughly every 15 seconds.
   Failure diagnostics retain the highest pressure and unavailable sample count;
   they do not infer the cause of a timeout. Monitoring stops when boot ends.
+  Monitoring and timeout handling are best-effort: synchronous CLI work can
+  delay them. Diagnostics report observation gaps over 30 seconds; pressure
+  during a gap is unobserved, even when the surrounding readings are normal.
   Doctor and failure diagnostics report macOS memory pressure when available;
   a failed query remains unknown. Existing swap or low free RAM alone is not
   enough to diagnose pressure.

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1461,6 +1461,10 @@ HOST MEMORY PRESSURE AND STALLED SIMULATORS
   a final boot-state query can take 30 seconds. Opening the Simulator app after
   boot is best-effort and takes at most 5 seconds. A timeout is not proof of an
   app crash or OOM.
+  During boot, Stim reports elapsed time, the simulator name, last boot output,
+  current pressure and the highest observed pressure roughly every 15 seconds.
+  Failure diagnostics retain the highest pressure and unavailable sample count;
+  they do not infer the cause of a timeout. Monitoring stops when boot ends.
   Doctor and failure diagnostics report macOS memory pressure when available;
   a failed query remains unknown. Existing swap or low free RAM alone is not
   enough to diagnose pressure.

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getExecutor, type Executor } from '../exec.ts';
-import { hostMemoryPressureAdvice, readHostMemoryPressure } from '../host-memory.ts';
+import { hostMemoryPressureAdvice, readHostMemoryPressure, type HostMemoryPressure } from '../host-memory.ts';
 import { createLineReader, stripAnsi, waitForChild } from '../process-output.ts';
 
 export interface IosSimRecord {
@@ -167,21 +167,23 @@ export function iosSimulatorFailureAdvice(exec: Executor = getExecutor()): strin
   );
 }
 
-function bootstatusTimeout(udid: string): NodeJS.ErrnoException {
-  const e = new Error(`xcrun simctl bootstatus ${udid} -b timed out`) as NodeJS.ErrnoException;
+function bootstatusTimeout(command: string): NodeJS.ErrnoException {
+  const e = new Error(`${command} timed out`) as NodeJS.ErrnoException;
   e.code = 'ETIMEDOUT';
   return e;
 }
 
-async function awaitBootstatus(udid: string, attemptMs: number): Promise<void> {
+async function awaitBootCommand(args: string[], attemptMs: number, onLine: (line: string) => void): Promise<void> {
+  const command = `xcrun ${args.join(' ')}`;
   const lines: string[] = [];
   const reader = createLineReader((raw) => {
     const line = stripAnsi(raw).trim();
     if (!line) return;
+    onLine(line);
     lines.push(line);
     if (lines.length > 10) lines.shift();
   });
-  const child = getExecutor().spawn('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
+  const child = getExecutor().spawn('xcrun', args, {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child.stdout?.on('data', (chunk) => reader.push(chunk));
@@ -210,15 +212,15 @@ async function awaitBootstatus(udid: string, attemptMs: number): Promise<void> {
       child.stderr?.destroy?.();
       child.unref();
       throw new Error(
-        `Timed out waiting for simctl bootstatus ${udid}; its process could not be confirmed stopped. Inspect pid ${child.pid ?? 'unknown'} before retrying.`,
+        `Timed out waiting for ${command}; its process could not be confirmed stopped. Inspect pid ${child.pid ?? 'unknown'} before retrying.`,
       );
     }
-    throw bootstatusTimeout(udid);
+    throw bootstatusTimeout(command);
   }
   if (result.error) throw result.error;
   if (result.code === 0) return;
   const detail = lines.length ? `: ${lines.join(' | ')}` : '';
-  throw new Error(`xcrun simctl bootstatus ${udid} -b failed with exit code ${result.code ?? 'unknown'}${detail}`);
+  throw new Error(`${command} failed with exit code ${result.code ?? 'unknown'}${detail}`);
 }
 
 export async function bootIosSim(
@@ -226,41 +228,83 @@ export async function bootIosSim(
   {
     timeoutMs = IOS_BOOT_TIMEOUT_MS,
     attemptMs = BOOTSTATUS_ATTEMPT_MS,
-  }: { timeoutMs?: number; attemptMs?: number } = {},
+    label = udid,
+    out = () => {},
+  }: { timeoutMs?: number; attemptMs?: number; label?: string; out?: (message: string) => void } = {},
 ): Promise<void> {
   const exec = getExecutor();
-  const deadline = Date.now() + timeoutMs;
+  const started = Date.now();
+  const deadline = started + timeoutMs;
+  let worst: HostMemoryPressure | null = null;
+  let unknown = 0;
+  let phase = 'requesting boot';
+  const ranks = { normal: 0, warning: 1, critical: 2 };
+  const sample = () => {
+    const pressure = readHostMemoryPressure(exec);
+    if (pressure === null) unknown++;
+    else if (worst === null || ranks[pressure] > ranks[worst]) worst = pressure;
+    return pressure;
+  };
+  const recovery =
+    "Stop unused slots in workspaces you own with `stim stop --slot <name>`, reduce concurrent builds, and retry after pressure falls. Ask before closing other agents' devices or apps. Repeated reboots under unchanged pressure may stall again.";
+  const report = () => {
+    const pressure = sample();
+    out(
+      `Simulator ${label} is still booting after ${Math.round((Date.now() - started) / 1000)}s. Last boot output: ${phase}. Memory pressure: ${pressure ?? 'unknown'}; highest observed: ${worst ?? 'unknown'}. Boot deadline: ${Math.round(timeoutMs / 1000)}s.${pressure === 'warning' || pressure === 'critical' ? ` Boot may be delayed or stalled. ${recovery}` : ''}`,
+    );
+  };
+  const onLine = (line: string) => {
+    phase = line.slice(0, 240);
+  };
+  sample();
+  const monitor = setInterval(report, 15000);
+  monitor.unref();
   try {
-    exec.runFile('xcrun', ['simctl', 'boot', udid], { timeoutMs, killSignal: 'SIGKILL' });
-  } catch (e) {
-    if (!String((e as Error)?.message || e).includes('Booted')) throw e;
-  }
-  // `simctl bootstatus -b` blocks until the boot finishes, and a first boot on a
-  // CPU-starved host (a CI runner sharing cores with xcodebuild) can legitimately
-  // outlast one attempt (#128).
-  for (;;) {
-    const remaining = deadline - Date.now();
-    if (remaining > 0) {
+    try {
+      await awaitBootCommand(['simctl', 'boot', udid], Math.max(1, deadline - Date.now()), onLine);
+      phase = 'waiting for boot completion';
+    } catch (e) {
+      if (!String((e as Error)?.message || e).includes('Booted')) throw e;
+    }
+    // `simctl bootstatus -b` blocks until the boot finishes, and a first boot on a
+    // CPU-starved host (a CI runner sharing cores with xcodebuild) can legitimately
+    // outlast one attempt (#128).
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining > 0) {
+        try {
+          await awaitBootCommand(
+            ['simctl', 'bootstatus', udid, '-b'],
+            Math.min(Math.max(remaining, BOOTSTATUS_ATTEMPT_FLOOR_MS), attemptMs),
+            onLine,
+          );
+          break;
+        } catch (e) {
+          if ((e as NodeJS.ErrnoException)?.code !== 'ETIMEDOUT') throw e;
+        }
+      }
+      let state: string | null | undefined;
       try {
-        await awaitBootstatus(udid, Math.min(Math.max(remaining, BOOTSTATUS_ATTEMPT_FLOOR_MS), attemptMs));
-        break;
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException)?.code !== 'ETIMEDOUT') throw e;
+        state = listAllIosSims({ timeoutMs: BOOT_STATE_LIST_TIMEOUT_MS }).find((s) => s.udid === udid)?.state ?? null;
+      } catch {
+        state = undefined;
+      }
+      const waited = Math.round((timeoutMs - Math.max(0, deadline - Date.now())) / 1000);
+      if (state !== 'Booting' && state !== 'Booted' && state !== undefined) {
+        throw new Error(`Simulator ${udid} reports "${state ?? 'missing'}" after ${waited}s of boot wait.`);
+      }
+      if (deadline - Date.now() <= 0) {
+        throw new Error(`Simulator ${udid} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`);
       }
     }
-    let state: string | null | undefined;
-    try {
-      state = listAllIosSims({ timeoutMs: BOOT_STATE_LIST_TIMEOUT_MS }).find((s) => s.udid === udid)?.state ?? null;
-    } catch {
-      state = undefined;
-    }
-    const waited = Math.round((timeoutMs - Math.max(0, deadline - Date.now())) / 1000);
-    if (state !== 'Booting' && state !== 'Booted' && state !== undefined) {
-      throw new Error(`Simulator ${udid} reports "${state ?? 'missing'}" after ${waited}s of boot wait.`);
-    }
-    if (deadline - Date.now() <= 0) {
-      throw new Error(`Simulator ${udid} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`);
-    }
+  } catch (error) {
+    sample();
+    throw new Error(
+      `${(error as Error)?.message || error} Last boot output: ${phase}. Highest observed memory pressure: ${worst ?? 'unknown'}; unavailable samples: ${unknown}. ${recovery} These observations do not establish an OOM crash.`,
+      { cause: error },
+    );
+  } finally {
+    clearInterval(monitor);
   }
   exec.runFileQuiet('open', ['-a', 'Simulator'], { timeoutMs: 5000, killSignal: 'SIGKILL' });
 }

--- a/packages/stim-cli/src/sim/ios.ts
+++ b/packages/stim-cli/src/sim/ios.ts
@@ -237,9 +237,14 @@ export async function bootIosSim(
   const deadline = started + timeoutMs;
   let worst: HostMemoryPressure | null = null;
   let unknown = 0;
+  let sampledAt = started;
+  let longestGapMs = 0;
   let phase = 'requesting boot';
   const ranks = { normal: 0, warning: 1, critical: 2 };
   const sample = () => {
+    const now = Date.now();
+    longestGapMs = Math.max(longestGapMs, now - sampledAt);
+    sampledAt = now;
     const pressure = readHostMemoryPressure(exec);
     if (pressure === null) unknown++;
     else if (worst === null || ranks[pressure] > ranks[worst]) worst = pressure;
@@ -247,10 +252,14 @@ export async function bootIosSim(
   };
   const recovery =
     "Stop unused slots in workspaces you own with `stim stop --slot <name>`, reduce concurrent builds, and retry after pressure falls. Ask before closing other agents' devices or apps. Repeated reboots under unchanged pressure may stall again.";
+  const coverage = () =>
+    longestGapMs > 30000
+      ? ` Observations were delayed: longest gap ${Math.round(longestGapMs / 1000)}s. Pressure during gaps is unobserved; blocking CLI work can also delay progress and timeout handling.`
+      : '';
   const report = () => {
     const pressure = sample();
     out(
-      `Simulator ${label} is still booting after ${Math.round((Date.now() - started) / 1000)}s. Last boot output: ${phase}. Memory pressure: ${pressure ?? 'unknown'}; highest observed: ${worst ?? 'unknown'}. Boot deadline: ${Math.round(timeoutMs / 1000)}s.${pressure === 'warning' || pressure === 'critical' ? ` Boot may be delayed or stalled. ${recovery}` : ''}`,
+      `Simulator ${label} is still booting after ${Math.round((Date.now() - started) / 1000)}s. Last boot output: ${phase}. Memory pressure: ${pressure ?? 'unknown'}; highest observed: ${worst ?? 'unknown'}. Boot deadline: ${Math.round(timeoutMs / 1000)}s.${coverage()}${pressure === 'warning' || pressure === 'critical' ? ` Boot may be delayed or stalled. ${recovery}` : ''}`,
     );
   };
   const onLine = (line: string) => {
@@ -300,7 +309,7 @@ export async function bootIosSim(
   } catch (error) {
     sample();
     throw new Error(
-      `${(error as Error)?.message || error} Last boot output: ${phase}. Highest observed memory pressure: ${worst ?? 'unknown'}; unavailable samples: ${unknown}. ${recovery} These observations do not establish an OOM crash.`,
+      `${(error as Error)?.message || error} Last boot output: ${phase}. Highest observed memory pressure: ${worst ?? 'unknown'}; unavailable samples: ${unknown}.${coverage()} ${recovery} These observations do not establish an OOM crash.`,
       { cause: error },
     );
   } finally {

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -51,7 +51,10 @@ During a slow local iOS boot, Stim reports the simulator name, elapsed time, las
 output, current memory pressure, and highest observed pressure roughly every
 15 seconds. Boot failures retain the highest pressure and the number of
 unavailable readings. Unknown readings are not treated as normal, and pressure
-does not prove the cause of a timeout. The boot deadline remains ten minutes.
+does not prove the cause of a timeout. The boot deadline remains ten minutes,
+but synchronous CLI work can delay observations, progress, and timeout handling.
+Diagnostics report observation gaps over 30 seconds; pressure during those gaps
+is unobserved, even when surrounding readings are normal.
 
 An agent should stop unused slots in workspaces it owns, reduce concurrent
 builds, and retry after pressure falls. Ask before closing another agent's

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -47,6 +47,17 @@ alone does not establish OOM. Stop only workspaces you own and have finished
 using; ask before closing other agents' simulators or heavy apps. SimSlim can
 reduce future resource use but is not a guaranteed fix for a stalled host.
 
+During a slow local iOS boot, Stim reports the simulator name, elapsed time, last boot
+output, current memory pressure, and highest observed pressure roughly every
+15 seconds. Boot failures retain the highest pressure and the number of
+unavailable readings. Unknown readings are not treated as normal, and pressure
+does not prove the cause of a timeout. The boot deadline remains ten minutes.
+
+An agent should stop unused slots in workspaces it owns, reduce concurrent
+builds, and retry after pressure falls. Ask before closing another agent's
+simulator or a user's app. Repeated reboots under unchanged pressure can repeat
+the stall.
+
 ## Remote devices
 
 Stim supports two optional remote backends:
@@ -86,14 +97,3 @@ App data remains on disk while parked; system apps, shared storage, accounts
 and device settings persist across reuse. Set `pool.androidParkedMax` to `0`
 when a fresh device is required. AVDs created before Stim recorded their
 creation configuration are deleted when removed.
-
-During a slow boot, Stim reports the simulator name, elapsed time, last boot
-output, current memory pressure, and highest observed pressure roughly every
-15 seconds. Boot failures retain the highest pressure and the number of
-unavailable readings. Unknown readings are not treated as normal, and pressure
-does not prove the cause of a timeout. The boot deadline remains ten minutes.
-
-An agent should stop unused slots in workspaces it owns, reduce concurrent
-builds, and retry after pressure falls. Ask before closing another agent's
-simulator or a user's app. Repeated reboots under unchanged pressure can repeat
-the stall.

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -86,3 +86,14 @@ App data remains on disk while parked; system apps, shared storage, accounts
 and device settings persist across reuse. Set `pool.androidParkedMax` to `0`
 when a fresh device is required. AVDs created before Stim recorded their
 creation configuration are deleted when removed.
+
+During a slow boot, Stim reports the simulator name, elapsed time, last boot
+output, current memory pressure, and highest observed pressure roughly every
+15 seconds. Boot failures retain the highest pressure and the number of
+unavailable readings. Unknown readings are not treated as normal, and pressure
+does not prove the cause of a timeout. The boot deadline remains ten minutes.
+
+An agent should stop unused slots in workspaces it owns, reduce concurrent
+builds, and retry after pressure falls. Ask before closing another agent's
+simulator or a user's app. Repeated reboots under unchanged pressure can repeat
+the stall.


### PR DESCRIPTION
## Description

A simulator boot can wait ten minutes while pressure rises after the initial allocation check. Agents receive no progress during that wait, and boot errors lose the pressure history.

## Solution

Report the simulator name, elapsed time, last boot output and current/highest observed memory pressure roughly every 15 seconds. Failures retain the highest observed pressure and unavailable sample counts, with guidance to stop unused owned slots and reduce concurrent builds before retrying. 

Observe the initial boot request asynchronously under the existing deadline and termination rules. The guide and website explain the limits: pressure and a timeout do not establish an OOM. Blocking CLI work can delay observations, progress, and timeout handling; diagnostics report observation gaps over 30 seconds as missing coverage.

Depends on #779. This changes diagnostics and process orchestration, not the timeout, ownership rules or automatic retry policy.

## Test plan

Regression tests cover pressure rising, unavailable samples, recovery before failure, retained boot output, initial-request timeout, and monitor cleanup. All repository checks and the website build/typecheck pass. A fresh owned iPhone simulator emitted the 15-second progress message, completed boot and process readiness, accepted an already-booted request, and was deleted through centralized teardown.

Fixes #792.

