### PR TITLE
fix: release agent-device sessions during device teardown

### DIFF
--- a/packages/stim-cli/src/__tests__/agent-device-cleanup.test.ts
+++ b/packages/stim-cli/src/__tests__/agent-device-cleanup.test.ts
@@ -1,0 +1,131 @@
+import { closeOwnedDeviceSessions, parseAgentDeviceSessions } from '../agent-device-cleanup.ts';
+import { resetExecutor, setExecutor } from '../exec.ts';
+
+const ios = { name: 'ios-task', platform: 'ios', device_udid: 'U1', id: 'U1', createdAt: 1789292795715 };
+const android = { name: 'android-task', platform: 'android', id: 'emulator-5554', createdAt: 1789292795716 };
+const payload = (sessions: unknown[]) => JSON.stringify({ success: true, data: { sessions } });
+let stderr: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+});
+afterEach(() => {
+  resetExecutor();
+  vi.restoreAllMocks();
+});
+
+test('parses live CLI records without treating malformed or cross-platform identities as targets', () => {
+  expect(
+    parseAgentDeviceSessions(
+      payload([
+        ios,
+        android,
+        null,
+        { ...ios, platform: 'macos' },
+        { ...ios, id: 'OTHER' },
+        { ...ios, createdAt: undefined },
+        { ...ios, name: '' },
+        { ...ios, device_udid: undefined },
+      ]),
+    ),
+  ).toEqual([{ name: ios.name, platform: 'ios', id: 'U1', createdAt: ios.createdAt }, android]);
+  for (const output of ['oops', '{}', '{"success":false,"data":{"sessions":[]}}']) {
+    expect(() => parseAgentDeviceSessions(output)).toThrow(/JSON|successful session list/);
+  }
+});
+
+function executor(lists: string[], close?: (args: string[]) => string) {
+  const calls: string[][] = [];
+  setExecutor({
+    runQuiet: () => '/bin/agent-device',
+    runFile: (_file, args, options) => {
+      calls.push(args);
+      expect(options.timeoutMs).toBeGreaterThan(0);
+      expect(options.timeoutMs).toBeLessThanOrEqual(5000);
+      expect(options.killSignal).toBe('SIGKILL');
+      if (args[0] === 'session') return lists.length > 1 ? lists.shift() : lists[0];
+      return close?.(args) ?? '{"success":true}';
+    },
+  });
+  return calls;
+}
+
+test.each([
+  [{ platform: 'ios' as const, id: 'U1' }, ios, '--udid'],
+  [{ platform: 'android' as const, id: 'emulator-5554' }, android, '--serial'],
+])('closes only exact matching sessions with a rejecting target guard: %j', (device, session, selector) => {
+  const calls = executor([payload([ios, android, { ...ios, name: 'unrelated', device_udid: 'U10', id: 'U10' }])]);
+  const owned = vi.fn<() => boolean>(() => true);
+  closeOwnedDeviceSessions(device, owned);
+  expect(calls.filter((args) => args[0] === 'close')).toEqual([
+    [
+      'close',
+      '--session',
+      session.name,
+      '--session-lock',
+      'reject',
+      '--platform',
+      device.platform,
+      selector,
+      device.id,
+      '--json',
+      '--daemon-transport',
+      'socket',
+    ],
+  ]);
+  expect(owned).toHaveBeenCalledOnce();
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining(`closed agent-device session ${session.name}`));
+});
+
+test.each([
+  { current: [] },
+  { current: [{ ...ios, id: 'U2', device_udid: 'U2' }] },
+  { current: [{ ...ios, createdAt: ios.createdAt + 1 }] },
+])('does not close a disappeared, rebound or recreated session: %j', ({ current }) => {
+  const calls = executor([payload([ios]), payload(current)]);
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(calls.some((args) => args[0] === 'close')).toBe(false);
+});
+
+test('does not close after device ownership changes', () => {
+  const calls = executor([payload([ios])]);
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => false);
+  expect(calls.some((args) => args[0] === 'close')).toBe(false);
+});
+
+test('contains a failed close and still closes the next matching session', () => {
+  const calls = executor([payload([ios, { ...ios, name: 'second' }])], (args) => {
+    if (args.includes(ios.name)) throw new Error('timed out');
+    return '{"success":true}';
+  });
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(calls.filter((args) => args[0] === 'close')).toHaveLength(2);
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('could not close agent-device session ios-task'));
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('closed agent-device session second'));
+});
+
+test('skips absent CLI and contains invalid inventory and unsuccessful close responses', () => {
+  const runFile = vi.fn<() => string>();
+  setExecutor({ runQuiet: () => null, runFile });
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(runFile).not.toHaveBeenCalled();
+  expect(stderr).not.toHaveBeenCalled();
+  executor(['garbage']);
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('could not list agent-device sessions'));
+  executor([payload([ios])], () => '{"success":false}');
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('could not close agent-device session'));
+});
+
+test('stops invoking agent-device once the per-device budget is exhausted', () => {
+  let now = 1000;
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
+  const calls = executor([payload([ios, { ...ios, name: 'second' }])], () => {
+    now += 15000;
+    return '{"success":true}';
+  });
+  closeOwnedDeviceSessions({ platform: 'ios', id: 'U1' }, () => true);
+  expect(calls).toHaveLength(3);
+  expect(stderr).toHaveBeenCalledWith(expect.stringContaining('agent-device cleanup timed out'));
+});

