### PR TITLE
test: support external temporary directories

### DIFF
--- a/packages/stim-cli/src/__tests__/fs-util.test.ts
+++ b/packages/stim-cli/src/__tests__/fs-util.test.ts
@@ -37,7 +37,7 @@ test('isOnMountedVolume resolves a symlinked ancestor instead of classifying the
     symlinkSync('/Volumes/UnmountedTestVolume/Developer', symlinkedAncestor);
     const projectPath = join(symlinkedAncestor, 'app');
 
-    expect(volumeRootFor(projectPath)).toBe('/');
+    expect(volumeRootFor(projectPath)).not.toBe('/Volumes/UnmountedTestVolume');
     expect(isOnMountedVolume(projectPath, ['/'])).toBe(false);
     expect(isOnMountedVolume(projectPath, ['/', '/Volumes/UnmountedTestVolume'])).toBe(true);
   } finally {
@@ -46,7 +46,7 @@ test('isOnMountedVolume resolves a symlinked ancestor instead of classifying the
 });
 
 test('isOnMountedVolume confirms a plain boot-volume path', () => {
-  expect(isOnMountedVolume(tmpdir(), ['/'])).toBe(true);
+  expect(isOnMountedVolume('/', ['/'])).toBe(true);
 });
 
 test('isOnMountedVolume returns false for a path it cannot resolve', () => {

--- a/packages/stim-cli/src/__tests__/ios-command.test.ts
+++ b/packages/stim-cli/src/__tests__/ios-command.test.ts
@@ -1302,7 +1302,7 @@ describe('the remote cache', () => {
     expect(exitCode).toBe(null);
     expect(!calls.order.includes('resolveRemote')).toBeTruthy();
     expect(!calls.order.includes('uploadRemote')).toBeTruthy();
-    expect(errs.filter((line) => /cache/.test(line))).toEqual([
+    expect(errs.filter((line) => line.startsWith(phaseLine('cache', '')))).toEqual([
       phaseLine('cache', 'compilation cache unavailable; Xcode did not report reliable statistics'),
     ]);
   });

--- a/packages/stim-cli/src/__tests__/status.test.ts
+++ b/packages/stim-cli/src/__tests__/status.test.ts
@@ -467,14 +467,16 @@ function dfExecutor(byVolume: Record<string, string>) {
   return asked;
 }
 
-test('a project on the boot volume reports one volume', async () => {
+test('a project and STIM_HOME on the boot volume report one volume', () => {
+  process.env.STIM_HOME = '/Users/someone/.stim';
   const asked = dfExecutor({ '/': dfOutput({ totalKb: 926 * 1024 * 1024, availableKb: 38 * 1024 * 1024 }) });
   const volumes = readVolumes('/Users/someone/code/app');
   expect(asked).toEqual(['/']);
   expect(volumes.map((v) => v.volume)).toEqual(['/']);
 });
 
-test('a project on another volume reports that volume alongside the boot one', async () => {
+test('a project on another volume reports that volume alongside the boot one', () => {
+  process.env.STIM_HOME = '/Users/someone/.stim';
   const asked = dfExecutor({
     '/': dfOutput({ totalKb: 926 * 1024 * 1024, availableKb: 38 * 1024 * 1024 }),
     '/Volumes/ExternalSSD': dfOutput({ totalKb: 2048 * 1024 * 1024, availableKb: 1536 * 1024 * 1024 }),


### PR DESCRIPTION
## Description

Four unit assertions fail when TMPDIR points to an external drive: volume fixtures assume the boot volume, and a cache-warning filter matches unrelated paths containing `/caches/`.

## Solution

Make the tested volume locations explicit and match cache diagnostics by their phase prefix. Preserve the symlink mount-safety checks.

## Test plan

- Full unit suite with the default TMPDIR: 4,332 passed, one skipped.
- Full unit suite with `TMPDIR=/Volumes/ExternalSSD/caches/stim-qa-tmp`: 4,332 passed, one skipped.
- Formatting, lint, build, type checking, knip, and runtime-floor checks passed.

Fixes #799
