### PR TITLE
fix: let current warm refreshes overlap sibling copies

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -128,7 +128,7 @@ eligible `.env` and local configuration files. Existing entries are preserved;
 existing ignored directories such as `node_modules` are skipped whole.
 
 `stim worktree warm --refresh` brings the source checkout up to date first: it
-fetches, fast-forwards whatever branch is checked out there, and installs what
+checks the upstream, fetches changes when needed, fast-forwards whatever branch is checked out there, and installs what
 the new commits moved before copying. It refuses a source checkout it cannot
 move (uncommitted tracked changes, a rebase or merge in progress, a detached
 HEAD, a diverged branch) and never switches branches. One lock per repository

--- a/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
@@ -242,6 +242,128 @@ test('--refresh fast-forwards the source checkout, then copies', async () => {
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
 });
 
+test('a current refresh copies under its shared claim while a sibling copy still holds the seed', async () => {
+  write(root, '.env', 'main env');
+  const held = await acquireWarmClaim({ repositoryRoot: root, phase: 'copy' });
+  const real = getExecutor();
+  const modes: string[][] = [];
+  const copyModes: string[][] = [];
+  let fetched = false;
+  setExecutor({
+    ...real,
+    runFile(cmd, args, options) {
+      if (cmd === 'git' && args.includes('--ignored')) {
+        copyModes.push(readClaimSet(warmClaimPath(root)).live.map((claim) => claim.mode));
+      }
+      return real.runFile(cmd, args, options);
+    },
+    runFileQuiet(cmd, args, options) {
+      if (cmd === 'git' && args.includes('fetch')) fetched = true;
+      if (cmd === 'git' && args.includes('ls-remote')) {
+        modes.push(readClaimSet(warmClaimPath(root)).live.map((claim) => claim.mode));
+      }
+      return real.runFileQuiet(cmd, args, options);
+    },
+  });
+  let completed = false;
+  const warming = runWarm(target, '--refresh').then((result) => {
+    completed = true;
+    return result;
+  });
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(completed).toBe(true);
+    expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
+    expect(readClaimSet(warmClaimPath(root)).live).toHaveLength(1);
+  } finally {
+    held.release();
+    await warming;
+  }
+  const result = await warming;
+  expect(result.code).toBe(0);
+  expect(result.stdout).toEqual([]);
+  expect(result.stderr).toContain('acquired shared (seed current)');
+  expect(fetched).toBe(false);
+  expect(modes).toEqual([['shared', 'shared']]);
+  expect(copyModes).toEqual([['shared', 'shared']]);
+});
+
+test.each(['fast-forward', 'remote changes', 'dependencies', 'pods'])(
+  'a refresh needing %s drains copies before fetching or installing',
+  async (change) => {
+    if (change === 'dependencies') {
+      write(root, 'pnpm-lock.yaml', 'lock v1\n');
+      commit(root, 'dependencies');
+      git(root, 'push', '-q', 'origin', 'main');
+    } else if (change === 'pods') {
+      write(root, 'ios/Podfile', "target 'mobile'\n");
+      write(root, 'ios/Podfile.lock', 'PODFILE CHECKSUM: v1\n');
+      commit(root, 'pods');
+      git(root, 'push', '-q', 'origin', 'main');
+    } else {
+      fallBehind({ 'src/new.ts': 'upstream work\n' });
+      if (change === 'remote changes') git(root, 'update-ref', 'refs/remotes/origin/main', 'HEAD');
+    }
+    write(root, '.env', 'main env');
+    const before = git(root, 'rev-parse', 'HEAD');
+    const held = await acquireWarmClaim({ repositoryRoot: root, phase: 'copy' });
+    const real = getExecutor();
+    const writes: string[] = [];
+    const modes: string[][] = [];
+    setExecutor({
+      ...real,
+      runFileQuiet(cmd, args, options) {
+        if (cmd === 'git' && args.includes('fetch')) {
+          writes.push('fetch');
+          modes.push(readClaimSet(warmClaimPath(root)).live.map((claim) => claim.mode));
+        }
+        return real.runFileQuiet(cmd, args, options);
+      },
+      spawn(cmd) {
+        writes.push(cmd);
+        modes.push(readClaimSet(warmClaimPath(root)).live.map((claim) => claim.mode));
+        return makeExitingChild(0);
+      },
+    });
+    const warming = runWarm(target, '--refresh');
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      expect(writes).toEqual([]);
+      expect(git(root, 'rev-parse', 'HEAD')).toBe(before);
+      expect(existsSync(join(target, '.env'))).toBe(false);
+    } finally {
+      held.release();
+    }
+    const result = await warming;
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('acquired exclusive (');
+    expect(writes).toEqual(
+      ['fast-forward', 'remote changes'].includes(change) ? ['fetch'] : ['fetch', change === 'pods' ? 'pod' : 'pnpm'],
+    );
+    expect(modes.every((mode) => mode.length === 1 && mode[0] === 'exclusive')).toBe(true);
+    expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
+  },
+);
+
+test('a refresh rechecks checkout safety after releasing shared and waiting for exclusive', async () => {
+  fallBehind({ 'src/new.ts': 'upstream work\n' });
+  const before = git(root, 'rev-parse', 'HEAD');
+  write(root, '.env', 'main env');
+  const held = await acquireWarmClaim({ repositoryRoot: root, phase: 'copy' });
+  const warming = runWarm(target, '--refresh');
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    write(root, 'package.json', '{"name":"edited-while-waiting"}\n');
+  } finally {
+    held.release();
+  }
+  const result = await warming;
+  expect(result.code).toBe(1);
+  expect(result.stderr).toContain('failed: STIM_MAIN_DIRTY');
+  expect(git(root, 'rev-parse', 'HEAD')).toBe(before);
+  expect(existsSync(join(target, '.env'))).toBe(false);
+});
+
 test('--refresh reports a fetch it could not run and continues with the local state', async () => {
   fallBehind({ 'src/new.ts': 'upstream work\n' });
   git(root, 'remote', 'set-url', 'origin', join(base, 'gone.git'));

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -139,30 +139,6 @@ export function registerWarm(worktree: Command): void {
           }
           return settings;
         };
-        if (opts.refresh) {
-          const settings = readSettings();
-          if (!settings) {
-            process.exitCode = 1;
-            return;
-          }
-          const failure = await withWarmClaim(
-            { repositoryRoot: root, phase: 'refresh', out: console.error },
-            (hold) => {
-              console.error(warmClaimAcquiredLine(hold.wait));
-              return refreshMainCheckout({
-                root,
-                appDir: mainCheckoutAppDir(root, target),
-                settings,
-                emit: (line) => console.error(line),
-                installer: hold.installer,
-              });
-            },
-          );
-          if (failure) {
-            reportRefreshFailure(failure);
-            return;
-          }
-        }
         const copy = (wait: WarmClaimWait | null): void => {
           if (wait?.holder) console.error(warmClaimAcquiredLine(wait));
           const incomplete = incompleteInstallRefusal(root, mainCheckoutAppDir(root, target));
@@ -198,6 +174,63 @@ export function registerWarm(worktree: Command): void {
           );
           if (result.failed.length) process.exitCode = 1;
         };
+        if (opts.refresh) {
+          const inspect = await acquireWarmClaim({
+            repositoryRoot: root,
+            phase: 'refresh',
+            mode: 'shared',
+            out: console.error,
+          });
+          let mutation: string;
+          try {
+            const settings = readSettings();
+            if (!settings) {
+              process.exitCode = 1;
+              return;
+            }
+            const lines: string[] = [];
+            const result = await refreshMainCheckout({
+              root,
+              appDir: mainCheckoutAppDir(root, target),
+              settings,
+              emit: (line) => lines.push(line),
+              inspectOnly: true,
+            });
+            if (!result || !('mutation' in result)) {
+              console.error(warmClaimAcquiredLine(inspect.wait, result ? 'shared' : 'shared (seed current)'));
+              for (const line of lines) console.error(line);
+              if (result) reportRefreshFailure(result);
+              else copy(null);
+              return;
+            }
+            mutation = result.mutation;
+          } finally {
+            inspect.release();
+          }
+          const failure = await withWarmClaim(
+            { repositoryRoot: root, phase: 'refresh', out: console.error },
+            async (hold) => {
+              console.error(warmClaimAcquiredLine(hold.wait, `exclusive (${mutation})`));
+              const settings = readSettings();
+              if (!settings) {
+                process.exitCode = 1;
+                return null;
+              }
+              return refreshMainCheckout({
+                root,
+                appDir: mainCheckoutAppDir(root, target),
+                settings,
+                emit: (line) => console.error(line),
+                installer: hold.installer,
+              });
+            },
+          );
+          if (failure) {
+            reportRefreshFailure(failure);
+            return;
+          }
+          if (process.exitCode) return;
+        }
         // Only the acquisition degrades: an error from the copy itself is not a claim that could not
         // be recorded, and must not start a second copy.
         let hold = null;

--- a/packages/stim-cli/src/engine/warm-claim.ts
+++ b/packages/stim-cli/src/engine/warm-claim.ts
@@ -64,6 +64,7 @@ export interface WarmClaimHold {
 export interface WarmClaimOptions {
   repositoryRoot: string;
   phase: WarmPhase;
+  mode?: 'shared' | 'exclusive';
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   pollMs?: number;
@@ -105,11 +106,12 @@ function waitingLine(holder: WarmClaimHolder, elapsedMs: number): string {
   );
 }
 
-export function warmClaimAcquiredLine(wait: WarmClaimWait): string {
-  if (!wait.holder || wait.waitedMs <= 0) return phaseLine('lock', 'acquired');
+export function warmClaimAcquiredLine(wait: WarmClaimWait, detail = ''): string {
+  const acquired = `acquired${detail ? ` ${detail}` : ''}`;
+  if (!wait.holder || wait.waitedMs <= 0) return phaseLine('lock', acquired);
   return phaseLine(
     'lock',
-    `acquired (waited ${formatElapsed(wait.waitedMs)} for ${warmCommand(wait.holder.phase)} pid ${wait.holder.pid}) -- stim guide lifecycle options`,
+    `${acquired} (waited ${formatElapsed(wait.waitedMs)} for ${warmCommand(wait.holder.phase)} pid ${wait.holder.pid}) -- stim guide lifecycle options`,
   );
 }
 
@@ -281,6 +283,7 @@ function timeoutError(holder: WarmClaimHolder | null, elapsedMs: number, root: s
 export async function acquireWarmClaim({
   repositoryRoot,
   phase,
+  mode = phase === 'refresh' ? 'exclusive' : 'shared',
   now = Date.now,
   sleep = defaultSleep,
   pollMs = WARM_CLAIM_POLL_MS,
@@ -300,7 +303,7 @@ export async function acquireWarmClaim({
         ? settleClaim(pending)
         : tryAcquireClaim({
             root,
-            mode: phase === 'refresh' ? 'exclusive' : 'shared',
+            mode,
             label: WARM_CLAIM_LABEL,
           });
       const acquired = attempt.acquired;

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -430,9 +430,11 @@ result as proof instead of requiring an unrelated screenshot.`,
 
   \`--refresh\` always prints a \`lock\` line, then its own facts, one per
   step, before those. A plain warm prints the \`lock\` line only when its copy
-  actually waited for another warm:
+  actually waited for another warm. A current refresh reports
+  \`lock        acquired shared (seed current)\`; a refresh needing changes
+  reports \`acquired exclusive\` with the reason from its initial check:
 
-    lock        acquired (waited 12s for stim worktree warm --refresh pid 41233) -- stim guide lifecycle options
+    lock        acquired exclusive (fast-forward 2 commits) (waited 12s for stim worktree warm --refresh pid 41233) -- stim guide lifecycle options
     checkout    janic/wip 2 commits behind origin/janic/wip -> fast-forwarded to 4b81e0c
                 not the default branch (main); worktrees seeded from this copy
                 carry janic/wip's dependencies
@@ -999,8 +1001,9 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   Running it in the source checkout refuses.
 
   \`--refresh\` WRITES TO THE SOURCE CHECKOUT before the copy, which is why it
-  is opt-in: it fetches, fast-forwards whatever branch is checked out there to
-  its \`@{upstream}\`, and installs what the new commits moved. It refuses a
+  is opt-in: it checks the upstream, fetches changes when needed, and fast-forwards
+  whatever branch is checked out there to its \`@{upstream}\`, and installs
+  what the new commits moved. It refuses a
   source checkout it cannot move -- uncommitted changes to tracked files or a
   rebase or merge in progress (STIM_MAIN_DIRTY), a detached HEAD
   (STIM_MAIN_DETACHED), or a branch that is both ahead and behind
@@ -1034,9 +1037,15 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   writes no failure anywhere -- is recovered the same way a failed one is.
 
   One lock per repository serialises this, whether or not you pass the flag:
-  \`--refresh\` holds it exclusively, and every copy holds it shared, so a copy
-  can never read a node_modules a refresh is rewriting. Two plain warms of the
-  same repository run together. The lock is keyed on the repository root, so
+  \`--refresh\` first checks under a shared claim. It uses \`git ls-remote\`
+  to compare the upstream's advertised commit with the local tracking ref without
+  updating Git refs or FETCH_HEAD. When the checkout, dependencies and Pods are
+  current, it keeps that shared claim through the copy, overlapping other copies.
+  A changed or unconfirmed upstream, fast-forward, dependency install or Pods
+  install requires an exclusive claim. It releases shared before waiting for
+  exclusive, then checks the checkout again before fetching or writing. Every
+  copy holds shared, so no copy reads a node_modules a refresh is rewriting.
+  The lock is keyed on the repository root, so
   two apps of one monorepo share it. It is the same ownership claim the build
   locks take: the holder's process IDENTITY decides, so a holder that dies frees
   it, a recycled pid cannot keep it, and a refresh whose install runs in a

--- a/packages/stim-cli/src/worktree-refresh.ts
+++ b/packages/stim-cli/src/worktree-refresh.ts
@@ -323,6 +323,27 @@ function branchRemote(root: string, branch: string): string {
   );
 }
 
+function remoteUpstreamIsCurrent(root: string, branch: string): boolean {
+  const exec = getExecutor();
+  const merge = exec.runFileQuiet('git', ['-C', root, 'config', '--get-all', `branch.${branch}.merge`])?.trim();
+  if (!merge) return true;
+  if (!merge.startsWith('refs/') || merge.includes('\n')) return false;
+  const remote = branchRemote(root, branch);
+  if (remote === '.') return true;
+  const local = resolveFullRef(root, '@{upstream}');
+  if (!local) return false;
+  const advertised = exec.runFileQuiet('git', ['-C', root, 'ls-remote', '--exit-code', '--refs', '--', remote, merge], {
+    timeoutMs: FETCH_TIMEOUT_MS,
+    env: { GIT_TERMINAL_PROMPT: '0' },
+  });
+  if (advertised === null) return false;
+  const refs = advertised
+    .trim()
+    .split('\n')
+    .map((line) => line.split(/\s+/));
+  return refs.length === 1 && refs[0]?.[0] === local && refs[0]?.[1] === merge;
+}
+
 function gitPath(...parts: string[]): string {
   return parts.filter((part) => part && part !== '.').join('/');
 }
@@ -411,8 +432,17 @@ export interface RefreshOptions {
   now?: () => number;
   heartbeatMs?: number;
   installer?: InstallerClaim;
+  inspectOnly?: boolean;
 }
 
+export interface RefreshMutation {
+  mutation: string;
+}
+
+export function refreshMainCheckout(
+  options: RefreshOptions & { inspectOnly: true },
+): Promise<RefreshFailure | RefreshMutation | null>;
+export function refreshMainCheckout(options: RefreshOptions & { inspectOnly?: false }): Promise<RefreshFailure | null>;
 export async function refreshMainCheckout({
   root,
   appDir,
@@ -422,7 +452,8 @@ export async function refreshMainCheckout({
   now = Date.now,
   heartbeatMs = HEARTBEAT_INTERVAL_MS,
   installer = NO_INSTALLER_CLAIM,
-}: RefreshOptions): Promise<RefreshFailure | null> {
+  inspectOnly = false,
+}: RefreshOptions): Promise<RefreshFailure | RefreshMutation | null> {
   const state = readMainCheckoutState(root);
   const refusal = mainCheckoutRefusal(root, state);
   if (refusal) return refusal;
@@ -458,15 +489,21 @@ export async function refreshMainCheckout({
   };
 
   const before = resolveFullRef(root, 'HEAD') ?? '';
-  // A fetch that prompts for credentials would hold the exclusive lock forever.
-  const fetched = getExecutor().runFileQuiet('git', ['-C', root, 'fetch', '--prune', branchRemote(root, branch)], {
-    timeoutMs: FETCH_TIMEOUT_MS,
-    env: { GIT_TERMINAL_PROMPT: '0' },
-  });
-  if (fetched === null) emit(phaseLine('checkout', 'could not fetch; continuing with the local state'));
+  if (inspectOnly) {
+    if (!remoteUpstreamIsCurrent(root, branch)) return { mutation: 'fetch upstream' };
+  } else {
+    const fetched = getExecutor().runFileQuiet('git', ['-C', root, 'fetch', '--prune', branchRemote(root, branch)], {
+      timeoutMs: FETCH_TIMEOUT_MS,
+      env: { GIT_TERMINAL_PROMPT: '0' },
+    });
+    if (fetched === null) emit(phaseLine('checkout', 'could not fetch; continuing with the local state'));
+  }
 
   const plan = checkoutPlan(locallyKnownUpstream(root));
   if (plan.kind === 'diverged') return divergedRefusal(root, branch, plan);
+  if (inspectOnly && plan.kind === 'fast-forward') {
+    return { mutation: `fast-forward ${plan.behind} commit${plan.behind === 1 ? '' : 's'}` };
+  }
 
   // The evidence that an install may be owed has to be durable before HEAD moves: the fast-forward runs
   // the repository's own hooks, and a retry that finds HEAD already moved, a node_modules present and no
@@ -512,6 +549,7 @@ export async function refreshMainCheckout({
   });
   const depsSubject = `source ${dependencies?.root ?? root}: ${deps.reason}`;
   if (deps.run && dependencies) {
+    if (inspectOnly) return { mutation: deps.reason };
     writeInstallEvidence(dependencies.root, dependencies.lock, consumed, false);
     const install = await runInstallCommand({
       command: dependencies.command,
@@ -551,6 +589,7 @@ export async function refreshMainCheckout({
     emit(stepLine('pods', `${where}${pods.reason}`, 'skipped'));
     return null;
   }
+  if (inspectOnly) return { mutation: pods.reason };
   const result = await runPodInstall(appDir, null, { spawnFn: spawn, now, heartbeatMs, onHeartbeat: emit });
   const podCommand = result.command ?? 'pod install';
   emit(

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -384,7 +384,7 @@ current linked worktree. It accepts a current subdirectory. The source checkout
 must be available in the same Git repository; running warm in the source
 checkout refuses.
 
-`--refresh` updates the source checkout before the copy: it fetches,
+`--refresh` updates the source checkout before the copy: it checks the upstream, fetches changes when needed,
 fast-forwards whatever branch is checked out there, and installs dependencies or
 Pods when the new commits moved a lockfile, when nothing is installed, or when
 `ios/Pods` does not match `ios/Podfile.lock`. See

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -97,8 +97,8 @@ worktrees. `stim worktree warm --refresh` updates it before the copy:
 code={`stim worktree warm --refresh`}
 />
 
-It fetches the branch's remote, fast-forwards **whatever branch the source
-checkout has** to its `@{upstream}`, and then installs only what the new commits
+It checks the branch's upstream, fetches changes when needed, and fast-forwards
+**whatever branch the source checkout has** to its `@{upstream}`, and then installs only what the new commits
 moved: the lockfile's own install command where the lockfile lives (the
 repository root in a monorepo), and `pod install` for the app you ran the
 command from. Each dependency and Pods step names its source directory and
@@ -125,10 +125,15 @@ terminal ever said so. Run `stim worktree warm --refresh`, which reinstalls for
 the same reason. A record of a different lockfile does not block a copy, and a
 repository with no record copies exactly as it did before.
 
-One lock per repository protects this, with or without the flag: `--refresh`
-holds it exclusively, and every copy holds it shared, so no copy can read a
-`node_modules` a refresh is rewriting. Two plain warms still run at the same
-time, and a holder that dies frees the lock. A refresh whose install runs in a
+One lock per repository protects this, with or without the flag. A refresh
+first checks under a shared claim: `git ls-remote` confirms the upstream commit
+without changing local Git refs. If the checkout, dependencies and Pods are
+current, it reports `acquired shared (seed current)` and copies alongside other
+warms. It takes an exclusive claim only when it needs to fetch changes,
+fast-forward or install, or cannot confirm the upstream. After waiting, it
+checks the checkout again before writing. Every copy holds shared, so no copy
+reads a `node_modules` a refresh is rewriting. A holder that dies frees the lock.
+A refresh whose install runs in a
 spawned process group holds the lock while any member of that group lives, so a
 package manager's postinstall writer cannot outlive the protection.
 


### PR DESCRIPTION
## Description

Parallel `worktree warm --refresh` runs wait behind sibling copies even when the seed needs no changes. [The original refresh implementation](https://github.com/appandflow/stim/commit/97ede367fcd80b04773b575f8349f3e3dbe4133b) deliberately held an exclusive claim for the whole refresh; only its writers need that protection.

## Solution

Check the upstream, dependencies and Pods under a shared claim, retaining it through the copy when the seed is current. `git ls-remote` avoids changing local refs during that check. Changes or an unconfirmed upstream require exclusive access, with checkout safety and install decisions checked again before fetching or writing. Installer process-group protection remains in place.

## Test plan

- Real local Git repositories: a current refresh finishes alongside a sibling's shared claim; refreshes needing fetch, fast-forward or installs wait before writing.
- Change a tracked file while escalation waits: refresh refuses with `STIM_MAIN_DIRTY`, leaves HEAD unchanged and copies nothing.
- All 87 end-to-end cases passed, including interrupted-install recovery. The APFS disk-image fixture passed separately with default TMPDIR after macOS rejected its external-volume mountpoint.

Fixes #804