--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -428,6 +428,8 @@ test('the agent and cleanup guides shut down owned simulators without an occupan
   expect(cleanup).toMatch(/do not check simulator occupancy/i);
   expect(cleanup).toMatch(/never shuts down an unowned simulator/i);
   expect(agent).not.toContain('agent-device close --shutdown');
+  expect(renderTopic('cleanup')).toMatch(/exact iOS UDID or live Android\nserial/);
+  expect(renderTopic('cleanup')).toContain('Physical devices are outside');
 });
 
 test('the guide names every path Stim ignores by default', () => {

--- a/packages/stim-cli/src/__tests__/teardown.test.ts
+++ b/packages/stim-cli/src/__tests__/teardown.test.ts
@@ -578,7 +578,7 @@ test('teardownOwnedAvd shuts down the running emulator and deletes the AVD', () 
     adb: 'List of devices attached\nemulator-5554\tdevice\n',
     avdName: 'stim-app',
   });
-  const resolutions = [{ serial: 'emulator-5554' }, { notRunning: true as const }];
+  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5554' }, { notRunning: true as const }];
   setExecutor(exec);
   const r = teardownOwnedAvd('stim-app', {
     del: true,
@@ -616,7 +616,7 @@ test('teardownOwnedAvd contains a throw instead of propagating it', () => {
       throwOn: 'delete avd',
     }),
   );
-  const resolutions = [{ serial: 'emulator-5554' }, { notRunning: true as const }];
+  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5554' }, { notRunning: true as const }];
   const r = teardownOwnedAvd('stim-app', {
     del: true,
     waitForShutdown: (_avdName, shutdown) => shutdown(60_000),
@@ -667,7 +667,7 @@ test('teardownOwnedAvd refuses an AVD with a live process that adb cannot resolv
 
 test('teardownOwnedAvd refuses deletion when the AVD restarts after shutdown', () => {
   const exec = androidExecutor({ avds: ['stim-app'], adb: 'List of devices attached\n' });
-  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5556' }];
+  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5554' }, { serial: 'emulator-5556' }];
   setExecutor(exec);
 
   const r = teardownOwnedAvd('stim-app', {
@@ -683,7 +683,7 @@ test('teardownOwnedAvd refuses deletion when the AVD restarts after shutdown', (
 
 test('teardownOwnedAvd rechecks the process lock immediately before deletion', () => {
   const exec = androidExecutor({ avds: ['stim-app'], adb: 'List of devices attached\n' });
-  const resolutions = [{ serial: 'emulator-5554' }, { notRunning: true as const }];
+  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5554' }, { notRunning: true as const }];
   setExecutor(exec);
 
   const r = teardownOwnedAvd('stim-app', {
@@ -707,4 +707,62 @@ test('ownership skip outcomes carry a machine-readable kind', () => {
 
   setExecutor(androidExecutor({ avds: ['Pixel_6'], adb: 'List of devices attached\n' }));
   expect(teardownOwnedAvd('Pixel_6', { del: true }).kind).toBe('not-owned');
+});
+
+test('iOS session close failure warns but shutdown still follows', () => {
+  const exec = iosExecutor({ sims: [OWNED] });
+  const write = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  setExecutor({
+    ...exec,
+    runQuiet: (command) => (command === 'command -v agent-device' ? '/bin/agent-device' : exec.runQuiet(command)),
+    runFile: (file, args) => {
+      if (file !== 'agent-device') return exec.runFile(file, args);
+      exec.calls.push([file, ...args].join(' '));
+      if (args[0] === 'close') throw new Error('close timed out');
+      return JSON.stringify({
+        success: true,
+        data: { sessions: [{ name: 'ui-task', platform: 'ios', device_udid: 'U1', id: 'U1', createdAt: 1 }] },
+      });
+    },
+  });
+  try {
+    expect(teardownOwnedIosSim('U1').status).toBe('torn-down');
+    const close = exec.calls.findIndex((command) => command.startsWith('agent-device close'));
+    expect(close).toBeGreaterThan(-1);
+    expect(close).toBeLessThan(exec.calls.findIndex((command) => command.includes('simctl shutdown')));
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('could not close agent-device session'));
+  } finally {
+    write.mockRestore();
+  }
+});
+
+test('iOS ownership loss during session inventory prevents close and shutdown', () => {
+  const exec = iosExecutor({ sims: [OWNED] });
+  const renamed = iosExecutor({ sims: [{ ...OWNED, name: 'User simulator' }] });
+  let listed = false;
+  setExecutor({
+    ...exec,
+    runQuiet: (command) => (command === 'command -v agent-device' ? '/bin/agent-device' : exec.runQuiet(command)),
+    runFile: (file, args) => {
+      if (file !== 'agent-device') return (listed ? renamed : exec).runFile(file, args);
+      exec.calls.push([file, ...args].join(' '));
+      listed = true;
+      return JSON.stringify({
+        success: true,
+        data: { sessions: [{ name: 'ui-task', platform: 'ios', device_udid: 'U1', id: 'U1', createdAt: 1 }] },
+      });
+    },
+  });
+  expect(teardownOwnedIosSim('U1').kind).toBe('not-owned');
+  expect(exec.calls.some((command) => /agent-device close|simctl shutdown/.test(command))).toBe(false);
+});
+
+test('Android serial reuse before shutdown keeps the device', () => {
+  const exec = androidExecutor({ avds: ['stim-app'] });
+  const resolutions = [{ serial: 'emulator-5554' }, { serial: 'emulator-5556' }];
+  setExecutor(exec);
+  const result = teardownOwnedAvd('stim-app', { resolveAvd: () => resolutions.shift()! });
+  expect(result.status).toBe('failed');
+  expect(result.reason).toMatch(/changed before shutdown/);
+  expect(exec.calls.some((command) => /emu kill|delete avd/.test(command))).toBe(false);
 });

--- a/packages/stim-cli/src/agent-device-cleanup.ts
+++ b/packages/stim-cli/src/agent-device-cleanup.ts
@@ -1,0 +1,90 @@
+import { phaseLine } from './command-output.ts';
+import { getExecutor } from './exec.ts';
+
+type Device = { platform: 'ios' | 'android'; id: string };
+interface Session {
+  name: string;
+  platform: string;
+  id: string;
+  createdAt: number;
+}
+
+export function parseAgentDeviceSessions(output: string): Session[] {
+  const result = JSON.parse(output);
+  if (result?.success !== true || !Array.isArray(result.data?.sessions)) {
+    throw new Error('agent-device did not return a successful session list');
+  }
+  return result.data.sessions.flatMap((entry: unknown) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const row = entry as Record<string, unknown>;
+    const id = row.platform === 'ios' ? row.device_udid : row.id;
+    if (
+      (row.platform !== 'ios' && row.platform !== 'android') ||
+      typeof row.name !== 'string' ||
+      !row.name.trim() ||
+      typeof id !== 'string' ||
+      !id ||
+      typeof row.createdAt !== 'number' ||
+      !Number.isFinite(row.createdAt) ||
+      (row.platform === 'ios' && row.id !== undefined && row.id !== id)
+    )
+      return [];
+    return [{ name: row.name, platform: row.platform, id, createdAt: row.createdAt }];
+  });
+}
+
+function report(message: string): void {
+  process.stderr.write(`${phaseLine('device', message)}\n`);
+}
+
+export function closeOwnedDeviceSessions(device: Device, stillOwned: () => boolean): void {
+  const exec = getExecutor();
+  const deadline = Date.now() + 15000;
+  const run = (args: string[]) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error('agent-device cleanup timed out');
+    return exec.runFile('agent-device', [...args, '--json', '--daemon-transport', 'socket'], {
+      timeoutMs: Math.min(5000, remaining),
+      killSignal: 'SIGKILL',
+    });
+  };
+  const list = () => parseAgentDeviceSessions(run(['session', 'list', '--session', 'stim-teardown-inventory']));
+  try {
+    if (!exec.runQuiet('command -v agent-device', { timeoutMs: 2000, killSignal: 'SIGKILL' })) return;
+    const sessions = list().filter((session) => session.platform === device.platform && session.id === device.id);
+    for (const session of sessions) {
+      try {
+        if (
+          !list().some(
+            (current) =>
+              current.name === session.name &&
+              current.platform === session.platform &&
+              current.id === session.id &&
+              current.createdAt === session.createdAt,
+          )
+        )
+          continue;
+        if (!stillOwned()) return;
+        const result = JSON.parse(
+          run([
+            'close',
+            '--session',
+            session.name,
+            '--session-lock',
+            'reject',
+            '--platform',
+            device.platform,
+            device.platform === 'ios' ? '--udid' : '--serial',
+            device.id,
+          ]),
+        );
+        if (result?.success !== true) throw new Error('agent-device did not confirm session close');
+        report(`closed agent-device session ${session.name} on ${device.id}`);
+      } catch (error) {
+        report(`could not close agent-device session ${session.name} on ${device.id}: ${(error as Error).message}`);
+      }
+    }
+  } catch (error) {
+    report(`could not list agent-device sessions for ${device.id}: ${(error as Error).message}`);
+  }
+}

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -191,6 +191,8 @@ the stim-<label> (<model> <runtime>) name. Never point Stim at a user-created
 emulator or simulator.
 
 worktree remove parks the workspace's simulator or emulator for later adoption.
+Before owned-device teardown, Stim best-effort closes local agent-device sessions
+on that exact device; failures warn and teardown continues (guide cleanup).
 A parked device is Stim-owned: never delete one by hand. gc --delete clears verified
 entries and keeps failures; see guide lifecycle pool. First launch on a
 physical iPhone can need the one-time taps named by the remedy.

--- a/packages/stim-cli/src/guide/cleanup.ts
+++ b/packages/stim-cli/src/guide/cleanup.ts
@@ -28,6 +28,16 @@ Those are the only two commands that delete. \`stim stop\` shuts a device
 DOWN and leaves it assigned, which is what makes returning to a branch cost a
 boot rather than a create, a provision and a reinstall.
 
+Before shutting down, parking or deleting an owned device, Stim best-effort
+closes local agent-device sessions bound to its exact iOS UDID or live Android
+serial. It rechecks device ownership and uses agent-device's rejecting session
+target guard; sessions on other devices stay open. Physical devices are outside
+this cleanup. agent-device is optional: a missing binary skips this step, and a
+failed or timed-out list/close prints a device line on stderr while teardown
+continues. Cleanup allows at most 15 seconds of agent-device calls per device.
+A local daemon that cannot use socket transport or a CLI without the target guard
+skips cleanup with a warning; no remote daemon is used.
+
 Neither touches $STIM_HOME/stats.json: \`gc\` never reports or trims the run
 counters \`stats\` prints, and there is no reset flag. Delete that one file to
 start the counters over. A file this version cannot read -- unparseable, or

--- a/packages/stim-cli/src/teardown.ts
+++ b/packages/stim-cli/src/teardown.ts
@@ -1,3 +1,4 @@
+import { closeOwnedDeviceSessions } from './agent-device-cleanup.ts';
 import { projectDeviceSlots } from './device-slots.ts';
 import { randomUUID } from 'node:crypto';
 import { lstatSync, renameSync, rmSync } from 'node:fs';
@@ -80,7 +81,10 @@ export function teardownParkedIosSim(
   { label, deleteSim = deleteParkedIosSim }: { label?: string; deleteSim?: typeof deleteParkedIosSim } = {},
 ): TeardownOutcome {
   try {
-    const removed = removeParkedAfter('ios', udid, () => deleteSim(udid));
+    const removed = removeParkedAfter('ios', udid, () => {
+      closeOwnedDeviceSessions({ platform: 'ios', id: udid }, () => Boolean(resolveOwnedIosSim(udid).sim));
+      deleteSim(udid);
+    });
     if (!removed) return { status: 'skipped', kind: 'not-parked', reason: 'simulator is no longer parked' };
     return { status: 'torn-down', label: label ?? removed.name };
   } catch (error) {
@@ -132,6 +136,11 @@ export function teardownOwnedIosSim(
       };
     }
     if (resolved.missing) return { status: 'missing' };
+    closeOwnedDeviceSessions({ platform: 'ios', id: udid }, () => Boolean(resolveOwnedIosSim(udid).sim));
+    const current = resolveOwnedIosSim(udid);
+    if (current.missing) return { status: 'missing' };
+    if (current.notOwned)
+      return { status: 'skipped', kind: 'not-owned', reason: 'simulator ownership changed before shutdown' };
     shutdownIosSim(udid);
     const sim = resolved.sim as IosSimRecord;
     if (del && park && park.max > 0) {
@@ -268,6 +277,12 @@ export function teardownOwnedAvd(
     if (orphanedDirectory) return { status: 'skipped', reason: 'AVD registration appeared; its data was kept.' };
     const serial = resolved.serial;
     if (serial) {
+      const stillOwned = () => {
+        const current = resolveAvd(avdName);
+        return !current.notOwned && !current.missing && current.serial === serial;
+      };
+      closeOwnedDeviceSessions({ platform: 'android', id: serial }, stillOwned);
+      if (!stillOwned()) throw new Error(`Owned AVD ${avdName} changed before shutdown; it was kept.`);
       waitForShutdown(avdName, (timeoutMs) => shutdownAndroidEmulator(serial, timeoutMs));
     } else {
       assertStopped(avdName);

--- a/website/docs/owned-devices.md
+++ b/website/docs/owned-devices.md
@@ -163,6 +163,15 @@ independently of the build source.
 - `stim gc --delete` removes verified resources from the report, including
   parked simulators, emulators, and expired device lease files.
 
+Before shutting down, parking or deleting an owned simulator or emulator, Stim
+attempts to close local `agent-device` sessions on that exact iOS UDID or live
+Android serial. It rechecks ownership and asks agent-device to reject a close if
+the session now targets another device. Sessions on other devices and physical
+devices stay open. The integration is optional: a missing binary skips cleanup;
+failures print a warning and device teardown continues. Agent-device calls have
+a combined 15-second budget per device and require local socket transport and
+support for `--session-lock reject`. Remote daemons are never used.
+
 If deletion fails, Stim keeps the ownership record and exits with an error. A
 later cleanup can then retry without losing track of the resource.
 


### PR DESCRIPTION
## Description

Parked devices can retain agent-device claims, so the next workspace that adopts them cannot open an automation session. Fixes #800.

## Solution

Central teardown best-effort closes local sessions on the exact owned iOS UDID or live Android serial before shutdown, parking or deletion. It rechecks both session identity and device ownership; `--session-lock reject` with the expected device selector prevents a reused session name from closing a session on another device.

The optional integration uses local socket transport and a 15-second per-device budget. Missing agent-device skips cleanup; unsupported guards, unavailable socket transport and failed closes warn while teardown continues. Physical devices and sessions on other devices are excluded.

## Test plan

With agent-device 0.20.10 on macOS, created disposable Stim-owned iOS simulators and an Android emulator. Verified real `session list --json` payloads, rejected closes with mismatching UDID/serial selectors, and successful session release through central iOS parking and Android stop. An unrelated simulator's session remained open. All fixture devices were removed through central teardown.
