### PR TITLE
fix: wait out Android boot timeouts under memory pressure

### DIFF
--- a/packages/stim-cli/src/__tests__/android-command.test.ts
+++ b/packages/stim-cli/src/__tests__/android-command.test.ts
@@ -5,7 +5,7 @@ import { resetExecutor, setExecutor } from '../exec.ts';
 import assert from 'node:assert';
 import { captureProcessToken } from '../process-identity.ts';
 import { ClaimRefusedError, ClaimUnavailableError, claimRemoveCommand } from '../ownership-claim.ts';
-import { AvdRecoveryError } from '../engine/device.ts';
+import { AvdBootError, AvdRecoveryError } from '../engine/device.ts';
 import { ensureRemoteBootOwned } from '../engine/device-remote.ts';
 import { once } from 'node:events';
 import { type ChildProcess, spawn } from 'node:child_process';
@@ -1790,6 +1790,29 @@ describe('the other refusals', () => {
     expect(result.error.code).toBe(NO_DEVICE);
     expect(result.error.message).toMatch(/Missing emulator engine program/);
     expect(result.error.remedy).not.toMatch(/JAVA_HOME/);
+  });
+
+  test.each(['prepare', 'boot'] as const)('preserves the pressure remedy from %s in STIM_NO_DEVICE', async (stage) => {
+    const reason = 'Emulator emulator-5554 did not finish booting within 360s.';
+    const remedy =
+      'macOS reports warning host memory pressure. Stop an unneeded device with `stim stop` only in a workspace you own, then run `stim android` again.';
+    const h = harness(
+      stage === 'prepare'
+        ? {
+            ensureDevice: async () => {
+              throw new AvdBootError(reason, remedy);
+            },
+            build: never('the build'),
+          }
+        : {
+            ensureDeviceBooted: async () => ({ failed: true, reason, remedy }),
+            install: never('the install'),
+          },
+    );
+    const result = await h.run();
+    assert(result.error);
+    expect(result.error.code).toBe(NO_DEVICE);
+    expect(result.error.remedy).toBe(remedy);
   });
 
   test('an ENOSPC ensureDevice throw uses the disk-space remedy without an emulator log', async () => {

--- a/packages/stim-cli/src/__tests__/engine-device.test.ts
+++ b/packages/stim-cli/src/__tests__/engine-device.test.ts
@@ -1,3 +1,4 @@
+import * as hostMemory from '../host-memory.ts';
 import { deviceSlotPlatforms } from '../device-slots.ts';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -48,6 +49,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   rmSync(tmpHome, { recursive: true, force: true });
   delete process.env.STIM_HOME;
   if (savedAndroidHome === undefined) delete process.env.ANDROID_HOME;
@@ -564,6 +567,120 @@ describe('ensureBooted: android', () => {
     });
     expect(result).toEqual({ ok: true, serial: 'emulator-5556' });
     expect(probes >= 5).toBeTruthy();
+  });
+
+  test.each([
+    ['warning', 'late boot', true, 121000, true],
+    ['critical', 'timeout', true, Infinity, true],
+    ['normal', 'timeout', true, Infinity, false],
+    [null, 'timeout', true, Infinity, false],
+    ['warning', 'process exit', false, Infinity, false],
+    ['warning', 'exit at timeout', true, Infinity, false],
+    ['warning', 'exit during extension', true, Infinity, true],
+    ['warning', 'unknown process', null, Infinity, false],
+  ] as const)('Android boot under %s pressure: %s', async (pressure, outcome, live, bootAt, extended) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(hostMemory, 'readHostMemoryPressure').mockReturnValue(pressure);
+    const events: string[] = [];
+    const probes: number[] = [];
+    const spawn = vi.fn<() => { pid?: number; unref: () => void }>(() => {
+      events.push('spawn');
+      return { pid: live === null ? undefined : 987654, unref() {} };
+    });
+    setExecutor({
+      run: (cmd) => (cmd === 'emulator -list-avds' ? 'stim-app' : 'List of devices attached'),
+      runQuiet: (cmd, opts) => {
+        if (cmd.includes('getprop')) {
+          probes.push(opts?.timeoutMs ?? 0);
+          return Date.now() >= bootAt && cmd.includes('sys.boot_completed') ? '1' : '';
+        }
+        return '';
+      },
+      runFile: () => '{"devices":{}}',
+      spawn,
+    });
+    const resultPromise = ensureBooted({
+      platform: 'android',
+      device: { avdName: 'stim-app', consolePort: 5556, owned: true },
+      timeoutMs: 120000,
+      alive: () =>
+        live === true &&
+        (outcome !== 'exit at timeout' || Date.now() < 120000) &&
+        (outcome !== 'exit during extension' || Date.now() < 130000),
+      out: (line) => events.push(line),
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(events.filter((line) => line.includes('retrying the boot wait'))).toHaveLength(extended ? 1 : 0);
+    expect(probes.every((timeout) => timeout > 0 && timeout <= 5000)).toBe(true);
+    const pressured = pressure === 'warning' || pressure === 'critical';
+    expect(events.some((line) => line.includes(`${pressure} host memory pressure`))).toBe(pressured);
+    expect(events.findIndex((line) => line.includes('host memory pressure'))).toBe(pressured ? 0 : -1);
+    const exited = ['process exit', 'exit at timeout', 'exit during extension'].includes(outcome);
+    const success = outcome === 'late boot';
+    expect(Boolean(result.ok)).toBe(success);
+    expect(Boolean(result.failed)).toBe(!success);
+    const expectedReason = success ? undefined : exited ? 'exited before' : extended ? 'within 360s' : 'within 120s';
+    expect(expectedReason === undefined ? result.reason : result.reason?.includes(expectedReason)).toBe(
+      success ? undefined : true,
+    );
+    const expectedRemedy = success
+      ? undefined
+      : exited
+        ? 'process exit'
+        : pressured
+          ? 'only in a workspace you own'
+          : 'stim doctor';
+    expect(expectedRemedy === undefined ? result.remedy : result.remedy?.includes(expectedRemedy)).toBe(
+      success ? undefined : true,
+    );
+    const expectedTime = success
+      ? 121000
+      : outcome === 'process exit'
+        ? 0
+        : outcome === 'exit at timeout'
+          ? 120000
+          : outcome === 'exit during extension'
+            ? 130000
+            : extended
+              ? 360000
+              : 120000;
+    expect(Date.now()).toBe(expectedTime);
+  });
+
+  test('running owned devices add context without claiming memory pressure or extending an untracked boot', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(hostMemory, 'readHostMemoryPressure').mockReturnValue(null);
+    upsertProject(tmpHome, {});
+    setDevice(tmpHome, 'android', { owned: true, avdName: 'stim-app', consolePort: 5556 });
+    const spawn = vi.fn<() => void>();
+    setExecutor({
+      run: (cmd) => {
+        if (cmd === 'emulator -list-avds') return 'stim-app';
+        if (cmd === 'adb devices') return 'List of devices attached\nemulator-5556\tdevice';
+        if (cmd.includes('emu avd name')) return 'stim-app';
+        return '';
+      },
+      runQuiet: (cmd) => (cmd.includes('emu avd name') ? 'stim-app\nOK' : ''),
+      runFile: () => '{"devices":{}}',
+      spawn,
+    });
+    const lines: string[] = [];
+    const pending = ensureBooted({
+      platform: 'android',
+      device: { avdName: 'stim-app', owned: true },
+      timeoutMs: 1000,
+      out: (line) => lines.push(line),
+    });
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    expect(result.failed).toBe(true);
+    expect(result.remedy).toContain('1 Stim-owned device is running');
+    expect(result.remedy).not.toMatch(/reports.*pressure|JAVA_HOME/);
+    expect(lines.join('')).not.toContain('retrying');
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   test('ensureBooted hands the caller log file to the emulator spawn', async () => {

--- a/packages/stim-cli/src/__tests__/sim-android.test.ts
+++ b/packages/stim-cli/src/__tests__/sim-android.test.ts
@@ -789,6 +789,43 @@ test('waitForBoot reports a timeout diagnostic when adb never answers', async ()
   expect(result.diagnostic).toEqual({ devices: '', sysBoot: '', devBoot: '', bootAnim: '' });
 });
 
+test.each([25, 2000])('boot timeout retains diagnostics within a separate budget (query cost %sms)', async (costMs) => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const calls: { cmd: string; at: number; timeoutMs: number }[] = [];
+  setExecutor({
+    runQuiet: (cmd, opts) => {
+      const at = Date.now();
+      const timeoutMs = opts?.timeoutMs ?? Infinity;
+      calls.push({ cmd, at, timeoutMs });
+      vi.setSystemTime(at + Math.min(costMs, timeoutMs));
+      if (costMs > timeoutMs) return null;
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\toffline\n';
+      return cmd.includes('init.svc.bootanim') ? 'running\n' : '0\n';
+    },
+  });
+  try {
+    const pending = waitForBoot('emulator-5554', 10, { commandTimeoutMs: 5000 });
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    const diagnostics = calls.filter(({ at }) => at >= 11);
+    expect(result.ok).toBe(false);
+    expect(result.diagnostic).toEqual({
+      devices: 'List of devices attached\nemulator-5554\toffline',
+      sysBoot: '0',
+      devBoot: costMs === 25 ? '0' : '',
+      bootAnim: costMs === 25 ? 'running' : '',
+    });
+    expect(diagnostics[0]).toEqual({ cmd: 'adb devices', at: 11, timeoutMs: 5000 });
+    expect(diagnostics.map(({ timeoutMs }) => timeoutMs)).toEqual(
+      costMs === 25 ? [5000, 4975, 4950, 4925] : [5000, 3000, 1000],
+    );
+    expect(Date.now() - diagnostics[0]!.at).toBeLessThanOrEqual(5000);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test('androidToolPath resolves each tool inside ANDROID_HOME when it exists', () => {
   const sdk = makeFakeSdk(tmpHome);
   process.env.ANDROID_HOME = sdk;

--- a/packages/stim-cli/src/commands/android.ts
+++ b/packages/stim-cli/src/commands/android.ts
@@ -129,6 +129,7 @@ import {
   ensureBooted,
   ensureOwnedDevice,
   AvdRecoveryError,
+  AvdBootError,
   type OwnedDeviceRecord,
 } from '../engine/device.ts';
 import {
@@ -1099,7 +1100,7 @@ export async function runAndroid(options: RunAndroidOptions = {} as RunAndroidOp
         logFile: emuLog,
         localEmulator: !(err instanceof AvdRecoveryError),
         remedy:
-          err instanceof AvdRecoveryError
+          err instanceof AvdBootError
             ? err.remedy
             : 'Check that JAVA_HOME and ANDROID_HOME are set correctly, and that an arm64 system image is installed (`sdkmanager "system-images;android-36;google_apis;arm64-v8a"`).',
       });

--- a/packages/stim-cli/src/commands/android/launch.ts
+++ b/packages/stim-cli/src/commands/android/launch.ts
@@ -472,12 +472,7 @@ export async function finishAndroidRun({
   const booted = await bootPromise;
   const runCommand = nativeRunCommand('android', slot, { physical, deviceId: booted.serial });
   if (booted.failed) {
-    const diag = noDeviceDiagnostic({
-      reason: booted.reason ?? 'The emulator did not boot.',
-      logFile: emuLog,
-      remedy: `Run \`stim status\` to see what Stim thinks it owns; re-running \`${runCommand}\` creates a fresh owned AVD.`,
-      localEmulator: !physical,
-    });
+    const diag = diagnoseBootFailure(booted, emuLog, runCommand, physical);
     return fail(NO_DEVICE, diag.message, diag.remedy, {
       lines: diag.lines,
       logPath: diag.logPath ? displayPath(root, diag.logPath) : null,
@@ -779,4 +774,15 @@ export async function finishAndroidRun({
   });
   if (remoteWasAbandoned || uploadWasAbandoned) exitAfterFlush(0);
   return { ok: true, facts };
+}
+
+function diagnoseBootFailure(booted: AndroidBootLike, logFile: string, runCommand: string, physical: boolean) {
+  return noDeviceDiagnostic({
+    reason: booted.reason ?? 'The emulator did not boot.',
+    logFile,
+    remedy:
+      booted.remedy ??
+      `Run \`stim status\` to see what Stim thinks it owns; re-running \`${runCommand}\` creates a fresh owned AVD.`,
+    localEmulator: !physical,
+  });
 }

--- a/packages/stim-cli/src/engine/device.ts
+++ b/packages/stim-cli/src/engine/device.ts
@@ -18,7 +18,7 @@ import {
 } from '../config.ts';
 import { pidExists } from '../metro.ts';
 import { getExecutor } from '../exec.ts';
-import { hostMemoryPressureAdvice, readHostMemoryPressure } from '../host-memory.ts';
+import { hostMemoryPressureAdvice, readHostMemoryPressure, type HostMemoryPressure } from '../host-memory.ts';
 import {
   bootIosSim,
   createOwnedIosSim,
@@ -558,7 +558,7 @@ function findOtherProjectOwningAvd(avdName: string, projectPath: string, selecte
   return null;
 }
 
-export class AvdRecoveryError extends Error {
+export class AvdBootError extends Error {
   readonly remedy: string;
 
   constructor(message: string, remedy: string, cause?: unknown) {
@@ -566,6 +566,8 @@ export class AvdRecoveryError extends Error {
     this.remedy = remedy;
   }
 }
+
+export class AvdRecoveryError extends AvdBootError {}
 
 async function ensureOwnedAndroidDevice({
   record,
@@ -948,14 +950,11 @@ async function bootOwnedAvdOnFreshPort({
   });
   const serial = `emulator-${claim.consolePort}`;
   try {
+    reportAndroidMemoryPressure(out);
     const pid = bootAndroidEmulator(avdName, claim.consolePort, { logFile });
     out(chalk.dim(phaseLine('device', `waiting for ${serial} to finish booting`)));
-    const result = await waitForBoot(serial, 120000, { aborted: emulatorGone(pid, alive) });
-    if (!result.ok) {
-      throw new Error(
-        `${bootFailurePrefix(serial, result.exited, 120000)} Diagnostic: ${JSON.stringify(result.diagnostic)}`,
-      );
-    }
+    const result = await waitForAndroidBoot({ serial, timeoutMs: 120000, pid, alive, out });
+    if (result.failed) throw new AvdBootError(result.reason!, result.remedy!);
     const running = getAvdNameForSerial(serial);
     if (running && running !== avdName) {
       throw new Error(
@@ -969,15 +968,83 @@ async function bootOwnedAvdOnFreshPort({
   }
 }
 
-function emulatorGone(pid: number | null, alive: Liveness): () => boolean {
-  if (!pid) return () => false;
-  return () => !alive(pid);
+function reportAndroidMemoryPressure(out: Notify): void {
+  const pressure = readHostMemoryPressure();
+  if (pressure === 'warning' || pressure === 'critical') {
+    out(
+      chalk.dim(
+        phaseLine(
+          'memory',
+          `macOS reports ${pressure} host memory pressure; emulator boot may be slow. Free memory with \`stim stop\` only in workspaces you own; ask before closing other apps or devices.`,
+        ),
+      ),
+    );
+  }
 }
 
-function bootFailurePrefix(serial: string, exited: boolean | undefined, timeoutMs: number): string {
-  return exited
+function androidBootRemedy(pressure: HostMemoryPressure | null): string {
+  let count: number | null = null;
+  try {
+    count = liveOwnedDeviceCount({
+      sims: process.platform === 'darwin' ? listAllIosSims({ timeoutMs: 2000 }) : [],
+      adbEmulators: listAdbDevices({ timeoutMs: 2000 }).emulators,
+      config: loadConfig(),
+    });
+  } catch {}
+  const observation =
+    pressure === 'warning' || pressure === 'critical' ? `macOS reports ${pressure} host memory pressure. ` : '';
+  const devices = count ? `${count} Stim-owned ${count === 1 ? 'device is' : 'devices are'} running. ` : '';
+  if (observation || devices) {
+    return `${observation}${devices}Stop an unneeded device with \`stim stop\` only in a workspace you own, then run \`stim android\` again; ask before closing other apps or devices. These observations do not establish the cause of the timeout or an OOM crash.`;
+  }
+  return 'Inspect the emulator log and run `stim doctor` to check JAVA_HOME, ANDROID_HOME, and installed system images, then run `stim android` again.';
+}
+
+async function waitForAndroidBoot({
+  serial,
+  timeoutMs,
+  pid = null,
+  alive = pidExists,
+  out,
+}: {
+  serial: string;
+  timeoutMs: number;
+  pid?: number | null;
+  alive?: Liveness;
+  out: Notify;
+}): Promise<BootResult> {
+  const aborted = () => pid !== null && !alive(pid);
+  const wait = (windowMs: number) => waitForBoot(serial, windowMs, { aborted, commandTimeoutMs: 5000 });
+  let result = await wait(timeoutMs);
+  if (result.ok) return { ok: true, serial };
+  let pressure = readHostMemoryPressure();
+  let elapsedMs = timeoutMs;
+  if (!result.exited && pid !== null && !aborted() && (pressure === 'warning' || pressure === 'critical')) {
+    const extensionMs = 240000;
+    out(
+      chalk.dim(
+        phaseLine(
+          'memory',
+          `macOS reports ${pressure} host memory pressure; retrying the boot wait once for the same live emulator ${serial} (up to ${extensionMs / 1000}s more).`,
+        ),
+      ),
+    );
+    result = await wait(extensionMs);
+    if (result.ok) return { ok: true, serial };
+    elapsedMs += extensionMs;
+    pressure = readHostMemoryPressure();
+  }
+  const exited = result.exited || aborted();
+  const reason = exited
     ? `The emulator process for ${serial} exited before the device finished booting.`
-    : `Emulator ${serial} did not finish booting within ${Math.round(timeoutMs / 1000)}s.`;
+    : `Emulator ${serial} did not finish booting within ${Math.round(elapsedMs / 1000)}s.`;
+  return {
+    failed: true,
+    reason: `${reason} Diagnostic: ${JSON.stringify(result.diagnostic)}`,
+    remedy: exited
+      ? 'Inspect the emulator log for the process exit, fix what it reports, then run `stim android` again.'
+      : androidBootRemedy(pressure),
+  };
 }
 
 export function liveOwnedDeviceCount({
@@ -1169,6 +1236,7 @@ interface BootResult {
   serial?: string;
   failed?: boolean;
   reason?: string;
+  remedy?: string;
 }
 
 export async function ensureBooted({
@@ -1304,27 +1372,16 @@ async function ensureAndroidBooted({
     return { failed: true, reason: `AVD ${device.avdName} is not Stim-owned by name; refusing to boot it.` };
   }
   if (resolved.serial) {
-    const ready = await waitForBoot(resolved.serial, timeoutMs);
-    if (!ready.ok) {
-      return {
-        failed: true,
-        reason: `Emulator ${resolved.serial} never reported boot completion. Diagnostic: ${JSON.stringify(ready.diagnostic)}`,
-      };
-    }
-    return { ok: true, serial: resolved.serial };
+    return waitForAndroidBoot({ serial: resolved.serial, timeoutMs, out });
   }
 
   const freshSerial = `emulator-${device.consolePort}`;
   if (device.owned && device.serial === freshSerial) {
-    const ready = await waitForBoot(freshSerial, timeoutMs);
-    if (ready.ok) return { ok: true, serial: freshSerial };
-    return {
-      failed: true,
-      reason: `Emulator ${freshSerial} never reported boot completion. Diagnostic: ${JSON.stringify(ready.diagnostic)}`,
-    };
+    return waitForAndroidBoot({ serial: freshSerial, timeoutMs, out });
   }
 
   const serial = `emulator-${pickConsolePort(device.consolePort)}`;
+  reportAndroidMemoryPressure(out);
   out(chalk.dim(phaseLine('device', `booting ${device.avdName} as ${serial}`)));
   let pid: number | null = null;
   try {
@@ -1335,14 +1392,7 @@ async function ensureAndroidBooted({
       reason: `Could not start emulator for AVD ${device.avdName}: ${(e as Error)?.message || e}`,
     };
   }
-  const ready = await waitForBoot(serial, timeoutMs, { aborted: emulatorGone(pid, alive) });
-  if (!ready.ok) {
-    return {
-      failed: true,
-      reason: `${bootFailurePrefix(serial, ready.exited, timeoutMs)} Diagnostic: ${JSON.stringify(ready.diagnostic)}`,
-    };
-  }
-  return { ok: true, serial };
+  return waitForAndroidBoot({ serial, timeoutMs, pid, alive, out });
 }
 
 function pickConsolePort(recorded: number | undefined) {

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -75,6 +75,12 @@ current and highest observed pressure; a timeout does not establish OOM.
 Avoid repeated reboots under unchanged pressure; do not restart other
 workspaces' devices or close their apps without asking. That guide covers
 the recovery steps and profile tradeoffs.
+An Android boot timeout under observed elevated memory pressure gets one
+extra wait while the emulator process this run started is alive. It never
+launches a second emulator. For a timeout, read guide errors STIM_NO_DEVICE
+and free memory by stopping only unneeded devices in workspaces you own;
+ask before closing other apps or devices. Device count alone is not evidence
+of memory pressure.
 For a linked native library carrying Git metadata, add the printed .git entries to
 .fingerprintignore only when the native build does not read Git state.
 

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -556,7 +556,8 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   serial; it never starts a second emulator. New-device preparation normally
   waits 120 seconds first; the later boot check waits 240 seconds. There is
   no extra wait for normal or unavailable pressure, a process that exited,
-  or a process whose liveness this run cannot check. adb probes are bounded.
+  or a process whose liveness this run cannot check. adb probes are bounded;
+  final diagnostic queries share a separate budget of up to five seconds.
   A timeout remedy reports observed pressure and the running owned-device
   count when available. Device count alone does not establish memory pressure
   or trigger the extra wait. Stop an unneeded device with \`stim stop\` only

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -549,6 +549,19 @@ so a Debug run on one is wired to a LAN origin instead of localhost.`,
   normally live under ~/.android/avd, and a booted AVD can use several GB. A
   boot whose emulator process exited is also reported at once rather than after
   the full cold-boot timeout.
+  Before a local Android emulator boot, a memory phase line reports observed
+  warning or critical macOS host memory pressure. If the initial boot wait
+  times out under that pressure and the process this run started is still
+  alive, Stim retries the WAIT once for up to 240 seconds more on the same
+  serial; it never starts a second emulator. New-device preparation normally
+  waits 120 seconds first; the later boot check waits 240 seconds. There is
+  no extra wait for normal or unavailable pressure, a process that exited,
+  or a process whose liveness this run cannot check. adb probes are bounded.
+  A timeout remedy reports observed pressure and the running owned-device
+  count when available. Device count alone does not establish memory pressure
+  or trigger the extra wait. Stop an unneeded device with \`stim stop\` only
+  in a workspace you own, then retry \`stim android\`; ask before closing
+  other apps or devices. Specific emulator log errors retain their remedies.
 
 "this project's sim is X, but --device-type asked for Y"
   The project already owns a simulator of a different model, and Stim will

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -157,6 +157,12 @@ ANDROID EMULATOR RESTARTS
   Rerun \`stim android\` with the same build options in that workspace to restore Metro
   forwarding, then reopen agent-device on the serial that run reports.
   Other workspaces' simulators and automation sessions remain theirs.
+  A local emulator boot reports observed warning or critical macOS memory
+  pressure before starting. A timeout under elevated pressure gets one
+  additional wait of up to 240 seconds only while the process this run
+  started is alive. Stim keeps waiting on the same emulator; it never
+  launches a duplicate. See \`stim guide errors STIM_NO_DEVICE\` for the
+  wait windows, diagnostics, and recovery steps.
 
 DESTRUCTIVE COMMANDS -- ask the user first
   gc --delete             deletes orphaned stim-* devices, tens of GB

--- a/packages/stim-cli/src/sim/android.ts
+++ b/packages/stim-cli/src/sim/android.ts
@@ -901,15 +901,21 @@ export async function waitForBoot(
       ),
     );
   }
-  const devicesOut = exec.runQuiet(`${androidTool('adb')} devices`, { timeoutMs: probeTimeout() });
+  const diagnosticDeadline = Date.now() + Math.min(commandTimeoutMs ?? 5000, 5000);
+  const diagnosticQuery = (args: string): string => {
+    const remaining = diagnosticDeadline - Date.now();
+    if (remaining <= 0) return '';
+    const value = exec.runQuiet(`${androidTool('adb')} ${args}`, { timeoutMs: remaining });
+    return typeof value === 'string' ? value.trim() : '';
+  };
   return {
     ok: false,
     ...(exited ? { exited: true as const } : {}),
     diagnostic: {
-      devices: typeof devicesOut === 'string' ? devicesOut.trim() : '',
-      sysBoot: getprop(exec, serial, 'sys.boot_completed', probeTimeout()),
-      devBoot: getprop(exec, serial, 'dev.bootcomplete', probeTimeout()),
-      bootAnim: getprop(exec, serial, 'init.svc.bootanim', probeTimeout()),
+      devices: diagnosticQuery('devices'),
+      sysBoot: diagnosticQuery(`-s ${serial} shell getprop sys.boot_completed`),
+      devBoot: diagnosticQuery(`-s ${serial} shell getprop dev.bootcomplete`),
+      bootAnim: diagnosticQuery(`-s ${serial} shell getprop init.svc.bootanim`),
     },
   };
 }

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -138,6 +138,21 @@ builds, and retry after pressure falls. Ask before closing another agent's
 simulator or a user's app. Repeated reboots under unchanged pressure can repeat
 the stall.
 
+Local Android emulator boots also print a memory phase line when macOS reports
+warning or critical pressure. If boot times out under that pressure, Stim
+extends the wait once by up to 240 seconds while the process it started is
+still alive. It waits on the same emulator and never launches a duplicate.
+New-device preparation waits 120 seconds initially; the later boot check uses
+240 seconds. Normal or unavailable pressure, an exited process, or unavailable
+process liveness does not trigger the extra wait. adb probes are bounded.
+
+Timeout remedies include observed pressure and the running Stim-owned device
+count when available. Device count alone does not prove memory pressure or
+trigger the extra wait. Specific emulator log errors keep their own remedies.
+Stop an unneeded device with `stim stop` only in a workspace you own, then rerun
+`stim android` with the same build options. Read
+`stim guide errors STIM_NO_DEVICE` for recovery details.
+
 ## Remote devices
 
 Stim supports two optional remote backends:


### PR DESCRIPTION
## Description

An Android emulator boot timeout gives a JAVA_HOME/system-image remedy even when macOS reports host memory pressure. Unlike iOS, the boot path also gives no memory-pressure observation before starting.

## Solution

Report observed pressure before local emulator boots and preserve pressure/device-count recovery advice through `STIM_NO_DEVICE`. After a timeout under warning or critical pressure, wait once more for up to 240 seconds on the same live process started by this run. No second emulator starts; exited or untracked processes and device count alone never trigger the extension. Specific emulator log errors retain their remedies.

## Test plan

- Pressure was not induced on the host. Deterministic clock tests cover delayed success, the single extension limit, exit at the timeout boundary and during the extension, and unavailable pressure or process liveness.
- On macOS, created an isolated Android 36 arm64 emulator, completed boot and the subsequent readiness check in 38 seconds under normal pressure, then centrally deleted that exact test device. Existing adb devices were unchanged.

Fixes #802
