### PR TITLE
fix: stop cache-suite Gradle daemons before removing their homes

### DIFF
--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -184,6 +184,13 @@ home. Every number it reports is a before/after around a COLD compile, and an
 inherited warm cache turns "the CAS gained 4,000 files" into a measurement of
 nothing.
 
+Android cache runs also own a disposable Gradle home. Cleanup runs each cached
+Gradle version's `--stop` against that home and waits for its recorded daemons
+to exit before removal. A shutdown failure fails the run and preserves its
+state for diagnosis. The same check protects cleanup of an earlier run whose
+owner has exited; homes with missing ownership or linked daemon registries
+are preserved. `--keep` retains the home without stopping its daemons.
+
 Run it by hand:
 
 ```bash

--- a/docs/e2e-and-ci.md
+++ b/docs/e2e-and-ci.md
@@ -188,8 +188,8 @@ Android cache runs also own a disposable Gradle home. Cleanup runs each cached
 Gradle version's `--stop` against that home and waits for its recorded daemons
 to exit before removal. A shutdown failure fails the run and preserves its
 state for diagnosis. The same check protects cleanup of an earlier run whose
-owner has exited; homes with missing ownership or linked daemon registries
-are preserved. `--keep` retains the home without stopping its daemons.
+owner has exited. Symlink homes and homes with missing ownership records or
+linked daemon registries are preserved. `--keep` retains the home without stopping its daemons.
 
 Run it by hand:
 

--- a/test/e2e/gradle-home.e2e.js
+++ b/test/e2e/gradle-home.e2e.js
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { removeGradleHome } from './native/gradle-home.mjs';
+import { getExecutor } from '../../packages/stim-cli/src/exec.ts';
+
+const cleanupModule = fileURLToPath(new URL('./native/gradle-home.mjs', import.meta.url));
+
+function fixture(t) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'stim-gradle-cleanup-')));
+  const home = join(root, 'owned');
+  mkdirSync(home);
+  writeFileSync(join(home, 'owner.pid'), String(process.pid));
+  const previousHome = process.env.STIM_HOME;
+  process.env.STIM_HOME = root;
+  t.after(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (previousHome === undefined) delete process.env.STIM_HOME;
+    else process.env.STIM_HOME = previousHome;
+  });
+  return { root, home };
+}
+
+function registry(home, pid) {
+  const dir = join(home, 'daemon', '9.0.0');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'registry.bin'), 'fixture');
+  if (pid) writeFileSync(join(dir, `daemon-${pid}.out.log`), 'fixture');
+}
+
+function binary(home, script) {
+  const path = join(home, 'wrapper', 'dists', 'gradle-9.0.0-bin', 'hash', 'gradle-9.0.0', 'bin', 'gradle');
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `#!${process.execPath}\n${script}\n`);
+  chmodSync(path, 0o755);
+}
+
+async function child(t, code, args = []) {
+  const process = getExecutor().spawn(globalThis.process.execPath, ['--input-type=module', '-e', code, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  t.after(() => {
+    if (process.exitCode === null && process.signalCode === null) process.kill('SIGKILL');
+  });
+  return process;
+}
+
+test('Gradle cleanup waits for daemon exit and leaves another home running', { timeout: 15000 }, async (t) => {
+  const { root, home } = fixture(t);
+  const marker = join(root, 'daemon-exited');
+  const daemon = await child(
+    t,
+    `
+    import { writeFileSync } from 'node:fs';
+    process.on('SIGTERM', () => setTimeout(() => {
+      writeFileSync(${JSON.stringify(marker)}, 'done');
+      process.exit(0);
+    }, 300));
+    console.log('ready');
+    setInterval(() => {}, 1000);
+  `,
+  );
+  await once(daemon.stdout, 'data');
+  const unrelated = await child(t, "console.log('ready'); setInterval(() => {}, 1000)");
+  await once(unrelated.stdout, 'data');
+  registry(home, daemon.pid);
+  const invoked = join(root, 'invoked.json');
+  binary(
+    home,
+    `
+    const fs = require('node:fs');
+    fs.writeFileSync(${JSON.stringify(invoked)}, JSON.stringify({args: process.argv.slice(2), home: process.env.GRADLE_USER_HOME}));
+    process.kill(${daemon.pid}, 'SIGTERM');
+  `,
+  );
+  const cleanup = await child(
+    t,
+    `
+    import { writeFileSync } from 'node:fs';
+    import { removeGradleHome } from ${JSON.stringify(cleanupModule)};
+    writeFileSync(${JSON.stringify(join(home, 'owner.pid'))}, String(process.pid));
+    removeGradleHome(${JSON.stringify(home)});
+  `,
+  );
+  let stderr = '';
+  cleanup.stderr.on('data', (data) => (stderr += data));
+  const [code] = await once(cleanup, 'close');
+  assert.equal(code, 0, stderr);
+  assert.equal(existsSync(marker), true);
+  assert.equal(existsSync(home), false);
+  assert.equal(unrelated.exitCode, null);
+  assert.doesNotThrow(() => process.kill(unrelated.pid, 0));
+  assert.deepEqual(JSON.parse(readFileSync(invoked, 'utf8')), {
+    args: ['--stop', '--gradle-user-home', home],
+    home,
+  });
+});
+
+test('Gradle stop failure retains its registry and home', (t) => {
+  const { home } = fixture(t);
+  registry(home);
+  binary(home, 'process.exit(7);');
+  assert.throws(() => removeGradleHome(home));
+  assert.equal(existsSync(join(home, 'daemon', '9.0.0', 'registry.bin')), true);
+});
+
+test('Gradle cleanup retains a live daemon when its distribution is missing', (t) => {
+  const { home } = fixture(t);
+  registry(home, process.pid);
+  assert.throws(() => removeGradleHome(home), /No cached Gradle/);
+  assert.equal(existsSync(home), true);
+});
+
+test('Gradle cleanup refuses missing ownership and another live owner', (t) => {
+  const { home } = fixture(t);
+  rmSync(join(home, 'owner.pid'));
+  assert.throws(() => removeGradleHome(home));
+  writeFileSync(join(home, 'owner.pid'), String(process.ppid));
+  assert.throws(() => removeGradleHome(home), /Cannot prove/);
+  assert.equal(existsSync(home), true);
+});
+
+test('Gradle cleanup refuses a registry linked outside its home', (t) => {
+  const { root, home } = fixture(t);
+  const unrelated = join(root, 'unrelated');
+  mkdirSync(unrelated);
+  symlinkSync(unrelated, join(home, 'daemon'));
+  assert.throws(() => removeGradleHome(home), /registry leaves/);
+  assert.equal(existsSync(unrelated), true);
+  assert.equal(existsSync(home), true);
+});

--- a/test/e2e/gradle-home.e2e.js
+++ b/test/e2e/gradle-home.e2e.js
@@ -143,3 +143,22 @@ test('Gradle cleanup refuses a registry linked outside its home', (t) => {
   assert.equal(existsSync(unrelated), true);
   assert.equal(existsSync(home), true);
 });
+
+test('Gradle cleanup preserves a symlink home target but accepts symlinked parents', { timeout: 5000 }, async (t) => {
+  const { root, home } = fixture(t);
+  const owner = await child(t, '');
+  await once(owner, 'close');
+  writeFileSync(join(home, 'owner.pid'), String(owner.pid));
+  const marker = join(home, 'retained');
+  writeFileSync(marker, 'preserve');
+  const alias = join(root, '.stim-e2e-gradle-alias');
+  symlinkSync(home, alias);
+  assert.throws(() => removeGradleHome(alias), /symlink/);
+  assert.equal(readFileSync(marker, 'utf8'), 'preserve');
+  assert.equal(existsSync(alias), true);
+
+  const parent = join(root, 'linked-parent');
+  symlinkSync(root, parent);
+  removeGradleHome(join(parent, 'owned'));
+  assert.equal(existsSync(home), false);
+});

--- a/test/e2e/native/gradle-home.mjs
+++ b/test/e2e/native/gradle-home.mjs
@@ -1,4 +1,4 @@
-import { existsSync, globSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { existsSync, globSync, lstatSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { getExecutor } from '../../../packages/stim-cli/src/exec.ts';
 
@@ -13,7 +13,9 @@ function isAlive(pid) {
 }
 
 export function removeGradleHome(home) {
-  if (!existsSync(home)) return;
+  const entry = lstatSync(home, { throwIfNoEntry: false });
+  if (!entry) return;
+  if (entry.isSymbolicLink()) throw new Error(`Cannot remove a symlink Gradle home: ${home}`);
   const canonical = realpathSync(home);
   const owner = Number(readFileSync(join(canonical, 'owner.pid'), 'utf8').trim());
   if (!Number.isInteger(owner) || owner <= 0 || (owner !== process.pid && isAlive(owner))) {

--- a/test/e2e/native/gradle-home.mjs
+++ b/test/e2e/native/gradle-home.mjs
@@ -1,0 +1,58 @@
+import { existsSync, globSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { getExecutor } from '../../../packages/stim-cli/src/exec.ts';
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+export function removeGradleHome(home) {
+  if (!existsSync(home)) return;
+  const canonical = realpathSync(home);
+  const owner = Number(readFileSync(join(canonical, 'owner.pid'), 'utf8').trim());
+  if (!Number.isInteger(owner) || owner <= 0 || (owner !== process.pid && isAlive(owner))) {
+    throw new Error(`Cannot prove Gradle home is unused: ${canonical}`);
+  }
+  const daemonRoot = join(canonical, 'daemon');
+  if (existsSync(daemonRoot) && realpathSync(daemonRoot) !== daemonRoot) {
+    throw new Error(`Gradle daemon registry leaves its owned home: ${daemonRoot}`);
+  }
+  const deadline = Date.now() + 60000;
+  const daemonPids = () =>
+    globSync('daemon/*/daemon-*.out.log', { cwd: canonical }).map((path) => {
+      const match = /\/daemon-(\d+)\.out\.log$/.exec(path);
+      if (!match) throw new Error(`Unrecognized Gradle daemon log: ${path}`);
+      return Number(match[1]);
+    });
+  const versions = globSync('daemon/*/registry.bin', { cwd: canonical }).map((path) => path.split('/')[1]);
+  for (const version of versions) {
+    const registry = join(daemonRoot, version, 'registry.bin');
+    if (realpathSync(registry) !== registry) {
+      throw new Error(`Gradle daemon registry leaves its owned home: ${registry}`);
+    }
+    const binaries = globSync('wrapper/dists/*/*/*/bin/gradle', { cwd: canonical }).filter(
+      (path) => path.split('/').at(-3) === `gradle-${version}`,
+    );
+    if (!binaries.length) {
+      if (daemonPids().some(isAlive)) throw new Error(`No cached Gradle ${version} to stop daemons in ${canonical}`);
+      continue;
+    }
+    getExecutor().runFile(join(canonical, binaries[0]), ['--stop', '--gradle-user-home', canonical], {
+      cwd: canonical,
+      env: { GRADLE_USER_HOME: canonical },
+      omitEnv: ['GRADLE_OPTS', 'JAVA_OPTS', 'JAVA_TOOL_OPTIONS', 'JDK_JAVA_OPTIONS', '_JAVA_OPTIONS'],
+      timeoutMs: Math.max(1, deadline - Date.now()),
+    });
+  }
+  while (daemonPids().some(isAlive)) {
+    if (Date.now() >= deadline) throw new Error(`Gradle daemons did not exit; preserving ${canonical}`);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+  rmSync(canonical, { recursive: true, force: true });
+}

--- a/test/e2e/native/run-cache-e2e.mjs
+++ b/test/e2e/native/run-cache-e2e.mjs
@@ -13,6 +13,7 @@ import {
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { removeGradleHome } from './gradle-home.mjs';
 import {
   FIXTURE_COMMANDS,
   assert,
@@ -78,21 +79,22 @@ process.env.STIM_HOME = HOME_DIR;
 let GRADLE_USER_HOME = process.env.GRADLE_USER_HOME || join(homedir(), '.gradle');
 let GRADLE_CACHE_DIR = join(GRADLE_USER_HOME, 'caches', 'build-cache-1');
 let GRADLE_HOME_IS_THROWAWAY = false;
+let preserveGradleHome = false;
 
 function seedGradleUserHome(source) {
   // Gradle resolves script classpath symlinks, so dependency caches are cloned into the disposable home.
   const base = existsSync(source) ? dirname(realpathSync(source)) : tmpdir();
-  // A crashed run cannot clean its own home; sweep predecessors only when
-  // their recorded owner pid is provably dead.
   for (const stale of readdirSync(base).filter((n) => n.startsWith('.stim-e2e-gradle-'))) {
     if (ownerIsAlive(join(base, stale))) continue;
-    cleanupTmp([join(base, stale)]);
+    try {
+      removeGradleHome(join(base, stale));
+    } catch (error) {
+      process.stderr.write(`[cache-e2e] preserving Gradle home: ${error.message}\n`);
+    }
   }
   const target = mkdtempSync(join(base, '.stim-e2e-gradle-'));
   try {
     writeFileSync(join(target, 'owner.pid'), String(process.pid));
-    // Daemons rooted in a deleted home can never be reused; a short idle
-    // timeout reaps them soon after each build.
     writeFileSync(join(target, 'gradle.properties'), 'org.gradle.daemon.idletimeout=30000\n');
     mkdirSync(join(target, 'caches'), { recursive: true });
     for (const [rel, dest] of [
@@ -116,7 +118,14 @@ function seedGradleUserHome(source) {
     throw err;
   }
   process.on('exit', () => {
-    if (!args.keep) rmSync(target, { recursive: true, force: true });
+    if (!args.keep && !preserveGradleHome) {
+      try {
+        removeGradleHome(target);
+      } catch (error) {
+        process.stderr.write(`[cache-e2e] Gradle cleanup failed: ${error.message}\n`);
+        process.exitCode = 1;
+      }
+    }
   });
   return target;
 }
@@ -1032,19 +1041,25 @@ if (args.dryRun) {
 }
 
 const startedAt = Date.now();
-main().then(
-  () => {
-    const summary = emitSummary(Date.now() - startedAt, null);
-    if (!args.keep)
-      cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR, GRADLE_HOME_IS_THROWAWAY ? GRADLE_USER_HOME : null]);
-    return process.exit(summary.ok ? 0 : 1);
-  },
-  (err) => {
-    log(`FATAL: ${err?.message || err}`);
+function finishRun(error) {
+  preserveGradleHome = Boolean(error?.preserveNativeState);
+  if (!args.keep && !preserveGradleHome && GRADLE_HOME_IS_THROWAWAY) {
+    try {
+      removeGradleHome(GRADLE_USER_HOME);
+    } catch (cleanupError) {
+      preserveGradleHome = true;
+      error = error
+        ? new AggregateError([error, cleanupError], `${error.message}; ${cleanupError.message}`)
+        : cleanupError;
+    }
+  }
+  if (error) {
+    log(`FATAL: ${error?.message || error}`);
     dumpDiagnostics(h, created);
-    emitSummary(Date.now() - startedAt, String(err?.message || err));
-    if (!args.keep)
-      cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR, GRADLE_HOME_IS_THROWAWAY ? GRADLE_USER_HOME : null], err);
-    return process.exit(1);
-  },
-);
+  }
+  const summary = emitSummary(Date.now() - startedAt, error ? String(error?.message || error) : null);
+  if (!args.keep && !preserveGradleHome) cleanupTmp([WORK_DIR, args.home ? null : HOME_DIR], error);
+  process.exit(summary.ok ? 0 : 1);
+}
+
+main().then(() => finishRun(null), finishRun);


### PR DESCRIPTION
## Description

An interrupted Android cache run can delete its temporary Gradle home while its daemon is still writing. A controlled Gradle 9.0 reproduction left the daemon alive and recreated `caches` and `daemon` after removal; the reported `ENOTEMPTY` itself did not recur. Fixes #702.

## Solution

Stop each cached Gradle version using the owned home, then wait for recorded daemon PIDs to exit before deleting it. Cleanup failure fails the run and preserves its state. Normal completion, the exit hook and dead-owner cleanup use the same check; symlink homes, unknown ownership and linked registries are preserved.

The [original idle-timeout design](https://github.com/appandflow/stim/commit/bf4640abef802d64903d7d4061aad8708a755a86) removed wrapper shutdown because fixture worktrees were already gone. Using the installation cached inside the Gradle home keeps shutdown available at that point.

## Test plan

On macOS with Gradle 9.0 and JDK 17, interrupted a task with two separate temporary-home daemons running. Cleanup took 432 ms: the selected daemon exited and its home disappeared; the other daemon and home remained intact. Both fixtures were then cleaned up. No native build or emulator was needed.

The focused end-to-end regressions cover delayed daemon exit, unrelated-process survival, failed shutdown, missing distribution/ownership, symlink homes and linked registries.

