### PR TITLE
test: stop unused workspace before the next pool boot

### DIFF
--- a/test/e2e/native/run-pool-e2e.mjs
+++ b/test/e2e/native/run-pool-e2e.mjs
@@ -47,6 +47,7 @@ async function main() {
   const wt1 = worktreeCreate('pool-1', appDir);
   const first = runIos(wt1);
   assert(first.adopted === false, `wt1 ran on an empty pool and must have created, not adopted:\n${first.deviceLine}`);
+  cli(['stop'], { cwd: wt1 });
   const wt2 = worktreeCreate('pool-2', appDir);
   const second = runIos(wt2);
   assert(second.adopted === false, `wt2 must have created its own sim, not adopted:\n${second.deviceLine}`);
@@ -54,7 +55,6 @@ async function main() {
 
   banner('remove: the first parks');
   cleanup.recordWorkspace(wt1);
-  cli(['stop'], { cwd: wt1 });
   const removed1 = worktreeRemove(wt1);
   assert(/ {2}device {6}parked stim-parked /.test(removed1), `worktree remove did not park:\n${removed1}`);
   assertPoolSize(1);


### PR DESCRIPTION
## Description

The native pool test leaves its first simulator and Metro running while booting the second, even though the first app is no longer used. The latest Expo pool timeout coincided with sustained memory pressure on a 7 GiB hosted runner.

## Solution

Move the existing first-workspace stop earlier, retaining its device assignment until removal. Distinct-device, park, eviction, adoption, and cleanup assertions remain intact; simultaneous-device coverage stays in the loop and cache suites. Runner configuration and production pool behavior are unchanged.

## Test plan

Both bare and Expo pool suites passed on the combined QA candidate, with temporary worktrees/build state on an external SSD. Verified the first simulator and Metro stop before the second boot, distinct devices, oldest-device eviction, adoption, and final cleanup. [Focused hosted validation](https://github.com/appandflow/stim/actions/runs/34728590028) uses the unchanged standard runners.

Fixes #797.

