### PR TITLE
test: prepare iOS simulators before concurrent native QA

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -286,3 +286,8 @@ Cache suites still require a cold artifact miss and race two commands against
 one empty cache. The preparation reduces overlapping first-boot work; it does
 not establish that host memory caused earlier failures or guarantee enough
 capacity for the eventual concurrent workload. Runner sizes are unchanged.
+
+If preparation or its shutdown fails, the suite preserves its temporary
+worktrees and `STIM_HOME` and prints the state location. Inspect the failure
+and use Stim with that home to clean up; do not erase ownership records while
+their simulators still exist.

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -271,3 +271,18 @@ setup timings, seeds and clears app data, verifies an unchanged APK skips
 installation, and checks that GC deletes the parked AVD. It uses separate launch
 and cleanup processes, like the CLI. The test removes its own devices and prints
 the temporary directory containing `result.json` and emulator logs.
+
+### Sequential iOS simulator preparation
+
+When an iOS fixture declares a SimSlim profile, the loop and cache suites
+prepare their required simulator assignments one at a time before starting
+the workload. Preparation creates or reuses an owned simulator, waits for boot
+and profile reconciliation, then shuts it down through Stim. It does not start
+Metro, build the app, or populate the native artifact cache. Stock fixtures
+and Android do not take this preparation path.
+
+The loop still asserts three distinct simulators are booted simultaneously.
+Cache suites still require a cold artifact miss and race two commands against
+one empty cache. The preparation reduces overlapping first-boot work; it does
+not establish that host memory caused earlier failures or guarantee enough
+capacity for the eventual concurrent workload. Runner sizes are unchanged.

--- a/test/e2e/native-worktrees.e2e.js
+++ b/test/e2e/native-worktrees.e2e.js
@@ -19,6 +19,7 @@ import {
   createFixture,
   createHarness,
   createWarmWorktree,
+  prepareIosDevices,
   workspaceLogsDir,
 } from './native/harness.mjs';
 
@@ -195,4 +196,57 @@ writeFileSync(join(app, 'package.json'), '{"name":"fixture"}\\n');
   assert.equal(git(app, 'status', '--porcelain'), '');
   assert.equal(git(app, 'show', 'HEAD:package.json'), '{"name":"prepared-fixture"}');
   assert.equal(git(app, 'ls-files', 'ios'), '');
+});
+
+test('native preparation stops each simulator before the next and stops after a failed preparation', (t) => {
+  const root = scratch(t);
+  const homes = [join(root, 'first'), join(root, 'second')];
+  for (const cwd of homes) {
+    mkdirSync(cwd);
+    writeFileSync(join(cwd, '.stim.json'), JSON.stringify({ ios: { simslimProfile: 'profile.json' } }));
+  }
+  for (const failure of [false, true]) {
+    const events = [];
+    const h = {
+      log() {},
+      sh(file, args, { cwd } = {}) {
+        if (file === 'xcrun')
+          return { code: 0, stdout: JSON.stringify({ devices: { ios: [{ udid: 'owned', state: 'Shutdown' }] } }) };
+        assert.equal(file, process.execPath);
+        assert.equal(args[2], cwd);
+        events.push(['prepare', cwd]);
+        return {
+          code: failure ? 1 : 0,
+          stdout: JSON.stringify({ udid: 'owned' }),
+          stderr: failure ? 'boot timed out' : '',
+        };
+      },
+      cli(args, { cwd }) {
+        assert.deepEqual(args, ['stop', '--slot', 'default', '--json']);
+        events.push(['stop', cwd]);
+        return { code: 0, stderr: '' };
+      },
+    };
+    const run = () =>
+      prepareIosDevices({
+        h,
+        platform: 'ios',
+        targets: homes.map((cwd) => ({ cwd })),
+        cleanup: {
+          recordWorkspace(cwd) {
+            events.push(['record', cwd]);
+          },
+        },
+      });
+    if (failure) assert.throws(run, /boot timed out/);
+    else run();
+    assert.deepEqual(
+      events,
+      (failure ? homes.slice(0, 1) : homes).flatMap((cwd) => [
+        ['prepare', cwd],
+        ['record', cwd],
+        ['stop', cwd],
+      ]),
+    );
+  }
 });

