### PR TITLE
fix: refuse logs for unused workspaces

### DIFF
--- a/packages/stim-cli/README.md
+++ b/packages/stim-cli/README.md
@@ -44,8 +44,9 @@ stim stop
 
 For `stim logs --errors`, a clean check requires exit code 0 and no matching
 errors in the captured logs. Exit code 0 alone means the query succeeded, even
-when it prints errors; an empty result does not prove launch or log capture
-succeeded.
+when it prints errors. A workspace that has never produced a log timeline
+refuses with `STIM_NO_PROJECT`; in a monorepo, the error names the nearest
+registered descendant app with logs when one exists.
 
 Use `stim start --reset-cache` to recover from stale Metro transforms or file-map
 state. It restarts only this app's verified owned Metro, keeping its port and

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -367,6 +367,19 @@ test('the agent workflow checks errors before and after edits, before cleanup', 
   expect(renderSection('lifecycle', 'readiness')).toContain('[stim:readiness] ready');
 });
 
+test('the logs guides distinguish an unused workspace from an empty filtered timeline', () => {
+  const logs = renderTopic('logs');
+  const agent = renderTopic('agent');
+  const lifecycle = renderTopic('lifecycle');
+  const noProject = renderSection('errors', 'STIM_NO_PROJECT');
+  for (const guide of [logs, agent, lifecycle, noProject]) {
+    expect(guide).toContain('STIM_NO_PROJECT');
+  }
+  expect(logs).toContain('nearest registered descendant app');
+  expect(logs).toMatch(/zero matches after filtering means STDOUT IS EMPTY,\s+exit code 0/);
+  expect(noProject).toContain('nearest registered descendant app');
+});
+
 test('the agent and lifecycle guides name both workflows', () => {
   for (const guide of [renderTopic('agent'), renderTopic('lifecycle')]) {
     assert(guide);

--- a/packages/stim-cli/src/__tests__/logs-command.test.ts
+++ b/packages/stim-cli/src/__tests__/logs-command.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';
@@ -14,6 +14,7 @@ import logsCommand, {
   validateLevel,
   validateSources,
 } from '../commands/logs.ts';
+import { getConfigPath, upsertProject } from '../config.ts';
 
 type ActionFn = (opts: Record<string, unknown>) => void | Promise<void>;
 
@@ -277,11 +278,53 @@ describe('logs command', () => {
     expect(out).toEqual([]);
   });
 
-  test('exits 0 when the workspace has no log directory at all', async () => {
+  test.each([{}, { json: true }])(
+    'refuses logs %j without a timeline and does not create workspace state',
+    async (options) => {
+      rmSync(workspaceDir(project), { recursive: true, force: true });
+      await run(options);
+      expect(exitCode).toBe(1);
+      expect(out).toEqual([]);
+      expect(errOut.join('\n')).toContain('STIM_NO_PROJECT');
+      expect(errOut.join('\n')).toContain(`No Stim workspace has run in ${project}`);
+      expect(existsSync(workspaceDir(project))).toBe(false);
+      expect(existsSync(getConfigPath())).toBe(false);
+    },
+  );
+
+  test('refuses an existing logs directory that has never captured a timeline', async () => {
+    await run({});
+    expect(exitCode).toBe(1);
+    expect(out).toEqual([]);
+    expect(errOut.join('\n')).toContain('STIM_NO_PROJECT');
+    expect(existsSync(logsDir)).toBe(true);
+    expect(existsSync(getConfigPath())).toBe(false);
+  });
+
+  test('suggests the nearest registered descendant app that has logs', async () => {
+    const app = join(project, 'apps', 'mobile');
+    const deeperApp = join(app, 'example');
+    for (const path of [app, deeperApp]) {
+      mkdirSync(path, { recursive: true });
+      writeFileSync(join(path, 'package.json'), JSON.stringify({ dependencies: { expo: '54.0.0' } }));
+      mkdirSync(workspaceLogsDir(path), { recursive: true });
+      writeFileSync(join(workspaceLogsDir(path), 'metro.ndjson'), '');
+      upsertProject(realpathSync(path), {});
+    }
     rmSync(workspaceDir(project), { recursive: true, force: true });
     await run({});
+    expect(exitCode).toBe(1);
+    expect(out).toEqual([]);
+    expect(errOut.join('\n')).toContain(`The nearest registered app with logs is ${realpathSync(app)}`);
+    expect(errOut.join('\n')).not.toContain(realpathSync(deeperApp));
+  });
+
+  test('a zero-byte timeline is a valid empty workspace query', async () => {
+    writeFileSync(join(logsDir, 'metro.ndjson'), '');
+    await run({ errors: true });
     expect(exitCode).toBe(null);
     expect(out).toEqual([]);
+    expect(errOut.join('\n')).toContain('No matching log records');
   });
 
   test('--errors applies the marker window across sources', async () => {

--- a/packages/stim-cli/src/commands/logs.ts
+++ b/packages/stim-cli/src/commands/logs.ts
@@ -2,11 +2,14 @@ import { validateDeviceSlot } from '../device-slots.ts';
 import chalk from 'chalk';
 import type { ChalkInstance } from 'chalk';
 import type { Command } from 'commander';
+import { realpathSync } from 'node:fs';
+import { relative, sep } from 'node:path';
+import { isPathPrefix, loadConfig } from '../config.ts';
 import { findProjectRoot } from '../project.ts';
 import { workspaceLogsDir } from '../paths.ts';
 import { LEVELS, SOURCES } from '../ndjson.ts';
 import type { NdjsonRecord } from '../ndjson.ts';
-import { buildCriteria, compileGrep, fileSizes, followLogs, parseSince, queryLogs } from '../logs-query.ts';
+import { buildCriteria, compileGrep, fileSizes, followLogs, logFiles, parseSince, queryLogs } from '../logs-query.ts';
 import { errorDiagnostics } from '../error-diagnostics.ts';
 import { launchErrorPreview } from '../launch-error-preview.ts';
 import { readWorkspaceState } from '../supervisor/state.ts';
@@ -100,6 +103,38 @@ export function validateLevel(level: string): LevelResult {
 
 export const ERRORS_PRINT_CAP = 20;
 
+function nearestRegisteredLogsProject(root: string, candidates: string[]): string | null {
+  return (
+    candidates
+      .filter((candidate) => candidate !== root && isPathPrefix(root, candidate))
+      .toSorted((a, b) => {
+        const depth = (path: string) => relative(root, path).split(sep).length;
+        return depth(a) - depth(b) || a.length - b.length || a.localeCompare(b);
+      })[0] ?? null
+  );
+}
+
+function registeredDescendantWithLogs(root: string): string | null {
+  const candidates = Object.keys(loadConfig()?.projects ?? {}).flatMap((path) => {
+    try {
+      const canonical = realpathSync(path);
+      return logFiles(workspaceLogsDir(canonical)).length > 0 ? [canonical] : [];
+    } catch {
+      return [];
+    }
+  });
+  return nearestRegisteredLogsProject(root, [...new Set(candidates)]);
+}
+
+function requireLogsWorkspace(root: string, dir: string): void {
+  if (logFiles(dir).length > 0) return;
+  const descendant = registeredDescendantWithLogs(root);
+  const remedy = descendant
+    ? ` The nearest registered app with logs is ${descendant}; run this command from there.`
+    : ' Run `stim start`, `stim ios`, or `stim android` in the app first.';
+  fail(`STIM_NO_PROJECT: No Stim workspace has run in ${root}.${remedy}`);
+}
+
 const LEVEL_COLOURS: Record<string, ChalkInstance> = {
   debug: chalk.dim,
   info: chalk.reset,
@@ -124,7 +159,7 @@ export default function logsCommand(program: Command): void {
   program
     .command('logs')
     .description(
-      "Query this workspace's merged NDJSON log timeline (bundler, client, device, build). Prints and exits; nothing matching is a successful, empty result. Use --follow to stream.",
+      "Query this workspace's merged NDJSON log timeline (bundler, client, device, build). Prints and exits; an existing timeline with nothing matching is a successful, empty result. Use --follow to stream.",
     )
     .option('--slot <name>', 'Only records attributed to this device slot', validateDeviceSlot)
     .option('--source <s...>', 'Only these sources: metro, client, device, build, or all')
@@ -176,6 +211,8 @@ export default function logsCommand(program: Command): void {
         const compiled = compileGrep(opts.grep);
         if (compiled.error) fail(compiled.error);
       }
+
+      requireLogsWorkspace(root, dir);
 
       const query = {
         slot: opts.slot,

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -175,8 +175,9 @@ RULES DURING THE LOOP
 - A clean logs --errors check requires exit code 0 AND no matching errors in
   captured logs. Exit code 0 alone means the query succeeded, even when errors
   were printed. Human output shows "No matching log records" on stderr for
-  zero matches; JSON mode prints zero bytes. This does not prove launch or log
-  capture succeeded. Do not read the NDJSON files directly.
+  zero matches; JSON mode prints zero bytes. A workspace with no captured
+  timeline refuses with STIM_NO_PROJECT and, in a monorepo, names the nearest
+  registered descendant app with logs. Do not read the NDJSON files directly.
 - Use stim status when resuming a workspace or recovering missing device,
   port, server, or build facts. A normal start and platform run already print
   them. Use stim doctor when a build is unexpectedly slow or the environment

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -816,7 +816,9 @@ captured"  (in metro.ndjson, bare RN)
   with no package.json above it, or one whose nearest package.json does not
   parse or depends on neither react-native nor expo, so the directory is not
   an app (the refusal names that package.json and says which of the two it
-  is; \`doctor\` reports the same directory as a finding), an
+  is; \`doctor\` reports the same directory as a finding), a \`logs\` query in
+  a workspace that has never produced a log timeline (the refusal names the
+  nearest registered descendant app with logs when one exists), an
   android/app/build.gradle that declares product flavors with
   no variant selected (the refusal names the debug variants), or a
   \`--device-type\`, \`--runtime\` or \`--system-image\` name that is BLANK or

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -62,6 +62,7 @@ a seed belongs to this workflow.
   #    For a clean check, require exit 0 AND no matching errors.
   #    Human mode prints "No matching log records" on stderr for zero matches.
   #    Exit 0 alone means the query succeeded, even when it printed errors.
+  #    A workspace with no captured timeline refuses with STIM_NO_PROJECT.
   stim logs --errors
 
   # 5. Edit the JS. Fast Refresh applies it; no Stim command is involved.

--- a/packages/stim-cli/src/guide/logs.ts
+++ b/packages/stim-cli/src/guide/logs.ts
@@ -10,10 +10,12 @@ discovered, not enumerated.
 
 EXIT 0 MEANS THE QUERY SUCCEEDED, whether or not records matched. A clean
 \`stim logs --errors\` check requires exit code 0 AND no matching errors in
-captured logs. An empty result does not prove launch or log capture succeeded;
-a workspace with no log directory also returns an empty result.
+captured logs. A workspace that has never produced a timeline refuses with
+STIM_NO_PROJECT instead of passing with an empty result. In a monorepo the
+refusal names the nearest registered descendant app with logs, when there is one.
 
-For zero matches: STDOUT IS EMPTY, exit code 0, and
+Once a timeline file exists, zero matches after filtering means STDOUT IS EMPTY,
+exit code 0, and
 one dim note on STDERR reading \`No matching log records in <logs dir>\`
 (human mode only -- \`--json\` prints nothing at all, on either stream).
 The only exit-1 paths are a malformed query and no project.

--- a/test/e2e/logs.e2e.js
+++ b/test/e2e/logs.e2e.js
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { workspaceLogsDir } from '../../packages/stim-cli/src/paths.ts';
+import { workspaceDir, workspaceLogsDir } from '../../packages/stim-cli/src/paths.ts';
 
 const CLI = fileURLToPath(new URL('../../packages/stim-cli/bin/cli.ts', import.meta.url));
 let home;
@@ -51,11 +51,14 @@ test('matching errors also exit 0, so a successful query alone is not a clean ch
   assert.equal(json.stderr, '');
 });
 
-test('no log directory is a successful empty query without evidence of capture', () => {
+test('no log directory refuses without creating workspace state', () => {
   const result = run(['--json']);
-  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.status, 1);
   assert.equal(result.stdout, '');
-  assert.equal(result.stderr, '');
+  assert.match(result.stderr, /STIM_NO_PROJECT/);
+  assert.match(result.stderr, /No Stim workspace has run/);
+  assert.equal(existsSync(workspaceDir(project)), false);
+  assert.equal(existsSync(join(home, 'config.json')), false);
 });
 
 test('an invalid query exits 1 with empty stdout and a diagnostic on stderr', () => {

--- a/website/docs/dev-server-and-logs.md
+++ b/website/docs/dev-server-and-logs.md
@@ -208,9 +208,9 @@ project checkout.
 Exit code 0 means the query succeeded, including when it prints errors. A clean
 `stim logs --errors` check requires exit code 0 and no matching errors in the
 captured logs. Human mode prints `No matching log records` on stderr for zero
-matches; JSON mode writes NDJSON and writes zero bytes for zero matches. An
-empty result does not prove launch or log capture succeeded: a workspace with
-no log directory also returns an empty result.
+matches; JSON mode writes NDJSON and writes zero bytes for zero matches. A
+workspace that has never produced a timeline refuses with `STIM_NO_PROJECT`
+and, in a monorepo, names the nearest registered descendant app with logs.
 
 `stim stop` ends the supervisor and log collectors. It also frees the reserved
 port and shuts down the owned local device.


### PR DESCRIPTION
## Description

Running `stim logs --errors` from a monorepo root that has never run Stim currently exits 0 with no matching records, so an agent can mistake the wrong workspace for a clean app. The original logs contract [deliberately made zero matches successful](https://github.com/appandflow/stim/blob/bdb5ec6241bf50dd129c20698509d6db6220e6ea/packages/rn-iso/src/commands/logs.js#L6-L9), but did not distinguish healthy filtered queries from a workspace with no timeline.

## Solution

Require an existing NDJSON timeline before querying logs. A never-used workspace refuses with `STIM_NO_PROJECT` before crash capture or state writes and names the nearest canonical registered descendant app with logs when one exists. Existing empty timeline files and filters that match no records keep their exit-0 and stdout contracts.

If a user removes every NDJSON file manually, they must run `stim start`, `stim ios`, or `stim android` before querying again.

## Test plan

- From a monorepo root with a registered descendant app timeline, verify `stim logs --errors` exits 1, keeps stdout empty, and names that app.
- From an app with a zero-byte timeline or records excluded by `--errors`, verify the command still exits 0 with no records.
- Process-level `logs.e2e.js`: 4/4 passed, including the refusal and no-state-write contract.

Fixes #801
