### PR TITLE
test: avoid lease false positives in release paths

### DIFF
--- a/packages/stim-cli/src/__tests__/stop.test.ts
+++ b/packages/stim-cli/src/__tests__/stop.test.ts
@@ -1215,9 +1215,17 @@ test('stop releases the leases this workspace holds and lists them', async () =>
 });
 
 test('stop says nothing about leases when this workspace holds none', async () => {
-  const r = await runStop({ root: tmpRoot, project: null, state: null, collectors: {}, report: () => {} });
+  const reported: string[] = [];
+  const r = await runStop({
+    root: tmpRoot,
+    project: null,
+    state: null,
+    collectors: {},
+    report: (line) => reported.push(line),
+  });
   expect(r.outcomes.releasedLeases).toEqual([]);
-  expect(r.summary).not.toMatch(/lease/);
+  expect(r.summary).toBe(`Stopped: nothing was running (${tmpRoot})`);
+  expect(reported.join('\n')).not.toMatch(/^  lease\s/m);
 });
 
 test('stop --json prints exactly one line of JSON on stdout', async () => {


### PR DESCRIPTION
## Description

The no-lease stop test fails when TMPDIR contains `release`, because it searches the entire summary, including the project path, for `lease`.

## Solution

Assert the complete no-op summary and absence of lease phase notifications, keeping the structured lease assertion.

## Test plan

Reproduced the assertion failure with `TMPDIR=/tmp/stim-release-qa-746`. With the fix, the full suite passes using that same directory: 4,332 passed, one skipped. Required repository checks pass.

Fixes #746
