### PR TITLE
fix: require ownership claims before warming worktrees

### DIFF
--- a/packages/stim-cli/src/__tests__/guide.test.ts
+++ b/packages/stim-cli/src/__tests__/guide.test.ts
@@ -294,8 +294,10 @@ test('the rendered guide carries the warm --refresh contract, not just its sourc
   // The refusal is on the unflagged path, so the plain-warm contract has to name it where a waiter looks.
   expect(options).toContain('STIM_DEPS_INCOMPLETE');
   expect(renderSection('errors', 'STIM_DEPS_INCOMPLETE')).toContain('warm-installs');
-  expect(renderSection('errors', 'warm')).toContain('appandflow/stim#696');
-  expect(options).toContain('appandflow/stim#696');
+  for (const code of [CLAIM_REFUSED, CLAIM_UNAVAILABLE]) {
+    expect(renderSection('errors', 'warm')).toContain(code);
+    expect(options).toContain(code);
+  }
 });
 
 test('the facts topic documents every reload strategy the command can report', () => {

--- a/packages/stim-cli/src/__tests__/ownership-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/ownership-claim.test.ts
@@ -201,8 +201,36 @@ describe('refusing instead of guessing', () => {
     mkdirSync(dirname(root), { recursive: true });
     writeFileSync(root, 'not a claim directory');
     const err = refusal(() => tryAcquireClaim({ root, mode: 'exclusive' }));
-    expect(err.message).toMatch(/is a file, not a claim directory/);
+    expect(err.claimPath).toBe(root);
+    expect(err.message).toContain('blocked by a non-directory path');
   });
+
+  test.each(['exclusive', 'shared'] as const)(
+    'a %s claim remedy preserves the actual blocking ancestor and its siblings',
+    (mode) => {
+      const home = dirname(root);
+      const blocker = join(home, "warm locks' file");
+      const bystander = join(home, 'keep');
+      writeFileSync(blocker, 'unrelated contents');
+      writeFileSync(bystander, 'keep');
+      const blocked = join(blocker, 'repository.lock');
+      try {
+        const err = refusal(() => tryAcquireClaim({ root: blocked, mode }));
+        expect(err.claimPath).toBe(blocker);
+        expect(err.removeCommand).toMatch(/^mv -i /);
+        getExecutor().run(err.removeCommand);
+        expect(readFileSync(`${blocker}.stim-backup`, 'utf8')).toBe('unrelated contents');
+        expect(readFileSync(bystander, 'utf8')).toBe('keep');
+        const acquired = tryAcquireClaim({ root: blocked, mode }).acquired;
+        expect(acquired).toBeDefined();
+        releaseClaim(acquired);
+      } finally {
+        rmSync(blocker, { recursive: true, force: true });
+        rmSync(`${blocker}.stim-backup`, { force: true });
+        rmSync(bystander, { force: true });
+      }
+    },
+  );
 
   test('the printed remedy, run as printed, clears the claim and nothing beside it', () => {
     const home = mkdtempSync(join(tmpdir(), 'stim-claim-remedy-'));

--- a/packages/stim-cli/src/__tests__/warm-claim-unavailable.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim-unavailable.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { Command } from 'commander';
@@ -13,8 +13,6 @@ const identity = vi.hoisted(() => ({
 }));
 const REASON = identity.reason;
 
-// Toggleable so a test can plant a claim another process would hold -- which needs a real captured
-// identity -- and then run warm on a Stim that cannot capture one.
 vi.mock('../process-identity.ts', async (importOriginal) => {
   const real = await importOriginal<typeof import('../process-identity.ts')>();
   return {
@@ -87,23 +85,14 @@ afterEach(() => {
   rmSync(base, { recursive: true, force: true });
 });
 
-test('a plain warm with no recordable process identity copies unsynchronised and says so', async () => {
-  const result = await runWarm(target);
-  expect(result.code).toBe(0);
-  expect(result.stdout).toEqual([]);
-  expect(result.stderr).toContain(REASON);
-  expect(result.stderr).toMatch(/lock {8}unavailable \(.*\); copying without it/);
-  expect(result.stderr).toMatch(/carry {7}complete: 1 ignored entries copied/);
-  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
-});
-
-test('--refresh with no recordable process identity refuses and names unique-pid', async () => {
+test.each([[], ['--refresh']])('warm %j refuses before copying when identity cannot be recorded', async (...args) => {
   const head = git(root, 'rev-parse', 'HEAD');
-  const result = await runWarm(target, '--refresh');
+  const result = await runWarm(target, ...args);
   expect(result.code).toBe(1);
+  expect(result.stdout).toEqual([]);
   expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
   expect(result.stderr).toContain(REASON);
-  expect(result.stderr).toContain('unique-pid');
+  expect(result.stderr).toContain('Reinstall Stim');
   expect(result.stderr).not.toMatch(/checkout|carry/);
   expect(existsSync(join(target, '.env'))).toBe(false);
   expect(git(root, 'rev-parse', 'HEAD')).toBe(head);
@@ -118,38 +107,14 @@ function plant(owner: () => { pid: number; processToken: string }, claimId: stri
   }
 }
 
-test('a plain warm with no claim of its own refuses while a refresh holds this repository', async () => {
-  const claim = plant(liveClaimOwner, 'refresh-in-flight');
-  const result = await runWarm(target);
-  expect(result.code).toBe(1);
-  expect(result.stderr).toMatch(
-    /lock {8}unavailable \(.*\); stim worktree warm --refresh \(pid \d+\) holds this repository/,
-  );
-  expect(result.stderr).toContain('Refusing to copy from a source checkout a refresh is rewriting');
-  expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
-  expect(existsSync(join(target, '.env'))).toBe(false);
-  expect(existsSync(claim)).toBe(true);
-});
-
-test('a plain warm with no claim of its own refuses past a claim it cannot resolve', async () => {
-  identity.available = true;
-  const owner = goneClaimOwner();
-  identity.available = false;
-  const claim = plantClaim(warmClaimPath(root), 'exclusive', owner, {
-    claimId: 'half-spawned',
-    child: { record: null },
-  });
-  const result = await runWarm(target);
-  expect(result.code).toBe(1);
-  expect(result.stderr).toContain('cannot be resolved');
-  expect(result.stderr).toContain(claim);
-  expect(existsSync(join(target, '.env'))).toBe(false);
-});
-
-test('a claim whose holder is gone does not stop the unsynchronised copy', async () => {
-  plant(() => goneClaimOwner(), 'dead-refresh');
-  const result = await runWarm(target);
-  expect(result.code).toBe(0);
-  expect(result.stderr).toMatch(/lock {8}unavailable \(.*\); copying without it/);
-  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
-});
+test.each([liveClaimOwner, goneClaimOwner])(
+  'identity-unavailable warm refuses regardless of existing holder liveness',
+  async (owner) => {
+    const claim = plant(owner, 'existing-refresh');
+    const result = await runWarm(target);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
+    expect(existsSync(join(target, '.env'))).toBe(false);
+    expect(existsSync(claim)).toBe(true);
+  },
+);

--- a/packages/stim-cli/src/__tests__/warm-claim.test.ts
+++ b/packages/stim-cli/src/__tests__/warm-claim.test.ts
@@ -2,25 +2,9 @@ import { once } from 'node:events';
 import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import {
-  acquireWarmClaim,
-  warmClaimAcquiredLine,
-  warmClaimBlockedLine,
-  warmClaimBlockedRefusal,
-  warmClaimBlocker,
-  warmClaimDegradation,
-  warmClaimPath,
-  warmClaimsDir,
-} from '../engine/warm-claim.ts';
+import { acquireWarmClaim, warmClaimAcquiredLine, warmClaimPath, warmClaimsDir } from '../engine/warm-claim.ts';
 import { getExecutor } from '../exec.ts';
-import {
-  CLAIM_PATH_NOT_A_DIRECTORY,
-  ClaimRefusedError,
-  ClaimUnavailableError,
-  exclusiveClaimDir,
-  readClaimSet,
-  sharedClaimDir,
-} from '../ownership-claim.ts';
+import { ClaimRefusedError, exclusiveClaimDir, readClaimSet, sharedClaimDir } from '../ownership-claim.ts';
 import { IMPOSSIBLE_PID, goneClaimOwner, plantClaim, recycledClaimOwner } from './_factories.ts';
 
 let home: string;
@@ -214,24 +198,14 @@ test('a wait attributes elapsed time to the waiter and names its holder every pr
 
 test('the acquired line reports a wait only when there was one', () => {
   expect(warmClaimAcquiredLine({ waitedMs: 0, holder: null })).toBe(`  ${'lock'.padEnd(11)} acquired`);
+  for (const waitedMs of [1, 250, 999]) {
+    expect(warmClaimAcquiredLine({ waitedMs, holder: { pid: 41233, phase: 'refresh' } })).toBe(
+      `  ${'lock'.padEnd(11)} acquired`,
+    );
+  }
   expect(warmClaimAcquiredLine({ waitedMs: 12_000, holder: { pid: 41233, phase: 'refresh' } })).toBe(
     `  ${'lock'.padEnd(11)} acquired (waited 12s for stim worktree warm --refresh pid 41233) -- stim guide lifecycle options`,
   );
-});
-
-test('a copy proceeds without a claim only when no claim could be recorded at all', () => {
-  expect(warmClaimDegradation(new ClaimUnavailableError('ENOSYS (no prebuild for this platform)'))).toContain(
-    'ENOSYS (no prebuild for this platform)',
-  );
-  expect(warmClaimDegradation(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }))).toBe(
-    'EACCES: permission denied',
-  );
-  expect(
-    warmClaimDegradation(
-      new ClaimRefusedError({ claimPath: '/h/a.claim', root: '/h', reason: 'truncated', label: 'worktree warm' }),
-    ),
-  ).toBe(null);
-  expect(warmClaimDegradation(Object.assign(new Error('waited'), { code: 'STIM_LOCK_TIMEOUT' }))).toBe(null);
 });
 
 test('the installer process group keeps the claim after the refresh that spawned it is gone', async () => {
@@ -325,53 +299,6 @@ test('a pid that no longer exists is not a writer to hold the claim for', async 
   expect(lines).toEqual([]);
   refresh.release();
   expect(existsSync(warmClaimPath(REPO))).toBe(false);
-});
-
-test('a claim store whose own path is a file degrades a copy; an unresolvable claim in it does not', () => {
-  const notADirectory = new ClaimRefusedError({
-    claimPath: '/h/warm-locks/main--a.lock',
-    root: '/h/warm-locks/main--a.lock',
-    reason: CLAIM_PATH_NOT_A_DIRECTORY,
-    label: 'worktree warm',
-  });
-  expect(warmClaimDegradation(notADirectory)).toBe(`/h/warm-locks/main--a.lock: ${CLAIM_PATH_NOT_A_DIRECTORY}`);
-  expect(
-    warmClaimDegradation(
-      new ClaimRefusedError({
-        claimPath: '/h/warm-locks/main--a.lock/exclusive/x.claim',
-        root: '/h/warm-locks/main--a.lock',
-        reason: 'its record is missing, truncated or not valid JSON',
-        label: 'worktree warm',
-      }),
-    ),
-  ).toBe(null);
-});
-
-test('a copy with no claim of its own reads what it would overlap before it copies', async () => {
-  expect(warmClaimBlocker(REPO)).toBe(null);
-
-  const copy = await acquireWarmClaim({ repositoryRoot: REPO, phase: 'copy', sleep: never });
-  expect(warmClaimBlocker(REPO)).toBe(null);
-  copy.release();
-
-  const refresh = await acquireWarmClaim({ repositoryRoot: REPO, phase: 'refresh', sleep: never });
-  const blocker = warmClaimBlocker(REPO);
-  expect(blocker).toEqual({ kind: 'refresh', holder: { pid: process.pid, phase: 'refresh' } });
-  expect(warmClaimBlockedLine('EACCES: permission denied', blocker!)).toMatch(
-    /^ {2}lock {8}unavailable \(EACCES: permission denied\); stim worktree warm --refresh \(pid \d+\) holds this repository$/,
-  );
-  expect(warmClaimBlockedRefusal(blocker!)).toContain('Refusing to copy from a source checkout a refresh is rewriting');
-  refresh.release();
-
-  plantClaim(warmClaimPath(REPO), 'exclusive', goneClaimOwner(), { claimId: 'dead-refresh' });
-  expect(warmClaimBlocker(REPO)).toBe(null);
-
-  const path = plantClaim(warmClaimPath(REPO), 'exclusive', goneClaimOwner(), {
-    claimId: 'half-spawned',
-    child: { record: null },
-  });
-  expect(warmClaimBlocker(REPO)).toEqual({ kind: 'unresolved', path, reason: expect.any(String) });
-  expect(warmClaimBlockedRefusal(warmClaimBlocker(REPO)!)).toContain(path);
 });
 
 test('settling the installer waits for its process group, not for the process that led it', async () => {

--- a/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
+++ b/packages/stim-cli/src/__tests__/worktree-refresh.test.ts
@@ -552,7 +552,7 @@ test('a refresh in flight blocks a plain warm from another app of the same repos
   held.release();
   const result = await warm;
   expect(result.code).toBe(0);
-  expect(result.stderr).toMatch(/lock {8}acquired \(waited \d+m?\d*s for stim worktree warm --refresh pid \d+\)/);
+  expect(result.stderr).toMatch(/lock {8}acquired/);
   expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
 });
 
@@ -687,50 +687,44 @@ test('a retry after a failed install runs it again instead of copying a half-ins
   expect(spawned).toEqual([]);
 });
 
-test('a plain warm copies without the lock when STIM_HOME cannot be written, and --refresh still refuses', async () => {
+test('both warm paths refuse an unwritable claim store before copying and report recovery', async () => {
   write(root, '.env', 'main env');
   const home = String(process.env.STIM_HOME);
   mkdirSync(home, { recursive: true });
   chmodSync(home, 0o500);
   try {
-    const plain = await runWarm(target);
-    expect(plain.code).toBe(0);
-    expect(plain.stdout).toEqual([]);
-    expect(plain.stderr).toMatch(/lock {8}unavailable \(.*\); copying without it/);
-    expect(plain.stderr).toMatch(/carry {7}complete: 1 ignored entries copied/);
-    expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
-
-    process.exitCode = 0;
-    rmSync(join(target, '.env'));
-    const refresh = await runWarm(target, '--refresh');
-    expect(refresh.code).toBe(1);
-    expect(refresh.stderr).toMatch(/Could not warm this worktree/);
-    expect(existsSync(join(target, '.env'))).toBe(false);
+    for (const args of [[], ['--refresh']]) {
+      process.exitCode = 0;
+      const result = await runWarm(target, ...args);
+      expect(result.code).toBe(1);
+      expect(result.stdout).toEqual([]);
+      expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
+      expect(result.stderr).toContain('Restore write access to the existing claim store');
+      expect(result.stderr).toContain(home);
+      expect(existsSync(join(target, '.env'))).toBe(false);
+    }
   } finally {
     chmodSync(home, 0o700);
   }
 });
 
-test('a dangling STIM_HOME link permits a plain copy but refuses refresh before changing the source', async () => {
+test('a dangling STIM_HOME link refuses both warm paths before copying or changing the source', async () => {
   write(root, '.env', 'main env');
   fallBehind({ 'package.json': '{"name":"updated-fixture"}\n' });
   const before = git(root, 'rev-parse', 'HEAD');
   symlinkSync(join(base, 'missing-home'), String(process.env.STIM_HOME));
 
-  const plain = await runWarm(target);
-  expect(plain.code).toBe(0);
-  expect(plain.stdout).toEqual([]);
-  expect(plain.stderr).toMatch(/lock {8}unavailable \(ENOENT:.*\); copying without it/);
-  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
-
-  rmSync(join(target, '.env'));
-  const refresh = await runWarm(target, '--refresh');
-  expect(refresh.code).toBe(1);
-  expect(refresh.stdout).toEqual([]);
-  expect(refresh.stderr).toMatch(/Could not warm this worktree: ENOENT:/);
-  expect(refresh.stderr).not.toContain('another process');
-  expect(existsSync(join(target, '.env'))).toBe(false);
-  expect(git(root, 'rev-parse', 'HEAD')).toBe(before);
+  for (const args of [[], ['--refresh']]) {
+    process.exitCode = 0;
+    const result = await runWarm(target, ...args);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toEqual([]);
+    expect(result.stderr).toContain('failed: STIM_CLAIM_UNAVAILABLE');
+    expect(result.stderr).toContain('ENOENT:');
+    expect(result.stderr).toContain('symlink targets');
+    expect(existsSync(join(target, '.env'))).toBe(false);
+    expect(git(root, 'rev-parse', 'HEAD')).toBe(before);
+  }
 });
 
 test('a copy that waited for the lock reads the exclusions the refresh left behind, not the ones it started with', async () => {
@@ -1004,27 +998,22 @@ test('the ledger records the lockfile the installer read, not the one on disk wh
   expect(installLedger()).toEqual({ lock: 'pnpm-lock.yaml', hash: sha256('lock v3\n'), completed: true });
 });
 
-test('a STIM_HOME that is a regular file degrades a plain warm and still refuses a --refresh', async () => {
+test('a STIM_HOME that is a regular file refuses both warm paths and names the blocking file', async () => {
   write(root, '.env', 'main env');
   const home = String(process.env.STIM_HOME);
   rmSync(home, { recursive: true, force: true });
   writeFileSync(home, 'not a directory');
 
-  const plain = await runWarm(target);
-  expect(plain.code).toBe(0);
-  expect(plain.stdout).toEqual([]);
-  expect(plain.stderr).toMatch(
-    /lock {8}unavailable \(.*: the claim path is a file, not a claim directory\); copying without it/,
-  );
-  expect(plain.stderr).toMatch(/carry {7}complete: 1 ignored entries copied, 0 kept, 0 failed/);
-  expect(readFileSync(join(target, '.env'), 'utf-8')).toBe('main env');
-
-  process.exitCode = 0;
-  rmSync(join(target, '.env'));
-  const refresh = await runWarm(target, '--refresh');
-  expect(refresh.code).toBe(1);
-  expect(refresh.stderr).toContain('failed: STIM_CLAIM_REFUSED');
-  expect(existsSync(join(target, '.env'))).toBe(false);
+  for (const args of [[], ['--refresh']]) {
+    process.exitCode = 0;
+    const result = await runWarm(target, ...args);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toEqual([]);
+    expect(result.stderr).toContain('failed: STIM_CLAIM_REFUSED');
+    expect(result.stderr).toContain(`mv -i '${home}' '${home}.stim-backup'`);
+    expect(readFileSync(home, 'utf8')).toBe('not a directory');
+    expect(existsSync(join(target, '.env'))).toBe(false);
+  }
 });
 
 test('a plain warm refuses the tree a real failed install left, and copies once a refresh finishes it', async () => {

--- a/packages/stim-cli/src/commands/worktree.ts
+++ b/packages/stim-cli/src/commands/worktree.ts
@@ -19,17 +19,7 @@ import { claimFailure } from '../ownership-claim.ts';
 import { parkedMaxSetting, POOL_SETTING_REMEDY } from '../sim-pool.ts';
 import type { ParkedDevice } from '../teardown.ts';
 import { withManagedRemoteWorktreeRemovalLock, withManagedTunnelRemovalLock } from '../engine/tunnel.ts';
-import {
-  acquireWarmClaim,
-  warmClaimAcquiredLine,
-  warmClaimBlockedLine,
-  warmClaimBlockedRefusal,
-  warmClaimBlocker,
-  warmClaimDegradation,
-  warmClaimUnavailableLine,
-  withWarmClaim,
-  type WarmClaimWait,
-} from '../engine/warm-claim.ts';
+import { acquireWarmClaim, warmClaimAcquiredLine, withWarmClaim, type WarmClaimWait } from '../engine/warm-claim.ts';
 import { incompleteInstallRefusal, refreshMainCheckout, type RefreshFailure } from '../worktree-refresh.ts';
 import { readMetroTunnel, readRemoteSession } from '../supervisor/state.ts';
 import {
@@ -231,33 +221,7 @@ export function registerWarm(worktree: Command): void {
           }
           if (process.exitCode) return;
         }
-        // Only the acquisition degrades: an error from the copy itself is not a claim that could not
-        // be recorded, and must not start a second copy.
-        let hold = null;
-        try {
-          hold = await acquireWarmClaim({ repositoryRoot: root, phase: 'copy', out: console.error });
-        } catch (error) {
-          const degraded = opts.refresh ? null : warmClaimDegradation(error);
-          if (degraded === null) throw error;
-          // Copying unsynchronised is what warm did before the claim existed -- but what came before held
-          // no refresh either. Reading the claim set classifies without writing anything and without
-          // refusing, so even a copy that cannot record a claim can see the one state it must not overlap.
-          const blocker = warmClaimBlocker(root);
-          if (blocker) {
-            console.error(chalk.dim(warmClaimBlockedLine(degraded, blocker)));
-            console.error(chalk.red(warmClaimBlockedRefusal(blocker)));
-            throw error;
-          }
-          console.error(chalk.dim(warmClaimUnavailableLine(degraded)));
-        }
-        if (!hold) copy(null);
-        else {
-          try {
-            copy(hold.wait);
-          } finally {
-            hold.release();
-          }
-        }
+        await withWarmClaim({ repositoryRoot: root, phase: 'copy', out: console.error }, (hold) => copy(hold.wait));
       } catch (error) {
         const code = (error as { code?: string })?.code;
         console.error(chalk.red(`Could not warm this worktree: ${(error as Error).message}`));

--- a/packages/stim-cli/src/engine/warm-claim.ts
+++ b/packages/stim-cli/src/engine/warm-claim.ts
@@ -4,14 +4,11 @@ import { formatElapsed, phaseLine } from '../command-output.ts';
 import { getConfigDir } from '../config.ts';
 import { captureProcessIdentity } from '../process-identity.ts';
 import {
-  CLAIM_PATH_NOT_A_DIRECTORY,
+  ClaimUnavailableError,
   claimRemoveCommand,
   clearClaimChild,
-  isClaimRefusal,
-  isClaimUnavailable,
   markClaimChildPending,
   processGroupAlive,
-  readClaimSet,
   releaseClaim,
   setClaimChild,
   settleClaim,
@@ -108,76 +105,10 @@ function waitingLine(holder: WarmClaimHolder, elapsedMs: number): string {
 
 export function warmClaimAcquiredLine(wait: WarmClaimWait, detail = ''): string {
   const acquired = `acquired${detail ? ` ${detail}` : ''}`;
-  if (!wait.holder || wait.waitedMs <= 0) return phaseLine('lock', acquired);
+  if (!wait.holder || wait.waitedMs < 1000) return phaseLine('lock', acquired);
   return phaseLine(
     'lock',
     `${acquired} (waited ${formatElapsed(wait.waitedMs)} for ${warmCommand(wait.holder.phase)} pid ${wait.holder.pid}) -- stim guide lifecycle options`,
-  );
-}
-
-export function warmClaimUnavailableLine(reason: string): string {
-  return phaseLine('lock', `unavailable (${reason}); copying without it`);
-}
-
-/**
- * The reason a copy may proceed without the claim, or null when it must refuse. Plain `warm` worked on an
- * unwritable STIM_HOME before any claim existed and only reads, so the states in which no claim can be
- * recorded at all degrade to an unsynchronised copy: no process identity, a claim store the filesystem
- * rejects, and a claim store whose own path holds a file. A claim record Stim cannot resolve and a wait
- * that ran out are refusals: neither state can exist unless the claim does, so refusing them takes
- * nothing away.
- */
-export function warmClaimDegradation(error: unknown): string | null {
-  if (isClaimUnavailable(error)) return error.message;
-  if (isClaimRefusal(error)) {
-    return error.reason === CLAIM_PATH_NOT_A_DIRECTORY ? `${error.claimPath}: ${error.reason}` : null;
-  }
-  const code = (error as { code?: string })?.code;
-  if (typeof code === 'string' && code.startsWith('STIM_')) return null;
-  return (error as Error)?.message ?? String(error);
-}
-
-export type WarmClaimBlocker =
-  | { kind: 'refresh'; holder: WarmClaimHolder }
-  | { kind: 'unresolved'; path: string; reason: string };
-
-/**
- * What a copy that could not record a claim of its own would overlap if it went ahead anyway. Reading the
- * claim set classifies without writing anything and without refusing, so it works in exactly the states
- * that made the claim unrecordable -- a read-only STIM_HOME included. It is a read before a copy rather
- * than a held claim, so a refresh that starts after it is not covered; it closes the window in which one
- * is already installing, which is the window a refresh actually occupies.
- */
-export function warmClaimBlocker(repositoryRoot: string): WarmClaimBlocker | null {
-  const survey = readClaimSet(warmClaimPath(repositoryRoot));
-  const refresh = survey.live.find((holder) => holder.mode === 'exclusive');
-  if (refresh) return { kind: 'refresh', holder: asHolder(refresh) };
-  // A claim record whose state cannot be established may be a refresh that was killed between spawning
-  // its install and recording it. A directory that could not be read is the storage failure already
-  // being degraded on, not a claim.
-  const unresolved = survey.unresolved.find((problem) => problem.path.endsWith('.claim'));
-  if (unresolved) return { kind: 'unresolved', path: unresolved.path, reason: unresolved.reason };
-  return null;
-}
-
-export function warmClaimBlockedLine(reason: string, blocker: WarmClaimBlocker): string {
-  const what =
-    blocker.kind === 'refresh'
-      ? `${warmCommand(blocker.holder.phase)} (pid ${blocker.holder.pid}) holds this repository`
-      : `a claim at ${blocker.path} cannot be resolved: ${blocker.reason}`;
-  return phaseLine('lock', `unavailable (${reason}); ${what}`);
-}
-
-export function warmClaimBlockedRefusal(blocker: WarmClaimBlocker): string {
-  if (blocker.kind === 'refresh') {
-    return (
-      'Refusing to copy from a source checkout a refresh is rewriting, even without a claim of its own. ' +
-      'Wait for that refresh to finish, then run warm again.'
-    );
-  }
-  return (
-    'Refusing to copy past a claim Stim cannot resolve. If nothing is warming, remove it and run warm ' +
-    `again:\n  ${claimRemoveCommand(blocker.path)}`
   );
 }
 
@@ -335,6 +266,9 @@ export async function acquireWarmClaim({
     }
   } catch (error) {
     releaseClaim(pending);
+    if (['EACCES', 'EPERM', 'EROFS', 'ENOENT'].includes((error as NodeJS.ErrnoException)?.code ?? '')) {
+      throw new ClaimUnavailableError((error as Error).message, { claimPath: root });
+    }
     throw error;
   }
 }

--- a/packages/stim-cli/src/guide/agent.ts
+++ b/packages/stim-cli/src/guide/agent.ts
@@ -57,6 +57,8 @@ warm checks for existing entries before copying, not during the copy. Do not
 edit files, install dependencies, or run another warm in that worktree until
 it finishes; concurrent files can be overwritten or removed.
 If warm fails or reports incomplete, resolve the reported failure first.
+A warm that cannot record its ownership claim refuses before copying. Follow
+the printed remedy and keep concurrent runs on the same STIM_HOME.
 
 Before native worktree work, run doctor for the platform in scope. It checks
 the source checkout from a linked worktree. Fix relevant findings and inspect the

--- a/packages/stim-cli/src/guide/errors.ts
+++ b/packages/stim-cli/src/guide/errors.ts
@@ -236,14 +236,13 @@ code, never on the message.`,
   \`worktree warm\` reports it for the repository-wide warm claim under
   ~/.stim/warm-locks on both paths, including a \`--refresh\` that spawned its
   install and was killed before recording which process: nothing was refreshed
-  and nothing was copied. One case is NOT this code for a plain warm: a
-  STIM_HOME (or a warm-locks path under it) that is a file rather than a
-  directory. No claim can be stored there at all, which is a filesystem state
-  that predates claims, so plain \`warm\` degrades to the unsynchronised copy it
-  performed before them and \`--refresh\` still refuses.`,
+  and nothing was copied. A STIM_HOME or warm-locks ancestor that is a file
+  also refuses. The message names that blocking path and prints a shell-quoted
+  move-aside command. Inspect it first: the file may contain unrelated data.
+  An existing backup prompts before overwriting; preserve both files.`,
     },
     STIM_CLAIM_UNAVAILABLE: {
-      summary: 'this process has no recordable identity, so no build lock or build slot can be taken at all',
+      summary: 'a process identity or warm claim store is unavailable, so the protected operation refuses',
       body: () => `STIM_CLAIM_UNAVAILABLE
   Every ownership claim records the holder's process identity, captured through
   the \`unique-pid\` native module. This code is that capture failing: no
@@ -255,16 +254,15 @@ code, never on the message.`,
   the same fingerprint while each believed it was alone. Reinstall Stim so the
   module for this platform is present, then run the command again. Nothing was
   built, installed or removed.
-  \`worktree warm --refresh\` refuses for the same reason, because it writes to
-  the source checkout. Plain \`worktree warm\` does NOT: it prints one dim
-  \`lock        unavailable (...)\` line and copies unsynchronised. A copy only
-  reads, so running it with no claim is what it did before the lock existed,
-  while refusing it would break a warm that works today -- an unwritable
-  STIM_HOME included.
-  It still reads the claim set first, which takes no claim: a live \`--refresh\`
-  claim, or a claim it cannot resolve, makes even the unsynchronised copy
-  refuse, and the line names what it found. Only a repository nothing is
-  warming is copied without a claim.`,
+  Both plain \`worktree warm\` and \`worktree warm --refresh\` refuse before
+  copying for the same reason. A copy without a claim would be invisible to a
+  refresh starting after it, allowing the source dependencies to change while
+  they are read.
+  Warm also reports this code for EACCES, EPERM, EROFS and ENOENT while taking a claim.
+  The message names the claim path and original filesystem error. Restore write
+  access to the existing claim store, checking parent permissions, symlink
+  targets, mount access and sandbox rules, then retry. Do not switch STIM_HOME to evade a claim:
+  concurrent runs must coordinate through the same store.`,
     },
     STIM_INSTALL_FAILED: {
       summary: 'simctl, adb, or devicectl refused the artifact; the one signer-conflict retry',
@@ -976,24 +974,14 @@ not on any remote"  (worktree remove)
   which is usually the repository root, so every app of it reads the same one.`,
     },
     warm: {
-      summary: 'two warm refusals whose text is incomplete, known and not fixed',
-      body: () => `"Could not warm this worktree: EACCES: permission denied, mkdir
-'<home>/warm-locks/<name>.lock'"  (worktree warm --refresh)
-  A STIM_HOME that \`--refresh\` cannot write. The refusal itself is right -- it
-  writes to the source checkout, so it will not run without a claim -- but it
-  carries no \`failed: <CODE>\` line, because EACCES is not a Stim code, and no
-  fix line. Make STIM_HOME writable, or set STIM_HOME to somewhere writable,
-  then run it again. A plain warm degrades in this state rather than refusing.
-
-"... the claim path is a file, not a claim directory", with a \`rm -rf\` that
-changes nothing  (worktree warm --refresh)
-  When \`$STIM_HOME/warm-locks\` or STIM_HOME itself is a regular FILE, the
-  refusal names \`warm-locks/<name>.lock\` -- a path that cannot exist under a
-  file -- so running the printed removal does nothing and the next run refuses
-  identically. Remove the file that is in the way and run it again. A plain
-  warm copies unsynchronised in this state.
-
-  Both are documented rather than fixed: appandflow/stim#696.`,
+      summary: 'worktree warm claim storage refusals and recovery',
+      body: () => `Both plain warm and --refresh require an ownership claim.
+  Permission-denied or read-only claim storage reports STIM_CLAIM_UNAVAILABLE
+  and names the path. Restore access to the existing claim store and retry.
+  A non-directory claim ancestor reports STIM_CLAIM_REFUSED and names the
+  blocking file. Inspect it and use the printed move-aside command to preserve
+  its contents before retrying. See guide errors STIM_CLAIM_UNAVAILABLE and
+  guide errors STIM_CLAIM_REFUSED for the recovery details.`,
     },
     carry: {
       summary: 'worktree warm copy results, lockfile mismatches, and remedies',

--- a/packages/stim-cli/src/guide/lifecycle.ts
+++ b/packages/stim-cli/src/guide/lifecycle.ts
@@ -1068,20 +1068,13 @@ OPT-IN CONCURRENCY LIMITS (UNLIMITED BY DEFAULT)
   holder every 30s and gives up with STIM_LOCK_TIMEOUT; a claim Stim cannot
   resolve refuses with STIM_CLAIM_REFUSED and names the removal rather than
   waiting on it or removing it.
-  A plain warm that cannot record a claim at all -- an unwritable STIM_HOME, a
-  STIM_HOME on a read-only mount or under a dangling symlink, a STIM_HOME that
-  is a file, or no \`unique-pid\` build for this platform
-  (STIM_CLAIM_UNAVAILABLE) -- says so in one dim line and copies without it,
-  exactly as it did before the lock existed, because a copy only reads.
-  \`--refresh\` refuses instead, because it writes. Before that unsynchronised
-  copy starts, warm still READS the claim set, which needs no claim of its own:
-  if a refresh holds this repository, or a claim in it cannot be resolved, the
-  copy refuses rather than reading a tree that is being rewritten. That read is
-  not a lock, so a refresh that starts after it is not covered; it closes the
-  window in which one is already installing. Closing the rest needs a claim,
-  which is the one thing that state cannot record, so the residual is
-  documented rather than fixed (appandflow/stim#696), as is the
-  \`acquired (waited 0s ...)\` a contended-but-fast wait prints.
+  Both plain warm and --refresh refuse before copying when no claim can be
+  recorded. Missing process identity, denied write access and read-only storage
+  report STIM_CLAIM_UNAVAILABLE with recovery instructions. Restore access to the
+  same claim store before retrying; choosing a different STIM_HOME would hide
+  concurrent warm operations. A non-directory claim path reports
+  STIM_CLAIM_REFUSED and names the blocking file with a move-aside command that
+  preserves its contents. Sub-second waits omit the elapsed-time suffix.
 
   Wait for warm to exit successfully (exit code 0) before running start,
   ios, android, or a dependency install in that worktree. If a shell tool

--- a/packages/stim-cli/src/ownership-claim.ts
+++ b/packages/stim-cli/src/ownership-claim.ts
@@ -84,13 +84,6 @@ export interface ClaimOptions {
 export const CLAIM_REFUSED = 'STIM_CLAIM_REFUSED';
 export const CLAIM_UNAVAILABLE = 'STIM_CLAIM_UNAVAILABLE';
 
-/**
- * The refusal reason for a claim store whose own path is occupied by a file. It names a filesystem
- * state that predates any claim, so a caller that only reads can tell it apart from an unresolvable
- * claim record and fall back to what it did before claims existed.
- */
-export const CLAIM_PATH_NOT_A_DIRECTORY = 'the claim path is a file, not a claim directory';
-
 const EXCLUSIVE_DIR = 'exclusive';
 const SHARED_DIR = 'shared';
 const CLAIM_SUFFIX = '.claim';
@@ -104,12 +97,28 @@ export class ClaimRefusedError extends Error {
   readonly reason: string;
   readonly removeCommand: string;
 
-  constructor({ claimPath, root, reason, label }: { claimPath: string; root: string; reason: string; label: string }) {
-    const removeCommand = claimRemoveCommand(claimPath.startsWith(root) ? claimPath : root);
+  constructor({
+    claimPath,
+    root,
+    reason,
+    label,
+    blockingFile = false,
+  }: {
+    claimPath: string;
+    root: string;
+    reason: string;
+    label: string;
+    blockingFile?: boolean;
+  }) {
+    const removeCommand = blockingFile
+      ? `mv -i ${quotedPath(claimPath)} ${quotedPath(`${claimPath}.stim-backup`)}`
+      : claimRemoveCommand(claimPath.startsWith(root) ? claimPath : root);
     super(
-      `Stim cannot tell whether the ${label} claim at ${claimPath} is still held: ${reason}. ` +
-        'It will not remove a claim it cannot prove is dead, and it will not wait on one either. ' +
-        `If nothing is using it, remove the claim and run the command again:\n  ${removeCommand}`,
+      blockingFile
+        ? `The ${label} claim store is blocked by a non-directory path at ${claimPath}. Inspect it before moving it aside; its contents may be unrelated to Stim. Preserve it with the command below (an existing backup prompts before overwriting), then run the command again:\n  ${removeCommand}`
+        : `Stim cannot tell whether the ${label} claim at ${claimPath} is still held: ${reason}. ` +
+            'It will not remove a claim it cannot prove is dead, and it will not wait on one either. ' +
+            `If nothing is using it, remove the claim and run the command again:\n  ${removeCommand}`,
     );
     this.claimPath = claimPath;
     this.reason = reason;
@@ -120,10 +129,18 @@ export class ClaimRefusedError extends Error {
 export class ClaimUnavailableError extends Error {
   readonly code: string = CLAIM_UNAVAILABLE;
   readonly reason: string;
+  readonly remedy: string;
 
-  constructor(reason: string) {
-    super(`Stim could not record a process identity, so it cannot take an ownership claim: ${reason}.`);
+  constructor(reason: string, { claimPath }: { claimPath?: string } = {}) {
+    super(
+      claimPath
+        ? `Stim could not write the ownership claim at ${claimPath}: ${reason}.`
+        : `Stim could not record a process identity, so it cannot take an ownership claim: ${reason}.`,
+    );
     this.reason = reason;
+    this.remedy = claimPath
+      ? `Restore write access to the existing claim store at ${quotedPath(claimPath)} (check parent permissions, symlink targets, mount access and sandbox rules)`
+      : 'Reinstall Stim so the unique-pid native module for this platform is present';
   }
 }
 
@@ -151,12 +168,7 @@ export interface ClaimFailure {
   remedy: string;
 }
 
-/**
- * The refusal a command reports for either error the claim primitive raises, and null for anything else.
- * Both are refusals: a claim Stim cannot resolve and a process identity it cannot record are the two
- * states in which it holds no claim, and running the operation a claim serializes without one gives a
- * competing run no protection at all.
- */
+/** Convert an unresolved claim, unavailable identity or inaccessible warm claim store into command recovery guidance. */
 export function claimFailure(err: unknown, retryCommand: string | null): ClaimFailure | null {
   const retry = retryCommand === null ? 'retry the same Stim command' : `run \`${retryCommand}\` again`;
   if (isClaimRefusal(err)) {
@@ -170,7 +182,7 @@ export function claimFailure(err: unknown, retryCommand: string | null): ClaimFa
     return {
       code: CLAIM_UNAVAILABLE,
       message: err.message,
-      remedy: `Reinstall Stim so the unique-pid native module for this platform is present, then ${retry}.`,
+      remedy: `${err.remedy}, then ${retry}.`,
     };
   }
   return null;
@@ -279,6 +291,35 @@ export function claimLiveness(holder: ClaimHolder): Liveness {
 
 function refuse(root: string, claimPath: string, label: string, reason: string): never {
   throw new ClaimRefusedError({ claimPath, root, label, reason });
+}
+
+function refuseNonDirectory(root: string, path: string, label: string): never {
+  let blocking: string | null = null;
+  for (let level = path; ; level = dirname(level)) {
+    try {
+      if (!statSync(level).isDirectory()) {
+        blocking = level;
+        break;
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') break;
+    }
+    if (dirname(level) === level) break;
+  }
+  if (blocking === null) {
+    throw new ClaimUnavailableError(
+      'the non-directory path could not be identified; the claim store may have changed',
+      { claimPath: root },
+    );
+  }
+  throw new ClaimRefusedError({
+    root,
+    claimPath: blocking,
+    label,
+    reason: 'the claim path is a file, not a claim directory',
+    blockingFile: true,
+  });
 }
 
 function names(dir: string): string[] | 'unreadable' {
@@ -502,7 +543,7 @@ function publishExclusive(root: string, payload: string, claimId: string, label:
     rmSync(staging, { recursive: true, force: true });
     const code = (err as NodeJS.ErrnoException)?.code;
     if (contended(err)) return null;
-    if (code === 'ENOTDIR') refuse(root, target, label, CLAIM_PATH_NOT_A_DIRECTORY);
+    if (code === 'ENOTDIR') refuseNonDirectory(root, target, label);
     throw err;
   }
 }
@@ -541,7 +582,7 @@ export function tryAcquireClaim({ root, mode, details = {}, label = 'ownership' 
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code === 'EEXIST' || code === 'ENOTDIR') {
-        refuse(root, root, label, CLAIM_PATH_NOT_A_DIRECTORY);
+        refuseNonDirectory(root, root, label);
       }
       if (contended(err)) continue;
       throw err;

--- a/test/e2e/worktree-warm.e2e.js
+++ b/test/e2e/worktree-warm.e2e.js
@@ -2,6 +2,7 @@ import { after, before, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -67,6 +68,65 @@ test('Git creates a clean checkout and warm copies ignored dependencies and nati
   assert.equal(readFileSync(join(linked, 'node_modules/pkg/index.js'), 'utf-8'), 'dependency');
   assert.equal(readFileSync(join(linked, 'ios/Pods/Manifest.lock'), 'utf-8'), 'pods');
   assert.equal(readFileSync(join(linked, 'ios/build/generated.cpp'), 'utf-8'), 'native');
+});
+
+test('warm refuses an unwritable claim store before copying, with a code and access remedy', () => {
+  write('node_modules/pkg/index.js', 'dependency');
+  const home = join(ctx.tmp, 'permission-home');
+  mkdirSync(home, { mode: 0o500 });
+  try {
+    for (const refresh of [false, true]) {
+      const linked = create(`permission-${refresh}`);
+      const result = spawnSync(process.execPath, [CLI, 'worktree', 'warm', ...(refresh ? ['--refresh'] : [])], {
+        cwd: linked,
+        env: { ...process.env, STIM_HOME: home },
+        encoding: 'utf-8',
+      });
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /failed: STIM_CLAIM_UNAVAILABLE/);
+      assert.match(result.stderr, /EACCES|EPERM/);
+      assert.match(result.stderr, /Restore write access to the existing claim store/);
+      assert.equal(existsSync(join(linked, 'node_modules')), false);
+    }
+  } finally {
+    chmodSync(home, 0o700);
+  }
+});
+
+test('warm names a file blocking the claim store and preserves it with the printed remedy', () => {
+  write('node_modules/pkg/index.js', 'dependency');
+  for (const level of ['home', 'warm-locks']) {
+    const home = join(ctx.tmp, `blocked-${level}`);
+    if (level === 'warm-locks') mkdirSync(home);
+    const blocker = level === 'home' ? home : join(home, 'warm-locks');
+    writeFileSync(blocker, 'preserve this file');
+    const linked = create(`blocked-worktree-${level}`);
+    const invoke = (args = []) =>
+      spawnSync(process.execPath, [CLI, 'worktree', 'warm', ...args], {
+        cwd: linked,
+        env: { ...process.env, STIM_HOME: home },
+        encoding: 'utf-8',
+      });
+    for (const args of [[], ['--refresh']]) {
+      const result = invoke(args);
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /failed: STIM_CLAIM_REFUSED/);
+      assert.equal(existsSync(join(linked, 'node_modules')), false);
+      const remedy = result.stderr.split('\n').find((line) => line.trimStart().startsWith('mv -i '));
+      assert.ok(remedy, result.stderr);
+      assert.ok(remedy.includes(`'${blocker}'`), remedy);
+    }
+    const remedy = invoke()
+      .stderr.split('\n')
+      .find((line) => line.trimStart().startsWith('mv -i '));
+    execFileSync('/bin/sh', ['-c', remedy], { encoding: 'utf-8' });
+    assert.equal(readFileSync(`${blocker}.stim-backup`, 'utf8'), 'preserve this file');
+    const recovered = invoke();
+    assert.equal(recovered.status, 0, recovered.stderr);
+    assert.equal(readFileSync(join(linked, 'node_modules/pkg/index.js'), 'utf8'), 'dependency');
+  }
 });
 
 test('warm leaves the selected tracked base unchanged and reports mismatched copied Pods', () => {

--- a/website/docs/worktrees.md
+++ b/website/docs/worktrees.md
@@ -137,11 +137,13 @@ A refresh whose install runs in a
 spawned process group holds the lock while any member of that group lives, so a
 package manager's postinstall writer cannot outlive the protection.
 
-A plain warm that cannot take the lock at all -- an unwritable `STIM_HOME`, say
--- says so in one line and copies without it, exactly as it did before the lock
-existed; `--refresh` refuses instead, because it needs the lock. Even that
-unsynchronised copy reads the lock first, which takes nothing: if a refresh is
-holding this repository, it refuses rather than copying a tree being rewritten.
+Both plain warm and `--refresh` refuse before copying when they cannot record a
+claim. Missing process identity, denied write access or read-only claim storage
+report `STIM_CLAIM_UNAVAILABLE` with recovery instructions. Restore access to the
+same claim store before retrying; a different `STIM_HOME` would hide concurrent
+warm operations. A non-directory claim path reports `STIM_CLAIM_REFUSED`, names
+the blocking file and prints a move-aside command that preserves its contents.
+Inspect that file first, and preserve any existing backup when prompted.
 
 ## Parallel environments
 


### PR DESCRIPTION
## Description

A plain warm without a recorded claim can overlap a later refresh and copy dependencies while they change. Claim failures also lack a Stim error code or name the wrong blocking path. Fixes #696.

## Solution

Require the existing shared ownership claim for every copy. This reverses the deliberate compatibility fallback in [#690](https://github.com/appandflow/stim/commit/97ede367fcd80b04773b575f8349f3e3dbe4133b): preserving claimless warm would leave the refresh race open. Previously successful warm runs with unavailable process identity or inaccessible claim storage now refuse before copying.

Storage access failures report `STIM_CLAIM_UNAVAILABLE` with the original error and recovery instructions for the same store. The shared claim primitive names the actual blocking file and prints a move-aside command that preserves its contents; this remedy also applies to other claim callers. Subsecond acquisitions omit the elapsed-time suffix instead of saying `waited 0s`.

## Test plan

- On macOS, exercised both warm paths against a mode-0500 claim home: empty stdout, exit 1, the access remedy and `STIM_CLAIM_UNAVAILABLE`, with no copied dependencies.
- Exercised a regular file at `STIM_HOME` and at `warm-locks`; ran the printed move-aside command, verified the original contents survived and warm succeeded on retry. The primitive test also covers shell quoting and preserving a sibling file.
- Missing process identity refuses before copying regardless of existing holder liveness. Existing shared-reader/exclusive-writer tests verify coordinated warm behavior.
