### PR TITLE
docs: explain Test App fingerprint exclusions

### DIFF
--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -853,6 +853,20 @@ WHAT MAKES THE CACHE ACTUALLY HIT: .FINGERPRINTIGNORE
   Never ignore a real native input -- a Podfile, a gradle file, the app config
   -- to force a hit: that trades a slow build for a wrong one.
 
+
+  React Native Test App can generate checkout-specific Android output under
+  node_modules/react-native-test-app/android/support/build. If fingerprint
+  differences point only there, add these project-specific entries:
+
+    node_modules/react-native-test-app/android/support/build
+    node_modules/react-native-test-app/android/support/build/**/*
+
+  Put them in the app root's .fingerprintignore and use the path as it appears
+  in the fingerprint sources; a hoisted or linked dependency may differ.
+  Keep android/support/build.gradle and native sources included. Confirm equal
+  fingerprints across built worktrees, and confirm a real native input edit
+  still changes the hash. These exclusions are not Stim defaults.
+
   \`stim doctor\` measures this directly rather than reading the file: it
   fingerprints HEAD in a temporary clean worktree, compares, and reports a
   mismatch naming the differing sources. Untracked, non-gitignored files under

--- a/website/docs/build-caches.md
+++ b/website/docs/build-caches.md
@@ -40,6 +40,39 @@ or Android target, Stim regenerates the current workspace's JavaScript and
 assets in a copy of the artifact. If that swap fails, it builds fresh. iOS
 physical-device Release runs always build fresh.
 
+### Generated dependency output and cache misses
+
+If identical worktrees build instead of reusing an artifact, compare their
+fingerprint sources before adding exclusions. A project-level
+`.fingerprintignore` can exclude generated output that does not affect native
+inputs. Never ignore an entire native dependency, its build scripts, or source
+files to force a cache hit.
+
+React Native Test App can put checkout-specific generated Android files under
+`node_modules/react-native-test-app/android/support/build`. When the differences
+are confined to that directory, add these entries to the app root's
+`.fingerprintignore`:
+
+```gitignore
+node_modules/react-native-test-app/android/support/build
+node_modules/react-native-test-app/android/support/build/**/*
+```
+
+Use the dependency path shown in the fingerprint sources; hoisted or linked
+layouts may differ. Keep `android/support/build.gradle` and native sources
+included. Verify that built worktrees agree and that changing a real native
+input still changes the fingerprint. Stim does not add these exclusions by
+default.
+
+A prompt to investigate a miss:
+
+> Investigate why these two worktrees do not share Stim's Android artifact
+> cache. Compare their fingerprint sources. If only React Native Test App's
+> generated support/build output differs, add a narrowly scoped
+> .fingerprintignore entry at the app root. Verify fingerprint parity and that
+> a real native input change still invalidates the cache. Do not ignore the
+> package, build scripts, or native sources. Report the evidence.
+
 ### EAS development builds
 
 With `--eas-profile <name>`, Stim downloads a compatible EAS development build


### PR DESCRIPTION
## Description

React Native Test App's generated Android support output can change fingerprints between otherwise identical worktrees. The narrow fixture workaround is already validated in #604; its remaining project guidance is missing.

## Solution

Document the two scoped `.fingerprintignore` entries in the build guide and website, with an investigation prompt. Require matching the actual dependency path, checking cross-worktree parity, and retaining sensitivity to real native input changes. Stim's default exclusions are unchanged.

## Test plan

Rendered `stim guide lifecycle builds` and built the website; both include the scoped example. This documents the existing workaround and does not change fingerprint behavior. Prior native lifecycle/cache and input-sensitivity evidence is recorded in #604.

Fixes #604