--- a/test/e2e/native-worktrees.e2e.js
+++ b/test/e2e/native-worktrees.e2e.js
@@ -20,6 +20,7 @@ import {
   createHarness,
   createWarmWorktree,
   prepareIosDevices,
+  cleanupTmp,
   workspaceLogsDir,
 } from './native/harness.mjs';
 
@@ -238,8 +239,18 @@ test('native preparation stops each simulator before the next and stops after a 
           },
         },
       });
-    if (failure) assert.throws(run, /boot timed out/);
-    else run();
+    if (failure) {
+      let observed;
+      try {
+        run();
+      } catch (error) {
+        observed = error;
+      }
+      assert.match(observed.message, /boot timed out/);
+      assert.equal(observed.preserveNativeState, true);
+      cleanupTmp(homes, observed);
+      assert.ok(homes.every((cwd) => existsSync(join(cwd, '.stim.json'))));
+    } else run();
     assert.deepEqual(
       events,
       (failure ? homes.slice(0, 1) : homes).flatMap((cwd) => [

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
@@ -177,6 +178,36 @@ export function createWarmWorktree({ h, sourceDir, workDir, name, created }) {
   assert(warmed.code === 0, `warming ${path} failed: ${warmed.stderr}`);
   h.log(`worktree ${name} (from ${sourceDir}) -> ${path}`);
   return path;
+}
+
+export function prepareIosDevices({ h, platform, targets, cleanup }) {
+  if (platform !== 'ios') return;
+  const script = fileURLToPath(new URL('./prepare-ios-device.mjs', import.meta.url));
+  for (const { cwd, slot = 'default', deviceType } of targets) {
+    const settingsPath = join(cwd, '.stim.json');
+    const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {};
+    if (!settings.ios?.simslimProfile) continue;
+    h.log(`preparing simulator ${slot} in ${cwd} before the multi-device workload`);
+    const result = h.sh(
+      process.execPath,
+      ['--experimental-strip-types', script, cwd, slot, ...(deviceType ? [deviceType] : [])],
+      {
+        cwd,
+        timeout: 25 * 60 * 1000,
+        allowFail: true,
+      },
+    );
+    cleanup.recordWorkspace(cwd);
+    const stopped = h.cli(['stop', '--slot', slot, '--json'], { cwd, allowFail: true });
+    assert(stopped.code === 0, `could not stop prepared simulator ${slot}: ${stopped.stderr}`);
+    assert(result.code === 0, `simulator preparation failed for ${slot}: ${result.stderr}`);
+    const { udid } = JSON.parse(result.stdout);
+    const inventory = JSON.parse(h.sh('xcrun', ['simctl', 'list', 'devices', '--json'], { timeout: 30000 }).stdout);
+    const sim = Object.values(inventory.devices)
+      .flat()
+      .find((device) => device.udid === udid);
+    assert(sim?.state === 'Shutdown', `prepared simulator ${slot} was not shut down`);
+  }
 }
 
 export function assertMatchingPods(appDir) {

--- a/test/e2e/native/harness.mjs
+++ b/test/e2e/native/harness.mjs
@@ -183,30 +183,38 @@ export function createWarmWorktree({ h, sourceDir, workDir, name, created }) {
 export function prepareIosDevices({ h, platform, targets, cleanup }) {
   if (platform !== 'ios') return;
   const script = fileURLToPath(new URL('./prepare-ios-device.mjs', import.meta.url));
-  for (const { cwd, slot = 'default', deviceType } of targets) {
-    const settingsPath = join(cwd, '.stim.json');
-    const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {};
-    if (!settings.ios?.simslimProfile) continue;
-    h.log(`preparing simulator ${slot} in ${cwd} before the multi-device workload`);
-    const result = h.sh(
-      process.execPath,
-      ['--experimental-strip-types', script, cwd, slot, ...(deviceType ? [deviceType] : [])],
-      {
-        cwd,
-        timeout: 25 * 60 * 1000,
-        allowFail: true,
-      },
+  try {
+    for (const { cwd, slot = 'default', deviceType } of targets) {
+      const settingsPath = join(cwd, '.stim.json');
+      const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {};
+      if (!settings.ios?.simslimProfile) continue;
+      h.log(`preparing simulator ${slot} in ${cwd} before the multi-device workload`);
+      const result = h.sh(
+        process.execPath,
+        ['--experimental-strip-types', script, cwd, slot, ...(deviceType ? [deviceType] : [])],
+        {
+          cwd,
+          timeout: 25 * 60 * 1000,
+          allowFail: true,
+        },
+      );
+      cleanup.recordWorkspace(cwd);
+      const stopped = h.cli(['stop', '--slot', slot, '--json'], { cwd, allowFail: true });
+      assert(stopped.code === 0, `could not stop prepared simulator ${slot}: ${stopped.stderr}`);
+      assert(result.code === 0, `simulator preparation failed for ${slot}: ${result.stderr}`);
+      const { udid } = JSON.parse(result.stdout);
+      const inventory = JSON.parse(h.sh('xcrun', ['simctl', 'list', 'devices', '--json'], { timeout: 30000 }).stdout);
+      const sim = Object.values(inventory.devices)
+        .flat()
+        .find((device) => device.udid === udid);
+      assert(sim?.state === 'Shutdown', `prepared simulator ${slot} was not shut down`);
+    }
+  } catch (error) {
+    error.preserveNativeState = true;
+    h.log(
+      `Simulator preparation failed. Keeping ownership state at ${h.env?.STIM_HOME ?? 'STIM_HOME'} and its worktrees for recovery.`,
     );
-    cleanup.recordWorkspace(cwd);
-    const stopped = h.cli(['stop', '--slot', slot, '--json'], { cwd, allowFail: true });
-    assert(stopped.code === 0, `could not stop prepared simulator ${slot}: ${stopped.stderr}`);
-    assert(result.code === 0, `simulator preparation failed for ${slot}: ${result.stderr}`);
-    const { udid } = JSON.parse(result.stdout);
-    const inventory = JSON.parse(h.sh('xcrun', ['simctl', 'list', 'devices', '--json'], { timeout: 30000 }).stdout);
-    const sim = Object.values(inventory.devices)
-      .flat()
-      .find((device) => device.udid === udid);
-    assert(sim?.state === 'Shutdown', `prepared simulator ${slot} was not shut down`);
+    throw error;
   }
 }
 
@@ -414,7 +422,8 @@ export function dumpDiagnostics(h, created) {
   }
 }
 
-export function cleanupTmp(dirs) {
+export function cleanupTmp(dirs, error) {
+  if (error?.preserveNativeState) return;
   for (const dir of dirs.filter(Boolean)) {
     try {
       rmSync(dir, { recursive: true, force: true });

--- a/test/e2e/native/prepare-ios-device.mjs
+++ b/test/e2e/native/prepare-ios-device.mjs
@@ -1,0 +1,24 @@
+import { realpathSync } from 'node:fs';
+import { getProject } from '../../../packages/stim-cli/src/config.ts';
+import { ensureOwnedDevice, ensureBooted } from '../../../packages/stim-cli/src/engine/device.ts';
+import { readCommittedSettings } from '../../../packages/stim-cli/src/settings.ts';
+
+if (!process.env.STIM_HOME) throw new Error('Native QA preparation requires an isolated STIM_HOME.');
+const [path, slot = 'default', deviceType] = process.argv.slice(2);
+const projectPath = realpathSync(path);
+const settings = readCommittedSettings(projectPath);
+if (!settings.ios?.simslimProfile) throw new Error('Native QA preparation requires an explicit SimSlim profile.');
+const out = (message) => process.stderr.write(`${message}\n`);
+const device = await ensureOwnedDevice({
+  platform: 'ios',
+  project: getProject(projectPath),
+  projectPath,
+  slot,
+  settings,
+  flags: deviceType ? { deviceType } : {},
+  out,
+  note: out,
+});
+const boot = await ensureBooted({ platform: 'ios', device, out });
+if (!boot.ok) throw new Error(boot.reason);
+process.stdout.write(`${JSON.stringify({ udid: boot.udid, slot })}\n`);

--- a/test/e2e/native/prepare-ios-device.mjs
+++ b/test/e2e/native/prepare-ios-device.mjs
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs';
-import { getProject } from '../../../packages/stim-cli/src/config.ts';
+import { upsertProject } from '../../../packages/stim-cli/src/config.ts';
 import { ensureOwnedDevice, ensureBooted } from '../../../packages/stim-cli/src/engine/device.ts';
 import { readCommittedSettings } from '../../../packages/stim-cli/src/settings.ts';
 
@@ -11,7 +11,7 @@ if (!settings.ios?.simslimProfile) throw new Error('Native QA preparation requir
 const out = (message) => process.stderr.write(`${message}\n`);
 const device = await ensureOwnedDevice({
   platform: 'ios',
-  project: getProject(projectPath),
+  project: upsertProject(projectPath, {}),
   projectPath,
   slot,
   settings,

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -30,6 +30,7 @@ import {
   growth,
   lastLines,
   preflight,
+  prepareIosDevices,
   quote,
   readNdjson,
   topFileNames,
@@ -235,6 +236,8 @@ async function main() {
   const dirtyByWorktree = [];
 
   const wt1 = worktreeCreate('e2e-cache-1', appDir);
+  const wt2 = worktreeCreate('e2e-cache-2', appDir);
+  prepareIosDevices({ h, platform: PLATFORM, cleanup, targets: [{ cwd: wt1 }, { cwd: wt2 }] });
   const start1 = startAndAssertMode(wt1);
   log(`wt1 start mode=${start1.mode} port=${start1.port}`);
 
@@ -266,7 +269,6 @@ async function main() {
           .filter((m) => /FROM-CACHE/.test(m))
       : [];
 
-  const wt2 = worktreeCreate('e2e-cache-2', appDir);
   const start2 = startAndAssertMode(wt2);
   log(`wt2 start mode=${start2.mode} port=${start2.port}`);
   const storeRoot2 = metroStoreRootFrom(wt2);
@@ -549,6 +551,7 @@ async function main() {
   } else {
     const wt3 = worktreeCreate('e2e-cache-3', appDir);
     const wt4 = worktreeCreate('e2e-cache-4', appDir);
+    prepareIosDevices({ h, platform: PLATFORM, cleanup, targets: [{ cwd: wt3 }, { cwd: wt4 }] });
     if (PLATFORM === 'ios') {
       assertMatchingPods(wt3);
       assertMatchingPods(wt4);

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -1043,7 +1043,7 @@ main().then(
     dumpDiagnostics(h, created);
     emitSummary(Date.now() - startedAt, String(err?.message || err));
     if (!args.keep)
-      cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR, GRADLE_HOME_IS_THROWAWAY ? GRADLE_USER_HOME : null]);
+      cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR, GRADLE_HOME_IS_THROWAWAY ? GRADLE_USER_HOME : null], err);
     return process.exit(1);
   },
 );

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -16,6 +16,7 @@ import {
   dumpDiagnostics,
   lastLines,
   preflight,
+  prepareIosDevices,
   quote,
   verifyCleanup,
   workspaceLogsDir,
@@ -64,6 +65,32 @@ async function main() {
   }
 
   const wt1 = worktreeCreate('e2e-1', appDir);
+  const wt2 = worktreeCreate('e2e-2', appDir);
+  const flags = [];
+  if (PLATFORM === 'ios') {
+    const inventory = JSON.parse(sh('xcrun', ['simctl', 'list', '--json'], { timeout: 30000 }).stdout);
+    const supported = new Set(
+      inventory.runtimes
+        .filter((runtime) => runtime.isAvailable && runtime.identifier.includes('.iOS-'))
+        .flatMap((runtime) => runtime.supportedDeviceTypes.map((type) => type.identifier)),
+    );
+    const tablet = inventory.devicetypes.find(
+      (type) => type.name.startsWith('iPad Pro') && supported.has(type.identifier),
+    );
+    assert(tablet, 'native slot QA requires an iPad device type supported by an available iOS runtime');
+    flags.push('--device-type', tablet.name);
+  }
+  prepareIosDevices({
+    h,
+    platform: PLATFORM,
+    cleanup,
+    targets: [
+      { cwd: wt1 },
+      { cwd: wt1, slot: 'second' },
+      { cwd: wt1, slot: 'third', deviceType: flags[1] },
+      { cwd: wt2 },
+    ],
+  });
   const start1 = startAndAssertMode(wt1);
   log(`wt1 start mode: ${start1.mode}`);
   const build1 = buildAndAssert(wt1, { expectCacheHit: false });
@@ -79,7 +106,6 @@ async function main() {
   assertArtifact(build1.appPath);
   handleLaunch(build1, 'wt1');
 
-  const wt2 = worktreeCreate('e2e-2', appDir);
   const start2 = startAndAssertMode(wt2);
   log(`wt2 start mode: ${start2.mode}`);
   const build2 = buildAndAssert(wt2, { expectCacheHit: true });
@@ -94,7 +120,7 @@ async function main() {
 
   cleanup.recordWorkspace(wt2);
   cli(['stop'], { cwd: wt2 });
-  verifyDeviceSlots(wt1, build1);
+  verifyDeviceSlots(wt1, build1, flags);
   cleanup.recordWorkspace(wt1);
   cli(['stop'], { cwd: wt1 });
   worktreeRemove(wt2);
@@ -102,7 +128,7 @@ async function main() {
   await verifyCleanup({ h, cleanup, appDir, created });
 }
 
-function verifyDeviceSlots(cwd, original) {
+function verifyDeviceSlots(cwd, original, thirdFlags) {
   banner('named slots: distinct devices, cached installs, reuse and scoped stop');
   const deviceId = (facts) => (PLATFORM === 'ios' ? facts.udid : facts.avdName);
   const runSlot = (slot, flags = []) => {
@@ -123,22 +149,21 @@ function verifyDeviceSlots(cwd, original) {
   assert(deviceId(second) !== deviceId(original), 'two same-model slots shared a device');
   const repeated = runSlot('second');
   assert(deviceId(repeated) === deviceId(second), 'repeated slot did not reuse its device');
-  const flags = [];
-  if (PLATFORM === 'ios') {
-    const inventory = JSON.parse(sh('xcrun', ['simctl', 'list', '--json'], { timeout: 30000 }).stdout);
-    const supported = new Set(
-      inventory.runtimes
-        .filter((runtime) => runtime.isAvailable && runtime.identifier.includes('.iOS-'))
-        .flatMap((runtime) => runtime.supportedDeviceTypes.map((type) => type.identifier)),
-    );
-    const tablet = inventory.devicetypes.find(
-      (type) => type.name.startsWith('iPad Pro') && supported.has(type.identifier),
-    );
-    assert(tablet, 'native slot QA requires an iPad device type supported by an available iOS runtime');
-    flags.push('--device-type', tablet.name);
-  }
-  const third = runSlot('third', flags);
+  const third = runSlot('third', thirdFlags);
   assert(new Set([original, second, third].map(deviceId)).size === 3, 'three slots did not get distinct devices');
+  if (PLATFORM === 'ios') {
+    const inventory = JSON.parse(sh('xcrun', ['simctl', 'list', 'devices', '--json'], { timeout: 30000 }).stdout);
+    const booted = new Set(
+      Object.values(inventory.devices)
+        .flat()
+        .filter((device) => device.state === 'Booted')
+        .map((device) => device.udid),
+    );
+    assert(
+      [original, second, third].every((facts) => booted.has(facts.udid)),
+      'all three slots must be booted simultaneously',
+    );
+  }
   const status = () =>
     cliJson(['status', '--json'], { cwd }).environments.find((environment) => environment.path === cwd);
   const before = status();

--- a/test/e2e/native/run-native-e2e.mjs
+++ b/test/e2e/native/run-native-e2e.mjs
@@ -305,7 +305,7 @@ main().then(
   (err) => {
     log(`FAIL ${VARIANT}: ${err?.message || err}`);
     dumpDiagnostics(h, created);
-    if (!args.keep) cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR]);
+    if (!args.keep) cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR], err);
     process.exit(1);
   },
 );


### PR DESCRIPTION
## Description

Multi-device native QA cold-boots additional simulators while earlier ones remain running. The initial boot must succeed before SimSlim can disable services, leaving that preparation vulnerable on constrained hosts.

## Solution

Prepare simulator assignments one at a time for iOS fixtures with an explicit SimSlim profile, then stop each through Stim before starting the workload. Preparation failures preserve the temporary ownership state and worktrees for recovery. Preparation does not start Metro, build an app or fill the native cache. The loop explicitly verifies three simulators are booted together; cold-build, cache-hit and concurrent single-flight assertions remain in place. Stock fixtures, Android and runner sizes are unchanged.

Depends on #781 for slot-aware native QA. Validation also includes the fixture profile from #785. This may reduce first-boot contention, but does not guarantee capacity for the eventual concurrent workload.

## Test plan

Regression coverage verifies that preparation stops one simulator before starting the next and still stops after a preparation failure. Both local bare/Expo iOS loops and cache suites passed with the reviewed fixture profile: cold misses, three simultaneously booted slots, single-flight results and final cleanup. In [the combined hosted run](https://github.com/appandflow/stim/actions/runs/34726498315), all iOS and Android loop/cache jobs passed. The separate Expo pool timeout is tracked by #797.

Fixes #793.



